### PR TITLE
[backport v1.1.14] Fix distributed werf hangs sometimes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/uber/jaeger-lib v1.2.1 // indirect
 	github.com/vishvananda/netlink v1.0.0 // indirect
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
+	github.com/werf/lockgate v0.0.0-20200625122100-41c30943229f
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20170512152554-8a8cc2c7e54a

--- a/go.sum
+++ b/go.sum
@@ -937,6 +937,10 @@ github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJ
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware/govmomi v0.20.1/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
+github.com/werf/kubedog v0.3.5-0.20200610123340-3e909edb5afe/go.mod h1:mSm773JaDFwmgzrOl6LRFDrlUjwk0yKS6WYBbC6E144=
+github.com/werf/lockgate v0.0.0-20200625122100-41c30943229f h1:3nh/f/qUDhQNyVAyOiXmiSko326AZvBKyIxHqx1wWPU=
+github.com/werf/lockgate v0.0.0-20200625122100-41c30943229f/go.mod h1:sChblfYDpXj4QW5SxdD7tUVlNzPKFzwOiNZAyh1BAKQ=
+github.com/werf/logboek v0.3.5-0.20200608145450-5b5f18fe7009/go.mod h1:z/o88w2pmtW11fFsHnXQFsTNzcPp1H+VCtCj7OUntwU=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b h1:6cLsL+2FW6dRAdl5iMtHgRogVCff0QpRi9653YmdcJA=

--- a/pkg/cleaning/images_cleanup.go
+++ b/pkg/cleaning/images_cleanup.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 	"github.com/flant/werf/pkg/werf"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/cleaning/stages_cleanup.go
+++ b/pkg/cleaning/stages_cleanup.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 	"github.com/flant/werf/pkg/werf"
 
 	"github.com/flant/werf/pkg/stages_manager"

--- a/pkg/cleaning/stages_purge.go
+++ b/pkg/cleaning/stages_purge.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 	"github.com/flant/werf/pkg/werf"
 
 	"github.com/flant/werf/pkg/stages_manager"

--- a/pkg/container_runtime/stage_image.go
+++ b/pkg/container_runtime/stage_image.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 	"github.com/flant/werf/pkg/werf"
 
 	"github.com/docker/docker/api/types"

--- a/pkg/git_repo/remote.go
+++ b/pkg/git_repo/remote.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 	"github.com/flant/werf/pkg/werf"
 
 	"github.com/flant/werf/pkg/true_git"

--- a/pkg/host_cleaning/host_cleanup.go
+++ b/pkg/host_cleaning/host_cleanup.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 	"github.com/flant/werf/pkg/werf"
 
 	"github.com/docker/docker/api/types"

--- a/pkg/image/manifest_cache.go
+++ b/pkg/image/manifest_cache.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 
 	"github.com/flant/werf/pkg/werf"
 

--- a/pkg/stages_manager/stages_manager.go
+++ b/pkg/stages_manager/stages_manager.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 
 	"github.com/flant/werf/pkg/image"
 

--- a/pkg/stapel/container.go
+++ b/pkg/stapel/container.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 
 	"github.com/flant/werf/pkg/werf"
 

--- a/pkg/storage/file_stages_storage_cache.go
+++ b/pkg/storage/file_stages_storage_cache.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/flant/logboek"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 
 	"github.com/flant/werf/pkg/werf"
 

--- a/pkg/storage/generic_lock_manager.go
+++ b/pkg/storage/generic_lock_manager.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"fmt"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 	"github.com/flant/logboek"
 	"github.com/flant/werf/pkg/werf"
 )

--- a/pkg/storage/kubernetes_lock_manager.go
+++ b/pkg/storage/kubernetes_lock_manager.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 	"github.com/flant/logboek"
 	"github.com/flant/werf/pkg/werf"
 )

--- a/pkg/storage/lock_manager.go
+++ b/pkg/storage/lock_manager.go
@@ -1,6 +1,6 @@
 package storage
 
-import "github.com/flant/lockgate"
+import "github.com/werf/lockgate"
 
 type LockManager interface {
 	LockStage(projectName, signature string) (LockHandle, error)

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 
 	"github.com/flant/werf/pkg/werf"
 

--- a/pkg/tmp_manager/gc.go
+++ b/pkg/tmp_manager/gc.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 
 	"github.com/flant/logboek"
 

--- a/pkg/true_git/work_tree.go
+++ b/pkg/true_git/work_tree.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 
 	"github.com/flant/werf/pkg/werf"
 

--- a/pkg/werf/main.go
+++ b/pkg/werf/main.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/flant/lockgate/pkg/file_lock"
+	"github.com/werf/lockgate/pkg/file_lock"
 	"github.com/flant/logboek"
 
-	"github.com/flant/lockgate"
+	"github.com/werf/lockgate"
 )
 
 var (
@@ -97,8 +97,8 @@ func ReleaseHostLock(lock lockgate.LockHandle) error {
 	return GetHostLocker().Release(lock)
 }
 
-func DefaultLockerOnWait(lock lockgate.LockHandle, doWait func() error) error {
-	logProcessMsg := fmt.Sprintf("Waiting for locked %q", lock.LockName)
+func DefaultLockerOnWait(lockName string, doWait func() error) error {
+	logProcessMsg := fmt.Sprintf("Waiting for locked %q", lockName)
 	return logboek.LogProcessInline(logProcessMsg, logboek.LogProcessInlineOptions{}, func() error {
 		return doWait()
 	})


### PR DESCRIPTION
The hanging case was in the lockgate library, described in the https://github.com/werf/lockgate/pull/24.