### PR TITLE
[publish-for-cleanup] Refactor DockerRegistry methods to store labels into manifest_only_image

### DIFF
--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -130,28 +130,18 @@ func (api *api) deleteImageByReference(reference string) error {
 	return nil
 }
 
-func (api *api) PutMetadata(reference string, metadata map[string]string) error {
+func (api *api) SetLabelsIntoImage(reference string, labels map[string]string) error {
 	ref, err := name.ParseReference(reference, api.parseReferenceOptions()...)
 	if err != nil {
 		return fmt.Errorf("parsing reference %q: %v", reference, err)
 	}
 
-	img := NewManifestOnlyImage(metadata)
+	img := NewManifestOnlyImage(labels)
 
 	if err := remote.Write(ref, img); err != nil {
 		return fmt.Errorf("write to the remote %s have failed: %s", ref.String(), err)
 	}
 	return nil
-}
-
-func (api *api) GetMetadata(reference string) (map[string]string, error) {
-	ref, err := name.ParseReference(reference, api.parseReferenceOptions()...)
-	if err != nil {
-		return nil, fmt.Errorf("parsing reference %q: %v", reference, err)
-	}
-	_ = ref
-
-	return nil, nil
 }
 
 func (api *api) image(reference string) (v1.Image, name.Reference, error) {

--- a/pkg/docker_registry/docker_registry.go
+++ b/pkg/docker_registry/docker_registry.go
@@ -26,9 +26,7 @@ type DockerRegistry interface {
 	GetRepoImageList(reference string) ([]*image.Info, error)
 	SelectRepoImageList(reference string, f func(string, *image.Info, error) (bool, error)) ([]*image.Info, error)
 	DeleteRepoImage(repoImageList ...*image.Info) error
-
-	PutMetadata(reference string, metadata map[string]string) error
-	GetMetadata(reference string) (map[string]string, error)
+	SetLabelsIntoImage(reference string, labels map[string]string) error
 
 	ResolveRepoMode(registryOrRepositoryAddress, repoMode string) (string, error)
 	String() string

--- a/pkg/docker_registry/manifest_only_image.go
+++ b/pkg/docker_registry/manifest_only_image.go
@@ -8,12 +8,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-type ManifestOnlyImage struct {
-	Metadata map[string]string
+type manifestOnlyImage struct {
+	Labels map[string]string
 }
 
-func NewManifestOnlyImage(metadata map[string]string) v1.Image {
-	if img, err := partial.UncompressedToImage(ManifestOnlyImage{Metadata: metadata}); err != nil {
+func NewManifestOnlyImage(labels map[string]string) v1.Image {
+	if img, err := partial.UncompressedToImage(manifestOnlyImage{Labels: labels}); err != nil {
 		panic(fmt.Sprintf("unable to create new ManifestOnlyImage: %s", err))
 	} else {
 		return img
@@ -21,20 +21,20 @@ func NewManifestOnlyImage(metadata map[string]string) v1.Image {
 }
 
 // MediaType implements partial.UncompressedImageCore.
-func (i ManifestOnlyImage) MediaType() (types.MediaType, error) {
+func (i manifestOnlyImage) MediaType() (types.MediaType, error) {
 	return types.DockerManifestSchema2, nil
 }
 
 // RawConfigFile implements partial.UncompressedImageCore.
-func (i ManifestOnlyImage) RawConfigFile() ([]byte, error) {
+func (i manifestOnlyImage) RawConfigFile() ([]byte, error) {
 	return partial.RawConfigFile(i)
 }
 
 // ConfigFile implements v1.Image.
-func (i ManifestOnlyImage) ConfigFile() (*v1.ConfigFile, error) {
+func (i manifestOnlyImage) ConfigFile() (*v1.ConfigFile, error) {
 	return &v1.ConfigFile{
 		Config: v1.Config{
-			Labels: i.Metadata,
+			Labels: i.Labels,
 		},
 		RootFS: v1.RootFS{
 			// Some clients check this.
@@ -43,6 +43,6 @@ func (i ManifestOnlyImage) ConfigFile() (*v1.ConfigFile, error) {
 	}, nil
 }
 
-func (i ManifestOnlyImage) LayerByDiffID(h v1.Hash) (partial.UncompressedLayer, error) {
+func (i manifestOnlyImage) LayerByDiffID(h v1.Hash) (partial.UncompressedLayer, error) {
 	return nil, fmt.Errorf("LayerByDiffID(%s): empty image", h)
 }


### PR DESCRIPTION
 - New method DockerRegistry.SetLabelsIntoImage.
 - Removed DockerRegistry.GetMetadata method: use DockerRegistry.TryGetRepoImage instead.