### PR TITLE
New synchronization http server with configurable backend

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -1053,10 +1053,10 @@ func GetSynchronization(cmdData *CmdData, stagesStorageAddress string) (string, 
 	} else {
 		if *cmdData.Synchronization == storage.LocalStorageAddress {
 			return *cmdData.Synchronization, nil
-		} else if strings.HasPrefix(*cmdData.Synchronization, "kubernetes://") {
+		} else if strings.HasPrefix(*cmdData.Synchronization, "kubernetes://") || strings.HasPrefix(*cmdData.Synchronization, "http://") || strings.HasPrefix(*cmdData.Synchronization, "https://") {
 			return *cmdData.Synchronization, nil
 		} else {
-			return "", fmt.Errorf("only --synchronization=%s or --synchronization=kubernetes://NAMESPACE is supported, got %q", storage.LocalStorageAddress, *cmdData.Synchronization)
+			return "", fmt.Errorf("only --synchronization=%s or --synchronization=kubernetes://NAMESPACE or --synchronization=http[s]://HOST:PORT/CLIENT_ID is supported, got %q", storage.LocalStorageAddress, *cmdData.Synchronization)
 		}
 	}
 }

--- a/cmd/werf/common/synchronization.go
+++ b/cmd/werf/common/synchronization.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/werf/werf/pkg/storage/synchronization_server"
+
 	"github.com/werf/werf/pkg/storage"
 	"github.com/werf/werf/pkg/werf"
 )
@@ -14,6 +16,8 @@ func GetStagesStorageCache(synchronization string) (storage.StagesStorageCache, 
 	} else if strings.HasPrefix(synchronization, "kubernetes://") {
 		ns := strings.TrimPrefix(synchronization, "kubernetes://")
 		return storage.NewKubernetesStagesStorageCache(ns), nil
+	} else if strings.HasPrefix(synchronization, "http://") || strings.HasPrefix(synchronization, "https://") {
+		return synchronization_server.NewStagesStorageCacheHttpClient(fmt.Sprintf("%s/stages-storage-cache", synchronization)), nil
 	} else {
 		panic(fmt.Sprintf("unknown synchronization param %q", synchronization))
 	}
@@ -25,6 +29,8 @@ func GetStorageLockManager(synchronization string) (storage.LockManager, error) 
 	} else if strings.HasPrefix(synchronization, "kubernetes://") {
 		ns := strings.TrimPrefix(synchronization, "kubernetes://")
 		return storage.NewKubernetesLockManager(ns), nil
+	} else if strings.HasPrefix(synchronization, "http://") || strings.HasPrefix(synchronization, "https://") {
+		return synchronization_server.NewLockManagerHttpClient(fmt.Sprintf("%s/lock-manager", synchronization)), nil
 	} else {
 		panic(fmt.Sprintf("unknown synchronization param %q", synchronization))
 	}

--- a/cmd/werf/main.go
+++ b/cmd/werf/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/werf/werf/cmd/werf/publish"
 	"github.com/werf/werf/cmd/werf/purge"
 	"github.com/werf/werf/cmd/werf/run"
+	"github.com/werf/werf/cmd/werf/synchronization"
 
 	helm_secret_decrypt "github.com/werf/werf/cmd/werf/helm/secret/decrypt"
 	helm_secret_encrypt "github.com/werf/werf/cmd/werf/helm/secret/encrypt"
@@ -115,6 +116,7 @@ Find more information at https://werf.io`),
 				dismiss.NewCmd(),
 				cleanup.NewCmd(),
 				purge.NewCmd(),
