### PR TITLE
[build] Fix 'Stage is no longer available in the repo stages storage' on stages cleanup

### DIFF
--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -85,7 +85,7 @@ func (storage *RepoStagesStorage) GetAllStages(projectName string) ([]image.Stag
 		logboek.Debug.LogF("-- RepoStagesStorage.GetRepoImagesBySignature fetched tags for %q: %#v\n", storage.RepoAddress, tags)
 
 		for _, tag := range tags {
-			if strings.HasPrefix(tag, RepoManagedImageRecord_ImageTagPrefix) {
+			if strings.HasPrefix(tag, RepoManagedImageRecord_ImageTagPrefix) || strings.HasPrefix(tag, RepoImageMetadataByCommitRecord_ImageTagPrefix) {
 				continue
 			}
 


### PR DESCRIPTION
 - Only enable strict checking of stage manifest existance when getting stage from stages-storage-cache.
 - Ignore bad stages without manifests otherwise
    - Print warning for these stages