### PR TITLE
[backport v1.1.19] Fix distributed werf hangs sometimes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/tonistiigi/fsutil v0.0.0-20190130224639-b4281fa67095 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	github.com/werf/kubedog v0.3.5-0.20200610123340-3e909edb5afe
-	github.com/werf/lockgate v0.0.0-20200618124604-b12f696bdd55
+	github.com/werf/lockgate v0.0.0-20200625122100-41c30943229f
 	github.com/werf/logboek v0.3.5-0.20200608145450-5b5f18fe7009
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -801,6 +801,8 @@ github.com/werf/lockgate v0.0.0-20200610124531-3e56c66ed101 h1:tPxINuU4/RjTCwfCW
 github.com/werf/lockgate v0.0.0-20200610124531-3e56c66ed101/go.mod h1:sChblfYDpXj4QW5SxdD7tUVlNzPKFzwOiNZAyh1BAKQ=
 github.com/werf/lockgate v0.0.0-20200618124604-b12f696bdd55 h1:/7jQqp5f/gZrnWXSR+2OgXVvDZuumAVKrLOOsXUKv4o=
 github.com/werf/lockgate v0.0.0-20200618124604-b12f696bdd55/go.mod h1:sChblfYDpXj4QW5SxdD7tUVlNzPKFzwOiNZAyh1BAKQ=
+github.com/werf/lockgate v0.0.0-20200625122100-41c30943229f h1:3nh/f/qUDhQNyVAyOiXmiSko326AZvBKyIxHqx1wWPU=
+github.com/werf/lockgate v0.0.0-20200625122100-41c30943229f/go.mod h1:sChblfYDpXj4QW5SxdD7tUVlNzPKFzwOiNZAyh1BAKQ=
 github.com/werf/logboek v0.3.5-0.20200608145450-5b5f18fe7009 h1:C9lbmDvP49QsQRZuGgYfmkzcb0+pUo8ucWxXql2GdJY=
 github.com/werf/logboek v0.3.5-0.20200608145450-5b5f18fe7009/go.mod h1:z/o88w2pmtW11fFsHnXQFsTNzcPp1H+VCtCj7OUntwU=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=


### PR DESCRIPTION
The hanging case was in the lockgate library, described in the https://github.com/werf/lockgate/pull/24.