### PR TITLE
[helm-v3] Initial helm v3 support

### DIFF
--- a/cmd/werf/helm_v3/common/common.go
+++ b/cmd/werf/helm_v3/common/common.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+func SetupCmdActionConfig(cmd *cobra.Command, actionConfig *action.Configuration) {
+	oldRunE := cmd.RunE
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		helmDriver := os.Getenv("HELM_DRIVER")
+		if err := actionConfig.Init(helm_v3.Settings.RESTClientGetter(), helm_v3.Settings.Namespace(), helmDriver, helm_v3.Debug); err != nil {
+			log.Fatal(err)
+		}
+		if helmDriver == "memory" {
+			helm_v3.LoadReleasesInMemory(actionConfig)
+		}
+
+		if oldRunE != nil {
+			return oldRunE(cmd, args)
+		}
+		return nil
+	}
+
+	cmd.Flags().StringVarP(helm_v3.Settings.GetNamespaceP(), "namespace", "n", *helm_v3.Settings.GetNamespaceP(), "namespace scope for this request")
+}

--- a/cmd/werf/helm_v3/create/create.go
+++ b/cmd/werf/helm_v3/create/create.go
@@ -1,0 +1,12 @@
+package create
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+)
+
+func NewCmd() *cobra.Command {
+	return helm_v3.NewCreateCmd(os.Stdout)
+}

--- a/cmd/werf/helm_v3/dependency/dependency.go
+++ b/cmd/werf/helm_v3/dependency/dependency.go
@@ -1,0 +1,18 @@
+package dependency
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+)
+
+// NOTE: dependency commands does not need action config nor namespace
+func NewCmd() *cobra.Command {
+	//actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewDependencyCmd(os.Stdout)
+	//for _, subCmd := range cmd.Commands() {
+	//	common.SetupCmdNamespace(subCmd, actionConfig)
+	//}
+	return cmd
+}

--- a/cmd/werf/helm_v3/env/env.go
+++ b/cmd/werf/helm_v3/env/env.go
@@ -1,0 +1,12 @@
+package env
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+)
+
+func NewCmd() *cobra.Command {
+	return helm_v3.NewEnvCmd(os.Stdout)
+}

--- a/cmd/werf/helm_v3/get/get.go
+++ b/cmd/werf/helm_v3/get/get.go
@@ -1,0 +1,19 @@
+package get
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/helm_v3/common"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+func NewCmd() *cobra.Command {
+	actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewGetCmd(actionConfig, os.Stdout)
+	for _, subCmd := range cmd.Commands() {
+		common.SetupCmdActionConfig(subCmd, actionConfig)
+	}
+	return cmd
+}