+				synchronization.NewCmd(),
 			},
 		},
 		{

--- a/cmd/werf/synchronization/main.go
+++ b/cmd/werf/synchronization/main.go
@@ -1,0 +1,141 @@
+package synchronization
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/werf/kubedog/pkg/kube"
+
+	"github.com/werf/lockgate"
+
+	"github.com/werf/werf/pkg/storage"
+	"github.com/werf/werf/pkg/storage/synchronization_server"
+
+	"github.com/spf13/cobra"
+
+	"github.com/werf/werf/cmd/werf/common"
+	"github.com/werf/werf/pkg/werf"
+)
+
+var cmdData struct {
+	Kubernetes                bool
+	KubernetesNamespacePrefix string
+
+	Local                          bool
+	LocalLockManagerBaseDir        string
+	LocalStagesStorageCacheBaseDir string
+
+	TTL  string
+	Host string
+	Port string
+}
+
+var commonCmdData common.CmdData
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "synchronization",
+		Short:                 "Run synchronization server",
+		Long:                  common.GetLongCommandDescription(`Run synchronization server`),
+		DisableFlagsInUseLine: true,
+		Annotations:           map[string]string{},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := common.ProcessLogOptions(&commonCmdData); err != nil {
+				common.PrintHelp(cmd)
+				return err
+			}
+
+			common.LogVersion()
+
+			return common.LogRunningTime(func() error {
+				return runSynchronization()
+			})
+		},
+	}
+
+	common.SetupTmpDir(&commonCmdData, cmd)
+	common.SetupHomeDir(&commonCmdData, cmd)
+
+	common.SetupLogOptions(&commonCmdData, cmd)
+
+	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeContext(&commonCmdData, cmd)
+
+	cmd.Flags().BoolVarP(&cmdData.Local, "local", "", common.GetBoolEnvironmentDefaultTrue("WERF_LOCAL"), "Use file lock-manager and file stages-storage-cache (true by default or $WERF_LOCAL)")
+	cmd.Flags().StringVarP(&cmdData.LocalLockManagerBaseDir, "local-lock-manager-base-dir", "", os.Getenv("WERF_LOCAL_LOCK_MANAGER_BASE_DIR"), "Use specified directory as base for file lock-manager (~/.werf/synchronization_server/lock_manager by default or $WERF_LOCAL_LOCK_MANAGER_BASE_DIR)")
+	cmd.Flags().StringVarP(&cmdData.LocalStagesStorageCacheBaseDir, "local-stages-storage-cache-base-dir", "", os.Getenv("WERF_LOCAL_STAGES_STORAGE_CACHE_BASE_DIR"), "Use specified directory as base for file stages-storage-cache (~/.werf/synchronization_server/stages_storage_cache by default or $WERF_LOCAL_STAGES_STORAGE_CACHE_BASE_DIR)")
+
+	cmd.Flags().BoolVarP(&cmdData.Kubernetes, "kubernetes", "", common.GetBoolEnvironmentDefaultFalse("WERF_KUBERNETES"), "Use kubernetes lock-manager stages-storage-cache (default $WERF_KUBERNETES)")
+	cmd.Flags().StringVarP(&cmdData.KubernetesNamespacePrefix, "kubernetes-namespace-prefix", "", os.Getenv("WERF_KUBERNETES_NAMESPACE_PREFIX"), "Use specified prefix for namespaces created for lock-manager and stages-storage-cache (defaults to 'werf-synchronization-' when --kubernetes option is used or $WERF_KUBERNETES_NAMESPACE_PREFIX)")
+
+	cmd.Flags().StringVarP(&cmdData.TTL, "ttl", "", os.Getenv("WERF_TTL"), "Time to live for lock-manager locks and stages-storage-cache records (default $WERF_TTL)")
+	cmd.Flags().StringVarP(&cmdData.Host, "host", "", os.Getenv("WERF_HOST"), "Bind synchronization server to the specified host (default localhost or $WERF_HOST)")
+	cmd.Flags().StringVarP(&cmdData.Port, "port", "", os.Getenv("WERF_PORT"), "Bind synchronization server to the specified port (default 55581 or $WERF_PORT)")
+
+	return cmd
+}
+
+func runSynchronization() error {
+	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
+		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	host, port := cmdData.Host, cmdData.Port
+	if host == "" {
+		host = "localhost"
+	}
+	if port == "" {
+		port = "55581"
+	}
+
+	var lockManagerFactoryFunc func(clientID string) (storage.LockManager, error)
+	var stagesStorageCacheFactoryFunc func(clientID string) (storage.StagesStorageCache, error)
+
+	if cmdData.Kubernetes {
+		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
+			return fmt.Errorf("cannot initialize kube: %s", err)
+		}
+
+		if err := common.InitKubedog(); err != nil {
+			return fmt.Errorf("cannot init kubedog: %s", err)
+		}
+
+		prefix := cmdData.KubernetesNamespacePrefix
+		if prefix == "" {
+			prefix = "werf-synchronization-"
+		}
+
+		lockManagerFactoryFunc = func(clientID string) (storage.LockManager, error) {
+			return storage.NewKubernetesLockManager(fmt.Sprintf("%s%s", prefix, clientID)), nil
+		}
+
+		stagesStorageCacheFactoryFunc = func(clientID string) (storage.StagesStorageCache, error) {
+			return storage.NewKubernetesStagesStorageCache(fmt.Sprintf("%s%s", prefix, clientID)), nil
+		}
+	} else {
+		lockManagerBaseDir := cmdData.LocalLockManagerBaseDir
+		if lockManagerBaseDir == "" {
+			lockManagerBaseDir = filepath.Join(werf.GetHomeDir(), "synchronization_server", "lock_manager")
+		}
+
+		stagesStorageCacheBaseDir := cmdData.LocalStagesStorageCacheBaseDir
+		if stagesStorageCacheBaseDir == "" {
+			stagesStorageCacheBaseDir = filepath.Join(werf.GetHomeDir(), "synchronization_server", "stages_storage_cache")
+		}
+
+		lockManagerFactoryFunc = func(clientID string) (storage.LockManager, error) {
+			if locker, err := lockgate.NewFileLocker(filepath.Join(lockManagerBaseDir, clientID)); err != nil {
+				return nil, err
+			} else {
+				return storage.NewGenericLockManager(locker), nil
+			}
+		}
+
+		stagesStorageCacheFactoryFunc = func(clientID string) (storage.StagesStorageCache, error) {
+			return storage.NewFileStagesStorageCache(filepath.Join(stagesStorageCacheBaseDir, clientID)), nil
+		}
+	}
+
+	return synchronization_server.RunSynchronizationServer(host, port, lockManagerFactoryFunc, stagesStorageCacheFactoryFunc)
+}

