### PR TITLE
Fix default namespace and helm-release name templates and default env…

### DIFF
--- a/cmd/werf/common/deploy_params.go
+++ b/cmd/werf/common/deploy_params.go
@@ -26,6 +26,8 @@ func GetHelmRelease(releaseOption string, environmentOption string, werfConfig *
 	var releaseTemplate string
 	if werfConfig.Meta.DeployTemplates.HelmRelease != nil {
 		releaseTemplate = *werfConfig.Meta.DeployTemplates.HelmRelease
+	} else if environmentOption == "" {
+		releaseTemplate = "[[ project ]]"
 	} else {
 		releaseTemplate = "[[ project ]]-[[ env ]]"
 	}
@@ -70,6 +72,8 @@ func GetKubernetesNamespace(namespaceOption string, environmentOption string, we
 	var namespaceTemplate string
 	if werfConfig.Meta.DeployTemplates.Namespace != nil {
 		namespaceTemplate = *werfConfig.Meta.DeployTemplates.Namespace
+	} else if environmentOption == "" {
+		namespaceTemplate = "[[ project ]]"
 	} else {
 		namespaceTemplate = "[[ project ]]-[[ env ]]"
 	}
@@ -160,10 +164,6 @@ func renderDeployParamTemplate(templateName, templateText string, environmentOpt
 	}
 
 	funcMap["env"] = func() (string, error) {
-		if environmentOption == "" {
-			return "default", nil
-		}
-
 		return environmentOption, nil
 	}
 


### PR DESCRIPTION
…ironment

 - use explicitly set template from werf.yaml if present;
 - when --env not set then use `[[ project ]]` template by default for both namespace and release;
 - when --env is set then use `[[ project ]]-[[ env ]]` template by default for both namespace and release.