### PR TITLE
Rework synchronization param, add base64 support for kubernetes-params

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -99,9 +99,8 @@ If one or more IMAGE_NAME parameters specified, werf will build images stages an
 	common.SetupIntrospectStage(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	common.SetupPublishReportPath(&commonCmdData, cmd)

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -80,9 +80,8 @@ It is safe to run this command periodically (daily is enough) by automated clean
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 	common.SetupWithoutKube(&commonCmdData, cmd)
 
@@ -110,7 +109,11 @@ func runCleanup() error {
 		return err
 	}
 
-	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}}); err != nil {
+	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
+		Context:          *commonCmdData.KubeContext,
+		ConfigPath:       *commonCmdData.KubeConfig,
+		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}
 

--- a/cmd/werf/common/synchronization.go
+++ b/cmd/werf/common/synchronization.go
@@ -27,22 +27,6 @@ func SetupSynchronization(cmdData *CmdData, cmd *cobra.Command) {
 	cmd.Flags().StringVarP(cmdData.Synchronization, "synchronization", "S", defaultValue, fmt.Sprintf("Address of synchronizer for multiple werf processes to work with a single stages storage (default :local if --stages-storage=:local or %s if non-local stages-storage specified or $WERF_SYNCHRONIZATION if set). The same address should be specified for all werf processes that work with a single stages storage. :local address allows execution of werf processes from a single host only.", storage.DefaultKubernetesStorageAddress))
 }
 
