### PR TITLE
[publish-for-cleanup] Implement metadata store for local stages storage

### DIFF
--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"fmt"
 	"math/rand"
 	"strings"
 	"time"
@@ -14,9 +15,22 @@ import (
 	"golang.org/x/net/context"
 )
 
-func CreateImage(ref string) error {
+func CreateImage(ref string, labels map[string]string) error {
 	ctx := context.Background()
-	_, err := apiClient.ImageImport(ctx, types.ImageImportSource{SourceName: "-"}, ref, types.ImageImportOptions{})
+
+	var opts types.ImageImportOptions
+
+	if len(labels) > 0 {
+		changeOption := "LABEL"
+
+		for k, v := range labels {
+			changeOption += fmt.Sprintf(" %s=%s", k, v)
+		}
+
+		opts.Changes = append(opts.Changes, changeOption)
+	}
+
+	_, err := apiClient.ImageImport(ctx, types.ImageImportSource{SourceName: "-"}, ref, opts)
 	return err
 }
 

--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -130,13 +130,13 @@ func (api *api) deleteImageByReference(reference string) error {
 	return nil
 }
 
-func (api *api) SetLabelsIntoImage(reference string, labels map[string]string) error {
+func (api *api) PushImage(reference string, opts PushImageOptions) error {
 	ref, err := name.ParseReference(reference, api.parseReferenceOptions()...)
 	if err != nil {
 		return fmt.Errorf("parsing reference %q: %v", reference, err)
 	}
 
-	img := NewManifestOnlyImage(labels)
+	img := NewManifestOnlyImage(opts.Labels)
 
 	if err := remote.Write(ref, img); err != nil {
 		return fmt.Errorf("write to the remote %s have failed: %s", ref.String(), err)

--- a/pkg/docker_registry/docker_registry.go
+++ b/pkg/docker_registry/docker_registry.go
@@ -26,10 +26,14 @@ type DockerRegistry interface {
 	GetRepoImageList(reference string) ([]*image.Info, error)
 	SelectRepoImageList(reference string, f func(string, *image.Info, error) (bool, error)) ([]*image.Info, error)
 	DeleteRepoImage(repoImageList ...*image.Info) error
-	SetLabelsIntoImage(reference string, labels map[string]string) error
+	PushImage(reference string, opts PushImageOptions) error
 
 	ResolveRepoMode(registryOrRepositoryAddress, repoMode string) (string, error)
 	String() string
+}
+
+type PushImageOptions struct {
+	Labels map[string]string
 }
 
 type DockerRegistryOptions struct {


### PR DESCRIPTION
 - Rename DockerRegistry.SetLabelsIntoImage to more generic DockerRegistry.PushImage.
    - PushImage now supports only creation of manifest-only-images with labels.
 - Refactor managed-image store procedure for repo-stages-storage to use DockerRegistry.PushImage instead of docker-push.