### PR TITLE
Fix getting of parentID from image manifest

### DIFF
--- a/pkg/image/info.go
+++ b/pkg/image/info.go
@@ -52,7 +52,7 @@ func NewInfoFromInspect(ref string, inspect *types.ImageInspect) *Info {
 		CreatedAtUnixNano: MustParseTimestampString(inspect.Created).UnixNano(),
 		RepoDigest:        repoDigest,
 		ID:                inspect.ID,
-		ParentID:          inspect.Parent,
+		ParentID:          inspect.Config.Image,
 		Size:              inspect.Size,
 	}
 }


### PR DESCRIPTION
Due to pulled image may have an empty Parent field