### PR TITLE
Optimistic git shallow clone handling

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -110,6 +110,7 @@ If one or more IMAGE_NAME parameters specified, werf will build images stages an
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.IntrospectAfterError, "introspect-error", "", false, "Introspect failed stage in the state, right after running failed assembly instruction")
 	cmd.Flags().BoolVarP(&cmdData.IntrospectBeforeError, "introspect-before-error", "", false, "Introspect failed stage in the clean state, before running all assembly instructions of the stage")

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -14,11 +14,13 @@ import (
 
 	"github.com/werf/werf/pkg/build"
 	"github.com/werf/werf/pkg/build/stage"
+	"github.com/werf/werf/pkg/cleaning"
 	cleanup "github.com/werf/werf/pkg/cleaning"
 	"github.com/werf/werf/pkg/config"
 	"github.com/werf/werf/pkg/container_runtime"
 	"github.com/werf/werf/pkg/deploy/helm"
 	"github.com/werf/werf/pkg/docker_registry"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/logging"
 	"github.com/werf/werf/pkg/storage"
 	"github.com/werf/werf/pkg/util"
@@ -72,6 +74,7 @@ type CmdData struct {
 
 	Synchronization           *string
 	GitHistorySynchronization *bool
+	AllowGitShallowClone      *bool
 
 	DockerConfig          *string
 	InsecureRegistry      *bool
@@ -701,6 +704,11 @@ Also, can be defined with $WERF_SECRET_VALUES* (e.g. $WERF_SECRET_VALUES_ENV=.he
 func SetupIgnoreSecretKey(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.IgnoreSecretKey = new(bool)
 	cmd.Flags().BoolVarP(cmdData.IgnoreSecretKey, "ignore-secret-key", "", GetBoolEnvironmentDefaultFalse("WERF_IGNORE_SECRET_KEY"), "Disable secrets decryption (default $WERF_IGNORE_SECRET_KEY)")
+}
+
+func SetupAllowGitShallowClone(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.AllowGitShallowClone = new(bool)
+	cmd.Flags().BoolVarP(cmdData.AllowGitShallowClone, "--allow-git-shallow-clone", "", GetBoolEnvironmentDefaultFalse("WERF_ALLOW_GIT_SHALLOW_CLONE"), "Sign the intention of using shallow clone despite restrictions (default $WERF_ALLOW_GIT_SHALLOW_CLONE)")
 }
 
 func SetupGitHistorySynchronization(cmdData *CmdData, cmd *cobra.Command) {
@@ -1403,4 +1411,41 @@ func SetupVirtualMergeFromCommit(cmdData *CmdData, cmd *cobra.Command) {
 func SetupVirtualMergeIntoCommit(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.VirtualMergeIntoCommit = new(string)
 	cmd.Flags().StringVarP(cmdData.VirtualMergeIntoCommit, "virtual-merge-into-commit", "", os.Getenv("WERF_VIRTUAL_MERGE_INTO_COMMIT"), "Commit hash for virtual/ephemeral merge commit which is base for changes introduced in the pull request ($WERF_VIRTUAL_MERGE_INTO_COMMIT by default)")
+}
+
+func GetLocalGitRepoForImagesCleanup(projectDir string, cmdData *CmdData) (cleaning.GitRepo, error) {
+	gitDir := filepath.Join(projectDir, ".git")
+	if exist, err := util.DirExists(gitDir); err != nil {
+		return nil, err
+	} else if exist {
+		logboek.LogOptionalLn()
+		localGitRepo, err := git_repo.OpenLocalRepo("own", projectDir)
+		if err != nil {
+			return nil, fmt.Errorf("get local git repo failed: %s", err)
+		}
+
+		if !*cmdData.AllowGitShallowClone && !*cmdData.GitHistorySynchronization {
+			isShallow, err := localGitRepo.IsShallowClone()
+			if err != nil {
+				return nil, fmt.Errorf("check shallow clone failed: %s", err)
+			}
+
+			if isShallow {
+				logboek.Warn.LogLn("Git shallow clone should not be used with images cleanup commands due to incompleteness of the repository history that is extremely essential for proper work.")
+				logboek.Warn.LogLn("If you still want to use shallow clone, add --allow-git-shallow-clone option (WERF_ALLOW_GIT_SHALLOW_CLONE=1).")
+
+				return nil, fmt.Errorf("git shallow clone is not allowed")
+			}
+		}
+
+		if *cmdData.GitHistorySynchronization {
+			if err := localGitRepo.SyncWithOrigin(); err != nil {
+				return nil, fmt.Errorf("synchronization failed: %s", err)
+			}
+		}
+
+		return localGitRepo, nil
+	} else {
+		return nil, nil
+	}
 }

--- a/cmd/werf/common/conveyor_options.go
+++ b/cmd/werf/common/conveyor_options.go
@@ -13,5 +13,6 @@ func GetConveyorOptions(commonCmdData *CmdData) build.ConveyorOptions {
 			VirtualMergeIntoCommit: *commonCmdData.VirtualMergeIntoCommit,
 		},
 		GitHistorySynchronization: *commonCmdData.GitHistorySynchronization,
+		AllowGitShallowClone:      *commonCmdData.AllowGitShallowClone,
 	}
 }

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -117,7 +117,9 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
 	common.SetupVirtualMerge(&commonCmdData, cmd)
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")
 

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -121,7 +121,9 @@ Read more info about Helm chart structure, Helm Release name, Kubernetes Namespa
 	common.SetupVirtualMerge(&commonCmdData, cmd)
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")
 

--- a/cmd/werf/diff/diff.go
+++ b/cmd/werf/diff/diff.go
@@ -111,7 +111,9 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
 	common.SetupVirtualMerge(&commonCmdData, cmd)
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")
 

--- a/cmd/werf/images/cleanup/cleanup.go
+++ b/cmd/werf/images/cleanup/cleanup.go
@@ -2,7 +2,6 @@ package cleanup
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -13,12 +12,10 @@ import (
 	"github.com/werf/werf/pkg/cleaning"
 	"github.com/werf/werf/pkg/container_runtime"
 	"github.com/werf/werf/pkg/docker"
-	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/stages_manager"
 	"github.com/werf/werf/pkg/tmp_manager"
 	"github.com/werf/werf/pkg/true_git"
-	"github.com/werf/werf/pkg/util"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -67,6 +64,7 @@ func NewCmd() *cobra.Command {
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.GitHistoryBasedCleanup, "git-history-based-cleanup", "", common.GetBoolEnvironmentDefaultFalse("WERF_GIT_HISTORY_BASED_CLEANUP"), "Use git history based cleanup (default $WERF_GIT_HISTORY_BASED_CLEANUP)")
 	cmd.Flags().BoolVarP(&cmdData.GitHistoryBasedCleanupV12, "git-history-based-cleanup-v1.2", "", common.GetBoolEnvironmentDefaultFalse("WERF_GIT_HISTORY_BASED_CLEANUP_v1_2"), "Use git history based cleanup and delete images tags without related image metadata (default $WERF_GIT_HISTORY_BASED_CLEANUP_v1_2)")
@@ -173,16 +171,9 @@ func runCleanup() error {
 	}
 	logboek.Debug.LogF("Managed images names: %v\n", imagesNames)
 
-	var localGitRepo cleaning.GitRepo
-	gitDir := filepath.Join(projectDir, ".git")
-	if exist, err := util.DirExists(gitDir); err != nil {
+	localGitRepo, err := common.GetLocalGitRepoForImagesCleanup(projectDir, &commonCmdData)
+	if err != nil {
 		return err
-	} else if exist {
-		logboek.LogOptionalLn()
-		localGitRepo, err = git_repo.OpenLocalRepo("own", projectDir, git_repo.OpenLocalRepoOptions{SynchronizeGitHistory: *commonCmdData.GitHistorySynchronization})
-		if err != nil {
-			return fmt.Errorf("get local git repo failed: %s", err)
-		}
 	}
 
 	policies, err := common.GetImagesCleanupPolicies(&commonCmdData)

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -80,7 +80,9 @@ If one or more IMAGE_NAME parameters specified, werf will publish only these ima
 	common.SetupVirtualMerge(commonCmdData, cmd)
 	common.SetupVirtualMergeFromCommit(commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(commonCmdData, cmd)
+
 	common.SetupGitHistorySynchronization(commonCmdData, cmd)
+	common.SetupAllowGitShallowClone(commonCmdData, cmd)
 
 	return cmd
 }

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -123,7 +123,9 @@ func NewCmd() *cobra.Command {
 	common.SetupVirtualMerge(&commonCmdData, cmd)
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.Shell, "shell", "", false, "Use predefined docker options and command for debug")
 	cmd.Flags().BoolVarP(&cmdData.Bash, "bash", "", false, "Use predefined docker options and command for debug")

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -78,7 +78,9 @@ func NewCmd() *cobra.Command {
 	common.SetupVirtualMerge(&commonCmdData, cmd)
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	return cmd
 }

--- a/cmd/werf/stages/build/cmd_factory/main.go
+++ b/cmd/werf/stages/build/cmd_factory/main.go
@@ -97,7 +97,9 @@ If one or more IMAGE_NAME parameters specified, werf will build only these image
 	common.SetupVirtualMerge(commonCmdData, cmd)
 	common.SetupVirtualMergeFromCommit(commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(commonCmdData, cmd)
+
 	common.SetupGitHistorySynchronization(commonCmdData, cmd)
+	common.SetupAllowGitShallowClone(commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.IntrospectAfterError, "introspect-error", "", false, "Introspect failed stage in the state, right after running failed assembly instruction")
 	cmd.Flags().BoolVarP(&cmdData.IntrospectBeforeError, "introspect-before-error", "", false, "Introspect failed stage in the clean state, before running all assembly instructions of the stage")

--- a/docs/_includes/cli/werf_build.md
+++ b/docs/_includes/cli/werf_build.md
@@ -43,6 +43,9 @@ werf build [IMAGE_NAME...] [options]
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --config='':
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir='':

--- a/docs/_includes/cli/werf_build_and_publish.md
+++ b/docs/_includes/cli/werf_build_and_publish.md
@@ -52,6 +52,9 @@ werf build-and-publish [IMAGE_NAME...] [options]
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --config='':
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir='':

--- a/docs/_includes/cli/werf_cleanup.md
+++ b/docs/_includes/cli/werf_cleanup.md
@@ -27,6 +27,9 @@ werf cleanup [options]
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --config='':
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir='':

--- a/docs/_includes/cli/werf_converge.md
+++ b/docs/_includes/cli/werf_converge.md
@@ -45,6 +45,9 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --add-annotation=[]:
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue.

--- a/docs/_includes/cli/werf_deploy.md
+++ b/docs/_includes/cli/werf_deploy.md
@@ -49,6 +49,9 @@ werf deploy [options]
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --add-annotation=[]:
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue.

--- a/docs/_includes/cli/werf_diff.md
+++ b/docs/_includes/cli/werf_diff.md
@@ -35,6 +35,9 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --add-annotation=[]:
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue.

--- a/docs/_includes/cli/werf_images_cleanup.md
+++ b/docs/_includes/cli/werf_images_cleanup.md
@@ -14,6 +14,9 @@ werf images cleanup [options]
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --config='':
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir='':

--- a/docs/_includes/cli/werf_images_publish.md
+++ b/docs/_includes/cli/werf_images_publish.md
@@ -27,6 +27,9 @@ werf images publish [IMAGE_NAME...] [options]
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --config='':
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir='':

--- a/docs/_includes/cli/werf_publish.md
+++ b/docs/_includes/cli/werf_publish.md
@@ -27,6 +27,9 @@ werf publish [IMAGE_NAME...] [options]
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --config='':
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir='':

--- a/docs/_includes/cli/werf_run.md
+++ b/docs/_includes/cli/werf_run.md
@@ -31,6 +31,9 @@ werf run [options] [IMAGE_NAME] [-- COMMAND ARG...]
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --bash=false:
             Use predefined docker options and command for debug
       --config='':

--- a/docs/_includes/cli/werf_stages_build.md
+++ b/docs/_includes/cli/werf_stages_build.md
@@ -43,6 +43,9 @@ werf stages build [IMAGE_NAME...] [options]
 {{ header }} Options
 
 ```shell
+      ----allow-git-shallow-clone=false:
+            Sign the intention of using shallow clone despite restrictions (default                 
+            $WERF_ALLOW_GIT_SHALLOW_CLONE)
       --config='':
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir='':

--- a/pkg/cleaning/images_cleanup.go
+++ b/pkg/cleaning/images_cleanup.go
@@ -25,7 +25,6 @@ import (
 	"github.com/werf/werf/pkg/stages_manager"
 	"github.com/werf/werf/pkg/storage"
 	"github.com/werf/werf/pkg/tag_strategy"
-	"github.com/werf/werf/pkg/true_git"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -93,8 +92,6 @@ type imagesCleanupManager struct {
 }
 
 type GitRepo interface {
-	Fetch(options true_git.FetchOptions) error
-	IsShallowClone() (bool, error)
 	PlainOpen() (*git.Repository, error)
 	IsCommitExists(commit string) (bool, error)
 	TagsList() ([]string, error)


### PR DESCRIPTION
* Ignore git shallow clone when it is possible
* Force using git shallow clone despite restrictions with option --allow-git-shallow-clone