### PR TITLE
Fix artifact import error '@ERROR: invalid uid root'

### DIFF
--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -53,8 +53,8 @@ func RunRsyncServer(ctx context.Context, dockerImageName string, tmpDir string) 
 	if err := ioutil.WriteFile(rsyncConfPath, []byte(fmt.Sprintf(`pid file = /.werf/rsyncd.pid
 lock file = /.werf/rsyncd.lock
 log file = /.werf/rsyncd.log
-uid = root
-gid = root
+uid = 0
+gid = 0
 port = %s
 
 [import]


### PR DESCRIPTION
Use 0:0 instead of root:root symbolic names in rsyncd which runs inside artifact.

Issue reproduces when artifact image does not have root line in the `/etc/passwd` file.

Refs https://github.com/werf/werf/issues/2762