### PR TITLE
Rework publish procedure for cleanup (part 1)

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -587,6 +587,14 @@ func (c *Conveyor) GetImageTmpDir(imageName string) string {
 	return filepath.Join(c.tmpDir, "image", imageName)
 }
 
+func (c *Conveyor) GetProjectRepoCommit() (string, error) {
+	if c.localGitRepo != nil {
+		return c.localGitRepo.HeadCommit()
+	} else {
+		return "", nil
+	}
+}
+
 func prepareImageBasedOnStapelImageConfig(imageInterfaceConfig config.StapelImageInterface, c *Conveyor) (*Image, error) {
 	image := &Image{}
 

--- a/pkg/build/stage/conveyor.go
+++ b/pkg/build/stage/conveyor.go
@@ -14,6 +14,8 @@ type Conveyor interface {
 
 	GetImportServer(imageName, stageName string) (import_server.ImportServer, error)
 	GetLocalGitRepoVirtualMergeOptions() VirtualMergeOptions
+
+	GetProjectRepoCommit() (string, error)
 }
 
 type VirtualMergeOptions struct {

--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -69,7 +69,11 @@ func (s *FromStage) GetDependencies(c Conveyor, prevImage, _ container_runtime.I
 	return util.Sha256Hash(args...), nil
 }
 
-func (s *FromStage) PrepareImage(_ Conveyor, prevBuiltImage, image container_runtime.ImageInterface) error {
+func (s *FromStage) PrepareImage(c Conveyor, prevBuiltImage, image container_runtime.ImageInterface) error {
+	if err := s.addProjectRepoCommitToLabels(c, image); err != nil {
+		return err
+	}
+
 	serviceMounts := s.getServiceMounts(prevBuiltImage)
 	s.addServiceMountsLabels(serviceMounts, image)
 

--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -130,6 +130,30 @@ func (api *api) deleteImageByReference(reference string) error {
 	return nil
 }
 
+func (api *api) PutMetadata(reference string, metadata map[string]string) error {
+	ref, err := name.ParseReference(reference, api.parseReferenceOptions()...)
+	if err != nil {
+		return fmt.Errorf("parsing reference %q: %v", reference, err)
+	}
+
+	img := NewManifestOnlyImage(metadata)
+
+	if err := remote.Write(ref, img); err != nil {
+		return fmt.Errorf("write to the remote %s have failed: %s", ref.String(), err)
+	}
+	return nil
+}
+
+func (api *api) GetMetadata(reference string) (map[string]string, error) {
+	ref, err := name.ParseReference(reference, api.parseReferenceOptions()...)
+	if err != nil {
+		return nil, fmt.Errorf("parsing reference %q: %v", reference, err)
+	}
+	_ = ref
+
+	return nil, nil
+}
+
 func (api *api) image(reference string) (v1.Image, name.Reference, error) {
 	ref, err := name.ParseReference(reference, api.parseReferenceOptions()...)
 	if err != nil {

--- a/pkg/docker_registry/docker_registry.go
+++ b/pkg/docker_registry/docker_registry.go
@@ -27,6 +27,9 @@ type DockerRegistry interface {
 	SelectRepoImageList(reference string, f func(string, *image.Info, error) (bool, error)) ([]*image.Info, error)
 	DeleteRepoImage(repoImageList ...*image.Info) error
 
+	PutMetadata(reference string, metadata map[string]string) error
+	GetMetadata(reference string) (map[string]string, error)
+
 	ResolveRepoMode(registryOrRepositoryAddress, repoMode string) (string, error)
 	String() string
 }

--- a/pkg/docker_registry/manifest_only_image.go
+++ b/pkg/docker_registry/manifest_only_image.go
@@ -1,0 +1,48 @@
+package docker_registry
+
+import (
+	"fmt"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type ManifestOnlyImage struct {
+	Metadata map[string]string
+}
+
+func NewManifestOnlyImage(metadata map[string]string) v1.Image {
+	if img, err := partial.UncompressedToImage(ManifestOnlyImage{Metadata: metadata}); err != nil {
+		panic(fmt.Sprintf("unable to create new ManifestOnlyImage: %s", err))
+	} else {
+		return img
+	}
+}
+
+// MediaType implements partial.UncompressedImageCore.
+func (i ManifestOnlyImage) MediaType() (types.MediaType, error) {
+	return types.DockerManifestSchema2, nil
+}
+
+// RawConfigFile implements partial.UncompressedImageCore.
+func (i ManifestOnlyImage) RawConfigFile() ([]byte, error) {
+	return partial.RawConfigFile(i)
+}
+
+// ConfigFile implements v1.Image.
+func (i ManifestOnlyImage) ConfigFile() (*v1.ConfigFile, error) {
+	return &v1.ConfigFile{
+		Config: v1.Config{
+			Labels: i.Metadata,
+		},
+		RootFS: v1.RootFS{
+			// Some clients check this.
+			Type: "layers",
+		},
+	}, nil
+}
+
+func (i ManifestOnlyImage) LayerByDiffID(h v1.Hash) (partial.UncompressedLayer, error) {
+	return nil, fmt.Errorf("LayerByDiffID(%s): empty image", h)
+}

--- a/pkg/image/const.go
+++ b/pkg/image/const.go
@@ -1,14 +1,15 @@
 package image
 
 const (
-	WerfLabel               = "werf"
-	WerfVersionLabel        = "werf-version"
-	WerfCacheVersionLabel   = "werf-cache-version"
-	WerfImageLabel          = "werf-image"
-	WerfImageNameLabel      = "werf-image-name"
-	WerfImageTagLabel       = "werf-image-tag"
-	WerfDockerImageName     = "werf-docker-image-name"
-	WerfStageSignatureLabel = "werf-stage-signature"
+	WerfLabel                  = "werf"
+	WerfVersionLabel           = "werf-version"
+	WerfCacheVersionLabel      = "werf-cache-version"
+	WerfImageLabel             = "werf-image"
+	WerfImageNameLabel         = "werf-image-name"
+	WerfImageTagLabel          = "werf-image-tag"
+	WerfDockerImageName        = "werf-docker-image-name"
+	WerfStageSignatureLabel    = "werf-stage-signature"
+	WerfProjectRepoCommitLabel = "werf-project-repo-commit"
 
 	WerfMountTmpDirLabel          = "werf-mount-type-tmp-dir"
 	WerfMountBuildDirLabel        = "werf-mount-type-build-dir"

--- a/pkg/stages_manager/stages_manager.go
+++ b/pkg/stages_manager/stages_manager.go
@@ -375,7 +375,7 @@ func (m *StagesManager) getStageDescription(stageID image.StageID) (*image.Stage
 		logboek.Info.LogF("Not found %s image info in manifest cache (CACHE MISS)\n", stageImageName)
 		logboek.Info.LogF("Getting signature %q uniqueID %d stage info from %s...\n", stageID.Signature, stageID.UniqueID, m.StagesStorage.String())
 		if stageDesc, err := m.StagesStorage.GetStageDescription(m.ProjectName, stageID.Signature, stageID.UniqueID); err != nil {
-			return nil, fmt.Errorf("error getting signature %q uniqueID %q stage info from %s: %s", stageID.Signature, stageID.UniqueID, m.StagesStorage.String(), err)
+			return nil, fmt.Errorf("error getting signature %q uniqueID %d stage info from %s: %s", stageID.Signature, stageID.UniqueID, m.StagesStorage.String(), err)
 		} else if stageDesc != nil {
 			logboek.Info.LogF("Storing image %s info into manifest cache\n", stageImageName)
 			if err := image.CommonManifestCache.StoreImageInfo(stageDesc.Info); err != nil {

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -32,8 +32,17 @@ type StagesStorage interface {
 	RmManagedImage(projectName, imageName string) error
 	GetManagedImages(projectName string) ([]string, error)
 
+	PutImageCommit(projectName, imageName, commit string, metadata *ImageMetadata) error
+	RmImageCommit(projectName, imageName, commit string) error
+	GetImageCommits(projectName, imageName string) ([]string, error)
+	GetImageMetadataByCommit(projectName, imageName, commit string) (*ImageMetadata, error)
+
 	String() string
 	Address() string
+}
+
+type ImageMetadata struct {
+	ContentSignature string
 }
 
 type StagesStorageOptions struct {


### PR DESCRIPTION
 - Store metadata for images in the stages storage: map stages-signature by commit-id and image-name.
    - Add new methods StagesStorage interface: PutImageCommit, RmImageCommit, GetImageMetadataByCommit, GetImageCommits.
    - Implemented fully only for repo-stages-storage.
 - Store project repository commit in the separate dedicated label: werf-project-repo-commit.