--- a/pkg/storage/generic_lock_manager.go
+++ b/pkg/storage/generic_lock_manager.go
@@ -17,10 +17,6 @@ type GenericLockManager struct {
 	Locker lockgate.Locker
 }
 
-type LockStagesAndImagesOptions struct {
-	GetOrCreateImagesOnly bool
-}
-
 func (manager *GenericLockManager) LockStage(projectName, signature string) (LockHandle, error) {
 	_, lock, err := manager.Locker.Acquire(genericStageLockName(projectName, signature), werf.SetupLockerDefaultOptions(lockgate.AcquireOptions{}))
 	return LockHandle{LockgateHandle: lock, ProjectName: projectName}, err
@@ -49,7 +45,7 @@ func (manager *GenericLockManager) LockDeployProcess(projectName string, release
 func (manager *GenericLockManager) Unlock(lock LockHandle) error {
 	err := manager.Locker.Release(lock.LockgateHandle)
 	if err != nil {
-		logboek.ErrF("ERROR: unable to release lock for %q: %s", lock.LockgateHandle.LockName, err)
+		logboek.ErrF("ERROR: unable to release lock for %q: %s\n", lock.LockgateHandle.LockName, err)
 	}
 	return err
 }

--- a/pkg/storage/kubernetes_lock_manager.go
+++ b/pkg/storage/kubernetes_lock_manager.go
@@ -107,7 +107,7 @@ func (manager *KuberntesLockManager) Unlock(lock LockHandle) error {
 	} else {
 		err := locker.Release(lock.LockgateHandle)
 		if err != nil {
-			logboek.ErrF("ERROR: unable to release lock for %q: %s", lock.LockgateHandle.LockName, err)
+			logboek.ErrF("ERROR: unable to release lock for %q: %s\n", lock.LockgateHandle.LockName, err)
 		}
 		return err
 	}

--- a/pkg/storage/lock_manager.go
+++ b/pkg/storage/lock_manager.go
@@ -8,10 +8,14 @@ type LockManager interface {
 	LockImage(projectName, imageName string) (LockHandle, error)
 	LockStagesAndImages(projectName string, opts LockStagesAndImagesOptions) (LockHandle, error)
 	LockDeployProcess(projectName string, releaseName string, kubeContextName string) (LockHandle, error)
-	Unlock(lock LockHandle) error
+	Unlock(lockHandle LockHandle) error
 }
 
 type LockHandle struct {
-	ProjectName    string
-	LockgateHandle lockgate.LockHandle
+	ProjectName    string              `json:"projectName"`
+	LockgateHandle lockgate.LockHandle `json:"lockgateHandle"`
+}
+
+type LockStagesAndImagesOptions struct {
+	GetOrCreateImagesOnly bool `json:"getOrCreateImagesOnly"`
 }

--- a/pkg/storage/synchronization_server/http_helpers.go
+++ b/pkg/storage/synchronization_server/http_helpers.go
@@ -1,0 +1,52 @@
+package synchronization_server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+func PerformPost(client *http.Client, url string, request, response interface{}) error {
+	body, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("unable to marshal request data: %s", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("unable to create POST request for %q: %s", url, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error requesting url %q: %s", url, err)
+	}
+
+	defer resp.Body.Close()
+	if body, err := ioutil.ReadAll(resp.Body); err != nil {
+		return fmt.Errorf("error reading response of %q request: %s", url, err)
+	} else if resp.StatusCode != 200 {
+		return fmt.Errorf("got bad response %s by url %q request:\n%s", resp.Status, url, body)
+	} else {
+		if err := json.Unmarshal(body, response); err != nil {
+			return fmt.Errorf("unable to unmarshal json body by url %q request: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func HandleRequest(w http.ResponseWriter, r *http.Request, request, response interface{}, actionFunc func()) {
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		http.Error(w, fmt.Sprintf("unable to unmarshal request json: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	actionFunc()
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/pkg/storage/synchronization_server/lock_manager_http_client.go
+++ b/pkg/storage/synchronization_server/lock_manager_http_client.go
@@ -1,0 +1,74 @@
+package synchronization_server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/werf/werf/pkg/storage"
+)
+
+func NewLockManagerHttpClient(url string) *LockManagerHttpClient {
+	return &LockManagerHttpClient{
+		URL:        url,
+		HttpClient: &http.Client{},
+	}
+}
+
+type LockManagerHttpClient struct {
+	URL        string
+	HttpClient *http.Client
+}
+
+func (client *LockManagerHttpClient) LockStage(projectName, signature string) (storage.LockHandle, error) {
+	var request = LockStageRequest{projectName, signature}
+	var response LockStageResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "lock-stage"), request, &response); err != nil {
+		return storage.LockHandle{}, err
+	}
+	return response.LockHandle, response.Err.Error
+}
+
+func (client *LockManagerHttpClient) LockStageCache(projectName, signature string) (storage.LockHandle, error) {
+	var request = LockStageCacheRequest{projectName, signature}
+	var response LockStageCacheResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "lock-stage-cache"), request, &response); err != nil {
+		return storage.LockHandle{}, err
+	}
+	return response.LockHandle, response.Err.Error
+}
+
+func (client *LockManagerHttpClient) LockImage(projectName, imageName string) (storage.LockHandle, error) {
+	var request = LockImageRequest{projectName, imageName}
+	var response LockImageResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "lock-image"), request, &response); err != nil {
+		return storage.LockHandle{}, err
+	}
+	return response.LockHandle, response.Err.Error
+}
+
+func (client *LockManagerHttpClient) LockStagesAndImages(projectName string, opts storage.LockStagesAndImagesOptions) (storage.LockHandle, error) {
+	var request = LockStagesAndImagesRequest{projectName, opts}
+	var response LockStagesAndImagesResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "lock-stages-and-images"), request, &response); err != nil {
+		return storage.LockHandle{}, err
+	}
+	return response.LockHandle, response.Err.Error
+}
+
+func (client *LockManagerHttpClient) LockDeployProcess(projectName string, releaseName string, kubeContextName string) (storage.LockHandle, error) {
+	var request = LockDeployProcessRequest{projectName, releaseName, kubeContextName}
+	var response LockDeployProcessResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "lock-deploy-process"), request, &response); err != nil {
+		return storage.LockHandle{}, err
+	}
+	return response.LockHandle, response.Err.Error
+}
+
+func (client *LockManagerHttpClient) Unlock(lockHandle storage.LockHandle) error {
+	var request = UnlockRequest{lockHandle}
+	var response UnlockResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "unlock"), request, &response); err != nil {
+		return err
+	}
+	return response.Err.Error
+}

