### PR TITLE
Fix cleanup panic "image ... metadata was not found"

### DIFF
--- a/pkg/cleaning/images_cleanup.go
+++ b/pkg/cleaning/images_cleanup.go
@@ -159,11 +159,9 @@ func (m *imagesCleanupManager) initImageCommitHashImageMetadata() error {
 				return fmt.Errorf("get image %s metadata by commit %s failed", imageName, commit)
 			}
 
-			if imageMetadata == nil {
-				panic(fmt.Sprintf("image %s metadata was not found: %s", imageName, err))
+			if imageMetadata != nil {
+				commitImageMetadata[plumbing.NewHash(commit)] = imageMetadata
 			}
-
-			commitImageMetadata[plumbing.NewHash(commit)] = imageMetadata
 		}
 
 		imageCommitImageMetadata[imageName] = commitImageMetadata

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -331,6 +331,11 @@ func (storage *RepoStagesStorage) GetImageMetadataByCommit(projectName, imageNam
 
 		return metadata, nil
 	} else {
+		logboek.Debug.LogF("imgInfo = %v\n", imgInfo)
+		if imgInfo != nil {
+			logboek.Debug.LogF("imgInfo.Labels = %v\n", imgInfo.Labels)
+		}
+
 		logboek.Info.LogF("No metadata found for image %q by commit %s\n", imageName, commit)
 		return nil, nil
 	}
@@ -362,7 +367,7 @@ func (storage *RepoStagesStorage) GetImageCommits(projectName, imageName string)
 			iName := unslugDockerImageTagAsImageName(sluggedImage)
 
 			if imageName == iName {
-				logboek.Debug.LogF("Found image %q metadata by commit %s\n", imageName, commit)
+				logboek.Debug.LogF("Found image %q metadata by commit %s, full image name: %s:%s\n", imageName, commit, storage.RepoAddress, tag)
 				res = append(res, commit)
 			}
 		}


### PR DESCRIPTION
Ignore unknown-manifest tags from docker-registry tags list when quering image metadata records.