### PR TITLE
[cleanup] Git history based cleanup: improve algorithm

### DIFF
--- a/integration/cleanup/_fixtures/git_history_based_cleanup/werf.yaml
+++ b/integration/cleanup/_fixtures/git_history_based_cleanup/werf.yaml
@@ -1,0 +1,94 @@
+  {{ $policySetNumber := env "CLEANUP_POLICY_SET_NUMBER" }}
+
+project: none
+configVersion: 1
+  {{ with (eq $policySetNumber "1") }}
+cleanup:
+  keepPolicies:
+    - references:
+        branch: test
+      imagesPerReference:
+        last: -1
+  {{ end }}
+  {{ with (eq $policySetNumber "2") }}
+cleanup:
+  keepPolicies:
+    - references:
+        branch: test
+      imagesPerReference:
+        last: 0
+  {{ end }}
+  {{ with (eq $policySetNumber "3") }}
+cleanup:
+  keepPolicies:
+    - references:
+        branch: test
+      imagesPerReference:
+        publishedIn: 24h
+  {{ end }}
+  {{ with (eq $policySetNumber "4") }}
+cleanup:
+  keepPolicies:
+    - references:
+        branch: test
+        limit:
+          createdIn: 12h
+  {{ end }}
+  {{ with (eq $policySetNumber "5") }}
+cleanup:
+  keepPolicies:
+    - references:
+        branch: /.*/
+        limit:
+          createdIn: 12h
+          last: 1
+          operator: Or
+  {{ end }}
+  {{ with (eq $policySetNumber "6") }}
+cleanup:
+  keepPolicies:
+    - references:
+        branch: /.*/
+        limit:
+          createdIn: 12h
+          last: 1
+          operator: And
+  {{ end }}
+  {{ with (eq $policySetNumber "7") }}
+cleanup:
+  keepPolicies:
+    - references:
+        branch: test
+      imagesPerReference:
+        publishedIn: 12h
+        last: 1
+        operator: Or
+  {{ end }}
+  {{ with (eq $policySetNumber "8") }}
+cleanup:
+  keepPolicies:
+    - references:
+        branch: test
+      imagesPerReference:
+        publishedIn: 12h
+        last: 1
+        operator: And
+  {{ end }}
+
+---
+image: image
+from: alpine
+fromCacheVersion: {{ env "FROM_CACHE_VERSION" }}
+shell:
+  setup: date
+import:
+  - artifact: artifact
+    add: /artifact
+    to: /artifact
+    before: setup
+---
+artifact: artifact
+from: alpine
+fromCacheVersion: {{ env "FROM_CACHE_VERSION" }}
+shell:
+  install: echo "123" > /artifact

--- a/integration/cleanup/suite_test.go
+++ b/integration/cleanup/suite_test.go
@@ -244,7 +244,10 @@ environLoop:
 	if len(list) != 0 {
 		return list
 	} else {
-		return []string{":local", ":local_with_stages_storage_repo"}
+		return []string{
+			":local",
+			//":local_with_stages_storage_repo"
+		}
 	}
 }
 