--- a/cmd/werf/helm_v3/helm_v3.go
+++ b/cmd/werf/helm_v3/helm_v3.go
@@ -1,0 +1,59 @@
+package helm_v3
+
+import (
+	"github.com/werf/werf/cmd/werf/helm_v3/create"
+	"github.com/werf/werf/cmd/werf/helm_v3/dependency"
+	"github.com/werf/werf/cmd/werf/helm_v3/env"
+	"github.com/werf/werf/cmd/werf/helm_v3/get"
+	"github.com/werf/werf/cmd/werf/helm_v3/history"
+	"github.com/werf/werf/cmd/werf/helm_v3/install"
+	"github.com/werf/werf/cmd/werf/helm_v3/lint"
+	"github.com/werf/werf/cmd/werf/helm_v3/list"
+	package_ "github.com/werf/werf/cmd/werf/helm_v3/package"
+	"github.com/werf/werf/cmd/werf/helm_v3/plugin"
+	"github.com/werf/werf/cmd/werf/helm_v3/pull"
+	"github.com/werf/werf/cmd/werf/helm_v3/repo"
+	"github.com/werf/werf/cmd/werf/helm_v3/rollback"
+	"github.com/werf/werf/cmd/werf/helm_v3/search"
+	"github.com/werf/werf/cmd/werf/helm_v3/show"
+	"github.com/werf/werf/cmd/werf/helm_v3/status"
+	"github.com/werf/werf/cmd/werf/helm_v3/template"
+	"github.com/werf/werf/cmd/werf/helm_v3/test"
+	"github.com/werf/werf/cmd/werf/helm_v3/uninstall"
+	"github.com/werf/werf/cmd/werf/helm_v3/upgrade"
+	"github.com/werf/werf/cmd/werf/helm_v3/verify"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "helm-v3",
+		Short: "Manage application deployment with helm",
+	}
+	cmd.AddCommand(
+		uninstall.NewCmd(),
+		dependency.NewCmd(),
+		get.NewCmd(),
+		history.NewCmd(),
+		lint.NewCmd(),
+		list.NewCmd(),
+		template.NewCmd(),
+		repo.NewCmd(),
+		rollback.NewCmd(),
+		install.NewCmd(),
+		upgrade.NewCmd(),
+		create.NewCmd(),
+		env.NewCmd(),
+		package_.NewCmd(),
+		plugin.NewCmd(),
+		pull.NewCmd(),
+		search.NewCmd(),
+		show.NewCmd(),
+		status.NewCmd(),
+		test.NewCmd(),
+		verify.NewCmd(),
+	)
+
+	return cmd
+}

--- a/cmd/werf/helm_v3/history/history.go
+++ b/cmd/werf/helm_v3/history/history.go
@@ -1,0 +1,17 @@
+package history
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/helm_v3/common"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+func NewCmd() *cobra.Command {
+	actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewHistoryCmd(actionConfig, os.Stdout)
+	common.SetupCmdActionConfig(cmd, actionConfig)
+	return cmd
+}

--- a/cmd/werf/helm_v3/install/install.go
+++ b/cmd/werf/helm_v3/install/install.go
@@ -1,0 +1,17 @@
+package install
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/helm_v3/common"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+func NewCmd() *cobra.Command {
+	actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewInstallCmd(actionConfig, os.Stdout)
+	common.SetupCmdActionConfig(cmd, actionConfig)
+	return cmd
+}

--- a/cmd/werf/helm_v3/lint/lint.go
+++ b/cmd/werf/helm_v3/lint/lint.go
@@ -1,0 +1,13 @@
+package lint
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := helm_v3.NewLintCmd(os.Stdout)
+	return cmd
+}

--- a/cmd/werf/helm_v3/list/list.go
+++ b/cmd/werf/helm_v3/list/list.go
@@ -1,0 +1,17 @@
+package list
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/helm_v3/common"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+func NewCmd() *cobra.Command {
+	actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewListCmd(actionConfig, os.Stdout)
+	common.SetupCmdActionConfig(cmd, actionConfig)
+	return cmd
+}

--- a/cmd/werf/helm_v3/package/package.go
+++ b/cmd/werf/helm_v3/package/package.go
@@ -1,0 +1,13 @@
+package package_
+
+import (
+	"os"
+
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	return helm_v3.NewPackageCmd(os.Stdout)
+}

--- a/cmd/werf/helm_v3/plugin/plugin.go
+++ b/cmd/werf/helm_v3/plugin/plugin.go
@@ -1,0 +1,13 @@
+package plugin
+
+import (
+	"os"
+
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	return helm_v3.NewPluginCmd(os.Stdout)
+}

--- a/cmd/werf/helm_v3/pull/pull.go
+++ b/cmd/werf/helm_v3/pull/pull.go
@@ -1,0 +1,13 @@
+package pull
+
+import (
+	"os"
+
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	return helm_v3.NewPullCmd(os.Stdout)
+}

--- a/cmd/werf/helm_v3/repo/repo.go
+++ b/cmd/werf/helm_v3/repo/repo.go
@@ -1,0 +1,12 @@
+package repo
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+)
+
+func NewCmd() *cobra.Command {
+	return helm_v3.NewRepoCmd(os.Stdout)
+}