--- a/pkg/storage/synchronization_server/lock_manager_http_handler.go
+++ b/pkg/storage/synchronization_server/lock_manager_http_handler.go
@@ -1,0 +1,144 @@
+package synchronization_server
+
+import (
+	"net/http"
+
+	"github.com/werf/werf/pkg/util"
+
+	"github.com/werf/logboek"
+	"github.com/werf/werf/pkg/storage"
+)
+
+func NewLockManagerHttpHandler(lockManager storage.LockManager) *LockManagerHttpHandler {
+	handler := &LockManagerHttpHandler{
+		LockManager: lockManager,
+		ServeMux:    http.NewServeMux(),
+	}
+	handler.HandleFunc("/lock-stage", handler.handleLockStage)
+	handler.HandleFunc("/lock-stage-cache", handler.handleLockStageCache)
+	handler.HandleFunc("/lock-image", handler.handleLockImage)
+	handler.HandleFunc("/lock-stages-and-images", handler.handleLockStagesAndImages)
+	handler.HandleFunc("/lock-deploy-process", handler.handleLockDeployProcess)
+	handler.HandleFunc("/unlock", handler.handleUnlock)
+
+	return handler
+}
+
+type LockManagerHttpHandler struct {
+	*http.ServeMux
+	LockManager storage.LockManager
+}
+
+type LockStageRequest struct {
+	ProjectName string `json:"projectName"`
+	Signature   string `json:"signature"`
+}
+type LockStageResponse struct {
+	Err        util.SerializableError `json:"err"`
+	LockHandle storage.LockHandle     `json:"lockHandle"`
+}
+
+func (handler *LockManagerHttpHandler) handleLockStage(w http.ResponseWriter, r *http.Request) {
+	var request LockStageRequest
+	var response LockStageResponse
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("LockManagerHttpHandler -- LockStage request %#v\n", request)
+		response.LockHandle, response.Err.Error = handler.LockManager.LockStage(request.ProjectName, request.Signature)
+		logboek.Debug.LogF("LockManagerHttpHandler -- LockStage response %#v\n", response)
+	})
+}
+
+type LockStageCacheRequest struct {
+	ProjectName string `json:"projectName"`
+	Signature   string `json:"signature"`
+}
+type LockStageCacheResponse struct {
+	Err        util.SerializableError `json:"err"`
+	LockHandle storage.LockHandle     `json:"lockHandle"`
+}
+
+func (handler *LockManagerHttpHandler) handleLockStageCache(w http.ResponseWriter, r *http.Request) {
+	var request LockStageCacheRequest
+	var response LockStageCacheResponse
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("LockManagerHttpHandler -- LockStageCache request %#v\n", request)
+		response.LockHandle, response.Err.Error = handler.LockManager.LockStageCache(request.ProjectName, request.Signature)
+		logboek.Debug.LogF("LockManagerHttpHandler -- LockStageCache response %#v\n", response)
+	})
+}
+
+type LockImageRequest struct {
+	ProjectName string `json:"projectName"`
+	ImageName   string `json:"imageName"`
+}
+type LockImageResponse struct {
+	Err        util.SerializableError `json:"err"`
+	LockHandle storage.LockHandle     `json:"lockHandle"`
+}
+
+func (handler *LockManagerHttpHandler) handleLockImage(w http.ResponseWriter, r *http.Request) {
+	var request LockImageRequest
+	var response LockImageResponse
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("LockManagerHttpHandler -- LockImage request %#v\n", request)
+		response.LockHandle, response.Err.Error = handler.LockManager.LockImage(request.ProjectName, request.ImageName)
+		logboek.Debug.LogF("LockManagerHttpHandler -- LockImage response %#v\n", response)
+	})
+}
+
+type LockStagesAndImagesRequest struct {
+	ProjectName string                             `json:"projectName"`
+	Opts        storage.LockStagesAndImagesOptions `json:"opts"`
+}
+type LockStagesAndImagesResponse struct {
+	Err        util.SerializableError `json:"err"`
+	LockHandle storage.LockHandle     `json:"lockHandle"`
+}
+
+func (handler *LockManagerHttpHandler) handleLockStagesAndImages(w http.ResponseWriter, r *http.Request) {
+	var request LockStagesAndImagesRequest
+	var response LockStagesAndImagesResponse
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("LockManagerHttpHandler -- LockStagesAndImages request %#v\n", request)
+		response.LockHandle, response.Err.Error = handler.LockManager.LockStagesAndImages(request.ProjectName, request.Opts)
+		logboek.Debug.LogF("LockManagerHttpHandler -- LockStagesAndImages response %#v\n", response)
+	})
+}
+
+type LockDeployProcessRequest struct {
+	ProjectName     string `json:"projectName"`
+	ReleaseName     string `json:"releaseName"`
+	KubeContextName string `json:"kubeContextName"`
+}
+type LockDeployProcessResponse struct {
+	Err        util.SerializableError `json:"err"`
+	LockHandle storage.LockHandle     `json:"lockHandle"`
+}
+
+func (handler *LockManagerHttpHandler) handleLockDeployProcess(w http.ResponseWriter, r *http.Request) {
+	var request LockDeployProcessRequest
+	var response LockDeployProcessResponse
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("LockManagerHttpHandler -- LockDeployProcess request %#v\n", request)
+		response.LockHandle, response.Err.Error = handler.LockManager.LockDeployProcess(request.ProjectName, request.ReleaseName, request.KubeContextName)
+		logboek.Debug.LogF("LockManagerHttpHandler -- LockDeployProcess response %#v\n", response)
+	})
+}
+
+type UnlockRequest struct {
+	LockHandle storage.LockHandle `json:"lockHandle"`
+}
+type UnlockResponse struct {
+	Err util.SerializableError `json:"err"`
+}
+
+func (handler *LockManagerHttpHandler) handleUnlock(w http.ResponseWriter, r *http.Request) {
+	var request UnlockRequest
+	var response UnlockResponse
+
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("LockManagerHttpHandler -- Unlock request %#v\n", request)
+		response.Err.Error = handler.LockManager.Unlock(request.LockHandle)
+		logboek.Debug.LogF("LockManagerHttpHandler -- Unlock response %#v\n", response)
+	})
+}

