### PR TITLE
[backport v1.1.16] Fix distributed werf hangs sometimes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/uber/jaeger-lib v1.2.1 // indirect
 	github.com/vishvananda/netlink v1.0.0 // indirect
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
-	github.com/werf/lockgate v0.0.0-20200618124604-b12f696bdd55
+	github.com/werf/lockgate v0.0.0-20200625122100-41c30943229f
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20170512152554-8a8cc2c7e54a

--- a/go.sum
+++ b/go.sum
@@ -933,6 +933,8 @@ github.com/vmware/govmomi v0.20.1/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59b
 github.com/werf/kubedog v0.3.5-0.20200610123340-3e909edb5afe/go.mod h1:mSm773JaDFwmgzrOl6LRFDrlUjwk0yKS6WYBbC6E144=
 github.com/werf/lockgate v0.0.0-20200618124604-b12f696bdd55 h1:/7jQqp5f/gZrnWXSR+2OgXVvDZuumAVKrLOOsXUKv4o=
 github.com/werf/lockgate v0.0.0-20200618124604-b12f696bdd55/go.mod h1:sChblfYDpXj4QW5SxdD7tUVlNzPKFzwOiNZAyh1BAKQ=
+github.com/werf/lockgate v0.0.0-20200625122100-41c30943229f h1:3nh/f/qUDhQNyVAyOiXmiSko326AZvBKyIxHqx1wWPU=
+github.com/werf/lockgate v0.0.0-20200625122100-41c30943229f/go.mod h1:sChblfYDpXj4QW5SxdD7tUVlNzPKFzwOiNZAyh1BAKQ=
 github.com/werf/logboek v0.3.5-0.20200608145450-5b5f18fe7009/go.mod h1:z/o88w2pmtW11fFsHnXQFsTNzcPp1H+VCtCj7OUntwU=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=


### PR DESCRIPTION
The hanging case was in the lockgate library, described in the https://github.com/werf/lockgate/pull/24.