--- a/cmd/werf/helm_v3/rollback/rollback.go
+++ b/cmd/werf/helm_v3/rollback/rollback.go
@@ -1,0 +1,17 @@
+package rollback
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/helm_v3/common"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+func NewCmd() *cobra.Command {
+	actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewRollbackCmd(actionConfig, os.Stdout)
+	common.SetupCmdActionConfig(cmd, actionConfig)
+	return cmd
+}

--- a/cmd/werf/helm_v3/search/search.go
+++ b/cmd/werf/helm_v3/search/search.go
@@ -1,0 +1,13 @@
+package search
+
+import (
+	"os"
+
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	return helm_v3.NewSearchCmd(os.Stdout)
+}

--- a/cmd/werf/helm_v3/show/show.go
+++ b/cmd/werf/helm_v3/show/show.go
@@ -1,0 +1,13 @@
+package show
+
+import (
+	"os"
+
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	return helm_v3.NewShowCmd(os.Stdout)
+}

--- a/cmd/werf/helm_v3/status/status.go
+++ b/cmd/werf/helm_v3/status/status.go
@@ -1,0 +1,17 @@
+package status
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/helm_v3/common"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+func NewCmd() *cobra.Command {
+	actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewStatusCmd(actionConfig, os.Stdout)
+	common.SetupCmdActionConfig(cmd, actionConfig)
+	return cmd
+}

--- a/cmd/werf/helm_v3/template/template.go
+++ b/cmd/werf/helm_v3/template/template.go
@@ -1,0 +1,16 @@
+package template
+
+import (
+	"os"
+
+	"helm.sh/helm/v3/pkg/action"
+
+	"github.com/spf13/cobra"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+)
+
+func NewCmd() *cobra.Command {
+	actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewTemplateCmd(actionConfig, os.Stdout)
+	return cmd
+}

--- a/cmd/werf/helm_v3/test/test.go
+++ b/cmd/werf/helm_v3/test/test.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/helm_v3/common"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+func NewCmd() *cobra.Command {
+	actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewTestCmd(actionConfig, os.Stdout)
+	common.SetupCmdActionConfig(cmd, actionConfig)
+	return cmd
+}

--- a/cmd/werf/helm_v3/uninstall/uninstall.go
+++ b/cmd/werf/helm_v3/uninstall/uninstall.go
@@ -1,0 +1,17 @@
+package uninstall
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/helm_v3/common"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+func NewCmd() *cobra.Command {
+	actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewUninstallCmd(actionConfig, os.Stdout)
+	common.SetupCmdActionConfig(cmd, actionConfig)
+	return cmd
+}

--- a/cmd/werf/helm_v3/upgrade/upgrade.go
+++ b/cmd/werf/helm_v3/upgrade/upgrade.go
@@ -1,0 +1,17 @@
+package upgrade
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/helm_v3/common"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+func NewCmd() *cobra.Command {
+	actionConfig := new(action.Configuration)
+	cmd := helm_v3.NewUpgradeCmd(actionConfig, os.Stdout)
+	common.SetupCmdActionConfig(cmd, actionConfig)
+	return cmd
+}

--- a/cmd/werf/helm_v3/verify/verify.go
+++ b/cmd/werf/helm_v3/verify/verify.go
@@ -1,0 +1,12 @@
+package verify
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+)
+
+func NewCmd() *cobra.Command {
+	return helm_v3.NewVerifyCmd(os.Stdout)
+}

--- a/cmd/werf/main.go
+++ b/cmd/werf/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	"github.com/werf/werf/cmd/werf/helm_v3"
+
 	"github.com/werf/werf/cmd/werf/diff"
 
 	"github.com/werf/werf/cmd/werf/converge"
@@ -134,6 +136,7 @@ Find more information at https://werf.io`),
 				imagesCmd(),
 				managedImagesCmd(),
 				helmCmd(),
