### PR TITLE
Fix AWS ECR build/publish problem 'Image has to have at least 1 layer'

### DIFF
--- a/pkg/build/publish_images_phase.go
+++ b/pkg/build/publish_images_phase.go
@@ -134,8 +134,6 @@ func (phase *PublishImagesPhase) publishImage(img *Image) error {
 				return err
 			}
 
-			// FIXME: Virtual merge commit?
-
 			if metadata, err := phase.Conveyor.StagesManager.StagesStorage.GetImageMetadataByCommit(phase.Conveyor.projectName(), img.GetName(), headCommit); err != nil {
 				return fmt.Errorf("unable to get image %s metadata by commit %s: %s", img.GetName(), headCommit, err)
 			} else if metadata != nil {

--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
+	"github.com/werf/werf/pkg/docker_registry/container_registry_extensions"
 	"github.com/werf/werf/pkg/image"
 )
 
@@ -136,7 +137,7 @@ func (api *api) PushImage(reference string, opts PushImageOptions) error {
 		return fmt.Errorf("parsing reference %q: %v", reference, err)
 	}
 
-	img := NewManifestOnlyImage(opts.Labels)
+	img := container_registry_extensions.NewManifestOnlyImage(opts.Labels)
 
 	oldDefaultTransport := http.DefaultTransport
 	http.DefaultTransport = api.getHttpTransport()

--- a/pkg/docker_registry/container_registry_extensions/manifest_only_image.go
+++ b/pkg/docker_registry/container_registry_extensions/manifest_only_image.go
@@ -1,4 +1,4 @@
-package docker_registry
+package container_registry_extensions
 
 import (
 	"fmt"
@@ -37,12 +37,12 @@ func (i manifestOnlyImage) ConfigFile() (*v1.ConfigFile, error) {
 			Labels: i.Labels,
 		},
 		RootFS: v1.RootFS{
-			// Some clients check this.
-			Type: "layers",
+			Type:    "layers",
+			DiffIDs: []v1.Hash{EmptyUncompressedLayer.diffID},
 		},
 	}, nil
 }
 
 func (i manifestOnlyImage) LayerByDiffID(h v1.Hash) (partial.UncompressedLayer, error) {
-	return nil, fmt.Errorf("LayerByDiffID(%s): empty image", h)
+	return EmptyUncompressedLayer, nil
 }

--- a/pkg/docker_registry/container_registry_extensions/uncompressed_layer.go
+++ b/pkg/docker_registry/container_registry_extensions/uncompressed_layer.go
@@ -1,0 +1,36 @@
+package container_registry_extensions
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+var EmptyUncompressedLayer = &uncompressedLayer{
+	diffID: v1.Hash{
+		Algorithm: "sha256",
+		Hex:       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	},
+	mediaType: types.DockerLayer,
+}
+
+type uncompressedLayer struct {
+	diffID    v1.Hash
+	mediaType types.MediaType
+	content   []byte
+}
+
+func (layer *uncompressedLayer) DiffID() (v1.Hash, error) {
+	return layer.diffID, nil
+}
+
+func (layer *uncompressedLayer) Uncompressed() (io.ReadCloser, error) {
+	return ioutil.NopCloser(bytes.NewBuffer(layer.content)), nil
+}
+
+func (layer *uncompressedLayer) MediaType() (types.MediaType, error) {
+	return layer.mediaType, nil
+}

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/werf/lockgate"
-
-	"github.com/werf/werf/pkg/werf"
-
 	"github.com/werf/werf/pkg/image"
 
 	"github.com/werf/werf/pkg/container_runtime"
@@ -174,12 +170,6 @@ func (storage *RepoStagesStorage) AddManagedImage(projectName, imageName string)
 
 	fullImageName := makeRepoManagedImageRecord(storage.RepoAddress, imageName)
 	logboek.Debug.LogF("-- RepoStagesStorage.AddManagedImage full image name: %s\n", fullImageName)
-
-	if _, lock, err := werf.AcquireHostLock(fmt.Sprintf("managed_image.%s-%s", projectName, imageName), lockgate.AcquireOptions{}); err != nil {
-		return err
-	} else {
-		defer werf.ReleaseHostLock(lock)
-	}
 
 	if isExists, err := storage.DockerRegistry.IsRepoImageExists(fullImageName); err != nil {
 		return err


### PR DESCRIPTION
Create empty zero-bytes layer for manifest-only images: managed images records and image metadata by commit id records.