-func SetupSynchronizationKubeConfig(cmdData *CmdData, cmd *cobra.Command) {
-	cmdData.SynchronizationKubeConfig = new(string)
-
-	defaultValue := os.Getenv("WERF_SYNCHRONIZATION_KUBE_CONFIG")
-
-	cmd.Flags().StringVarP(cmdData.SynchronizationKubeConfig, "synchronization-kube-config", "", defaultValue, "Kubernetes config to use for synchronization. This option should be explicitly set when --kube-config has been explicitly specified.")
-}
-
-func SetupSynchronizationKubeContext(cmdData *CmdData, cmd *cobra.Command) {
-	cmdData.SynchronizationKubeContext = new(string)
-
-	defaultValue := os.Getenv("WERF_SYNCHRONIZATION_KUBE_CONTEXT")
-
-	cmd.Flags().StringVarP(cmdData.SynchronizationKubeContext, "synchronization-kube-context", "", defaultValue, "Kubernetes context to use for synchronization.")
-}
-
 type SynchronizationType string
 
 const (
@@ -54,105 +38,104 @@ const (
 type SynchronizationParams struct {
 	Address             string
 	SynchronizationType SynchronizationType
-
-	KubeConfig    string
-	KubeContext   string
-	KubeNamespace string
+	KubeParams          *storage.KubernetesSynchronizationParams
 }
 
 func checkSynchronizationKubernetesParamsForWarnings(cmdData *CmdData) {
-	var doPrintWarn bool
-
-	specifiedKubeConfig := *cmdData.KubeConfig
-	if kubeConfigEnv := os.Getenv("KUBECONFIG"); kubeConfigEnv != "" {
-		specifiedKubeConfig = kubeConfigEnv
+	if *cmdData.Synchronization != "" {
+		return
 	}
 
-	if specifiedKubeConfig != "" && *cmdData.SynchronizationKubeConfig == "" {
-		if !doPrintWarn {
-			werf.GlobalWarningLn(`##########################################################################################################################`)
-		}
-		doPrintWarn = true
-
-		werf.GlobalWarningLn(`##  Required --synchronization-kube-config (or WERF_SYNCHRONIZATION_KUBE_CONFIG env var) param to be specified explicitly,`)
-		werf.GlobalWarningLn(fmt.Sprintf(`##  because --kube-config (or WERF_KUBE_CONFIG or KUBECONFIG env var) = %s has been specified explicitly.`, *cmdData.KubeConfig))
+	doPrintWarning := false
+	if *cmdData.KubeConfigBase64 != "" {
+		doPrintWarning = true
+		werf.GlobalWarningLn(`###`)
+		werf.GlobalWarningLn(`##  Required --synchronization param (or WERF_SYNCHRONIZATION env var) to be specified explicitly,`)
+		werf.GlobalWarningLn(fmt.Sprintf(`##  because --kube-config-base64=%s (or WERF_KUBE_CONFIG_BASE64, or WERF_KUBECONFIG_BASE64, or $KUBECONFIG_BASE64 env var) has been specified explicitly.`, *cmdData.KubeConfigBase64))
+	} else if kubeConfigEnv := os.Getenv("KUBECONFIG"); kubeConfigEnv != "" {
+		doPrintWarning = true
+		werf.GlobalWarningLn(`###`)
+		werf.GlobalWarningLn(`##  Required --synchronization param (or WERF_SYNCHRONIZATION env var) to be specified explicitly,`)
+		werf.GlobalWarningLn(fmt.Sprintf(`##  because KUBECONFIG=%s env var has been specified explicitly.`, kubeConfigEnv))
+	} else if *cmdData.KubeConfig != "" {
+		doPrintWarning = true
+		werf.GlobalWarningLn(`###`)
+		werf.GlobalWarningLn(`##  Required --synchronization param (or WERF_SYNCHRONIZATION env var) to be specified explicitly,`)
+		werf.GlobalWarningLn(fmt.Sprintf(`##  because --kube-config=%s (or WERF_KUBE_CONFIG, or WERF_KUBECONFIG, or KUBECONFIG env var) has been specified explicitly.`, kubeConfigEnv))
+	} else if *cmdData.KubeContext != "" {
+		doPrintWarning = true
+		werf.GlobalWarningLn(`###`)
+		werf.GlobalWarningLn(`##  Required --synchronization param (or WERF_SYNCHRONIZATION env var) to be specified explicitly,`)
+		werf.GlobalWarningLn(fmt.Sprintf(`##  because --kube-context=%s (or WERF_KUBE_CONTEXT env var) has been specified explicitly.`, kubeConfigEnv))
 	}
 
-	if *cmdData.KubeContext != "" && *cmdData.SynchronizationKubeContext == "" {
-		if !doPrintWarn {
-			werf.GlobalWarningLn(`##########################################################################################################################`)
-		} else {
-			werf.GlobalWarningLn(`##  `)
-		}
-		doPrintWarn = true
-
-		werf.GlobalWarningLn(`##  Required --synchronization-kube-context (or WERF_SYNCHRONIZATION_KUBE_CONTEXT env var) param to be specified explicitly,`)
-		werf.GlobalWarningLn(fmt.Sprintf(`##  because --kube-context (or WERF_KUBE_CONTEXT env var) = %s has been specified explicitly.`, *cmdData.KubeContext))
-	}
-
-	if doPrintWarn {
+	if doPrintWarning {
 		werf.GlobalWarningLn(`##  `)
 		werf.GlobalWarningLn(`##  IMPORTANT: all invocations of the werf for any single project should use the same`)
-		werf.GlobalWarningLn(`##  --synchronization-kube-config (or WERF_SYNCHRONIZATION_KUBE_CONFIG env var) and`)
-		werf.GlobalWarningLn(`##  --synchronization-kube-context (or WERF_SYNCHRONIZATION_KUBE_CONTEXT env var) params values`)
+		werf.GlobalWarningLn(`##  --synchronization param (or WERF_SYNCHRONIZATION env var) value`)
 		werf.GlobalWarningLn(`##  to prevent inconsistency of the werf setup for this project.`)
+		werf.GlobalWarningLn(`##  `)
+		werf.GlobalWarningLn(`##  Format of the synchronization param: kubernetes://NAMESPACE[:CONTEXT][@(base64:BASE64_CONFIG_DATA)|CONFIG_PATH]`)
 		werf.GlobalWarningLn(`##  `)
 		werf.GlobalWarningLn(`##  By default werf stores synchronization data using --synchronization=kubernetes://werf-synchronization namespace`)
 		werf.GlobalWarningLn(`##  with default kube-config and kube-context.`)
 		werf.GlobalWarningLn(`##  `)
 		werf.GlobalWarningLn(`##  For example, configure werf synchronization with the following settings:`)
 		werf.GlobalWarningLn(`##  `)
-		werf.GlobalWarningLn(`##      export WERF_SYNCHRONIZATION_KUBE_CONFIG=~/.kube/config`)
-		werf.GlobalWarningLn(`##      export WERF_SYNCHRONIZATION_KUBE_CONTEXT=werf-synchronization`)
+		werf.GlobalWarningLn(`##      export WERF_SYNCHRONIZATION=kubernetes://werf-synchronization:mycontext@/root/.kube/custom-config`)
+		werf.GlobalWarningLn(`##  `)
+		werf.GlobalWarningLn(`##  — these same settings required to be used in every werf invocation for your project.`)
 		werf.GlobalWarningLn(`##  `)
 		werf.GlobalWarningLn(`##  More info about synchronization: https://werf.io/documentation/reference/stages_and_images.html#synchronization-locks-and-stages-storage-cache`)
-		werf.GlobalWarningLn(`##########################################################################################################################`)
+		werf.GlobalWarningLn(`###`)
 	}
 }
 
 func GetSynchronization(cmdData *CmdData, stagesStorageAddress string) (*SynchronizationParams, error) {
-	synchronizationKubeConfig := *cmdData.SynchronizationKubeConfig
-	if synchronizationKubeConfig == "" {
-		synchronizationKubeConfig = *cmdData.KubeConfig
+	var defaultKubernetesSynchronization string
+	if *cmdData.Synchronization == "" {
+		defaultKubernetesSynchronization = storage.DefaultKubernetesStorageAddress
+
+		if *cmdData.KubeContext != "" {
+			defaultKubernetesSynchronization += fmt.Sprintf(":%s", *cmdData.KubeContext)
+		}
+
+		if *cmdData.KubeConfigBase64 != "" {
+			defaultKubernetesSynchronization += fmt.Sprintf("@base64:%s", *cmdData.KubeConfigBase64)
+		} else if *cmdData.KubeConfig != "" {
+			defaultKubernetesSynchronization += fmt.Sprintf("@%s", *cmdData.KubeConfig)
+		}
 	}
 
-	synchronizationKubeContext := *cmdData.SynchronizationKubeContext
-	if synchronizationKubeContext == "" {
-		synchronizationKubeContext = *cmdData.KubeContext
+	getKubeParamsFunc := func(address string) (*SynchronizationParams, error) {
+		res := &SynchronizationParams{}
+		res.SynchronizationType = KubernetesSynchronization
+		res.Address = address
+
+		if params, err := storage.ParseKubernetesSynchronization(res.Address); err != nil {
+			return nil, fmt.Errorf("unable to parse synchronization address %s: %s", res.Address, err)
+		} else {
+			res.KubeParams = params
+			return res, nil
+		}
 	}
 
 	if *cmdData.Synchronization == "" {
 		if stagesStorageAddress == storage.LocalStorageAddress {
-			return &SynchronizationParams{Address: storage.LocalStorageAddress, SynchronizationType: LocalSynchronization}, nil
+			return &SynchronizationParams{SynchronizationType: LocalSynchronization, Address: storage.LocalStorageAddress}, nil
 		} else {
 			checkSynchronizationKubernetesParamsForWarnings(cmdData)
-
-			return &SynchronizationParams{
-				Address:             storage.DefaultKubernetesStorageAddress,
-				SynchronizationType: KubernetesSynchronization,
-				KubeConfig:          synchronizationKubeConfig,
-				KubeContext:         synchronizationKubeContext,
-				KubeNamespace:       strings.TrimPrefix(storage.DefaultKubernetesStorageAddress, "kubernetes://"),
-			}, nil
+			return getKubeParamsFunc(defaultKubernetesSynchronization)
 		}
+	} else if *cmdData.Synchronization == storage.LocalStorageAddress {
+		return &SynchronizationParams{Address: *cmdData.Synchronization, SynchronizationType: LocalSynchronization}, nil
+	} else if strings.HasPrefix(*cmdData.Synchronization, "kubernetes://") {
+		checkSynchronizationKubernetesParamsForWarnings(cmdData)
+		return getKubeParamsFunc(*cmdData.Synchronization)
+	} else if strings.HasPrefix(*cmdData.Synchronization, "http://") || strings.HasPrefix(*cmdData.Synchronization, "https://") {
+		return &SynchronizationParams{Address: *cmdData.Synchronization, SynchronizationType: HttpSynchronization}, nil
 	} else {
-		if *cmdData.Synchronization == storage.LocalStorageAddress {
-			return &SynchronizationParams{Address: *cmdData.Synchronization, SynchronizationType: LocalSynchronization}, nil
-		} else if strings.HasPrefix(*cmdData.Synchronization, "kubernetes://") {
-			checkSynchronizationKubernetesParamsForWarnings(cmdData)
-
-			return &SynchronizationParams{
-				Address:             *cmdData.Synchronization,
-				SynchronizationType: KubernetesSynchronization,
-				KubeConfig:          synchronizationKubeConfig,
-				KubeContext:         synchronizationKubeContext,
-				KubeNamespace:       strings.TrimPrefix(*cmdData.Synchronization, "kubernetes://"),
-			}, nil
-		} else if strings.HasPrefix(*cmdData.Synchronization, "http://") || strings.HasPrefix(*cmdData.Synchronization, "https://") {
-			return &SynchronizationParams{Address: *cmdData.Synchronization, SynchronizationType: HttpSynchronization}, nil
-		} else {
-			return nil, fmt.Errorf("only --synchronization=%s or --synchronization=kubernetes://NAMESPACE or --synchronization=http[s]://HOST:PORT/CLIENT_ID is supported, got %q", storage.LocalStorageAddress, *cmdData.Synchronization)
-		}
+		return nil, fmt.Errorf("only --synchronization=%s or --synchronization=kubernetes://NAMESPACE or --synchronization=http[s]://HOST:PORT/CLIENT_ID is supported, got %q", storage.LocalStorageAddress, *cmdData.Synchronization)
 	}
 }
 
@@ -161,12 +144,16 @@ func GetStagesStorageCache(synchronization *SynchronizationParams) (storage.Stag
 	case LocalSynchronization:
 		return storage.NewFileStagesStorageCache(werf.GetStagesStorageCacheDir()), nil
 	case KubernetesSynchronization:
-		if config, err := kube.GetKubeConfig(kube.KubeConfigOptions{KubeConfig: synchronization.KubeConfig, KubeContext: synchronization.KubeContext}); err != nil {
-			return nil, fmt.Errorf("unable to load synchronization kube config %q (context %q)", synchronization.KubeConfig, synchronization.KubeContext)
+		if config, err := kube.GetKubeConfig(kube.KubeConfigOptions{
+			ConfigPath:       synchronization.KubeParams.ConfigPath,
+			ConfigDataBase64: synchronization.KubeParams.ConfigDataBase64,
+			Context:          synchronization.KubeParams.ConfigContext,
+		}); err != nil {
+			return nil, fmt.Errorf("unable to load synchronization kube config %q (context %q)", synchronization.KubeParams.ConfigPath, synchronization.KubeParams.ConfigContext)
 		} else if client, err := kubernetes.NewForConfig(config.Config); err != nil {
 			return nil, fmt.Errorf("unable to create synchronization kubernetes client: %s", err)
 		} else {
-			return storage.NewKubernetesStagesStorageCache(synchronization.KubeNamespace, client), nil
+			return storage.NewKubernetesStagesStorageCache(synchronization.KubeParams.Namespace, client), nil
 		}
 	case HttpSynchronization:
 		return synchronization_server.NewStagesStorageCacheHttpClient(fmt.Sprintf("%s/stages-storage-cache", synchronization.Address)), nil
@@ -180,14 +167,18 @@ func GetStorageLockManager(synchronization *SynchronizationParams) (storage.Lock
 	case LocalSynchronization:
 		return storage.NewGenericLockManager(werf.GetHostLocker()), nil
 	case KubernetesSynchronization:
-		if config, err := kube.GetKubeConfig(kube.KubeConfigOptions{KubeConfig: synchronization.KubeConfig, KubeContext: synchronization.KubeContext}); err != nil {
-			return nil, fmt.Errorf("unable to load synchronization kube config %q (context %q)", synchronization.KubeConfig, synchronization.KubeContext)
+		if config, err := kube.GetKubeConfig(kube.KubeConfigOptions{
+			ConfigPath:       synchronization.KubeParams.ConfigPath,
+			ConfigDataBase64: synchronization.KubeParams.ConfigDataBase64,
+			Context:          synchronization.KubeParams.ConfigContext,
+		}); err != nil {
+			return nil, fmt.Errorf("unable to load synchronization kube config %q (context %q)", synchronization.KubeParams.ConfigPath, synchronization.KubeParams.ConfigContext)
 		} else if dynamicClient, err := dynamic.NewForConfig(config.Config); err != nil {
 			return nil, fmt.Errorf("unable to create synchronization kubernetes dynamic client: %s", err)
 		} else if client, err := kubernetes.NewForConfig(config.Config); err != nil {
 			return nil, fmt.Errorf("unable to create synchronization kubernetes client: %s", err)
 		} else {
-			return storage.NewKubernetesLockManager(synchronization.KubeNamespace, client, dynamicClient), nil
+			return storage.NewKubernetesLockManager(synchronization.KubeParams.Namespace, client, dynamicClient), nil
 		}
 	case HttpSynchronization:
 		return synchronization_server.NewLockManagerHttpClient(fmt.Sprintf("%s/lock-manager", synchronization.Address)), nil

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -91,10 +91,9 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 	common.SetupHelmChartDir(&commonCmdData, cmd)
 	common.SetupHelmReleaseStorageNamespace(&commonCmdData, cmd)
@@ -252,7 +251,11 @@ func runConverge() error {
 		return err
 	}
 
-	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}}); err != nil {
+	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
+		Context:          *commonCmdData.KubeContext,
+		ConfigPath:       *commonCmdData.KubeConfig,
+		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}
 

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -90,6 +90,7 @@ Read more info about Helm chart structure, Helm Release name, Kubernetes Namespa
 
 	common.SetupHelmChartDir(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 	common.SetupHelmReleaseStorageNamespace(&commonCmdData, cmd)
 	common.SetupHelmReleaseStorageType(&commonCmdData, cmd)
@@ -101,8 +102,6 @@ Read more info about Helm chart structure, Helm Release name, Kubernetes Namespa
 	common.SetupImagesRepoOptions(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read and pull images from the specified stages storage and images repo")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
@@ -176,7 +175,11 @@ func runDeploy() error {
 		return err
 	}
 
-	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}}); err != nil {
+	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
+		Context:          *commonCmdData.KubeContext,
+		ConfigPath:       *commonCmdData.KubeConfig,
+		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}
 

--- a/cmd/werf/diff/diff.go
+++ b/cmd/werf/diff/diff.go
@@ -85,10 +85,9 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 	common.SetupHelmChartDir(&commonCmdData, cmd)
 	common.SetupHelmReleaseStorageNamespace(&commonCmdData, cmd)
@@ -246,7 +245,11 @@ func runDiff() error {
 		return err
 	}
 
-	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}}); err != nil {
+	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
+		Context:          *commonCmdData.KubeContext,
+		ConfigPath:       *commonCmdData.KubeConfig,
+		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}
 

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -69,14 +69,13 @@ Read more info about Helm Release name, Kubernetes Namespace and how to change i
 
 	common.SetupStagesStorageOptions(&commonCmdData, cmd)
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 
 	common.SetupEnvironment(&commonCmdData, cmd)
 	common.SetupRelease(&commonCmdData, cmd)
 	common.SetupNamespace(&commonCmdData, cmd)
 
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 	common.SetupHelmReleaseStorageNamespace(&commonCmdData, cmd)
 	common.SetupHelmReleaseStorageType(&commonCmdData, cmd)
@@ -141,7 +140,11 @@ func runDismiss() error {
 
 	projectName := werfConfig.Meta.Project
 
-	err = kube.Init(kube.InitOptions{kube.KubeConfigOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}})
+	err = kube.Init(kube.InitOptions{kube.KubeConfigOptions{
+		Context:          *commonCmdData.KubeContext,
+		ConfigPath:       *commonCmdData.KubeConfig,
+		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+	}})
 	if err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}

--- a/cmd/werf/helm/deploy_chart/main.go
+++ b/cmd/werf/helm/deploy_chart/main.go
@@ -139,7 +139,11 @@ func runDeployChart(chartDirOrChartReference string, releaseName string) error {
 		return err
 	}
 
-	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}}); err != nil {
+	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
+		Context:          *commonCmdData.KubeContext,
+		ConfigPath:       *commonCmdData.KubeConfig,
+		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}
 

