### PR TITLE
[render] Fix stub env value ENV

### DIFF
--- a/cmd/werf/helm/common/common.go
+++ b/cmd/werf/helm/common/common.go
@@ -23,7 +23,7 @@ import (
 
 func GetEnvironmentOrStub(environmentOption string) string {
 	if environmentOption == "" {
-		return "ENV"
+		return "env"
 	}
 	return environmentOption
 }


### PR DESCRIPTION
Error: bad Helm release 'project-ENV' rendered by template '[[ project ]]-[[ env ]]': helm release name should be a valid DNS-1123 subdomain and be maximum 53 chars: a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')