### PR TITLE
(go-deeper) Fix overlapping git.add paths bug with binary patches

### DIFF
--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -40,6 +40,8 @@ type Patch interface {
 	GetFilePath() string
 	IsEmpty() bool
 	HasBinary() bool
+	GetPaths() []string
+	GetBinaryPaths() []string
 }
 
 type Archive interface {

--- a/pkg/git_repo/patch_file.go
+++ b/pkg/git_repo/patch_file.go
@@ -23,9 +23,17 @@ func (p *PatchFile) GetFilePath() string {
 }
 
 func (p *PatchFile) IsEmpty() bool {
-	return p.Descriptor.IsEmpty
+	return len(p.Descriptor.Paths) == 0
 }
 
 func (p *PatchFile) HasBinary() bool {
-	return p.Descriptor.HasBinary
+	return len(p.Descriptor.BinaryPaths) > 0
+}
+
+func (p *PatchFile) GetPaths() []string {
+	return p.Descriptor.Paths
+}
+
+func (p *PatchFile) GetBinaryPaths() []string {
+	return p.Descriptor.BinaryPaths
 }

--- a/pkg/true_git/patch.go
+++ b/pkg/true_git/patch.go
@@ -16,8 +16,8 @@ type PatchOptions struct {
 }
 
 type PatchDescriptor struct {
-	IsEmpty   bool
-	HasBinary bool
+	Paths       []string
+	BinaryPaths []string
 }
 
 func PatchWithSubmodules(out io.Writer, gitDir, workTreeDir string, opts PatchOptions) (*PatchDescriptor, error) {
@@ -195,8 +195,18 @@ WaitForData:
 	}
 
 	desc := &PatchDescriptor{
-		IsEmpty:   (p.OutLines == 0),
-		HasBinary: p.HasBinary,
+		Paths:       p.Paths,
+		BinaryPaths: p.BinaryPaths,
+	}
+
+	if debugPatch() {
+		fmt.Printf("Patch paths count is %d, binary paths count is %d\n", len(desc.Paths), len(desc.BinaryPaths))
+		for _, path := range desc.Paths {
+			fmt.Printf("Patch path `%s`\n", path)
+		}
+		for _, path := range desc.BinaryPaths {
+			fmt.Printf("Binary patch path `%s`\n", path)
+		}
 	}
 
 	return desc, nil


### PR DESCRIPTION
In current version dapp will remove all files in container by path `git.to` and then reapply archive on patch-stage. This way dapp will broke another git paths added to the same file-tree, possibly to different subdirectories.

Changed algorithm of applying changes when a binary file has been changed in patch. In this case dapp will apply changes on patch-stage as follows:

* Delete all files changed in patch.
* Delete all remaining empty directories.
* Unpack full archive of git spec.