### PR TITLE
Refactor `--check-all-namespaces` cleanup option

### DIFF
--- a/cmd/werf/common/cleanup_namespaces_scan.go
+++ b/cmd/werf/common/cleanup_namespaces_scan.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/werf/kubedog/pkg/kube"
+	"github.com/werf/logboek"
+)
+
+func SetupScanContextNamespaceOnly(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.ScanContextNamespaceOnly = new(bool)
+	cmd.Flags().BoolVarP(cmdData.ScanContextNamespaceOnly, "scan-context-namespace-only", "", GetBoolEnvironmentDefaultFalse("WERF_SCAN_CONTEXT_NAMESPACE_ONLY"), "Scan for used images only in namespace linked with context for each available context in kube-config (or only for the context specified with option --kube-context). When disabled will scan all namespaces in all contexts (or only for the context specified with option --kube-context). (Default $WERF_SCAN_CONTEXT_NAMESPACE_ONLY)")
+}
+
+func GetKubernetesContextClients(cmdData *CmdData) ([]*kube.ContextClient, error) {
+	var res []*kube.ContextClient
+	if contextClients, err := kube.GetAllContextsClients(kube.GetAllContextsClientsOptions{KubeConfig: *cmdData.KubeConfig}); err != nil {
+		return nil, err
+	} else {
+		if *cmdData.KubeContext != "" {
+			for _, cc := range contextClients {
+				if cc.ContextName == *cmdData.KubeContext {
+					res = append(res, cc)
+					break
+				}
+			}
+
+			if len(res) == 0 {
+				return nil, fmt.Errorf("cannot find specified kube context %q", *cmdData.KubeContext)
+			}
+		} else {
+			res = contextClients
+		}
+	}
+
+	for _, contextClient := range res {
+		logboek.Debug().LogF("GetKubernetesContextClients -- context %q namespace %q\n", contextClient.ContextName, contextClient.ContextNamespace)
+	}
+
+	return res, nil
+}
+
+func GetKubernetesNamespaceRestrictionByContext(cmdData *CmdData, contextClients []*kube.ContextClient) map[string]string {
+	res := map[string]string{}
+	for _, contextClient := range contextClients {
+		if *cmdData.ScanContextNamespaceOnly {
+			res[contextClient.ContextName] = contextClient.ContextNamespace
+		} else {
+			// "" - cluster scope, therefore all namespaces
+			res[contextClient.ContextName] = ""
+		}
+	}
+
+	for contextName, restrictionNamespace := range res {
+		logboek.Debug().LogF("GetKubernetesNamespaceRestrictionByContext -- context %q restriction namespace %q\n", contextName, restrictionNamespace)
+	}
+
+	return res
+}

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -117,6 +117,8 @@ type CmdData struct {
 	VirtualMerge           *bool
 	VirtualMergeFromCommit *string
 	VirtualMergeIntoCommit *string
+
+	ScanContextNamespaceOnly *bool
 }
 
 const (

--- a/docs/_includes/cli/werf_cleanup.md
+++ b/docs/_includes/cli/werf_cleanup.md
@@ -146,6 +146,11 @@ werf cleanup [options]
             The following docker registry implementations are supported: ecr, acr, default,         
             dockerhub, gcr, github, gitlab, harbor, quay.
             Default $WERF_REPO_IMPLEMENTATION or auto mode (detect implementation by a registry).
+      --scan-context-namespace-only=false:
+            Scan for used images only in namespace linked with context for each available context   
+            in kube-config (or only for the context specified with option --kube-context). When     
+            disabled will scan all namespaces in all contexts (or only for the context specified    
+            with option --kube-context). (Default $WERF_SCAN_CONTEXT_NAMESPACE_ONLY)
       --skip-tls-verify-registry=false:
             Skip TLS certificate validation when accessing a registry (default                      
             $WERF_SKIP_TLS_VERIFY_REGISTRY)

--- a/docs/_includes/cli/werf_images_cleanup.md
+++ b/docs/_includes/cli/werf_images_cleanup.md
@@ -132,6 +132,11 @@ werf images cleanup [options]
             The following docker registry implementations are supported: ecr, acr, default,         
             dockerhub, gcr, github, gitlab, harbor, quay.
             Default $WERF_REPO_IMPLEMENTATION or auto mode (detect implementation by a registry).
+      --scan-context-namespace-only=false:
+            Scan for used images only in namespace linked with context for each available context   
+            in kube-config (or only for the context specified with option --kube-context). When     
+            disabled will scan all namespaces in all contexts (or only for the context specified    
+            with option --kube-context). (Default $WERF_SCAN_CONTEXT_NAMESPACE_ONLY)
       --skip-tls-verify-registry=false:
             Skip TLS certificate validation when accessing a registry (default                      
             $WERF_SKIP_TLS_VERIFY_REGISTRY)

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tonistiigi/fsutil v0.0.0-20200724193237-c3ed55f3b481 // indirect
 	github.com/tonistiigi/go-rosetta v0.0.0-20200727161949-f79598599c5d // indirect
-	github.com/werf/kubedog v0.4.1-0.20200818145659-3aa022a95c07
+	github.com/werf/kubedog v0.4.1-0.20200907160731-10aec4300377
 	github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea
 	github.com/werf/logboek v0.4.6
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -1486,8 +1486,11 @@ github.com/werf/helm/v3 v3.0.0-20200907120758-5c417a1ff7cf h1:s6kl0aPbCwYkvMGuWA
 github.com/werf/helm/v3 v3.0.0-20200907120758-5c417a1ff7cf/go.mod h1:ZaXz/vzktgwjyGGFbUWtIQkscfE7WYoRGP2szqAFHR0=
 github.com/werf/kubedog v0.4.1-0.20200818145659-3aa022a95c07 h1:pKU78lxdl5Ck4zkWzwH74FOnAC3uf/5u5rbS8SRcXwk=
 github.com/werf/kubedog v0.4.1-0.20200818145659-3aa022a95c07/go.mod h1:b/5MyrNDmxXtr68uucMmZCZmWS3h7cfAcgqtQbHsw5o=
+github.com/werf/kubedog v0.4.1-0.20200907160731-10aec4300377 h1:bQgmFAC6Q7FEVR0Xa8I875LgTTxlHnWM/qGtHAK3OZQ=
+github.com/werf/kubedog v0.4.1-0.20200907160731-10aec4300377/go.mod h1:b/5MyrNDmxXtr68uucMmZCZmWS3h7cfAcgqtQbHsw5o=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea h1:R5tJUhL5a3YfHTrHWyuAdJW3h//fmONrpHJjjAZ79e4=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea/go.mod h1:/CeY6KDiBSCU9PUmjt7zGhqpzp8FAPg/wNVfLZHQGWI=
+github.com/werf/logboek v0.3.5-0.20200608145450-5b5f18fe7009/go.mod h1:z/o88w2pmtW11fFsHnXQFsTNzcPp1H+VCtCj7OUntwU=
 github.com/werf/logboek v0.4.3 h1:aXAVLlGT/ZiD8Srj+B71Tw20PtDyuYZSEJZjODNraeA=
 github.com/werf/logboek v0.4.3/go.mod h1:79ek+WZSj2+UDdQcebk9lbOKj6S7PaJEljVihgQdJq8=
 github.com/werf/logboek v0.4.4 h1:uhxh+yGz/bxhBKeyovCBiu0UXWDRTc3M61+KJugDcbA=


### PR DESCRIPTION
 - Option renamed to `--scan-context-namespace-only=true|false` (false by default).
 - Refactored scanning for available contexts, added support for in-cluster configs.
 - Added option to the both commands: `werf cleanup` and `werf images cleanup`.

refs https://github.com/werf/kubedog/pull/179
refs https://github.com/werf/werf/pull/2660