### PR TITLE
GitHub Actions: fix case sensitive of repository name

### DIFF
--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -314,9 +314,10 @@ func generateGithubEnvs(ctx context.Context, w io.Writer, dockerConfig, taggingS
 	}
 
 	ciGithubOwnerWithProject := os.Getenv("GITHUB_REPOSITORY")
+	ciGithubDockerPackage := strings.ToLower(ciGithubOwnerWithProject)
 
 	var imagesRepo, stagesStorageRepo string
-	if ciGithubOwnerWithProject != "" {
+	if ciGithubDockerPackage != "" {
 		projectDir, err := common.GetProjectDir(&commonCmdData)
 		if err != nil {
 			return fmt.Errorf("getting project dir failed: %s", err)
@@ -328,7 +329,7 @@ func generateGithubEnvs(ctx context.Context, w io.Writer, dockerConfig, taggingS
 		}
 
 		if werfConfig != nil {
-			projectRepo := fmt.Sprintf("%s/%s", githubRegistry, ciGithubOwnerWithProject)
+			projectRepo := fmt.Sprintf("%s/%s", githubRegistry, ciGithubDockerPackage)
 			multirepo := projectRepo
 			monorepo := fmt.Sprintf("%s/%s", projectRepo, werfConfig.Meta.Project)
 


### PR DESCRIPTION
Error: error creating docker registry accessor for repo "docker.pkg.github.com/ExamplAccount/example-repo-name/stages": repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: ExamplAccount/example-repo-name/stages