### PR TITLE
[cleanup] Change configuration syntax: replace createdIn/publishedIn with in

### DIFF
--- a/docs/pages_ru/configuration/cleanup.md
+++ b/docs/pages_ru/configuration/cleanup.md
@@ -11,11 +11,11 @@ summary: |
         <span class="na">tag</span><span class="pi">:</span> <span class="s">&lt;string|/REGEXP/&gt;</span>
         <span class="na">limit</span><span class="pi">:</span>
           <span class="na">last</span><span class="pi">:</span> <span class="s">&lt;int&gt;</span>
-          <span class="na">createdIn</span><span class="pi">:</span> <span class="s">&lt;duration string&gt;</span>
+          <span class="na">in</span><span class="pi">:</span> <span class="s">&lt;duration string&gt;</span>
           <span class="na">operator</span><span class="pi">:</span> <span class="s">&lt;And|Or&gt;</span>
       <span class="na">imagesPerReference</span><span class="pi">:</span>
         <span class="na">last</span><span class="pi">:</span> <span class="s">&lt;int&gt;</span>
-        <span class="na">publishedIn</span><span class="pi">:</span> <span class="s">&lt;duration string&gt;</span>
+        <span class="na">in</span><span class="pi">:</span> <span class="s">&lt;duration string&gt;</span>
         <span class="na">operator</span><span class="pi">:</span> <span class="s">&lt;And|Or&gt;</span>
   </code></pre></div></div>  
 ---
@@ -46,14 +46,14 @@ branch: /^(master|production)$/
     branch: /^features\/.*/
     limit:
       last: 10
-      createdIn: 168h
+      in: 168h
       operator: And
 ``` 
 
 В примере описывается выборка из не более чем 10 последних веток с префиксом `features/` в имени, в которых была какая-либо активность за последнюю неделю.
 
 - Параметр `last: <int>` позволяет выбирать последние `n` references из определённого в `branch`/`tag` множества.
-- Параметр `createdIn: <duration string>` (синтаксис доступен в [документации](https://golang.org/pkg/time/#ParseDuration)) позволяет выбирать git-теги, которые были созданы в указанный период, или git-ветки с активностью в рамках периода. Также для определённого множества `branch`/`tag`.
+- Параметр `in: <duration string>` (синтаксис доступен в [документации](https://golang.org/pkg/time/#ParseDuration)) позволяет выбирать git-теги, которые были созданы в указанный период, или git-ветки с активностью в рамках периода. Также для определённого множества `branch`/`tag`.
 - Параметр `operator: <And|Or>` определяет какие references будут результатом политики, те которые удовлетворяют оба условия или любое из них (`And` по умолчанию).
 
 По умолчанию при сканировании reference количество искомых образов не ограничено, но поведение может настраиваться группой параметров `imagesPerReference`:
@@ -61,12 +61,12 @@ branch: /^(master|production)$/
 ```yaml
 imagesPerReference:
   last: <int>