--- a/pkg/storage/synchronization_server/stages_storage_cache_http_client.go
+++ b/pkg/storage/synchronization_server/stages_storage_cache_http_client.go
@@ -1,0 +1,69 @@
+package synchronization_server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/werf/werf/pkg/image"
+)
+
+func NewStagesStorageCacheHttpClient(url string) *StagesStorageCacheHttpClient {
+	return &StagesStorageCacheHttpClient{
+		URL:        url,
+		HttpClient: &http.Client{},
+	}
+}
+
+type StagesStorageCacheHttpClient struct {
+	URL        string
+	HttpClient *http.Client
+}
+
+func (client *StagesStorageCacheHttpClient) String() string {
+	return fmt.Sprintf("http-client %s", client.URL)
+}
+
+func (client *StagesStorageCacheHttpClient) GetAllStages(projectName string) (bool, []image.StageID, error) {
+	var request = GetAllStagesRequest{projectName}
+	var response GetAllStagesResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "get-all-stages"), request, &response); err != nil {
+		return false, nil, err
+	}
+	return response.Found, response.Stages, response.Err.Error
+}
+
+func (client *StagesStorageCacheHttpClient) DeleteAllStages(projectName string) error {
+	var request = DeleteAllStagesRequest{projectName}
+	var response DeleteAllStagesResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "delete-all-stages"), request, &response); err != nil {
+		return err
+	}
+	return response.Err.Error
+}
+
+func (client *StagesStorageCacheHttpClient) GetStagesBySignature(projectName, signature string) (bool, []image.StageID, error) {
+	var request = GetStagesBySignatureRequest{projectName, signature}
+	var response GetStagesBySignatureResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "get-stages-by-signature"), request, &response); err != nil {
+		return false, nil, err
+	}
+	return response.Found, response.Stages, response.Err.Error
+}
+
+func (client *StagesStorageCacheHttpClient) StoreStagesBySignature(projectName, signature string, stages []image.StageID) error {
+	var request = StoreStagesBySignatureRequest{projectName, signature, stages}
+	var response StoreStagesBySignatureResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "store-stages-by-signature"), request, &response); err != nil {
+		return err
+	}
+	return response.Err.Error
+}
+
+func (client *StagesStorageCacheHttpClient) DeleteStagesBySignature(projectName, signature string) error {
+	var request = DeleteStagesBySignatureRequest{projectName, signature}
+	var response DeleteStagesBySignatureResponse
+	if err := PerformPost(client.HttpClient, fmt.Sprintf("%s/%s", client.URL, "delete-stages-by-signature"), request, &response); err != nil {
+		return err
+	}
+	return response.Err.Error
+}

