### PR TITLE
Change service values format

### DIFF
--- a/pkg/deploy/werf_chart/template_helpers.go
+++ b/pkg/deploy/werf_chart/template_helpers.go
@@ -2,26 +2,26 @@ package werf_chart
 
 var TemplateHelpers = `{{- define "_werf_image" -}}
 {{-   $context := index . 0 -}}
-{{-   if $context.Values.global.werf.is_stub -}}
-{{      $context.Values.global.werf.stub_image }}
+{{-   if $context.Values.werf.is_stub -}}
+{{      $context.Values.werf.stub_image }}
 {{-   else -}}
-{{-     if not $context.Values.global.werf.is_nameless_image -}}
+{{-     if not $context.Values.werf.is_nameless_image -}}
 {{-       required "No image specified for template" nil -}}
 {{-     end -}}
-{{      $context.Values.global.werf.image.docker_image }}
+{{      $context.Values.werf.image }}
 {{-   end -}}
 {{- end -}}
 
 {{- define "_werf_image2" -}}
 {{-   $name := index . 0 -}}
 {{-   $context := index . 1 -}}
-{{-   if $context.Values.global.werf.is_stub -}}
-{{      $context.Values.global.werf.stub_image }}
+{{-   if $context.Values.werf.is_stub -}}
+{{      $context.Values.werf.stub_image }}
 {{-   else -}}
-{{-     if $context.Values.global.werf.is_nameless_image -}}
+{{-     if $context.Values.werf.is_nameless_image -}}
 {{-       required (printf "No image should be specified for template, got '%s'" $name) nil -}}
 {{-     end -}}
-{{      index (required (printf "Unknown image '%s' specified for template" $name) (pluck $name $context.Values.global.werf.image | first)) "docker_image" }}
+{{      required (printf "Unknown image '%s' specified for template" $name) (pluck $name $context.Values.werf.image | first) }}
 {{-   end -}}
 {{- end -}}
 


### PR DESCRIPTION
 - do not use .Values.global.werf section, use .Values.werf instead (subcharts does not need to have an access for image-related info);
 - change image-related values format: `.Values.werf.image.NAME` or `.Values.werf.image` (for nameless images);
 - use `werf_image` as a main way to generate full image name.