### PR TITLE
Adding rels to docs links for security

### DIFF
--- a/docs/_includes/slack_popup.html
+++ b/docs/_includes/slack_popup.html
@@ -3,7 +3,7 @@
     <div class="popup__content">
         <a href="javascript:void(0)" data-close-popup class="popup__close">✕</a>
         <div class="popup__title">
-            Присоединяйтесь к англоязычному комьюнити в Slack <a href="https://cncf.io" target="_blank">CNCF</a>
+            Присоединяйтесь к англоязычному сообществу в Slack <a href="https://cncf.io/" rel="noopener noreferrer" target="_blank">CNCF</a>
         </div>
         <div class="popup__subtitle">
             Шаг 1:
@@ -18,20 +18,20 @@
             Войти в канал #werf
         </a>
         <div class="popup__text">
-            Мы выбрали Slack CNCF, т.к. там зарегистрировано самое большое количество участников в области Kubernetes.
+            Мы выбрали Slack от CNCF, т.к. там зарегистрировано самое большое количество Kubernetes-энтузиастов.
         </div>
     </div>
 {%- else %}
     <div class="popup__content">
         <a href="javascript:void(0)" data-close-popup class="popup__close">✕</a>
         <div class="popup__title">
-            Join the party at <a href="https://cncf.io" target="_blank">CNCF</a> Slack
+            Join the party at <a href="https://cncf.io/" rel="noopener noreferrer" target="_blank">CNCF</a> Slack
         </div>
         <div class="popup__subtitle">
             Step 1:
         </div>
         <a href="{{ site.social_links[page.lang].slack_1 }}" target="_blank" class="page__btn page__btn_w popup__btn">
-            Get invite to CNCF Slack
+            Get an invite to CNCF Slack
         </a>
         <div class="popup__subtitle">
             Step 2:
@@ -40,7 +40,7 @@
             Join #werf channel
         </a>
         <div class="popup__text">
-            We chose CNCF Slack because most of the Kubernetes community members are registered there.
+            We've chosen CNCF Slack since most of the Kubernetes community members are there.
         </div>
     </div>
 {%- endif %}

--- a/docs/_includes/topnav.html
+++ b/docs/_includes/topnav.html
@@ -78,7 +78,7 @@
                 <li class="header__menu-icon"><a href="{{ site.social_links[site.site_lang].twitter }}" target="_blank" class="page__icon page__icon_twitter"></a></li>
                 <li class="header__menu-icon"><a href="#" data-open-popup="slack" target="_blank" class="page__icon page__icon_slack"></a></li>
                 {%- endif %}
-                <li class="header__menu-icon"><a href="https://github.com/werf/werf" target="_blank" class="page__icon page__icon_github"></a></li>
+                <li class="header__menu-icon"><a href="https://github.com/werf/werf" rel="noopener noreferrer" target="_blank" class="page__icon page__icon_github"></a></li>
                 <li class="header__menu-icon header__menu-icon_search"><a href="javascript:void(0)" class="page__icon page__icon_search"></a></li>
                 <!-- language button -->
                 <!-- div>


### PR DESCRIPTION
As SonarCloud [recommends](https://sonarcloud.io/component_measures?id=werf_werf&metric=security_rating&selected=werf_werf%3Adocs%2F_includes%2Ftopnav.html&view=list):

> Add rel="noopener noreferrer" to this link to prevent the original page from being modified by the opened link.