### PR TITLE
[dockerfile, digest] Fix ENV/ARG replacement for dockefile instructions

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
-	"github.com/moby/buildkit/frontend/dockerfile/shell"
 
 	"github.com/werf/logboek"
 	"github.com/werf/logboek/pkg/style"
@@ -1220,30 +1219,17 @@ func prepareImageBasedOnImageFromDockerfile(ctx context.Context, imageFromDocker
 
 	dockerTargetStage := dockerStages[dockerTargetIndex]
 
-	dockerTopLevelArgsHash := map[string]string{}
-	var dockerTopLevelArgsArray []string
-	for key, valueInterf := range imageFromDockerfileConfig.Args {
-		value := fmt.Sprintf("%v", valueInterf)
-		dockerTopLevelArgsHash[key] = value
-		dockerTopLevelArgsArray = append(dockerTopLevelArgsArray, fmt.Sprintf("%s=%v", key, value))
+	ds, err := stage.NewDockerStages(
+		dockerStages,
+		util.MapStringInterfaceToMapStringString(imageFromDockerfileConfig.Args),
+		dockerMetaArgs,
+		dockerTargetIndex,
+	)
+	if err != nil {
+		return nil, err
 	}
 
-	shlex := shell.NewLex(parser.DefaultEscapeToken)
-	for _, arg := range dockerMetaArgs {
-		// skip predefined ARG value if defined by the user with args directive
-		if _, ok := dockerTopLevelArgsHash[arg.Key]; ok {
-			continue
-		}
-
-		resolvedValue, err := shlex.ProcessWord(arg.ValueString(), dockerTopLevelArgsArray)
-		if err != nil {
-			return nil, fmt.Errorf("resolve dockerfile ARG %s=%s failed: %s", arg.Key, arg.ValueString(), err)
-		}
-		dockerTopLevelArgsHash[arg.Key] = resolvedValue
-		dockerTopLevelArgsArray = append(dockerTopLevelArgsArray, fmt.Sprintf("%s=%s", arg.Key, resolvedValue))
-	}
-
-	resolvedBaseName, err := shlex.ProcessWord(dockerTargetStage.BaseName, dockerTopLevelArgsArray)
+	resolvedBaseName, err := ds.ShlexProcessWordWithMetaArgs(dockerTargetStage.BaseName)
 	if err != nil {
 		return nil, err
 	}
@@ -1267,7 +1253,7 @@ func prepareImageBasedOnImageFromDockerfile(ctx context.Context, imageFromDocker
 			imageFromDockerfileConfig.Network,
 			imageFromDockerfileConfig.SSH,
 		),
-		stage.NewDockerStages(dockerStages, dockerTopLevelArgsHash, dockerTopLevelArgsArray, dockerTargetIndex),
+		ds,
 		stage.NewContextChecksum(c.projectDir, dockerignorePathMatcher, localGitRepo),
 		baseStageOptions,
 	)

--- a/pkg/build/stage/dockerfile.go
+++ b/pkg/build/stage/dockerfile.go
@@ -399,7 +399,13 @@ func (s *DockerfileStage) GetDependencies(ctx context.Context, _ Conveyor, _, _ 
 		}
 	}
 
-	return util.Sha256Hash(stagesDependencies[s.dockerTargetStageIndex]...), nil
+	dockerfileStageDependencies := stagesDependencies[s.dockerTargetStageIndex]
+
+	if dockerfileStageDependenciesDebug() {
+		logboek.Context(ctx).LogLn(dockerfileStageDependencies)
+	}
+
+	return util.Sha256Hash(dockerfileStageDependencies...), nil
 }
 
 func (s *DockerfileStage) dockerfileInstructionDependencies(ctx context.Context, dockerStageID int, cmd interface{}, isOnbuildInstruction bool, isBaseImageOnbuildInstruction bool) ([]string, []string, error) {
@@ -922,4 +928,8 @@ func uniquePaths(paths []string) []string {
 	}
 
 	return result
+}
+
+func dockerfileStageDependenciesDebug() bool {
+	return os.Getenv("WERF_DEBUG_DOCKERFILE_STAGE_DEPENDENCIES") == "1"
 }

--- a/pkg/util/cast.go
+++ b/pkg/util/cast.go
@@ -2,6 +2,15 @@ package util
 
 import "fmt"
 
+func MapStringInterfaceToMapStringString(value map[string]interface{}) map[string]string {
+	result := map[string]string{}
+	for key, valueInterf := range value {
+		result[key] = fmt.Sprintf("%v", valueInterf)
+	}
+
+	return result
+}
+
 func InterfaceToStringArray(value interface{}) ([]string, error) {
 	switch value.(type) {
 	case []interface{}:


### PR DESCRIPTION
According to:
* [Understand how ARG and FROM interact](https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact)
* [Using ARG variables](https://docs.docker.com/engine/reference/builder/#using-arg-variables)
* [Impact on build caching](https://docs.docker.com/engine/reference/builder/#impact-on-build-caching)
* [Environment replacement](https://docs.docker.com/engine/reference/builder/#environment-replacement)
* [Using ARG variables](https://docs.docker.com/engine/reference/builder/#using-arg-variables)

fixes https://github.com/werf/werf/issues/2771