### PR TITLE
Fix manifest-cache not filled with manifests of newly built stages

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -412,6 +412,11 @@ func (phase *BuildPhase) atomicBuildStageImage(img *Image, stg stage.Interface) 
 
 			phase.Conveyor.SetStageImage(stageImageObj)
 
+			logboek.Info.LogF("Storing new image %s info into manifest cache\n", stageImageObj.GetStageDescription().Info.Name)
+			if err := image.CommonManifestCache.StoreImageInfo(stageImageObj.GetStageDescription().Info); err != nil {
+				return fmt.Errorf("error storing image %s info into manifest cache: %s", stageImageObj.GetStageDescription().Info.Name, err)
+			}
+
 			if err := logboek.Default.LogProcess(
 				fmt.Sprintf("Store into stages storage"),
 				logboek.LevelLogProcessOptions{},

--- a/pkg/image/manifest_cache.go
+++ b/pkg/image/manifest_cache.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/werf/lockgate"
+	"github.com/werf/logboek"
 
 	"github.com/werf/werf/pkg/werf"
 
@@ -33,6 +34,9 @@ func NewManifestCache(cacheDir string) *ManifestCache {
 }
 
 func (cache *ManifestCache) GetImageInfo(imageName string) (*Info, error) {
+	logboek.Debug.LogProcessStart(fmt.Sprintf("-- ManifestCache.GetImageInfo %s", imageName), logboek.LevelLogProcessStartOptions{})
+	defer logboek.Debug.LogProcessEnd(logboek.LevelLogProcessEndOptions{})
+
 	if lock, err := cache.lock(imageName); err != nil {
 		return nil, err
 	} else {
@@ -55,6 +59,9 @@ func (cache *ManifestCache) GetImageInfo(imageName string) (*Info, error) {
 }
 
 func (cache *ManifestCache) StoreImageInfo(imgInfo *Info) error {
+	logboek.Debug.LogProcessStart(fmt.Sprintf("-- ManifestCache.StoreImageInfo %s", imgInfo.Name), logboek.LevelLogProcessStartOptions{})
+	defer logboek.Debug.LogProcessEnd(logboek.LevelLogProcessEndOptions{})
+
 	if lock, err := cache.lock(imgInfo.Name); err != nil {
 		return err
 	} else {

--- a/pkg/stages_manager/stages_manager.go
+++ b/pkg/stages_manager/stages_manager.go
@@ -388,11 +388,9 @@ func (m *StagesManager) getStageDescription(stageID image.StageID, opts getStage
 	if stageDesc, err := m.StagesStorage.GetStageDescription(m.ProjectName, stageID.Signature, stageID.UniqueID); err != nil {
 		return nil, fmt.Errorf("error getting signature %q uniqueID %d stage info from %s: %s", stageID.Signature, stageID.UniqueID, m.StagesStorage.String(), err)
 	} else if stageDesc != nil {
-		if opts.WithManifestCache {
-			logboek.Debug.LogF("Storing image %s info into manifest cache\n", stageImageName)
-			if err := image.CommonManifestCache.StoreImageInfo(stageDesc.Info); err != nil {
-				return nil, fmt.Errorf("error storing image %s info into manifest cache: %s", stageImageName, err)
-			}
+		logboek.Debug.LogF("Storing image %s info into manifest cache\n", stageImageName)
+		if err := image.CommonManifestCache.StoreImageInfo(stageDesc.Info); err != nil {
+			return nil, fmt.Errorf("error storing image %s info into manifest cache: %s", stageImageName, err)
 		}
 
 		return stageDesc, nil


### PR DESCRIPTION
Store manifest of newly built stage into manifest stage immediately after building, before storing this stage into stages storage.