### PR TITLE
[git] Do not use 'git worktree add --no-checkout' option

### DIFF
--- a/pkg/true_git/work_tree.go
+++ b/pkg/true_git/work_tree.go
@@ -160,7 +160,7 @@ func switchWorkTree(repoDir, workTreeDir string, commit string, withSubmodules b
 	if _, err := os.Stat(workTreeDir); os.IsNotExist(err) {
 		cmd = exec.Command(
 			"git", "-C", repoDir,
-			"worktree", "add", "--force", "--detach", "--no-checkout", workTreeDir,
+			"worktree", "add", "--force", "--detach", workTreeDir, commit,
 		)
 		output = setCommandRecordingLiveOutput(cmd)
 		if debugWorktreeSwitch() {


### PR DESCRIPTION
This option is not avaiable in the v2.17.1 version of git, which is the latest avaiable version for 18.04 lts ubuntu.

Specify target commit instead (which is by the way a faster and more precise approach).