--- a/pkg/storage/synchronization_server/stages_storage_cache_http_handler.go
+++ b/pkg/storage/synchronization_server/stages_storage_cache_http_handler.go
@@ -1,0 +1,123 @@
+package synchronization_server
+
+import (
+	"net/http"
+
+	"github.com/werf/logboek"
+	"github.com/werf/werf/pkg/image"
+	"github.com/werf/werf/pkg/util"
+
+	"github.com/werf/werf/pkg/storage"
+)
+
+func NewStagesStorageCacheHttpHandler(stagesStorageCache storage.StagesStorageCache) *StagesStorageCacheHttpHandler {
+	handler := &StagesStorageCacheHttpHandler{
+		StagesStorageCache: stagesStorageCache,
+		ServeMux:           http.NewServeMux(),
+	}
+	handler.HandleFunc("/get-all-stages", handler.handleGetAllStages)
+	handler.HandleFunc("/delete-all-stages", handler.handleDeleteAllStages)
+	handler.HandleFunc("/get-stages-by-signature", handler.handleGetStagesBySignature)
+	handler.HandleFunc("/store-stages-by-signature", handler.handleStoreStagesBySignature)
+	handler.HandleFunc("/delete-stages-by-signature", handler.handleDeleteStagesBySignature)
+
+	return handler
+}
+
+type StagesStorageCacheHttpHandler struct {
+	*http.ServeMux
+	StagesStorageCache storage.StagesStorageCache
+}
+
+type GetAllStagesRequest struct {
+	ProjectName string `json:"projectName"`
+}
+type GetAllStagesResponse struct {
+	Err    util.SerializableError `json:"err"`
+	Found  bool                   `json:"found"`
+	Stages []image.StageID        `json:"stages"`
+}
+
+func (handler *StagesStorageCacheHttpHandler) handleGetAllStages(w http.ResponseWriter, r *http.Request) {
+	var request GetAllStagesRequest
+	var response GetAllStagesResponse
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("StagesStorageCacheHttpHandler -- GetAllStages request %#v\n", request)
+		response.Found, response.Stages, response.Err.Error = handler.StagesStorageCache.GetAllStages(request.ProjectName)
+		logboek.Debug.LogF("StagesStorageCacheHttpHandler -- GetAllStages response %#v\n", response)
+	})
+}
+
+type DeleteAllStagesRequest struct {
+	ProjectName string `json:"projectName"`
+}
+type DeleteAllStagesResponse struct {
+	Err util.SerializableError `json:"err"`
+}
+
+func (handler *StagesStorageCacheHttpHandler) handleDeleteAllStages(w http.ResponseWriter, r *http.Request) {
+	var request DeleteAllStagesRequest
+	var response DeleteAllStagesResponse
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("StagesStorageCacheHttpHandler -- DeleteAllStages request %#v\n", request)
+		response.Err.Error = handler.StagesStorageCache.DeleteAllStages(request.ProjectName)
+		logboek.Debug.LogF("StagesStorageCacheHttpHandler -- DeleteAllStages response %#v\n", response)
+	})
+}
+
+type GetStagesBySignatureRequest struct {
+	ProjectName string `json:"projectName"`
+	Signature   string `json:"signature"`
+}
+type GetStagesBySignatureResponse struct {
+	Err    util.SerializableError `json:"err"`
+	Found  bool                   `json:"found"`
+	Stages []image.StageID        `json:"stages"`
+}
+
+func (handler *StagesStorageCacheHttpHandler) handleGetStagesBySignature(w http.ResponseWriter, r *http.Request) {
+	var request GetStagesBySignatureRequest
+	var response GetStagesBySignatureResponse
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("StagesStorageCacheHttpHandler -- GetStagesBySignature request %#v\n", request)
+		response.Found, response.Stages, response.Err.Error = handler.StagesStorageCache.GetStagesBySignature(request.ProjectName, request.Signature)
+		logboek.Debug.LogF("StagesStorageCacheHttpHandler -- GetStagesBySignature response %#v\n", response)
+	})
+}
+
+type StoreStagesBySignatureRequest struct {
+	ProjectName string          `json:"projectName"`
+	Signature   string          `json:"signature"`
+	Stages      []image.StageID `json:"stages"`
+}
+type StoreStagesBySignatureResponse struct {
+	Err util.SerializableError `json:"err"`
+}
+
+func (handler *StagesStorageCacheHttpHandler) handleStoreStagesBySignature(w http.ResponseWriter, r *http.Request) {
+	var request StoreStagesBySignatureRequest
+	var response StoreStagesBySignatureResponse
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("StagesStorageCacheHttpHandler -- StoreStagesBySignature request %#v\n", request)
+		response.Err.Error = handler.StagesStorageCache.StoreStagesBySignature(request.ProjectName, request.Signature, request.Stages)
+		logboek.Debug.LogF("StagesStorageCacheHttpHandler -- StoreStagesBySignature response %#v\n", response)
+	})
+}
+
+type DeleteStagesBySignatureRequest struct {
+	ProjectName string `json:"projectName"`
+	Signature   string `json:"signature"`
+}
+type DeleteStagesBySignatureResponse struct {
+	Err util.SerializableError `json:"err"`
+}
+
+func (handler *StagesStorageCacheHttpHandler) handleDeleteStagesBySignature(w http.ResponseWriter, r *http.Request) {
+	var request DeleteStagesBySignatureRequest
+	var response DeleteStagesBySignatureResponse
+	HandleRequest(w, r, &request, &response, func() {
+		logboek.Debug.LogF("StagesStorageCacheHttpHandler -- DeleteStagesBySignature request %#v\n", request)
+		response.Err.Error = handler.StagesStorageCache.DeleteStagesBySignature(request.ProjectName, request.Signature)
+		logboek.Debug.LogF("StagesStorageCacheHttpHandler -- DeleteStagesBySignature response %#v\n", response)
+	})
+}

