### PR TITLE
Define --helm-chart-dir in the werf.yaml

### DIFF
--- a/cmd/werf/build/main.go
+++ b/cmd/werf/build/main.go
@@ -66,8 +66,9 @@ If one or more IMAGE_NAME parameters specified, werf will build only these image
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupSSHKey(&commonCmdData, cmd)

--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -58,8 +58,9 @@ Currently supported only GitLab (gitlab) and GitHub (github) CI systems`,
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command will copy specified or default (~/.docker) config to the temporary directory and may perform additional login with new config.")

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -51,8 +51,9 @@ It is safe to run this command periodically (daily is enough) by automated clean
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -132,7 +132,8 @@ func SetupConfigPath(cmdData *CmdData, cmd *cobra.Command) {
 
 func SetupConfigTemplatesDir(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.ConfigTemplatesDir = new(string)
-	cmd.Flags().StringVarP(cmdData.ConfigTemplatesDir, "config-templates-dir", "", os.Getenv("WERF_CONFIG_TEMPLATES_DIR"), `Change to the custom configuration templates directory (default $WERF_CONFIG_TEMPLATES_DIR or .werf in working directory)`)
+	cmd.Flags().StringVarP(cmdData.ConfigTemplatesDir, "config-templates-dir", "", os.Getenv("WERF_CONFIG_TEMPLATES_DIR"), `Chan
+ge to the custom configuration templates directory (default $WERF_CONFIG_TEMPLATES_DIR or .werf in working directory)`)
 }
 
 func SetupTmpDir(cmdData *CmdData, cmd *cobra.Command) {
@@ -217,11 +218,6 @@ environLoop:
 	}
 
 	return result
-}
-
-func SetupHelmChartDir(cmdData *CmdData, cmd *cobra.Command) {
-	cmdData.HelmChartDir = new(string)
-	cmd.Flags().StringVarP(cmdData.HelmChartDir, "helm-chart-dir", "", os.Getenv("WERF_HELM_CHART_DIR"), "Use custom helm chart dir (default $WERF_HELM_CHART_DIR or .helm in working directory)")
 }
 
 func SetupEnvironment(cmdData *CmdData, cmd *cobra.Command) {
@@ -959,23 +955,13 @@ func GetProjectDir(cmdData *CmdData) (string, error) {
 	return currentDir, nil
 }
 
-func GetHelmChartDir(projectDir string, cmdData *CmdData) (string, error) {
+func GetHelmChartDir(projectDir string, cmdData *CmdData, werfConfig *config.WerfConfig) (string, error) {
 	var helmChartDir string
 
-	customHelmChartDir := *cmdData.HelmChartDir
-	if customHelmChartDir != "" {
-		helmChartDir = customHelmChartDir
+	if werfConfig.Meta.MetaDeploy.HelmChartDir != nil && *werfConfig.Meta.MetaDeploy.HelmChartDir != "" {
+		helmChartDir = *werfConfig.Meta.MetaDeploy.HelmChartDir
 	} else {
 		helmChartDir = filepath.Join(projectDir, ".helm")
-	}
-
-	exist, err := util.FileExists(helmChartDir)
-	if err != nil {
-		return "", err
-	}
-
-	if !exist {
-		return "", fmt.Errorf("helm chart dir %s not found", helmChartDir)
 	}
 
 	return helmChartDir, nil

--- a/cmd/werf/common/deploy_params.go
+++ b/cmd/werf/common/deploy_params.go
@@ -31,8 +31,8 @@ func GetHelmRelease(releaseOption string, environmentOption string, werfConfig *
 	}
 
 	var releaseTemplate string
-	if werfConfig.Meta.DeployTemplates.HelmRelease != nil {
-		releaseTemplate = *werfConfig.Meta.DeployTemplates.HelmRelease
+	if werfConfig.Meta.MetaDeploy.HelmRelease != nil {
+		releaseTemplate = *werfConfig.Meta.MetaDeploy.HelmRelease
 	} else if environmentOption == "" {
 		releaseTemplate = "[[ project ]]"
 	} else {
@@ -49,8 +49,8 @@ func GetHelmRelease(releaseOption string, environmentOption string, werfConfig *
 	}
 
 	var helmReleaseSlug bool
-	if werfConfig.Meta.DeployTemplates.HelmReleaseSlug != nil {
-		helmReleaseSlug = *werfConfig.Meta.DeployTemplates.HelmReleaseSlug
+	if werfConfig.Meta.MetaDeploy.HelmReleaseSlug != nil {
+		helmReleaseSlug = *werfConfig.Meta.MetaDeploy.HelmReleaseSlug
 	} else {
 		helmReleaseSlug = true
 	}
@@ -77,8 +77,8 @@ func GetKubernetesNamespace(namespaceOption string, environmentOption string, we
 	}
 
 	var namespaceTemplate string
-	if werfConfig.Meta.DeployTemplates.Namespace != nil {
-		namespaceTemplate = *werfConfig.Meta.DeployTemplates.Namespace
+	if werfConfig.Meta.MetaDeploy.Namespace != nil {
+		namespaceTemplate = *werfConfig.Meta.MetaDeploy.Namespace
 	} else if environmentOption == "" {
 		namespaceTemplate = "[[ project ]]"
 	} else {
@@ -95,8 +95,8 @@ func GetKubernetesNamespace(namespaceOption string, environmentOption string, we
 	}
 
 	var namespaceSlug bool
-	if werfConfig.Meta.DeployTemplates.NamespaceSlug != nil {
-		namespaceSlug = *werfConfig.Meta.DeployTemplates.NamespaceSlug
+	if werfConfig.Meta.MetaDeploy.NamespaceSlug != nil {
+		namespaceSlug = *werfConfig.Meta.MetaDeploy.NamespaceSlug
 	} else {
 		namespaceSlug = true
 	}

--- a/cmd/werf/compose/main.go
+++ b/cmd/werf/compose/main.go
@@ -152,8 +152,9 @@ Image environment name format: $WERF_IMAGE_<UPPERCASE_WERF_IMAGE_NAME>_NAME ($WE
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupSSHKey(&commonCmdData, cmd)

--- a/cmd/werf/config/list/list.go
+++ b/cmd/werf/config/list/list.go
@@ -35,8 +35,9 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 

--- a/cmd/werf/config/render/render.go
+++ b/cmd/werf/config/render/render.go
@@ -54,8 +54,9 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -373,7 +373,8 @@ func run(ctx context.Context, projectDir string) error {
 		LoadOptions: loader.LoadOptions{
 			ChartExtender:               wc,
 			SubchartExtenderFactoryFunc: func() chart.ChartExtender { return werf_chart.NewWerfChart(werf_chart.WerfChartOptions{}) },
-			FilesLoader:                 common.MakeGitFilesLoader(ctx, localGitRepo, projectDir, *commonCmdData.DisableDeterminism),
+			LoadDirFunc:                 common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableDeterminism),
+			LocateChartFunc:             common.MakeLocateChartFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableDeterminism),
 		},
 		PostRenderer: wc.ExtraAnnotationsAndLabelsPostRenderer,
 		ValueOpts: &values.Options{

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -71,8 +71,9 @@ Read more info about Helm Release name, Kubernetes Namespace and how to change i
 
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupDir(&commonCmdData, cmd)
 

--- a/cmd/werf/helm/get_autogenerated_values.go
+++ b/cmd/werf/helm/get_autogenerated_values.go
@@ -50,8 +50,9 @@ These values includes project name, docker images ids and other`),
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupSSHKey(&commonCmdData, cmd)

