### PR TITLE
[go deeper] Enable deployment tracking with kubedog by default

### DIFF
--- a/lib/dapp/kube/dapp/command/deploy.rb
+++ b/lib/dapp/kube/dapp/command/deploy.rb
@@ -262,7 +262,7 @@ module Dapp
                   ::Timeout::timeout(timeout) do
                     deployment_managers.each {|deployment_manager|
                       if deployment_manager.should_watch?
-                        if ENV["KUBEDOG"] == "1"
+                        if ENV["KUBEDOG"] != "0"
                           res = ruby2go_deploy_watcher(
                             "action" => "watch deployment",
                             "resourceName" => deployment_manager.name,
@@ -272,7 +272,7 @@ module Dapp
                           )
 
                           if res["error"]
-                            raise res["error"]
+                            raise ::Dapp::Kube::Kubernetes::Error::Default.new data: {message: res["error"]}
                           end
                         else
                           deployment_manager.watch_till_ready!

--- a/pkg/process_exterminator/main.go
+++ b/pkg/process_exterminator/main.go
@@ -1,4 +1,4 @@
-package kill_cord
+package process_exterminator
 
 import (
 	"bufio"
@@ -39,7 +39,7 @@ func run(parentsPids []int) {
 
 			err := writePidToFile(os.Getpid(), filepath.Join(dapp.GetHomeDir(), ".killed_pids"))
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Kill cord error: %s\n", err)
+				fmt.Fprintf(os.Stderr, "Process exterminator error: %s\n", err)
 			}
 
 			syscall.Kill(ownPid, syscall.SIGINT)

--- a/pkg/ruby2go/ruby2go.go
+++ b/pkg/ruby2go/ruby2go.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"syscall"
 
-	"github.com/flant/dapp/pkg/kill_cord"
+	"github.com/flant/dapp/pkg/process_exterminator"
 	"github.com/flant/dapp/pkg/util"
 )
 
@@ -64,9 +64,9 @@ func writeJsonObjectToFile(obj map[string]interface{}, path string) error {
 func RunCli(progname string, runFunc func(map[string]interface{}) (interface{}, error)) {
 	Trap()
 
-	err := kill_cord.Init()
+	err := process_exterminator.Init()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Kill cord initialization error: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Process exterminator initialization error: %s\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Refine deployment tracking error: error without backtrace