--- a/pkg/storage/synchronization_server/synchronization_server.go
+++ b/pkg/storage/synchronization_server/synchronization_server.go
@@ -1,0 +1,98 @@
+package synchronization_server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/werf/logboek"
+	"github.com/werf/werf/pkg/storage"
+)
+
+func RunSynchronizationServer(ip, port string, lockManagerFactoryFunc func(clientID string) (storage.LockManager, error), stagesStorageCacheFactoryFunc func(clientID string) (storage.StagesStorageCache, error)) error {
+	handler := NewSynchronizationServerHandler(lockManagerFactoryFunc, stagesStorageCacheFactoryFunc)
+	return http.ListenAndServe(fmt.Sprintf("%s:%s", ip, port), handler)
+}
+
+type SynchronizationServerHandler struct {
+	LockManagerFactoryFunc        func(clientID string) (storage.LockManager, error)
+	StagesStorageCacheFactoryFunc func(clientID string) (storage.StagesStorageCache, error)
+
+	mux                             sync.Mutex
+	SyncrhonizationServerByClientID map[string]*SynchronizationServerHandlerByClientID
+}
+
+func NewSynchronizationServerHandler(lockManagerFactoryFunc func(requestID string) (storage.LockManager, error), stagesStorageCacheFactoryFunc func(requestID string) (storage.StagesStorageCache, error)) *SynchronizationServerHandler {
+	return &SynchronizationServerHandler{
+		LockManagerFactoryFunc:          lockManagerFactoryFunc,
+		StagesStorageCacheFactoryFunc:   stagesStorageCacheFactoryFunc,
+		SyncrhonizationServerByClientID: make(map[string]*SynchronizationServerHandlerByClientID),
+	}
+}
+
+func (server *SynchronizationServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	logboek.Debug.LogF("SynchronizationServerHandler -- ServeHTTP url path = %q\n", r.URL.Path)
+
+	clientID := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/"), "/", 2)[0]
+	logboek.Debug.LogF("SynchronizationServerHandler -- ServeHTTP clientID = %q\n", clientID)
+
+	if clientID == "" {
+		http.Error(w, fmt.Sprintf("Bad request: cannot get clientID from URL path %q", r.URL.Path), http.StatusBadRequest)
+		return
+	}
+
+	if clientServer, err := server.getOrCreateHandlerByClientID(clientID); err != nil {
+		http.Error(w, fmt.Sprintf("Internal error: %s", err), http.StatusInternalServerError)
+		return
+	} else {
+		fmt.Printf("clientServer=%#v\n", clientServer)
+		http.StripPrefix(fmt.Sprintf("/%s", clientID), clientServer).ServeHTTP(w, r)
+	}
+}
+
+func (server *SynchronizationServerHandler) getOrCreateHandlerByClientID(clientID string) (*SynchronizationServerHandlerByClientID, error) {
+	server.mux.Lock()
+	defer server.mux.Unlock()
+
+	if handler, hasKey := server.SyncrhonizationServerByClientID[clientID]; hasKey {
+		return handler, nil
+	} else {
+		lockManager, err := server.LockManagerFactoryFunc(clientID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create lock manager for clientID %q: %s", clientID, err)
+		}
+
+		stagesStorageCache, err := server.StagesStorageCacheFactoryFunc(clientID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create stages storage cache for clientID %q: %s", clientID, err)
+		}
+
+		handler := NewSynchronizationServerHandlerByClientID(clientID, lockManager, stagesStorageCache)
+		server.SyncrhonizationServerByClientID[clientID] = handler
+
+		logboek.Debug.LogF("SynchronizationServerHandler -- Created new syncrhonization server handler by clientID %q: %v\n", clientID, handler)
+		return handler, nil
+	}
+}
+
+type SynchronizationServerHandlerByClientID struct {
+	*http.ServeMux
+	ClientID           string
+	LockManager        storage.LockManager
+	StagesStorageCache storage.StagesStorageCache
+}
+
+func NewSynchronizationServerHandlerByClientID(clientID string, lockManager storage.LockManager, stagesStorageCache storage.StagesStorageCache) *SynchronizationServerHandlerByClientID {
+	srv := &SynchronizationServerHandlerByClientID{
+		ServeMux:           http.NewServeMux(),
+		ClientID:           clientID,
+		LockManager:        lockManager,
+		StagesStorageCache: stagesStorageCache,
+	}
+
+	srv.Handle("/lock-manager/", http.StripPrefix("/lock-manager", NewLockManagerHttpHandler(lockManager)))
+	srv.Handle("/stages-storage-cache/", http.StripPrefix("/stages-storage-cache", NewStagesStorageCacheHttpHandler(stagesStorageCache)))
+
+	return srv
+}