--- a/cmd/werf/helm/rollback/rollback.go
+++ b/cmd/werf/helm/rollback/rollback.go
@@ -98,7 +98,11 @@ func runRollback(releaseName string, revision int32) error {
 		return err
 	}
 
-	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}}); err != nil {
+	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
+		Context:          *commonCmdData.KubeContext,
+		ConfigPath:       *commonCmdData.KubeConfig,
+		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}
 

--- a/cmd/werf/host/project/purge/purge.go
+++ b/cmd/werf/host/project/purge/purge.go
@@ -59,9 +59,8 @@ func NewCmd() *cobra.Command {
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	common.SetupDryRun(&commonCmdData, cmd)

--- a/cmd/werf/images/cleanup/cleanup.go
+++ b/cmd/werf/images/cleanup/cleanup.go
@@ -74,9 +74,8 @@ func NewCmd() *cobra.Command {
 	common.SetupDryRun(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 	common.SetupWithoutKube(&commonCmdData, cmd)
 
@@ -104,7 +103,11 @@ func runCleanup() error {
 		return err
 	}
 
-	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}}); err != nil {
+	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
+		Context:          *commonCmdData.KubeContext,
+		ConfigPath:       *commonCmdData.KubeConfig,
+		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}
 

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -70,9 +70,8 @@ If one or more IMAGE_NAME parameters specified, werf will publish only these ima
 	common.SetupLogProjectDir(commonCmdData, cmd)
 
 	common.SetupSynchronization(commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(commonCmdData, cmd)
 	common.SetupKubeConfig(commonCmdData, cmd)
+	common.SetupKubeConfigBase64(commonCmdData, cmd)
 	common.SetupKubeContext(commonCmdData, cmd)
 
 	common.SetupPublishReportPath(commonCmdData, cmd)

--- a/cmd/werf/images/purge/purge.go
+++ b/cmd/werf/images/purge/purge.go
@@ -55,9 +55,8 @@ func NewCmd() *cobra.Command {
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	common.SetupDryRun(&commonCmdData, cmd)

--- a/cmd/werf/managed_images/add/add.go
+++ b/cmd/werf/managed_images/add/add.go
@@ -52,9 +52,8 @@ func NewCmd() *cobra.Command {
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/managed_images/ls/ls.go
+++ b/cmd/werf/managed_images/ls/ls.go
@@ -49,9 +49,8 @@ func NewCmd() *cobra.Command {
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/managed_images/rm/rm.go
+++ b/cmd/werf/managed_images/rm/rm.go
@@ -53,9 +53,8 @@ func NewCmd() *cobra.Command {
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -65,9 +65,8 @@ WARNING: Do not run this command during any other werf command is working on the
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	common.SetupDryRun(&commonCmdData, cmd)

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -114,9 +114,8 @@ func NewCmd() *cobra.Command {
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	common.SetupDryRun(&commonCmdData, cmd)

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -71,9 +71,8 @@ func NewCmd() *cobra.Command {
 	common.SetupDryRun(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	common.SetupVirtualMerge(&commonCmdData, cmd)

--- a/cmd/werf/stages/build/cmd_factory/main.go
+++ b/cmd/werf/stages/build/cmd_factory/main.go
@@ -90,9 +90,8 @@ If one or more IMAGE_NAME parameters specified, werf will build only these image
 	common.SetupLogProjectDir(commonCmdData, cmd)
 
 	common.SetupSynchronization(commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(commonCmdData, cmd)
 	common.SetupKubeConfig(commonCmdData, cmd)
+	common.SetupKubeConfigBase64(commonCmdData, cmd)
 	common.SetupKubeContext(commonCmdData, cmd)
 
 	common.SetupVirtualMerge(commonCmdData, cmd)

--- a/cmd/werf/stages/cleanup/cleanup.go
+++ b/cmd/werf/stages/cleanup/cleanup.go
@@ -62,9 +62,8 @@ func NewCmd() *cobra.Command {
 	common.SetupDryRun(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/stages/purge/purge.go
+++ b/cmd/werf/stages/purge/purge.go
@@ -61,9 +61,8 @@ func NewCmd() *cobra.Command {
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	common.SetupDryRun(&commonCmdData, cmd)

--- a/cmd/werf/stages/switch_from_local/main.go
+++ b/cmd/werf/stages/switch_from_local/main.go
@@ -59,9 +59,8 @@ func NewCmd() *cobra.Command {
 	stages_common.SetupToStagesStorage(&commonCmdData, &cmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/stages/sync/main.go
+++ b/cmd/werf/stages/sync/main.go
@@ -60,9 +60,8 @@ func NewCmd() *cobra.Command {
 	stages_common.SetupCleanupLocalCache(&cmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeConfig(&commonCmdData, cmd)
-	common.SetupSynchronizationKubeContext(&commonCmdData, cmd)
 	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/synchronization/main.go
+++ b/cmd/werf/synchronization/main.go
@@ -93,7 +93,11 @@ func runSynchronization() error {
 	var stagesStorageCacheFactoryFunc func(clientID string) (storage.StagesStorageCache, error)
 
 	if cmdData.Kubernetes {
-		if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}}); err != nil {
+		if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
+			Context:          *commonCmdData.KubeContext,
+			ConfigPath:       *commonCmdData.KubeConfig,
+			ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		}}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tonistiigi/fsutil v0.0.0-20190130224639-b4281fa67095 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
-	github.com/werf/kubedog v0.3.5-0.20200707154239-8015c267710f
+	github.com/werf/kubedog v0.3.5-0.20200709122502-d4a85f7484cf
 	github.com/werf/lockgate v0.0.0-20200625122100-41c30943229f
 	github.com/werf/logboek v0.3.5-0.20200608145450-5b5f18fe7009
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b // indirect

--- a/go.sum
+++ b/go.sum
@@ -783,8 +783,8 @@ github.com/vmware/govmomi v0.20.1/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59b
 github.com/werf/helm v0.0.0-20200506171044-5fb767b2db6c h1:Ew/xqh7yfDn3+b1yJeFdzxv+Kain/liLSStE8X+eprQ=
 github.com/werf/helm v0.0.0-20200506171044-5fb767b2db6c/go.mod h1:rBQrZQK7AGqzCP1Ve/pE1irL0A9WGQySaDXhpZ6AIJM=
 github.com/werf/kubedog v0.3.5-0.20200610123340-3e909edb5afe/go.mod h1:mSm773JaDFwmgzrOl6LRFDrlUjwk0yKS6WYBbC6E144=
-github.com/werf/kubedog v0.3.5-0.20200707154239-8015c267710f h1:NS/Z0YYmSFI7wf7TmI5vOd1F8Q6LhcnDlKr8ZmyJObM=
-github.com/werf/kubedog v0.3.5-0.20200707154239-8015c267710f/go.mod h1:mSm773JaDFwmgzrOl6LRFDrlUjwk0yKS6WYBbC6E144=
+github.com/werf/kubedog v0.3.5-0.20200709122502-d4a85f7484cf h1:x5lYB238N7AqRvZ2+nRMlB/gIBbnEZuOqHwvCw2Oe5g=
+github.com/werf/kubedog v0.3.5-0.20200709122502-d4a85f7484cf/go.mod h1:mSm773JaDFwmgzrOl6LRFDrlUjwk0yKS6WYBbC6E144=
 github.com/werf/lockgate v0.0.0-20200610124531-3e56c66ed101 h1:tPxINuU4/RjTCwfCW8pPtcGj20Bxc3Hd9aHZJ42Snyg=
 github.com/werf/lockgate v0.0.0-20200610124531-3e56c66ed101/go.mod h1:sChblfYDpXj4QW5SxdD7tUVlNzPKFzwOiNZAyh1BAKQ=
 github.com/werf/lockgate v0.0.0-20200618124604-b12f696bdd55 h1:/7jQqp5f/gZrnWXSR+2OgXVvDZuumAVKrLOOsXUKv4o=

--- a/pkg/storage/synchronization.go
+++ b/pkg/storage/synchronization.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"errors"
+	"strings"
+)
+
+var (
+	ErrBadKubernetesSyncrhonizationAddress = errors.New("bad kubernetes syncrhonization address")
+)
+
+type KubernetesSynchronizationParams struct {
+	ConfigDataBase64 string
+	ConfigPath       string
+	ConfigContext    string
+	Namespace        string
+}
+
+func ParseKubernetesSynchronization(address string) (*KubernetesSynchronizationParams, error) {
+	if !strings.HasPrefix(address, "kubernetes://") {
+		return nil, ErrBadKubernetesSyncrhonizationAddress
+	}
+	addressWithoutScheme := strings.TrimPrefix(address, "kubernetes://")
+
+	res := &KubernetesSynchronizationParams{}
+
+	namespaceWithConextAndConfigParts := strings.SplitN(addressWithoutScheme, "@", 2)
+	var namespaceWithContext, config string
+	if len(namespaceWithConextAndConfigParts) == 2 {
+		namespaceWithContext, config = namespaceWithConextAndConfigParts[0], namespaceWithConextAndConfigParts[1]
+	} else {
+		namespaceWithContext = namespaceWithConextAndConfigParts[0]
+	}
+
+	namespaceAndContextParts := strings.SplitN(namespaceWithContext, ":", 2)
+	if len(namespaceAndContextParts) == 2 {
+		res.Namespace, res.ConfigContext = namespaceAndContextParts[0], namespaceAndContextParts[1]
+	} else {
+		res.Namespace = namespaceAndContextParts[0]
+	}
+
+	if config != "" {
+		if strings.HasPrefix(config, "base64:") {
+			configBase64 := strings.TrimPrefix(config, "base64:")
+			res.ConfigDataBase64 = configBase64
+		} else {
+			res.ConfigPath = config
+		}
+	}
+
+	return res, nil
+}

--- a/pkg/storage/synchronization_test.go
+++ b/pkg/storage/synchronization_test.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"testing"
+)
+
+func TestParseKubernetesSynchronization(t *testing.T) {
+	if params, err := ParseKubernetesSynchronization("kubertenes://allo"); err != ErrBadKubernetesSyncrhonizationAddress {
+		t.Errorf("unexpected parse response: params=%v err=%v", params, err)
+	}
+
+	checkKubernetesSyncrhonization(t, DefaultKubernetesStorageAddress, &KubernetesSynchronizationParams{
+		ConfigContext: "",
+		ConfigPath:    "",
+		Namespace:     "werf-synchronization",
+	})
+
+	checkKubernetesSyncrhonization(t, "kubernetes://mynamespace:mycontext@/tmp/kubeconfig", &KubernetesSynchronizationParams{
+		Namespace:     "mynamespace",
+		ConfigContext: "mycontext",
+		ConfigPath:    "/tmp/kubeconfig",
+	})
+
+	checkKubernetesSyncrhonization(t, "kubernetes://werf-synchronization-2@base64:YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eTogL2hvbWUvbXlob21lLy5taW5pa3ViZS9jYS5jcnQKICAgIHNlcnZlcjogaHR0cHM6Ly8xNzIuMTcuMC40Ojg0NDMKICBuYW1lOiBtaW5pa3ViZQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogbWluaWt1YmUKICAgIHVzZXI6IG1pbmlrdWJlCiAgbmFtZTogbWluaWt1YmUKY3VycmVudC1jb250ZXh0OiAiIgpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IG1pbmlrdWJlCiAgdXNlcjoKICAgIGNsaWVudC1jZXJ0aWZpY2F0ZTogL2hvbWUvbXlob21lLy5taW5pa3ViZS9wcm9maWxlcy9taW5pa3ViZS9jbGllbnQuY3J0CiAgICBjbGllbnQta2V5OiAvaG9tZS9teWhvbWUvLm1pbmlrdWJlL3Byb2ZpbGVzL21pbmlrdWJlL2NsaWVudC5rZXkK", &KubernetesSynchronizationParams{
+		Namespace:        "werf-synchronization-2",
+		ConfigDataBase64: "YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eTogL2hvbWUvbXlob21lLy5taW5pa3ViZS9jYS5jcnQKICAgIHNlcnZlcjogaHR0cHM6Ly8xNzIuMTcuMC40Ojg0NDMKICBuYW1lOiBtaW5pa3ViZQpjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogbWluaWt1YmUKICAgIHVzZXI6IG1pbmlrdWJlCiAgbmFtZTogbWluaWt1YmUKY3VycmVudC1jb250ZXh0OiAiIgpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IG1pbmlrdWJlCiAgdXNlcjoKICAgIGNsaWVudC1jZXJ0aWZpY2F0ZTogL2hvbWUvbXlob21lLy5taW5pa3ViZS9wcm9maWxlcy9taW5pa3ViZS9jbGllbnQuY3J0CiAgICBjbGllbnQta2V5OiAvaG9tZS9teWhvbWUvLm1pbmlrdWJlL3Byb2ZpbGVzL21pbmlrdWJlL2NsaWVudC5rZXkK",
+	})
+
+}
+
+func checkKubernetesSyncrhonization(t *testing.T, address string, expected *KubernetesSynchronizationParams) {
+	if params, err := ParseKubernetesSynchronization(address); err != nil {
+		t.Error(err)
+	} else if expected == nil {
+		if params != nil {
+			t.Errorf("expected nil kubernetes params, got %#v", params)
+		}
+	} else {
+		if params.ConfigContext != expected.ConfigContext {
+			t.Errorf("expected kube context %#v, got %#v", expected.ConfigContext, params.ConfigContext)
+		}
+		if params.ConfigDataBase64 != expected.ConfigDataBase64 {
+			t.Errorf("expected config data base64:\n%s\n\ngot:\n%s", expected.ConfigDataBase64, params.ConfigDataBase64)
+		}
+		if params.ConfigPath != expected.ConfigPath {
+			t.Errorf("expected config path %#v, got %#v", expected.ConfigPath, params.ConfigPath)
+		}
+		if params.Namespace != expected.Namespace {
+			t.Errorf("expected namespace %#v, got %#v", expected.Namespace, params.Namespace)
+		}
+	}
+}


### PR DESCRIPTION
 - Reworked --syncrhonization param (WERF_SYNCHRONIZATION env var): specify all kube-related params in the URI-like string:
     - kubernetes://NAMESPACE[:CONTEXT][@(base64:BASE64_CONFIG_DATA)|CONFIG_PATH]
 - Added --kube-config-base64 param (or WERF_KUBECONFIG_BASE64, or WERF_KUBE_CONFIG_BASE64, or KUBECONFIG_BASE64 env var) support.
     - Werf does not generate config file and unpacks specified base64 yaml config into memory.
