### PR TITLE
[distributed builds] Implement lockgate.Locker compatible LockerWithRetry wrapper

### DIFF
--- a/pkg/storage/kubernetes_lock_manager.go
+++ b/pkg/storage/kubernetes_lock_manager.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/werf/werf/pkg/werf/locker_with_retry"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/werf/kubedog/pkg/kube"
@@ -46,7 +48,10 @@ func (manager *KuberntesLockManager) getLockerForProject(projectName string) (lo
 			Resource: "configmaps",
 		}, name, manager.Namespace,
 	)
-	manager.LockerPerProject[projectName] = locker
+
+	lockerWithRetry := locker_with_retry.NewLockerWithRetry(locker, locker_with_retry.LockerWithRetryOptions{MaxAcquireAttempts: 10, MaxReleaseAttempts: 10})
+
+	manager.LockerPerProject[projectName] = lockerWithRetry
 
 	return locker, nil
 }

--- a/pkg/werf/locker_with_retry/locker_with_retry.go
+++ b/pkg/werf/locker_with_retry/locker_with_retry.go
@@ -1,0 +1,65 @@
+package locker_with_retry
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/werf/lockgate"
+	"github.com/werf/logboek"
+)
+
+type LockerWithRetry struct {
+	Locker  lockgate.Locker
+	Options LockerWithRetryOptions
+}
+
+type LockerWithRetryOptions struct {
+	MaxAcquireAttempts int
+	MaxReleaseAttempts int
+}
+
+func NewLockerWithRetry(locker lockgate.Locker, opts LockerWithRetryOptions) *LockerWithRetry {
+	return &LockerWithRetry{Locker: locker, Options: opts}
+}
+
+func (locker *LockerWithRetry) Acquire(lockName string, opts lockgate.AcquireOptions) (acquired bool, handle lockgate.LockHandle, err error) {
+	executeWithRetry(locker.Options.MaxAcquireAttempts, func() error {
+		acquired, handle, err = locker.Locker.Acquire(lockName, opts)
+		if err != nil {
+			logboek.Error.LogF("ERROR: unable to acquire lock %s: %s\n", lockName, err)
+		}
+		return err
+	})
+
+	return
+}
+
+func (locker *LockerWithRetry) Release(lock lockgate.LockHandle) (err error) {
+	executeWithRetry(locker.Options.MaxAcquireAttempts, func() error {
+		err = locker.Locker.Release(lock)
+		if err != nil {
+			logboek.Error.LogF("ERROR: unable to release lock %s %s: %s\n", lock.UUID, lock.LockName, err)
+		}
+		return err
+	})
+
+	return
+}
+
+func executeWithRetry(maxAttempts int, executeFunc func() error) {
+	attempt := 1
+
+executeAttempt:
+	if err := executeFunc(); err != nil {
+		if attempt == maxAttempts {
+			return
+		}
+
+		seconds := rand.Intn(10) // from 0 to 10 seconds
+		logboek.Warn.LogF("Retrying in %d seconds (%d/%d) ...\n", seconds, attempt, maxAttempts)
+		time.Sleep(time.Duration(seconds) * time.Second)
+
+		attempt += 1
+		goto executeAttempt
+	}
+}


### PR DESCRIPTION
 - Use LockerWithRetry wrapper for all kubernetes locks in werf (5 attempts for acquire/release operations are configured).
 - Log all failed attempts to the stderr.