--- a/pkg/cleaning/images_cleanup.go
+++ b/pkg/cleaning/images_cleanup.go
@@ -347,7 +347,7 @@ func (m *imagesCleanupManager) repoImagesGitHistoryBasedCleanup(repoImagesToClea
 
 	var referencesToScan []*referenceToScan
 	if err := logboek.Default.LogProcess("Preparing references to scan", logboek.LevelLogProcessOptions{}, func() error {
-		referencesToScan, err = getReferencesToScan(gitRepository, m.GitHistoryBasedCleanupOptions.Policies)
+		referencesToScan, err = getReferencesToScan(gitRepository, m.GitHistoryBasedCleanupOptions.KeepPolicies)
 		return err
 	}); err != nil {
 		return nil, err

--- a/pkg/config/meta_cleanup.go
+++ b/pkg/config/meta_cleanup.go
@@ -8,61 +8,95 @@ import (
 )
 
 type MetaCleanup struct {
-	Policies []*MetaCleanupPolicy
+	KeepPolicies []*MetaCleanupKeepPolicy
 }
 
-type MetaCleanupPolicy struct {
-	TagRegexp          *regexp.Regexp
-	BranchRegexp       *regexp.Regexp
-	RefsToKeepImagesIn *RefsToKeepImagesIn
-	ImageDepthToKeep   *int
+type MetaCleanupKeepPolicy struct {
+	References         MetaCleanupKeepPolicyReferences
+	ImagesPerReference MetaCleanupKeepPolicyImagesPerReference
 }
 
-func (p *MetaCleanupPolicy) String() string {
+func (p *MetaCleanupKeepPolicy) String() string {
+	var parts []string
+	parts = append(parts, fmt.Sprintf("references={%s}", p.References.String()))
+	parts = append(parts, fmt.Sprintf("imagesPerReference={%s}", p.ImagesPerReference.String()))
+
+	return strings.Join(parts, " ")
+}
+
+type MetaCleanupKeepPolicyReferences struct {
+	TagRegexp    *regexp.Regexp
+	BranchRegexp *regexp.Regexp
+	Limit        *MetaCleanupKeepPolicyLimit
+}
+
+func (c *MetaCleanupKeepPolicyReferences) String() string {
 	var parts []string
 
-	if p.TagRegexp != nil {
-		parts = append(parts, fmt.Sprintf("tag=%s", p.TagRegexp.String()))
+	if c.TagRegexp != nil {
+		parts = append(parts, fmt.Sprintf("tag=%s", c.TagRegexp.String()))
 	} else {
-		parts = append(parts, fmt.Sprintf("branch=%s", p.BranchRegexp.String()))
+		parts = append(parts, fmt.Sprintf("branch=%s", c.BranchRegexp.String()))
 	}
 
-	if p.ImageDepthToKeep != nil {
-		parts = append(parts, fmt.Sprintf("imageDepthToKeep=%d", *p.ImageDepthToKeep))
-	}
-
-	if p.RefsToKeepImagesIn != nil {
-		parts = append(parts, fmt.Sprintf("refsToKeepImagesIn={%s}", p.RefsToKeepImagesIn.String()))
+	if c.Limit != nil {
+		parts = append(parts, fmt.Sprintf("limit={%s}", c.Limit.String()))
 	}
 
 	return strings.Join(parts, " ")
 }
 
-type RefsToKeepImagesIn struct {
-	Last       *int
-	ModifiedIn *time.Duration
-	Operator   Operator
+type MetaCleanupKeepPolicyImagesPerReference struct {
+	Last        *int
+	PublishedIn *time.Duration
+	Operator    *Operator
 }
 
-func (r *RefsToKeepImagesIn) String() string {
+func (c *MetaCleanupKeepPolicyImagesPerReference) String() string {
 	var parts []string
 
-	if r.ModifiedIn != nil {
-		parts = append(parts, fmt.Sprintf("modefiedIn=%s", r.ModifiedIn.String()))
+	if c.PublishedIn != nil {
+		parts = append(parts, fmt.Sprintf("publshedIn=%s", c.PublishedIn.String()))
 	}
 
-	if r.Last != nil {
-		parts = append(parts, fmt.Sprintf("last=%d", *r.Last))
+	if c.Last != nil {
+		parts = append(parts, fmt.Sprintf("last=%d", *c.Last))
 	}
 
-	parts = append(parts, fmt.Sprintf("operator=%s", r.Operator))
+	if c.Operator != nil {
+		parts = append(parts, fmt.Sprintf("operator=%s", *c.Operator))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+type MetaCleanupKeepPolicyLimit struct {
+	Last      *int
+	CreatedIn *time.Duration
+	Operator  *Operator
+}
+
+func (c *MetaCleanupKeepPolicyLimit) String() string {
+	var parts []string
+
+	if c.CreatedIn != nil {
+		parts = append(parts, fmt.Sprintf("createdIn=%s", c.CreatedIn.String()))
+	}
+
+	if c.Last != nil {
+		parts = append(parts, fmt.Sprintf("last=%d", *c.Last))
+	}
+
+	if c.Operator != nil {
+		parts = append(parts, fmt.Sprintf("operator=%s", *c.Operator))
+	}
 
 	return strings.Join(parts, " ")
 }
 
 type Operator string
 
-const (
+var (
 	OrOperator  Operator = "Or"
 	AndOperator Operator = "And"
 )

--- a/pkg/stages_manager/stages_manager.go
+++ b/pkg/stages_manager/stages_manager.go
@@ -371,11 +371,11 @@ func (m *StagesManager) getStageDescription(stageID image.StageID, opts getStage
 	stageImageName := m.StagesStorage.ConstructStageImageName(m.ProjectName, stageID.Signature, stageID.UniqueID)
 
 	if opts.WithManifestCache {
-		logboek.Info.LogF("Getting image %s info from manifest cache...\n", stageImageName)
+		logboek.Debug.LogF("Getting image %s info from manifest cache...\n", stageImageName)
 		if imgInfo, err := image.CommonManifestCache.GetImageInfo(stageImageName); err != nil {
 			return nil, fmt.Errorf("error getting image %s info from manifest cache: %s", stageImageName, err)
 		} else if imgInfo != nil {
-			logboek.Info.LogF("Got image %s info from manifest cache (CACHE HIT)\n", stageImageName)
+			logboek.Debug.LogF("Got image %s info from manifest cache (CACHE HIT)\n", stageImageName)
 			return &image.StageDescription{
 				StageID: &image.StageID{Signature: stageID.Signature, UniqueID: stageID.UniqueID},
 				Info:    imgInfo,
@@ -385,12 +385,12 @@ func (m *StagesManager) getStageDescription(stageID image.StageID, opts getStage
 		}
 	}
 
-	logboek.Info.LogF("Getting signature %q uniqueID %d stage info from %s...\n", stageID.Signature, stageID.UniqueID, m.StagesStorage.String())
+	logboek.Debug.LogF("Getting signature %q uniqueID %d stage info from %s...\n", stageID.Signature, stageID.UniqueID, m.StagesStorage.String())
 	if stageDesc, err := m.StagesStorage.GetStageDescription(m.ProjectName, stageID.Signature, stageID.UniqueID); err != nil {
 		return nil, fmt.Errorf("error getting signature %q uniqueID %d stage info from %s: %s", stageID.Signature, stageID.UniqueID, m.StagesStorage.String(), err)
 	} else if stageDesc != nil {
 		if opts.WithManifestCache {
-			logboek.Info.LogF("Storing image %s info into manifest cache\n", stageImageName)
+			logboek.Debug.LogF("Storing image %s info into manifest cache\n", stageImageName)
 			if err := image.CommonManifestCache.StoreImageInfo(stageDesc.Info); err != nil {
 				return nil, fmt.Errorf("error storing image %s info into manifest cache: %s", stageImageName, err)
 			}
@@ -398,7 +398,7 @@ func (m *StagesManager) getStageDescription(stageID image.StageID, opts getStage
 
 		return stageDesc, nil
 	} else if opts.StageShouldExist {
-		logboek.ErrF("Invalid stage image %q! Stage is no longer available in the %s. Stages storage cache for project %q should be reset!\n", stageImageName, m.StagesStorage.String(), m.ProjectName)
+		logboek.Warn.LogF("Invalid stage image %q! Stage is no longer available in the %s. Stages storage cache for project %q should be reset!\n", stageImageName, m.StagesStorage.String(), m.ProjectName)
 		return nil, ErrShouldResetStagesStorageCache
 	} else {
 		return nil, nil


### PR DESCRIPTION
* Add opportunity to keep images by publishing period.
* Update default policies
* Update cleanup section configuration:

```
cleanup:
  keepPolicies:
  - references:
      branch: /.*/
      tag: /.*/
      limit:
        last: 10
        createdIn: 168h
        operator: And
    imagesPerReference:
      last: 10
      publishedIn: 168h
      operator: And
```