### PR TITLE
Fix klog warning messages

### DIFF
--- a/cmd/werf/common/kubedog.go
+++ b/cmd/werf/common/kubedog.go
@@ -15,6 +15,18 @@ func InitKubedog(ctx context.Context) error {
 	// set flag.Parsed() for glog
 	flag.CommandLine.Parse([]string{})
 
+	fs := flag.NewFlagSet("klog", flag.PanicOnError)
+	klog.InitFlags(fs)
+	if err := fs.Set("logtostderr", "false"); err != nil {
+		return err
+	}
+	if err := fs.Set("alsologtostderr", "false"); err != nil {
+		return err
+	}
+	if err := fs.Set("stderrthreshold", "5"); err != nil {
+		return err
+	}
+
 	// Suppress info and warnings from client-go reflector
 	klog.SetOutputBySeverity("INFO", ioutil.Discard)
 	klog.SetOutputBySeverity("WARNING", ioutil.Discard)


### PR DESCRIPTION
Suppress klog info/warning log levels. Print error level through logboek.