-  publishedIn: <duration string>
+  in: <duration string>
   operator: <And|Or>
 ```
 
 - Параметр `last: <int>` определяет количество искомых образов для каждого reference. По умолчанию количество не ограничено (`-1`).
-- Параметр `publishedIn: <duration string>` (синтаксис доступен в [документации](https://golang.org/pkg/time/#ParseDuration)) определяет период, в рамках которого необходимо выполнять поиск образов.
+- Параметр `in: <duration string>` (синтаксис доступен в [документации](https://golang.org/pkg/time/#ParseDuration)) определяет период, в рамках которого необходимо выполнять поиск образов.
 - Параметр `operator: <And|Or>` определяет какие образы сохранятся после применения политики, те которые удовлетворяют оба условия или любое из них (`And` по умолчанию)
 
 > Для git-тегов проверяется только HEAD-коммит и значение `last` >1 не имеет никакого смысла, является невалидным
@@ -101,11 +101,11 @@ cleanup:
       branch: /.*/
       limit:
         last: 10
-        createdIn: 168h
+        in: 168h
         operator: And
     imagesPerReference:
       last: 2
-      publishedIn: 168h
+      in: 168h
       operator: And
   - references:  
       branch: /^(master|staging|production)$/

--- a/integration/cleanup/_fixtures/git_history_based_cleanup/werf.yaml
+++ b/integration/cleanup/_fixtures/git_history_based_cleanup/werf.yaml
@@ -24,7 +24,7 @@ cleanup:
     - references:
         branch: test
       imagesPerReference:
-        publishedIn: 24h
+        in: 24h
   {{ end }}
   {{ with (eq $policySetNumber "4") }}
 cleanup:
@@ -32,7 +32,7 @@ cleanup:
     - references:
         branch: test
         limit:
-          createdIn: 12h
+          in: 12h
   {{ end }}
   {{ with (eq $policySetNumber "5") }}
 cleanup:
@@ -40,7 +40,7 @@ cleanup:
     - references:
         branch: /.*/
         limit:
-          createdIn: 12h
+          in: 12h
           last: 1
           operator: Or
   {{ end }}
@@ -50,7 +50,7 @@ cleanup:
     - references:
         branch: /.*/
         limit:
-          createdIn: 12h
+          in: 12h
           last: 1
           operator: And
   {{ end }}
@@ -60,7 +60,7 @@ cleanup:
     - references:
         branch: test
       imagesPerReference:
-        publishedIn: 12h
+        in: 12h
         last: 1
         operator: Or
   {{ end }}
@@ -70,7 +70,7 @@ cleanup:
     - references:
         branch: test
       imagesPerReference:
-        publishedIn: 12h
+        in: 12h
         last: 1
         operator: And
   {{ end }}

--- a/integration/cleanup/images_cleanup_test.go
+++ b/integration/cleanup/images_cleanup_test.go
@@ -591,8 +591,8 @@ var _ = forEachDockerRegistryImplementation("cleaning images", func() {
 							3,
 							2,
 							func(tags []string) {
-								Ω(tags).Should(ContainElement(tag2))
-								Ω(tags).Should(ContainElement(tag3))
+								Ω(tags).Should(ContainElement(imagesRepo.ImageRepositoryTag("image", tag2)))
+								Ω(tags).Should(ContainElement(imagesRepo.ImageRepositoryTag("image", tag3)))
 							},
 						)
 					})
@@ -604,7 +604,7 @@ var _ = forEachDockerRegistryImplementation("cleaning images", func() {
 							3,
 							1,
 							func(tags []string) {
-								Ω(tags).Should(ContainElement(tag3))
+								Ω(tags).Should(ContainElement(imagesRepo.ImageRepositoryTag("image", tag3)))
 							},
 						)
 					})
@@ -675,8 +675,8 @@ var _ = forEachDockerRegistryImplementation("cleaning images", func() {
 							3,
 							2,
 							func(tags []string) {
-								Ω(tags).Should(ContainElement(tag2))
-								Ω(tags).Should(ContainElement(tag3))
+								Ω(tags).Should(ContainElement(imagesRepo.ImageRepositoryTag("image", tag2)))
+								Ω(tags).Should(ContainElement(imagesRepo.ImageRepositoryTag("image", tag3)))
 							},
 						)
 					})
@@ -688,7 +688,7 @@ var _ = forEachDockerRegistryImplementation("cleaning images", func() {
 							3,
 							1,
 							func(tags []string) {
-								Ω(tags).Should(ContainElement(tag3))
+								Ω(tags).Should(ContainElement(imagesRepo.ImageRepositoryTag("image", tag3)))
 							},
 						)
 					})

--- a/integration/cleanup/images_cleanup_test.go
+++ b/integration/cleanup/images_cleanup_test.go
@@ -428,7 +428,7 @@ var _ = forEachDockerRegistryImplementation("cleaning images", func() {
 					imagesCleanupCheck(werfCommand, 1, 0)
 				})
 
-				It("should remove image by imagesPerReference.publishedIn", func() {
+				It("should remove image by imagesPerReference.in", func() {
 					stubs.SetEnv("CLEANUP_POLICY_SET_NUMBER", "3")
 
 					setLastCommitCommitterWhen(time.Now().Add(-(25 * time.Hour)))
@@ -470,7 +470,7 @@ var _ = forEachDockerRegistryImplementation("cleaning images", func() {
 					imagesCleanupCheck(werfCommand, 1, 1)
 				})
 
-				It("should remove image by references.limit.createdIn", func() {
+				It("should remove image by references.limit.in", func() {
 					stubs.SetEnv("CLEANUP_POLICY_SET_NUMBER", "4")
 
 					setLastCommitCommitterWhen(time.Now().Add(-(13 * time.Hour)))
@@ -584,7 +584,7 @@ var _ = forEachDockerRegistryImplementation("cleaning images", func() {
 						)
 					})
 
-					It("should remove image by references.limit.createdIn OR references.limit.last", func() {
+					It("should remove image by references.limit.in OR references.limit.last", func() {
 						stubs.SetEnv("CLEANUP_POLICY_SET_NUMBER", "5")
 						imagesCleanupCheck(
 							werfCommand,
@@ -597,7 +597,7 @@ var _ = forEachDockerRegistryImplementation("cleaning images", func() {
 						)
 					})
 
-					It("should remove image by references.limit.createdIn AND references.limit.last", func() {
+					It("should remove image by references.limit.in AND references.limit.last", func() {
 						stubs.SetEnv("CLEANUP_POLICY_SET_NUMBER", "6")
 						imagesCleanupCheck(
 							werfCommand,
@@ -668,7 +668,7 @@ var _ = forEachDockerRegistryImplementation("cleaning images", func() {
 						)
 					})
 
-					It("should remove image by imagesPerReference.publishedIn OR imagesPerReference.last", func() {
+					It("should remove image by imagesPerReference.in OR imagesPerReference.last", func() {
 						stubs.SetEnv("CLEANUP_POLICY_SET_NUMBER", "7")
 						imagesCleanupCheck(
 							werfCommand,
@@ -681,7 +681,7 @@ var _ = forEachDockerRegistryImplementation("cleaning images", func() {
 						)
 					})
 
-					It("should remove image by imagesPerReference.publishedIn AND imagesPerReference.last", func() {
+					It("should remove image by imagesPerReference.in AND imagesPerReference.last", func() {
 						stubs.SetEnv("CLEANUP_POLICY_SET_NUMBER", "8")
 						imagesCleanupCheck(
 							werfCommand,

--- a/pkg/config/meta_cleanup.go
+++ b/pkg/config/meta_cleanup.go
@@ -19,7 +19,11 @@ type MetaCleanupKeepPolicy struct {
 func (p *MetaCleanupKeepPolicy) String() string {
 	var parts []string
 	parts = append(parts, fmt.Sprintf("references={%s}", p.References.String()))
-	parts = append(parts, fmt.Sprintf("imagesPerReference={%s}", p.ImagesPerReference.String()))
+
+	imagesPerReferencePart := p.ImagesPerReference.String()
+	if imagesPerReferencePart != "" {
+		parts = append(parts, fmt.Sprintf("imagesPerReference={%s}", imagesPerReferencePart))
+	}
 
 	return strings.Join(parts, " ")
 }
@@ -47,40 +51,20 @@ func (c *MetaCleanupKeepPolicyReferences) String() string {
 }
 
 type MetaCleanupKeepPolicyImagesPerReference struct {
-	Last        *int
-	PublishedIn *time.Duration
-	Operator    *Operator
-}
-
-func (c *MetaCleanupKeepPolicyImagesPerReference) String() string {
-	var parts []string
-
-	if c.PublishedIn != nil {
-		parts = append(parts, fmt.Sprintf("publshedIn=%s", c.PublishedIn.String()))
-	}
-
-	if c.Last != nil {
-		parts = append(parts, fmt.Sprintf("last=%d", *c.Last))
-	}
-
-	if c.Operator != nil {
-		parts = append(parts, fmt.Sprintf("operator=%s", *c.Operator))
-	}
-
-	return strings.Join(parts, " ")
+	MetaCleanupKeepPolicyLimit
 }
 
 type MetaCleanupKeepPolicyLimit struct {
-	Last      *int
-	CreatedIn *time.Duration
-	Operator  *Operator
+	Last     *int
+	In       *time.Duration
+	Operator *Operator
 }
 
 func (c *MetaCleanupKeepPolicyLimit) String() string {
 	var parts []string
 
-	if c.CreatedIn != nil {
-		parts = append(parts, fmt.Sprintf("createdIn=%s", c.CreatedIn.String()))
+	if c.In != nil {
+		parts = append(parts, fmt.Sprintf("in=%s", c.In.String()))
 	}
 
 	if c.Last != nil {


### PR DESCRIPTION
```
cleanup:
  keepPolicies:
  - references:
      branch: <string|/REGEXP/>
      tag: <string|/REGEXP/>
      limit:
        last: <int>
        in: <duration string>
        operator: <And|Or>
    imagesPerReference:
      last: <int>
      in: <duration string>
      operator: <And|Or>
```