--- a/cmd/werf/helm/get_namespace.go
+++ b/cmd/werf/helm/get_namespace.go
@@ -31,7 +31,7 @@ func NewGetNamespaceCmd() *cobra.Command {
 	common.SetupDir(&getNamespaceCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
 	common.SetupConfigPath(&getNamespaceCmdData, cmd)
-	common.SetupConfigTemplatesDir(&getNamespaceCmdData, cmd)
+
 	common.SetupTmpDir(&getNamespaceCmdData, cmd)
 	common.SetupHomeDir(&getNamespaceCmdData, cmd)
 	common.SetupEnvironment(&getNamespaceCmdData, cmd)

--- a/cmd/werf/helm/get_release.go
+++ b/cmd/werf/helm/get_release.go
@@ -31,7 +31,7 @@ func NewGetReleaseCmd() *cobra.Command {
 	common.SetupDir(&getReleaseCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
 	common.SetupConfigPath(&getReleaseCmdData, cmd)
-	common.SetupConfigTemplatesDir(&getReleaseCmdData, cmd)
+
 	common.SetupTmpDir(&getReleaseCmdData, cmd)
 	common.SetupHomeDir(&getReleaseCmdData, cmd)
 	common.SetupEnvironment(&getReleaseCmdData, cmd)

--- a/cmd/werf/helm/helm.go
+++ b/cmd/werf/helm/helm.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/werf/werf/pkg/deploy/werf_chart"
+
 	helm_secret_decrypt "github.com/werf/werf/cmd/werf/helm/secret/decrypt"
 	helm_secret_encrypt "github.com/werf/werf/cmd/werf/helm/secret/encrypt"
 	helm_secret_file_decrypt "github.com/werf/werf/cmd/werf/helm/secret/file/decrypt"
@@ -21,6 +23,8 @@ import (
 	"github.com/werf/werf/pkg/deploy/helm"
 
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
 
 	"github.com/werf/werf/cmd/werf/common"
 	cmd_werf_common "github.com/werf/werf/cmd/werf/common"
@@ -69,7 +73,12 @@ func NewCmd() *cobra.Command {
 		cmd_helm.NewPluginCmd(os.Stdout),
 		cmd_helm.NewPullCmd(os.Stdout),
 		cmd_helm.NewSearchCmd(os.Stdout),
-		cmd_helm.NewShowCmd(os.Stdout),
+		cmd_helm.NewShowCmd(os.Stdout, cmd_helm.ShowCmdOptions{
+			LoadOptions: loader.LoadOptions{
+				ChartExtender:               werf_chart.NewWerfChart(werf_chart.WerfChartOptions{}),
+				SubchartExtenderFactoryFunc: func() chart.ChartExtender { return werf_chart.NewWerfChart(werf_chart.WerfChartOptions{}) },
+			},
+		}),
 		cmd_helm.NewStatusCmd(actionConfig, os.Stdout),
 		cmd_helm.NewTestCmd(actionConfig, os.Stdout),
 		cmd_helm.NewVerifyCmd(os.Stdout),

--- a/cmd/werf/managed_images/add/add.go
+++ b/cmd/werf/managed_images/add/add.go
@@ -38,8 +38,9 @@ func NewCmd() *cobra.Command {
 	common.SetupProjectName(&commonCmdData, cmd)
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupSSHKey(&commonCmdData, cmd)

--- a/cmd/werf/managed_images/ls/ls.go
+++ b/cmd/werf/managed_images/ls/ls.go
@@ -36,8 +36,9 @@ func NewCmd() *cobra.Command {
 	common.SetupProjectName(&commonCmdData, cmd)
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupSSHKey(&commonCmdData, cmd)

--- a/cmd/werf/managed_images/rm/rm.go
+++ b/cmd/werf/managed_images/rm/rm.go
@@ -40,8 +40,9 @@ func NewCmd() *cobra.Command {
 	common.SetupProjectName(&commonCmdData, cmd)
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupSSHKey(&commonCmdData, cmd)

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -51,8 +51,9 @@ WARNING: Do not run this command during any other werf command is working on the
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -78,8 +78,9 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupSSHKey(&commonCmdData, cmd)
@@ -103,7 +104,7 @@ func NewCmd() *cobra.Command {
 	common.SetupKubeConfig(&commonCmdData, cmd)
 	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
-	common.SetupHelmChartDir(&commonCmdData, cmd)
+
 	common.SetupStatusProgressPeriod(&commonCmdData, cmd)
 	common.SetupHooksStatusProgressPeriod(&commonCmdData, cmd)
 	common.SetupReleasesHistoryMax(&commonCmdData, cmd)
@@ -191,7 +192,7 @@ func runRender() error {
 
 	projectName := werfConfig.Meta.Project
 
-	chartDir, err := common.GetHelmChartDir(projectDir, &commonCmdData)
+	chartDir, err := common.GetHelmChartDir(projectDir, &commonCmdData, werfConfig)
 	if err != nil {
 		return fmt.Errorf("getting helm chart dir failed: %s", err)
 	}

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -107,8 +107,9 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupSSHKey(&commonCmdData, cmd)

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -51,8 +51,9 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupDisableDeterminism(&commonCmdData, cmd)
-	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupSSHKey(&commonCmdData, cmd)

--- a/go.mod
+++ b/go.mod
@@ -144,4 +144,4 @@ replace github.com/containerd/containerd => github.com/containerd/containerd v1.
 
 replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
 
-replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201112095157-718e2f06aa35
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201113193039-e8103b38e3e8

--- a/go.sum
+++ b/go.sum
@@ -1415,6 +1415,8 @@ github.com/werf/helm/v3 v3.0.0-20201112082654-c5d8cef19ba3 h1:pCkZkxaHj0itAbjH0H
 github.com/werf/helm/v3 v3.0.0-20201112082654-c5d8cef19ba3/go.mod h1:jbfz/BoYmpJ3njhHBdH7F3kR8CNUGeRueliFtOhQK+M=
 github.com/werf/helm/v3 v3.0.0-20201112095157-718e2f06aa35 h1:b4FW3d+onjlu6EKLiJ5A4zdlYve4K4HXTEdHMoVNoCg=
 github.com/werf/helm/v3 v3.0.0-20201112095157-718e2f06aa35/go.mod h1:jbfz/BoYmpJ3njhHBdH7F3kR8CNUGeRueliFtOhQK+M=
+github.com/werf/helm/v3 v3.0.0-20201113193039-e8103b38e3e8 h1:fGbJLRZb+YDi2odWhVBAWoC7VDi2uY37aMZlMOXhyRI=
+github.com/werf/helm/v3 v3.0.0-20201113193039-e8103b38e3e8/go.mod h1:jbfz/BoYmpJ3njhHBdH7F3kR8CNUGeRueliFtOhQK+M=
 github.com/werf/kubedog v0.4.1-0.20200818145659-3aa022a95c07 h1:pKU78lxdl5Ck4zkWzwH74FOnAC3uf/5u5rbS8SRcXwk=
 github.com/werf/kubedog v0.4.1-0.20200818145659-3aa022a95c07/go.mod h1:b/5MyrNDmxXtr68uucMmZCZmWS3h7cfAcgqtQbHsw5o=
 github.com/werf/kubedog v0.4.1-0.20200907160731-10aec4300377 h1:bQgmFAC6Q7FEVR0Xa8I875LgTTxlHnWM/qGtHAK3OZQ=

--- a/pkg/config/meta.go
+++ b/pkg/config/meta.go
@@ -1,8 +1,8 @@
 package config
 
 type Meta struct {
-	ConfigVersion   int
-	Project         string
-	DeployTemplates MetaDeployTemplates
-	Cleanup         MetaCleanup
+	ConfigVersion int
+	Project       string
+	MetaDeploy    MetaDeploy
+	Cleanup       MetaCleanup
 }

--- a/pkg/config/meta_deploy.go
+++ b/pkg/config/meta_deploy.go
@@ -1,6 +1,7 @@
 package config
 
-type MetaDeployTemplates struct {
+type MetaDeploy struct {
+	HelmChartDir    *string
 	HelmRelease     *string
 	HelmReleaseSlug *bool
 	Namespace       *string

--- a/pkg/config/raw_meta.go
+++ b/pkg/config/raw_meta.go
@@ -8,10 +8,11 @@ import (
 )
 
 type rawMeta struct {
-	ConfigVersion   *int                    `yaml:"configVersion,omitempty"`
-	Project         *string                 `yaml:"project,omitempty"`
-	DeployTemplates *rawMetaDeployTemplates `yaml:"deploy,omitempty"`
-	Cleanup         *rawMetaCleanup         `yaml:"cleanup,omitempty"`
+	ConfigVersion      *int            `yaml:"configVersion,omitempty"`
+	Project            *string         `yaml:"project,omitempty"`
+	ConfigTempaltesDir *string         `yaml:"templatesDir,omitempty"`
+	MetaDeploy         *rawMetaDeploy  `yaml:"deploy,omitempty"`
+	Cleanup            *rawMetaCleanup `yaml:"cleanup,omitempty"`
 
 	doc *doc `yaml:"-"` // parent
 
@@ -29,6 +30,10 @@ func (c *rawMeta) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	if err := checkOverflow(c.UnsupportedAttributes, nil, c.doc); err != nil {
 		return err
+	}
+
+	if c.ConfigTempaltesDir != nil && *c.ConfigTempaltesDir == "" {
+		return newDetailedConfigError("'templatesDir' field cannot be empty!", nil, c.doc)
 	}
 
 	if c.ConfigVersion == nil || *c.ConfigVersion != 1 {
@@ -66,8 +71,8 @@ func (c *rawMeta) toMeta() *Meta {
 		meta.Cleanup = c.Cleanup.toMetaCleanup()
 	}
 
-	if c.DeployTemplates != nil {
-		meta.DeployTemplates = c.DeployTemplates.toDeployTemplates()
+	if c.MetaDeploy != nil {
+		meta.MetaDeploy = c.MetaDeploy.toMetaDeploy()
 	}
 
 	return meta

--- a/pkg/config/raw_meta_deploy.go
+++ b/pkg/config/raw_meta_deploy.go
@@ -1,6 +1,7 @@
 package config
 
-type rawMetaDeployTemplates struct {
+type rawMetaDeploy struct {
+	HelmChartDir    *string `yaml:"helmChartDir,omitempty"`
 	HelmRelease     *string `yaml:"helmRelease,omitempty"`
 	HelmReleaseSlug *bool   `yaml:"helmReleaseSlug,omitempty"`
 	Namespace       *string `yaml:"namespace,omitempty"`
@@ -11,13 +12,13 @@ type rawMetaDeployTemplates struct {
 	UnsupportedAttributes map[string]interface{} `yaml:",inline"`
 }
 
-func (c *rawMetaDeployTemplates) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *rawMetaDeploy) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if parent, ok := parentStack.Peek().(*rawMeta); ok {
 		c.rawMeta = parent
 	}
 
 	parentStack.Push(c)
-	type plain rawMetaDeployTemplates
+	type plain rawMetaDeploy
 	err := unmarshal((*plain)(c))
 	parentStack.Pop()
 	if err != nil {
@@ -26,6 +27,10 @@ func (c *rawMetaDeployTemplates) UnmarshalYAML(unmarshal func(interface{}) error
 
 	if err := checkOverflow(c.UnsupportedAttributes, nil, c.rawMeta.doc); err != nil {
 		return err
+	}
+
+	if c.HelmChartDir != nil && *c.HelmChartDir == "" {
+		return newDetailedConfigError("helmChartDir field cannot be empty!", nil, c.rawMeta.doc)
 	}
 
 	if c.HelmRelease != nil && *c.HelmRelease == "" {
@@ -39,11 +44,12 @@ func (c *rawMetaDeployTemplates) UnmarshalYAML(unmarshal func(interface{}) error
 	return nil
 }
 
-func (c *rawMetaDeployTemplates) toDeployTemplates() MetaDeployTemplates {
-	deployTemplates := MetaDeployTemplates{}
-	deployTemplates.HelmRelease = c.HelmRelease
-	deployTemplates.HelmReleaseSlug = c.HelmReleaseSlug
-	deployTemplates.Namespace = c.Namespace
-	deployTemplates.NamespaceSlug = c.NamespaceSlug
-	return deployTemplates
+func (c *rawMetaDeploy) toMetaDeploy() MetaDeploy {
+	metaDeploy := MetaDeploy{}
+	metaDeploy.HelmChartDir = c.HelmChartDir
+	metaDeploy.HelmRelease = c.HelmRelease
+	metaDeploy.HelmReleaseSlug = c.HelmReleaseSlug
+	metaDeploy.Namespace = c.Namespace
+	metaDeploy.NamespaceSlug = c.NamespaceSlug
+	return metaDeploy
 }


### PR DESCRIPTION
```
configVersion: 1
deploy:
  helmChartDir: .helm
```

There is no more `--helm-char-dir` option.

Refs https://github.com/werf/werf/issues/2874.
Fixes https://github.com/werf/werf/issues/2897.