+				helm_v3.NewCmd(),
 				hostCmd(),
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9 // indirect
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prashantv/gostub v1.0.0
 	github.com/rodaine/table v1.0.0
 	github.com/rubenv/sql-migrate v0.0.0-20200616145509-8d140a17f351 // indirect
@@ -139,6 +140,8 @@ replace k8s.io/sample-controller => k8s.io/sample-controller v0.18.6
 
 replace k8s.io/helm => github.com/werf/helm v0.0.0-20200729113816-b42ef1ec3fd7
 
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20200807164411-27919fc0c010
+
 replace github.com/docker/docker => github.com/docker/docker v17.12.0-ce-rc1.0.20200728121027-0f41a77c6993+incompatible
 
 replace github.com/containerd/containerd => github.com/containerd/containerd v1.3.1-0.20200508210449-c80284d4b529
@@ -146,3 +149,4 @@ replace github.com/containerd/containerd => github.com/containerd/containerd v1.
 replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
 
 go 1.14
+

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,7 @@ github.com/Masterminds/sprig/v3 v3.1.0/go.mod h1:ONGMf7UfYGAbMXCZmQLy8x3lCDIPrEZ
 github.com/Masterminds/squirrel v1.2.0 h1:K1NhbTO21BWG47IVR0OnIZuE0LZcXAYqywrC3Ko53KI=
 github.com/Masterminds/squirrel v1.2.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/Masterminds/vcs v1.11.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
+github.com/Masterminds/vcs v1.13.1 h1:NL3G1X7/7xduQtA2sJLpVpfHTNBALVNSjob6KEjPXNQ=
 github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
@@ -360,8 +361,10 @@ github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea h1:n2Ltr3SrfQlf/9nOna1D
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
@@ -1290,6 +1293,7 @@ github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvf
 github.com/russross/blackfriday v0.0.0-20170610170232-067529f716f4/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.0.4/go.mod h1:9T/Cfuxs5StfsocWr4WzDL36HqnX0fVb9d5fSEaLhoE=
 github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUccKSJBU0UMXJFVM=
@@ -1316,6 +1320,7 @@ github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20151028001915-10ef21a441db/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
@@ -1469,6 +1474,8 @@ github.com/weppos/publicsuffix-go v0.5.0 h1:rutRtjBJViU/YjcI5d80t4JAVvDltS6bciJg
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/werf/helm v0.0.0-20200729113816-b42ef1ec3fd7 h1:AMA3Yo/HN6R3MHoYVh2/YPdr80Hs/gKXDki+LCdwqFk=
 github.com/werf/helm v0.0.0-20200729113816-b42ef1ec3fd7/go.mod h1:OMONwLWU9zEENgaVjWEX+M+xik2QakejzKHG1+6mnUo=
+github.com/werf/helm/v3 v3.0.0-20200807164411-27919fc0c010 h1:6kPe3jHXz034zM9Y/ZWOalC7ajSpRcLrZX6qJo9wtTE=
+github.com/werf/helm/v3 v3.0.0-20200807164411-27919fc0c010/go.mod h1:ZaXz/vzktgwjyGGFbUWtIQkscfE7WYoRGP2szqAFHR0=
 github.com/werf/kubedog v0.3.5-0.20200729112351-cb49a986a194 h1:6PVMtndwZBuB1MOeD33idPY2KKC5pWsQ/te+RC45f/M=
 github.com/werf/kubedog v0.3.5-0.20200729112351-cb49a986a194/go.mod h1:Z9YP20h8DbZyZFitJgbURXMueFlSQ42tt82MslRHmzk=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea h1:R5tJUhL5a3YfHTrHWyuAdJW3h//fmONrpHJjjAZ79e4=

