### PR TITLE
Ability to enable/disable checking of all kube namespaces during cleaning images from registry

### DIFF
--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -25,6 +25,7 @@ var commonCmdData common.CmdData
 var cmdData struct {
 	GitHistoryBasedCleanup    bool
 	GitHistoryBasedCleanupV12 bool
+	CheckAllNamespaces        bool
 }
 
 func NewCmd() *cobra.Command {
@@ -72,7 +73,7 @@ It is safe to run this command periodically (daily is enough) by automated clean
 
 	cmd.Flags().BoolVarP(&cmdData.GitHistoryBasedCleanup, "git-history-based-cleanup", "", common.GetBoolEnvironmentDefaultTrue("WERF_GIT_HISTORY_BASED_CLEANUP"), "Use git history based cleanup (default $WERF_GIT_HISTORY_BASED_CLEANUP)")
 	cmd.Flags().BoolVarP(&cmdData.GitHistoryBasedCleanupV12, "git-history-based-cleanup-v1.2", "", common.GetBoolEnvironmentDefaultFalse("WERF_GIT_HISTORY_BASED_CLEANUP_v1_2"), "Use git history based cleanup and delete images tags without related image metadata (default $WERF_GIT_HISTORY_BASED_CLEANUP_v1_2)")
-
+	cmd.Flags().BoolVarP(&cmdData.CheckAllNamespaces, "check-all-namespaces", "", common.GetBoolEnvironmentDefaultTrue("WERF_CHECK_ALL_NAMESPACES"), "Check images in all namespaces (default $WERF_CHECK_ALL_NAMESPACES)")
 	common.SetupDryRun(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)
@@ -205,11 +206,24 @@ func runCleanup() error {
 		}
 	}
 
+	kubernetesNamespaces := map[string]string{}
+	clientConfig, _ := kube.GetClientConfig("", *commonCmdData.KubeConfig, nil)
+	rc, _ := clientConfig.RawConfig()
+	for contextName, context := range rc.Contexts {
+		if cmdData.CheckAllNamespaces {
+			// "" - cluster scope, therefore all namespaces
+			kubernetesNamespaces[contextName] = ""
+		} else {
+			kubernetesNamespaces[contextName] = context.Namespace
+		}
+	}
+
 	cleanupOptions := cleaning.CleanupOptions{
 		ImagesCleanupOptions: cleaning.ImagesCleanupOptions{
 			ImageNameList:                 imagesNames,
 			LocalGit:                      localGitRepo,
 			KubernetesContextsClients:     kubernetesContextsClients,
+			KubernetesNamespaces:          kubernetesNamespaces,
 			WithoutKube:                   *commonCmdData.WithoutKube,
 			Policies:                      policies,
 			GitHistoryBasedCleanup:        cmdData.GitHistoryBasedCleanup,


### PR DESCRIPTION
My case: there are several projects in one cluster, each project has access only to certain namespaces. Therefore, the werf cleanup does not work as it tries to extract images from the entire cluster. For example:
```bash
627.191299ms Using werf config render file: /private/var/folders/82/qx_s8s_n3c3016fsx1rbbjsh0000gn/T/werf-config-render-088482510
633.265926ms Using images repo docker registry implementation: default
633.301918ms Using images repo mode: multirepo
633.337162ms -- LocalDockerServerStagesStorage.GetManagedImages cross-stitch
792.055737ms Managed images names: [backend migrations notifications static]
851.228204ms 
851.264639ms ┌ Running images cleanup
863.395068ms │ ┌ Fetching repo images data
863.425751ms │ │ ┌ Fetching repo images
2m42.6553478 │ │ └ Fetching repo images (161.78 seconds)
2m42.6554011 │ └ Fetching repo images data (161.79 seconds)
2m42.6554378 │ 
2m42.6554631 │ ┌ Skipping repo images that are being used in Kubernetes
2m42.6622105 │ │ Getting deployed docker images (context stand) ... (0.51 seconds) FAILED
2m43.1712105 │ └ Skipping repo images that are being used in Kubernetes (0.52 seconds) FAILED
2m43.1817046 └ Running images cleanup (162.33 seconds) FAILED
2m43.2183839 
2m43.2183878 Running time 163.22 seconds
2m43.2320993 Error: cannot get deployed imagesRepoImageList: cannot get Pods images: pods is forbidden: User "system:serviceaccount:example-project:deploy"   ↵
2m43.2600260 cannot list resource "pods" in API group "" at the cluster scope
```
 I've added the --check-all-namespaces (WERF_CHECK_ALL_NAMESPACES) flag that controls this behavior. The default behavior has not changed, but for my case this flag can be turned off, in which case the werf will only check the namespaces that are specified in the contexts of the configuration file.

I may not have corrected the code very nicely, I had to add an additional argument with map namespaces to many functions. But I can change it if necessary for another option, for example, add information about namespaces to `KubernetesContextsClients`.
