### PR TITLE
Fix redundant fetching of origin within CI jobs

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -3,10 +3,6 @@ package build_and_publish
 import (
 	"fmt"
 
-	"github.com/werf/werf/pkg/image"
-
-	"github.com/werf/werf/pkg/stages_manager"
-
 	"github.com/spf13/cobra"
 
 	"github.com/werf/logboek"
@@ -15,8 +11,10 @@ import (
 	"github.com/werf/werf/pkg/build"
 	"github.com/werf/werf/pkg/container_runtime"
 	"github.com/werf/werf/pkg/docker"
+	"github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/logging"
 	"github.com/werf/werf/pkg/ssh_agent"
+	"github.com/werf/werf/pkg/stages_manager"
 	"github.com/werf/werf/pkg/tmp_manager"
 	"github.com/werf/werf/pkg/true_git"
 	"github.com/werf/werf/pkg/werf"
@@ -109,7 +107,8 @@ If one or more IMAGE_NAME parameters specified, werf will build images stages an
 	common.SetupVirtualMerge(&commonCmdData, cmd)
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
-	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+
+	common.SetupGitUnshallow(&commonCmdData, cmd)
 	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.IntrospectAfterError, "introspect-error", "", false, "Introspect failed stage in the state, right after running failed assembly instruction")

--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -282,6 +282,7 @@ func generateGitlabEnvs(w io.Writer, taggingStrategy string) error {
 	}
 
 	writeEnv(w, "WERF_GIT_HISTORY_SYNCHRONIZATION", "1", false)
+	writeEnv(w, "WERF_GIT_UNSHALLOW", "1", false)
 	writeEnv(w, "WERF_LOG_COLOR_MODE", werfLogColorMode, false)
 	writeEnv(w, "WERF_LOG_PROJECT_DIR", "1", false)
 	writeEnv(w, "WERF_ENABLE_PROCESS_EXTERMINATOR", "1", false)

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -74,6 +74,7 @@ type CmdData struct {
 
 	Synchronization           *string
 	GitHistorySynchronization *bool
+	GitUnshallow              *bool
 	AllowGitShallowClone      *bool
 
 	DockerConfig          *string
@@ -709,6 +710,11 @@ func SetupIgnoreSecretKey(cmdData *CmdData, cmd *cobra.Command) {
 func SetupAllowGitShallowClone(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.AllowGitShallowClone = new(bool)
 	cmd.Flags().BoolVarP(cmdData.AllowGitShallowClone, "--allow-git-shallow-clone", "", GetBoolEnvironmentDefaultFalse("WERF_ALLOW_GIT_SHALLOW_CLONE"), "Sign the intention of using shallow clone despite restrictions (default $WERF_ALLOW_GIT_SHALLOW_CLONE)")
+}
+
+func SetupGitUnshallow(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.GitUnshallow = new(bool)
+	cmd.Flags().BoolVarP(cmdData.GitUnshallow, "git-unshallow", "", GetBoolEnvironmentDefaultFalse("WERF_GIT_UNSHALLOW"), "Convert project git clone to full one (default $WERF_GIT_UNSHALLOW)")
 }
 
 func SetupGitHistorySynchronization(cmdData *CmdData, cmd *cobra.Command) {

--- a/cmd/werf/common/conveyor_options.go
+++ b/cmd/werf/common/conveyor_options.go
@@ -12,7 +12,7 @@ func GetConveyorOptions(commonCmdData *CmdData) build.ConveyorOptions {
 			VirtualMergeFromCommit: *commonCmdData.VirtualMergeFromCommit,
 			VirtualMergeIntoCommit: *commonCmdData.VirtualMergeIntoCommit,
 		},
-		GitHistorySynchronization: *commonCmdData.GitHistorySynchronization,
-		AllowGitShallowClone:      *commonCmdData.AllowGitShallowClone,
+		GitUnshallow:         *commonCmdData.GitUnshallow,
+		AllowGitShallowClone: *commonCmdData.AllowGitShallowClone,
 	}
 }

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -118,7 +118,7 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupGitUnshallow(&commonCmdData, cmd)
 	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -120,7 +120,7 @@ Read more info about Helm chart structure, Helm Release name, Kubernetes Namespa
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupGitUnshallow(&commonCmdData, cmd)
 	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")

--- a/cmd/werf/diff/diff.go
+++ b/cmd/werf/diff/diff.go
@@ -112,7 +112,7 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupGitUnshallow(&commonCmdData, cmd)
 	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -81,7 +81,7 @@ If one or more IMAGE_NAME parameters specified, werf will publish only these ima
 	common.SetupVirtualMergeFromCommit(commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(commonCmdData, cmd)
 
-	common.SetupGitHistorySynchronization(commonCmdData, cmd)
+	common.SetupGitUnshallow(commonCmdData, cmd)
 	common.SetupAllowGitShallowClone(commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -124,7 +124,7 @@ func NewCmd() *cobra.Command {
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupGitUnshallow(&commonCmdData, cmd)
 	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.Shell, "shell", "", false, "Use predefined docker options and command for debug")

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -79,7 +79,7 @@ func NewCmd() *cobra.Command {
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	common.SetupGitHistorySynchronization(&commonCmdData, cmd)
+	common.SetupGitUnshallow(&commonCmdData, cmd)
 	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/stages/build/cmd_factory/main.go
+++ b/cmd/werf/stages/build/cmd_factory/main.go
@@ -98,7 +98,7 @@ If one or more IMAGE_NAME parameters specified, werf will build only these image
 	common.SetupVirtualMergeFromCommit(commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(commonCmdData, cmd)
 
-	common.SetupGitHistorySynchronization(commonCmdData, cmd)
+	common.SetupGitUnshallow(commonCmdData, cmd)
 	common.SetupAllowGitShallowClone(commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.IntrospectAfterError, "introspect-error", "", false, "Introspect failed stage in the state, right after running failed assembly instruction")

--- a/docs/_includes/cli/werf_build.md
+++ b/docs/_includes/cli/werf_build.md
@@ -58,9 +58,8 @@ werf build [IMAGE_NAME...] [options]
             ~/.docker (in the order of priority)
             Command needs granted permissions to read, pull and push images into the specified      
             stages storage, to pull base images
-      --git-history-synchronization=false:
-            Synchronize git branches and tags with remote origin (default                           
-            $WERF_GIT_HISTORY_SYNCHRONIZATION)
+      --git-unshallow=false:
+            Convert project git clone to full one (default $WERF_GIT_UNSHALLOW)
   -h, --help=false:
             help for build
       --home-dir='':

--- a/docs/_includes/cli/werf_build_and_publish.md
+++ b/docs/_includes/cli/werf_build_and_publish.md
@@ -67,9 +67,8 @@ werf build-and-publish [IMAGE_NAME...] [options]
             ~/.docker (in the order of priority)
             Command needs granted permissions to read, pull and push images into the specified      
             stages storage, to push images into the specified images repo, to pull base images
-      --git-history-synchronization=false:
-            Synchronize git branches and tags with remote origin (default                           
-            $WERF_GIT_HISTORY_SYNCHRONIZATION)
+      --git-unshallow=false:
+            Convert project git clone to full one (default $WERF_GIT_UNSHALLOW)
   -h, --help=false:
             help for build-and-publish
       --home-dir='':

--- a/docs/_includes/cli/werf_converge.md
+++ b/docs/_includes/cli/werf_converge.md
@@ -73,9 +73,8 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
             stages storage, to push images into the specified images repo, to pull base images
       --env='':
             Use specified environment (default $WERF_ENV)
-      --git-history-synchronization=false:
-            Synchronize git branches and tags with remote origin (default                           
-            $WERF_GIT_HISTORY_SYNCHRONIZATION)
+      --git-unshallow=false:
+            Convert project git clone to full one (default $WERF_GIT_UNSHALLOW)
       --helm-chart-dir='':
             Use custom helm chart dir (default $WERF_HELM_CHART_DIR or .helm in working directory)
       --helm-release-storage-namespace='kube-system':

--- a/docs/_includes/cli/werf_deploy.md
+++ b/docs/_includes/cli/werf_deploy.md
@@ -77,9 +77,8 @@ werf deploy [options]
             storage and images repo
       --env='':
             Use specified environment (default $WERF_ENV)
-      --git-history-synchronization=false:
-            Synchronize git branches and tags with remote origin (default                           
-            $WERF_GIT_HISTORY_SYNCHRONIZATION)
+      --git-unshallow=false:
+            Convert project git clone to full one (default $WERF_GIT_UNSHALLOW)
       --helm-chart-dir='':
             Use custom helm chart dir (default $WERF_HELM_CHART_DIR or .helm in working directory)
       --helm-release-storage-namespace='kube-system':

--- a/docs/_includes/cli/werf_diff.md
+++ b/docs/_includes/cli/werf_diff.md
@@ -63,9 +63,8 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
             stages storage, to push images into the specified images repo, to pull base images
       --env='':
             Use specified environment (default $WERF_ENV)
-      --git-history-synchronization=false:
-            Synchronize git branches and tags with remote origin (default                           
-            $WERF_GIT_HISTORY_SYNCHRONIZATION)
+      --git-unshallow=false:
+            Convert project git clone to full one (default $WERF_GIT_UNSHALLOW)
       --helm-chart-dir='':
             Use custom helm chart dir (default $WERF_HELM_CHART_DIR or .helm in working directory)
       --helm-release-storage-namespace='kube-system':

--- a/docs/_includes/cli/werf_images_publish.md
+++ b/docs/_includes/cli/werf_images_publish.md
@@ -42,9 +42,8 @@ werf images publish [IMAGE_NAME...] [options]
             ~/.docker (in the order of priority)
             Command needs granted permissions to read and pull images from the specified stages     
             storage and push images into images repo
-      --git-history-synchronization=false:
-            Synchronize git branches and tags with remote origin (default                           
-            $WERF_GIT_HISTORY_SYNCHRONIZATION)
+      --git-unshallow=false:
+            Convert project git clone to full one (default $WERF_GIT_UNSHALLOW)
   -h, --help=false:
             help for publish
       --home-dir='':

--- a/docs/_includes/cli/werf_publish.md
+++ b/docs/_includes/cli/werf_publish.md
@@ -42,9 +42,8 @@ werf publish [IMAGE_NAME...] [options]
             ~/.docker (in the order of priority)
             Command needs granted permissions to read and pull images from the specified stages     
             storage and push images into images repo
-      --git-history-synchronization=false:
-            Synchronize git branches and tags with remote origin (default                           
-            $WERF_GIT_HISTORY_SYNCHRONIZATION)
+      --git-unshallow=false:
+            Convert project git clone to full one (default $WERF_GIT_UNSHALLOW)
   -h, --help=false:
             help for publish
       --home-dir='':

--- a/docs/_includes/cli/werf_run.md
+++ b/docs/_includes/cli/werf_run.md
@@ -52,9 +52,8 @@ werf run [options] [IMAGE_NAME] [-- COMMAND ARG...]
             Define docker run options (default $WERF_DOCKER_OPTIONS)
       --dry-run=false:
             Indicate what the command would do without actually doing that (default $WERF_DRY_RUN)
-      --git-history-synchronization=false:
-            Synchronize git branches and tags with remote origin (default                           
-            $WERF_GIT_HISTORY_SYNCHRONIZATION)
+      --git-unshallow=false:
+            Convert project git clone to full one (default $WERF_GIT_UNSHALLOW)
   -h, --help=false:
             help for run
       --home-dir='':

--- a/docs/_includes/cli/werf_stages_build.md
+++ b/docs/_includes/cli/werf_stages_build.md
@@ -58,9 +58,8 @@ werf stages build [IMAGE_NAME...] [options]
             ~/.docker (in the order of priority)
             Command needs granted permissions to read, pull and push images into the specified      
             stages storage, to pull base images
-      --git-history-synchronization=false:
-            Synchronize git branches and tags with remote origin (default                           
-            $WERF_GIT_HISTORY_SYNCHRONIZATION)
+      --git-unshallow=false:
+            Convert project git clone to full one (default $WERF_GIT_UNSHALLOW)
   -h, --help=false:
             help for build
       --home-dir='':

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -72,7 +72,7 @@ type Conveyor struct {
 
 type ConveyorOptions struct {
 	LocalGitRepoVirtualMergeOptions stage.VirtualMergeOptions
-	GitHistorySynchronization       bool
+	GitUnshallow                    bool
 	AllowGitShallowClone            bool
 }
 
@@ -804,21 +804,23 @@ func generateGitMappings(imageBaseConfig *config.StapelImageBase, c *Conveyor) (
 			return nil, errors.New("local git mapping is used but project git repository is not found")
 		}
 
-		isShallowClone, err := localGitRepo.IsShallowClone()
-		if err != nil {
-			return nil, fmt.Errorf("check shallow clone failed: %s", err)
-		}
+		if !c.AllowGitShallowClone {
+			isShallowClone, err := localGitRepo.IsShallowClone()
+			if err != nil {
+				return nil, fmt.Errorf("check shallow clone failed: %s", err)
+			}
 
-		if isShallowClone {
-			if c.GitHistorySynchronization {
-				if err := localGitRepo.FetchOrigin(); err != nil {
-					return nil, err
+			if isShallowClone {
+				if c.GitUnshallow {
+					if err := localGitRepo.FetchOrigin(); err != nil {
+						return nil, err
+					}
+				} else {
+					logboek.Warn.LogLn("The usage of shallow git clone may break reproducibility and slow down incremental rebuilds.")
+					logboek.Warn.LogLn("If you still want to use shallow clone, add --allow-git-shallow-clone option (WERF_ALLOW_GIT_SHALLOW_CLONE=1).")
+
+					return nil, fmt.Errorf("shallow git clone is not allowed")
 				}
-			} else if !c.AllowGitShallowClone {
-				logboek.Warn.LogLn("The usage of shallow git clone may break reproducibility and slow down incremental rebuilds.")
-				logboek.Warn.LogLn("If you still want to use shallow clone, add --allow-git-shallow-clone option (WERF_ALLOW_GIT_SHALLOW_CLONE=1).")
-
-				return nil, fmt.Errorf("shallow git clone is not allowed")
 			}
 		}
 


### PR DESCRIPTION
* Add --git-unshallow option to regulate shallow git clone handling. If it is true, git clone will be converted to a full one (git fetch --unshallow), otherwise, the command will fail with the warning message.
* Substitute --git-history-synchronization option with --git-unshallow in all commands except images cleanup.
* By default git unshallow procedure is enabled with werf ci-env (WERF_GIT_UNSHALLOW=1).