### PR TITLE
Fix 'patch does not apply' error in github actions

### DIFF
--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -327,6 +327,10 @@ func (gm *GitMapping) AddGitCommitToImageLabels(image container_runtime.ImageInt
 			gm.VirtualMergeFromCommitLabel(): commitInfo.VirtualMergeFromCommit,
 			gm.VirtualMergeIntoCommitLabel(): commitInfo.VirtualMergeIntoCommit,
 		})
+	} else {
+		image.Container().ServiceCommitChangeOptions().AddLabel(map[string]string{
+			gm.VirtualMergeLabel(): "false",
+		})
 	}
 }
 


### PR DESCRIPTION
`"virtual-merge-commit": "true"` label in the docker image of the stage was not reset to false when building a new image for regular commit (not virtual merge commit).