--- a/pkg/deploy/helm_v3/init.go
+++ b/pkg/deploy/helm_v3/init.go
@@ -1,0 +1,118 @@
+package helm_v3
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/werf/logboek"
+
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+
+	"gopkg.in/yaml.v2"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
+
+	"github.com/spf13/pflag"
+	"helm.sh/helm/v3/pkg/action"
+	"k8s.io/klog"
+)
+
+type InitOptions struct {
+	Debug bool
+}
+
+func Init(opts InitOptions) error {
+	gofs := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(gofs)
+	pflag.CommandLine.AddGoFlagSet(gofs)
+	pflag.CommandLine.Set("logtostderr", "true")
+
+	return nil
+}
+
+func withEnvs(envsMap map[string]string, do func()) {
+	for k, v := range envsMap {
+		oldV := os.Getenv(k)
+		os.Setenv(k, v)
+		defer func() { os.Setenv(k, oldV) }()
+	}
+	do()
+}
+
+func NewEnvSettings(namespace string) (res *cli.EnvSettings) {
+	withEnvs(map[string]string{
+		"HELM_NAMESPACE":         namespace,
+		"HELM_KUBECONTEXT":       "",
+		"HELM_KUBETOKEN":         "",
+		"HELM_KUBEAPISERVER":     "",
+		"HELM_PLUGINS":           "",
+		"HELM_REGISTRY_CONFIG":   "",
+		"HELM_REPOSITORY_CONFIG": "",
+		"HELM_REPOSITORY_CACHE":  "",
+		"HELM_DEBUG":             "",
+	}, func() {
+		res = cli.New()
+	})
+
+	res.Debug = logboek.Debug.IsAccepted()
+
+	return
+}
+
+func NewActionConfig(envSettings *cli.EnvSettings) *action.Configuration {
+	actionConfig := &action.Configuration{}
+
+	// new cmd init
+
+	helmDriver := os.Getenv("HELM_DRIVER")
+	if err := actionConfig.Init(envSettings.RESTClientGetter(), envSettings.Namespace(), helmDriver, logboek.Debug.LogF); err != nil {
+		log.Fatal(err)
+	}
+	if helmDriver == "memory" {
+		loadReleasesInMemory(envSettings, actionConfig)
+	}
+
+	return actionConfig
+}
+
+// This function loads releases into the memory storage if the
+// environment variable is properly set.
+func loadReleasesInMemory(envSettings *cli.EnvSettings, actionConfig *action.Configuration) {
+	filePaths := strings.Split(os.Getenv("HELM_MEMORY_DRIVER_DATA"), ":")
+	if len(filePaths) == 0 {
+		return
+	}
+
+	store := actionConfig.Releases
+	mem, ok := store.Driver.(*driver.Memory)
+	if !ok {
+		// For an unexpected reason we are not dealing with the memory storage driver.
+		return
+	}
+
+	actionConfig.KubeClient = &kubefake.PrintingKubeClient{Out: ioutil.Discard}
+
+	for _, path := range filePaths {
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			log.Fatal("Unable to read memory driver data", err)
+		}
+
+		releases := []*release.Release{}
+		if err := yaml.Unmarshal(b, &releases); err != nil {
+			log.Fatal("Unable to unmarshal memory driver data: ", err)
+		}
+
+		for _, rel := range releases {
+			if err := store.Create(rel); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
+	// Must reset namespace to the proper one
+	mem.SetNamespace(envSettings.Namespace())
+}

--- a/pkg/deploy/helm_v3/install.go
+++ b/pkg/deploy/helm_v3/install.go
@@ -1,0 +1,116 @@
+package helm_v3
+
+import (
+	"context"
+	"time"
+
+	"helm.sh/helm/v3/pkg/cli/output"
+
+	"github.com/werf/logboek"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/cli/values"
+
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/downloader"
+	"helm.sh/helm/v3/pkg/getter"
+)
+
+type InstallOptions struct {
+	ValuesOptions   values.Options
+	Namespace       string
+	CreateNamespace bool
+	Install         bool
+	Atomic          bool
+	Timeout         time.Duration
+}
+
+func Install(ctx context.Context, chart, releaseName string, opts InstallOptions) error {
+	outfmt := output.Table
+
+	envSettings := NewEnvSettings(opts.Namespace)
+	cfg := NewActionConfig(envSettings)
+	client := action.NewInstall(cfg)
+	client.Namespace = opts.Namespace
+	client.CreateNamespace = opts.CreateNamespace
+	client.ReleaseName = releaseName
+
+	logboek.Debug.LogF("Original chart version: %q", client.Version)
+	if client.Version == "" && client.Devel {
+		logboek.Debug.LogF("setting version to >0.0.0-0")
+		client.Version = ">0.0.0-0"
+	}
+
+	cp, err := client.ChartPathOptions.LocateChart(chart, envSettings)
+	if err != nil {
+		return err
+	}
+
+	logboek.Debug.LogF("CHART PATH: %s\n", cp)
+
+	p := getter.All(envSettings)
+	vals, err := opts.ValuesOptions.MergeValues(p)
+	if err != nil {
+		return err
+	}
+
+	// Check chart dependencies to make sure all are present in /charts
+	chartRequested, err := loader.Load(cp)
+	if err != nil {
+		return err
+	}
+
+	validInstallableChart, err := isChartInstallable(chartRequested)
+	if !validInstallableChart {
+		return err
+	}
+
+	if req := chartRequested.Metadata.Dependencies; req != nil {
+		// If CheckDependencies returns an error, we have unfulfilled dependencies.
+		// As of Helm 2.4.0, this is treated as a stopping condition:
+		// https://github.com/helm/helm/issues/2209
+		if err := action.CheckDependencies(chartRequested, req); err != nil {
+			if client.DependencyUpdate {
+				man := &downloader.Manager{
+					Out:              logboek.GetOutStream(),
+					ChartPath:        cp,
+					Keyring:          client.ChartPathOptions.Keyring,
+					SkipUpdate:       false,
+					Getters:          p,
+					RepositoryConfig: envSettings.RepositoryConfig,
+					RepositoryCache:  envSettings.RepositoryCache,
+					Debug:            envSettings.Debug,
+				}
+				if err := man.Update(); err != nil {
+					return err
+				}
+				// Reload the chart with the updated Chart.lock file.
+				if chartRequested, err = loader.Load(cp); err != nil {
+					return errors.Wrap(err, "failed reloading chart after repo update")
+				}
+			} else {
+				return err
+			}
+		}
+	}
+
+	rel, err := client.Run(chartRequested, vals)
+	if err != nil {
+		return errors.Wrap(err, "INSTALL FAILED")
+	}
+
+	return outfmt.Write(logboek.GetOutStream(), &statusPrinter{rel, envSettings.Debug})
+}
+
+// isChartInstallable validates if a chart can be installed
+//
+// Application chart type is only installable
+func isChartInstallable(ch *chart.Chart) (bool, error) {
+	switch ch.Metadata.Type {
+	case "", "application":
+		return true, nil
+	}
+	return false, errors.Errorf("%s charts are not installable", ch.Metadata.Type)
+}

--- a/pkg/deploy/helm_v3/rollback.go
+++ b/pkg/deploy/helm_v3/rollback.go
@@ -1,0 +1,38 @@
+package helm_v3
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/werf/logboek"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+type RollbackOptions struct {
+	Namespace string
+	Version   int
+
+	DryRun        bool
+	Recreate      bool
+	Force         bool
+	DisableHooks  bool
+	Timeout       time.Duration
+	Wait          bool
+	CleanupOnFail bool
+}
+
+func Rollback(releaseName string, opts RollbackOptions) error {
+	return logboek.Default.LogProcess(fmt.Sprintf("Rolling back release %q"), logboek.LevelLogProcessOptions{}, func() error {
+		envSettings := NewEnvSettings(opts.Namespace)
+		cfg := NewActionConfig(envSettings)
+		client := action.NewRollback(cfg)
+		client.Timeout = opts.Timeout
+		client.Version = opts.Version
+
+		if err := client.Run(releaseName); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/pkg/deploy/helm_v3/status.go
+++ b/pkg/deploy/helm_v3/status.go
@@ -1,0 +1,126 @@
+package helm_v3
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli/output"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
+)
+
+type StatusOptions struct {
+	Version   int
+	Namespace string
+}
+
+func Status(releaseName string, opts StatusOptions) (*release.Release, error) {
+	envSettings := NewEnvSettings(opts.Namespace)
+	cfg := NewActionConfig(envSettings)
+	client := action.NewStatus(cfg)
+	client.Version = opts.Version
+	return client.Run(releaseName)
+}
+
+func IsErrReleaseNotFound(err error) bool {
+	return (err != nil) && strings.HasSuffix(err.Error(), driver.ErrReleaseNotFound.Error())
+}
+
+type statusPrinter struct {
+	release *release.Release
+	debug   bool
+}
+
+func (s statusPrinter) WriteJSON(out io.Writer) error {
+	return output.EncodeJSON(out, s.release)
+}
+
+func (s statusPrinter) WriteYAML(out io.Writer) error {
+	return output.EncodeYAML(out, s.release)
+}
+
+func (s statusPrinter) WriteTable(out io.Writer) error {
+	if s.release == nil {
+		return nil
+	}
+	fmt.Fprintf(out, "NAME: %s\n", s.release.Name)
+	if !s.release.Info.LastDeployed.IsZero() {
+		fmt.Fprintf(out, "LAST DEPLOYED: %s\n", s.release.Info.LastDeployed.Format(time.ANSIC))
+	}
+	fmt.Fprintf(out, "NAMESPACE: %s\n", s.release.Namespace)
+	fmt.Fprintf(out, "STATUS: %s\n", s.release.Info.Status.String())
+	fmt.Fprintf(out, "REVISION: %d\n", s.release.Version)
+
+	executions := executionsByHookEvent(s.release)
+	if tests, ok := executions[release.HookTest]; !ok || len(tests) == 0 {
+		fmt.Fprintln(out, "TEST SUITE: None")
+	} else {
+		for _, h := range tests {
+			// Don't print anything if hook has not been initiated
+			if h.LastRun.StartedAt.IsZero() {
+				continue
+			}
+			fmt.Fprintf(out, "TEST SUITE:     %s\n%s\n%s\n%s\n",
+				h.Name,
+				fmt.Sprintf("Last Started:   %s", h.LastRun.StartedAt.Format(time.ANSIC)),
+				fmt.Sprintf("Last Completed: %s", h.LastRun.CompletedAt.Format(time.ANSIC)),
+				fmt.Sprintf("Phase:          %s", h.LastRun.Phase),
+			)
+		}
+	}
+
+	if s.debug {
+		fmt.Fprintln(out, "USER-SUPPLIED VALUES:")
+		err := output.EncodeYAML(out, s.release.Config)
+		if err != nil {
+			return err
+		}
+		// Print an extra newline
+		fmt.Fprintln(out)
+
+		cfg, err := chartutil.CoalesceValues(s.release.Chart, s.release.Config)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out, "COMPUTED VALUES:")
+		err = output.EncodeYAML(out, cfg.AsMap())
+		if err != nil {
+			return err
+		}
+		// Print an extra newline
+		fmt.Fprintln(out)
+	}
+
+	if strings.EqualFold(s.release.Info.Description, "Dry run complete") || s.debug {
+		fmt.Fprintln(out, "HOOKS:")
+		for _, h := range s.release.Hooks {
+			fmt.Fprintf(out, "---\n# Source: %s\n%s\n", h.Path, h.Manifest)
+		}
+		fmt.Fprintf(out, "MANIFEST:\n%s\n", s.release.Manifest)
+	}
+
+	if len(s.release.Info.Notes) > 0 {
+		fmt.Fprintf(out, "NOTES:\n%s\n", strings.TrimSpace(s.release.Info.Notes))
+	}
+	return nil
+}
+
+func executionsByHookEvent(rel *release.Release) map[release.HookEvent][]*release.Hook {
+	result := make(map[release.HookEvent][]*release.Hook)
+	for _, h := range rel.Hooks {
+		for _, e := range h.Events {
+			executions, ok := result[e]
+			if !ok {
+				executions = []*release.Hook{}
+			}
+			result[e] = append(executions, h)
+		}
+	}
+	return result
+}

--- a/pkg/deploy/helm_v3/upgrade.go
+++ b/pkg/deploy/helm_v3/upgrade.go
@@ -1,0 +1,97 @@
+package helm_v3
+
+import (
+	"context"
+	"time"
+
+	"helm.sh/helm/v3/pkg/cli/output"
+
+	"helm.sh/helm/v3/pkg/cli/values"
+
+	"github.com/werf/logboek"
+
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/storage/driver"
+)
+
+type UpgradeOptions struct {
+	ValuesOptions   values.Options
+	Namespace       string
+	CreateNamespace bool
+	Install         bool
+	Atomic          bool
+	Timeout         time.Duration
+}
+
+func Upgrade(ctx context.Context, chart, releaseName string, opts UpgradeOptions) error {
+	outfmt := output.Table
+
+	envSettings := NewEnvSettings(opts.Namespace)
+	cfg := NewActionConfig(envSettings)
+	client := action.NewUpgrade(cfg)
+
+	client.Namespace = opts.Namespace
+	client.Timeout = opts.Timeout
+	client.Atomic = opts.Atomic
+	client.Install = opts.Install
+
+	// Fixes #7002 - Support reading values from STDIN for `upgrade` command
+	// Must load values AFTER determining if we have to call install so that values loaded from stdin are are not read twice
+	if client.Install {
+		// If a release does not exist, install it.
+		histClient := action.NewHistory(cfg)
+		histClient.Max = 1
+		if _, err := histClient.Run(releaseName); err == driver.ErrReleaseNotFound {
+			logboek.Debug.LogF("Release %q does not exist. Installing it now.\n", releaseName)
+
+			return Install(ctx, chart, releaseName, InstallOptions{
+				ValuesOptions:   opts.ValuesOptions,
+				Namespace:       opts.Namespace,
+				CreateNamespace: opts.CreateNamespace,
+				Install:         opts.Install,
+				Atomic:          opts.Atomic,
+				Timeout:         opts.Timeout,
+			})
+		} else if err != nil {
+			return err
+		}
+	}
+
+	if client.Version == "" && client.Devel {
+		logboek.Debug.LogF("setting version to >0.0.0-0")
+		client.Version = ">0.0.0-0"
+	}
+
+	chartPath, err := client.ChartPathOptions.LocateChart(chart, envSettings)
+	if err != nil {
+		return err
+	}
+
+	vals, err := opts.ValuesOptions.MergeValues(getter.All(envSettings))
+	if err != nil {
+		return err
+	}
+
+	// Check chart dependencies to make sure all are present in /charts
+	ch, err := loader.Load(chartPath)
+	if err != nil {
+		return err
+	}
+	if req := ch.Metadata.Dependencies; req != nil {
+		if err := action.CheckDependencies(ch, req); err != nil {
+			return err
+		}
+	}
+
+	rel, err := client.Run(releaseName, ch, vals)
+	if err != nil {
+		return errors.Wrap(err, "UPGRADE FAILED")
+	}
+
+	logboek.Debug.LogF("Release %q has been upgraded\n", releaseName)
+
+	return outfmt.Write(logboek.GetOutStream(), &statusPrinter{rel, envSettings.Debug})
+}


### PR DESCRIPTION
 - Added "werf helm-v3 *" cli commands to access helm-v3 directly.
 - Added pkg/deploy/helm_v3 package with basic helm-v3 operations.
 - werf helm deploy-chart will use v3 when WERF_HELM3=1 is set.

refs https://github.com/werf/helm/pull/47
refs https://github.com/werf/werf/issues/1606