--- a/pkg/util/serializable_error.go
+++ b/pkg/util/serializable_error.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type SerializableError struct {
+	Error error
+}
+
+func (obj SerializableError) MarshalJSON() ([]byte, error) {
+	var errMsg string
+	if obj.Error != nil {
+		errMsg = obj.Error.Error()
+	}
+	return json.Marshal(errMsg)
+}
+
+func (obj *SerializableError) UnmarshalJSON(data []byte) error {
+	var errMsg string
+	if err := json.Unmarshal(data, &errMsg); err != nil {
+		return err
+	}
+	if errMsg != "" {
+		obj.Error = errors.New(errMsg)
+	}
+	return nil
+}

--- a/playground/synchronization_client/main.go
+++ b/playground/synchronization_client/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/werf/logboek"
+
+	"github.com/werf/werf/pkg/werf"
+
+	"github.com/werf/werf/pkg/storage/synchronization_server"
+)
+
+func doMain() error {
+	if err := werf.Init("", ""); err != nil {
+		return err
+	}
+
+	if err := logboek.Init(); err != nil {
+		return err
+	}
+
+	logboek.SetLevel(logboek.Debug)
+
+	client := synchronization_server.NewLockManagerHttpClient("http://localhost:55581/lock-manager")
+	if lockHandle, err := client.LockStage("myproj", "5050505050"); err != nil {
+		return err
+	} else {
+		time.Sleep(10 * time.Second)
+		if err := client.Unlock(lockHandle); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	if err := doMain(); err != nil {
+		fmt.Fprintf(os.Stderr, "ERR: %s\n", err)
+		os.Exit(1)
+	}
+}

--- a/playground/synchronization_server/main.go
+++ b/playground/synchronization_server/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/werf/lockgate"
+
+	"github.com/werf/logboek"
+
+	"github.com/werf/werf/pkg/werf"
+
+	"github.com/werf/werf/pkg/storage"
+
+	"github.com/werf/werf/pkg/storage/synchronization_server"
+)
+
+func doMain() error {
+	if err := werf.Init("", ""); err != nil {
+		return err
+	}
+
+	if err := logboek.Init(); err != nil {
+		return err
+	}
+
+	logboek.SetLevel(logboek.Debug)
+
+	synchronizationServerDir := "synchronization-server"
+
+	return synchronization_server.RunSynchronizationServer(
+		"localhost", "55581",
+		func(clientID string) (storage.LockManager, error) {
+			if locker, err := lockgate.NewFileLocker(filepath.Join(synchronizationServerDir, "lock-manager", clientID)); err != nil {
+				return nil, err
+			} else {
+				return storage.NewGenericLockManager(locker), nil
+			}
+		},
+		func(clientID string) (storage.StagesStorageCache, error) {
+			return storage.NewFileStagesStorageCache(filepath.Join(synchronizationServerDir, "stages-storage-cache", clientID)), nil
+		},
+	)
+}
+
+func main() {
+	if err := doMain(); err != nil {
+		fmt.Fprintf(os.Stderr, "ERR: %s\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
 - werf synchronization command
 - Implement LockManagerHttpClient LockManager interface compatible.
 - Implement LockManagerHttpHandler which respond to corresponding methods of LockManager interface.
 - Implement StagesStorageCacheHttpClient StagesStorageCache interface compatible.
 - Implement StagesStorageCacheHttpHandler which respond to corresponding methods of StagesStorageCache interface.
 - Http handlers can be initialized with arbitrary lock-manager or stages-storage-cache implementation by interface param.
    - werf synchronization --local --local-lock-manager-base-dir --local-stages-storage-cache-base-dir (store locks and cache in local filesystem, this server will not keep data on restarts).
    - werf synchronization --kubernetes --kubernetes-namespace-prefix="werf-synchronization-" (store locks and cache in the kubernetes)
 - Implemented syncrhonization server with clientID support.

Not implemented yet:
 - --ttl param for werf synchronization command: should set ttl for locks and cache records;
 - /new-client-id command for werf-synchronization server to generate new unique clientID.
