### PR TITLE
Add git-patches and git-archives cache to git_repo.GitDataManager

### DIFF
--- a/cmd/werf/build/main.go
+++ b/cmd/werf/build/main.go
@@ -100,8 +100,6 @@ If one or more IMAGE_NAME parameters specified, werf will build only these image
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	
-	
 	common.SetupParallelOptions(&commonCmdData, cmd, common.DefaultBuildParallelTasksLimit)
 
 	return cmd
@@ -113,6 +111,10 @@ func run(commonCmdData *common.CmdData, imagesToProcess []string) error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := image.Init(); err != nil {

--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -85,6 +85,10 @@ func runCIEnv(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	if err := common.ValidateArgumentCount(1, args, cmd); err != nil {
 		return err
 	}

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -92,6 +92,10 @@ func runCleanup() error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	if err := true_git.Init(true_git.Options{LiveGitOutput: *commonCmdData.LogVerbose || *commonCmdData.LogDebug}); err != nil {
 		return err
 	}

--- a/cmd/werf/compose/main.go
+++ b/cmd/werf/compose/main.go
@@ -187,9 +187,6 @@ Image environment name format: $WERF_IMAGE_<UPPERCASE_WERF_IMAGE_NAME>_NAME ($WE
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	
-	
-
 	cmd.Flags().StringVarP(&cmdData.RawComposeOptions, "docker-compose-options", "", os.Getenv("WERF_DOCKER_COMPOSE_OPTIONS"), "Define docker-compose options (default $WERF_DOCKER_COMPOSE_OPTIONS)")
 	cmd.Flags().StringVarP(&cmdData.RawComposeCommandOptions, "docker-compose-command-options", "", os.Getenv("WERF_DOCKER_COMPOSE_COMMAND_OPTIONS"), "Define docker-compose command options (default $WERF_DOCKER_COMPOSE_COMMAND_OPTIONS)")
 	cmd.Flags().StringVarP(&cmdData.ComposeBinPath, "docker-compose-bin-path", "", os.Getenv("WERF_DOCKER_COMPOSE_BIN_PATH"), "Define docker-compose bin path (default $WERF_DOCKER_COMPOSE_BIN_PATH)")
@@ -246,6 +243,10 @@ func runMain(dockerComposeCmdName string, cmdData cmdDataType, commonCmdData com
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := image.Init(); err != nil {

--- a/cmd/werf/config/list/list.go
+++ b/cmd/werf/config/list/list.go
@@ -52,6 +52,10 @@ func run() error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	projectDir, err := common.GetProjectDir(&commonCmdData)
 	if err != nil {
 		return fmt.Errorf("getting project dir failed: %s", err)

--- a/cmd/werf/config/render/render.go
+++ b/cmd/werf/config/render/render.go
@@ -28,6 +28,10 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("initialization error: %s", err)
 			}
 
+			if err := git_repo.Init(); err != nil {
+				return err
+			}
+
 			projectDir, err := common.GetProjectDir(&commonCmdData)
 			if err != nil {
 				return fmt.Errorf("getting project dir failed: %s", err)

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -129,8 +129,6 @@ werf converge --repo registry.mydomain.com/web --env production`,
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	
-	
 	common.SetupParallelOptions(&commonCmdData, cmd, common.DefaultBuildParallelTasksLimit)
 
 	common.SetupSkipBuild(&commonCmdData, cmd)
@@ -149,6 +147,10 @@ func runMain(ctx context.Context) error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := image.Init(); err != nil {

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -111,6 +111,10 @@ func runDismiss() error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	if err := image.Init(); err != nil {
 		return err
 	}

--- a/cmd/werf/helm/get_autogenerated_values.go
+++ b/cmd/werf/helm/get_autogenerated_values.go
@@ -69,9 +69,6 @@ These values includes project name, docker images ids and other`),
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	
-	
-
 	common.SetupNamespace(&commonCmdData, cmd)
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read and pull images from the specified repo")
@@ -92,6 +89,10 @@ func runGetServiceValues() error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := image.Init(); err != nil {

--- a/cmd/werf/helm/get_namespace.go
+++ b/cmd/werf/helm/get_namespace.go
@@ -48,6 +48,10 @@ func runGetNamespace() error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	projectDir, err := common.GetProjectDir(&getNamespaceCmdData)
 	if err != nil {
 		return fmt.Errorf("getting project dir failed: %s", err)

--- a/cmd/werf/helm/get_release.go
+++ b/cmd/werf/helm/get_release.go
@@ -48,6 +48,10 @@ func runGetRelease() error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	projectDir, err := common.GetProjectDir(&getReleaseCmdData)
 	if err != nil {
 		return fmt.Errorf("getting project dir failed: %s", err)

--- a/cmd/werf/helm/install.go
+++ b/cmd/werf/helm/install.go
@@ -8,6 +8,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 
 	"github.com/werf/werf/pkg/deploy/werf_chart"
@@ -38,6 +39,10 @@ func NewInstallCmd(actionConfig *action.Configuration) *cobra.Command {
 	oldRunE := cmd.RunE
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := werf.Init(*installCmdData.TmpDir, *installCmdData.HomeDir); err != nil {
+			return err
+		}
+
+		if err := git_repo.Init(); err != nil {
 			return err
 		}
 

--- a/cmd/werf/helm/secret/decrypt/decrypt.go
+++ b/cmd/werf/helm/secret/decrypt/decrypt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/werf/werf/cmd/werf/common"
 	secret_common "github.com/werf/werf/cmd/werf/helm/secret/common"
 	"github.com/werf/werf/pkg/deploy/secret"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -62,6 +63,10 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 func runSecretDecrypt() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	projectDir, err := common.GetProjectDir(&commonCmdData)

--- a/cmd/werf/helm/secret/encrypt/encrypt.go
+++ b/cmd/werf/helm/secret/encrypt/encrypt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/werf/werf/cmd/werf/common"
 	secret_common "github.com/werf/werf/cmd/werf/helm/secret/common"
 	"github.com/werf/werf/pkg/deploy/secret"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -61,6 +62,10 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 func runSecretEncrypt() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	projectDir, err := common.GetProjectDir(&commonCmdData)

--- a/cmd/werf/helm/secret/file/decrypt/decrypt.go
+++ b/cmd/werf/helm/secret/file/decrypt/decrypt.go
@@ -9,6 +9,7 @@ import (
 	"github.com/werf/werf/cmd/werf/common"
 	secret_common "github.com/werf/werf/cmd/werf/helm/secret/common"
 	"github.com/werf/werf/pkg/deploy/secret"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -72,6 +73,10 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 func runSecretDecrypt(filePath string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	projectDir, err := common.GetProjectDir(&commonCmdData)

--- a/cmd/werf/helm/secret/file/edit/edit.go
+++ b/cmd/werf/helm/secret/file/edit/edit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/werf/werf/cmd/werf/common"
 	secret_common "github.com/werf/werf/cmd/werf/helm/secret/common"
 	"github.com/werf/werf/pkg/deploy/secret"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -51,6 +52,10 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 func runSecretEdit(filepPath string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	projectDir, err := common.GetProjectDir(&commonCmdData)

--- a/cmd/werf/helm/secret/file/encrypt/encrypt.go
+++ b/cmd/werf/helm/secret/file/encrypt/encrypt.go
@@ -9,6 +9,7 @@ import (
 	"github.com/werf/werf/cmd/werf/common"
 	secret_common "github.com/werf/werf/cmd/werf/helm/secret/common"
 	"github.com/werf/werf/pkg/deploy/secret"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -68,6 +69,10 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 func runSecretEncrypt(filePath string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	projectDir, err := common.GetProjectDir(&commonCmdData)

--- a/cmd/werf/helm/secret/rotate_secret_key/rotate_secret_key.go
+++ b/cmd/werf/helm/secret/rotate_secret_key/rotate_secret_key.go
@@ -69,6 +69,10 @@ func runRotateSecretKey(cmd *cobra.Command, secretValuesPaths ...string) error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	projectDir, err := common.GetProjectDir(&commonCmdData)
 	if err != nil {
 		return fmt.Errorf("getting project dir failed: %s", err)

--- a/cmd/werf/helm/secret/values/decrypt/decrypt.go
+++ b/cmd/werf/helm/secret/values/decrypt/decrypt.go
@@ -9,6 +9,7 @@ import (
 	"github.com/werf/werf/cmd/werf/common"
 	secret_common "github.com/werf/werf/cmd/werf/helm/secret/common"
 	"github.com/werf/werf/pkg/deploy/secret"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -77,6 +78,10 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 func runSecretDecrypt(filePath string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	projectDir, err := common.GetProjectDir(&commonCmdData)

--- a/cmd/werf/helm/secret/values/edit/edit.go
+++ b/cmd/werf/helm/secret/values/edit/edit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/werf/werf/cmd/werf/common"
 	secret_common "github.com/werf/werf/cmd/werf/helm/secret/common"
 	"github.com/werf/werf/pkg/deploy/secret"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -51,6 +52,10 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 func runSecretEdit(filepPath string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	projectDir, err := common.GetProjectDir(&commonCmdData)

--- a/cmd/werf/helm/secret/values/encrypt/encrypt.go
+++ b/cmd/werf/helm/secret/values/encrypt/encrypt.go
@@ -9,6 +9,7 @@ import (
 	"github.com/werf/werf/cmd/werf/common"
 	secret_common "github.com/werf/werf/cmd/werf/helm/secret/common"
 	"github.com/werf/werf/pkg/deploy/secret"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -68,6 +69,10 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 func runSecretEncrypt(filePath string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	projectDir, err := common.GetProjectDir(&commonCmdData)

--- a/cmd/werf/helm/template.go
+++ b/cmd/werf/helm/template.go
@@ -8,6 +8,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 
 	"github.com/werf/werf/pkg/deploy/werf_chart"
@@ -38,6 +39,10 @@ func NewTemplateCmd(actionConfig *action.Configuration) *cobra.Command {
 	oldRunE := cmd.RunE
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := werf.Init(*templateCmdData.TmpDir, *templateCmdData.HomeDir); err != nil {
+			return err
+		}
+
+		if err := git_repo.Init(); err != nil {
 			return err
 		}
 

--- a/cmd/werf/helm/upgrade.go
+++ b/cmd/werf/helm/upgrade.go
@@ -8,6 +8,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 
 	"github.com/werf/werf/pkg/deploy/werf_chart"
@@ -36,6 +37,10 @@ func NewUpgradeCmd(actionConfig *action.Configuration) *cobra.Command {
 	oldRunE := cmd.RunE
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := werf.Init(*upgradeCmdData.TmpDir, *upgradeCmdData.HomeDir); err != nil {
+			return err
+		}
+
+		if err := git_repo.Init(); err != nil {
 			return err
 		}
 

--- a/cmd/werf/host/cleanup/cleanup.go
+++ b/cmd/werf/host/cleanup/cleanup.go
@@ -3,6 +3,7 @@ package cleanup
 import (
 	"fmt"
 
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/image"
 
 	"github.com/spf13/cobra"
@@ -64,6 +65,10 @@ func runGC() error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := image.Init(); err != nil {

--- a/cmd/werf/host/project/list/list.go
+++ b/cmd/werf/host/project/list/list.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/docker"
+	"github.com/werf/werf/pkg/git_repo"
 	imagePkg "github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/werf"
 )
@@ -64,6 +65,10 @@ func run() error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := docker.Init(ctx, *commonCmdData.DockerConfig, *commonCmdData.LogVerbose, *commonCmdData.LogDebug); err != nil {

--- a/cmd/werf/host/project/purge/purge.go
+++ b/cmd/werf/host/project/purge/purge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/werf/werf/pkg/cleaning"
 	"github.com/werf/werf/pkg/container_runtime"
 	"github.com/werf/werf/pkg/docker"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/storage/manager"
 	"github.com/werf/werf/pkg/werf"
@@ -75,6 +76,10 @@ func run(projectNames ...string) error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := image.Init(); err != nil {

--- a/cmd/werf/host/purge/purge.go
+++ b/cmd/werf/host/purge/purge.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/docker"
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/host_cleaning"
 	"github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/werf"
@@ -68,6 +69,10 @@ func runReset() error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := image.Init(); err != nil {

--- a/cmd/werf/managed_images/add/add.go
+++ b/cmd/werf/managed_images/add/add.go
@@ -71,6 +71,10 @@ func run(imageName string) error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	if err := image.Init(); err != nil {
 		return err
 	}

--- a/cmd/werf/managed_images/ls/ls.go
+++ b/cmd/werf/managed_images/ls/ls.go
@@ -69,6 +69,10 @@ func run() error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	if err := image.Init(); err != nil {
 		return err
 	}

--- a/cmd/werf/managed_images/rm/rm.go
+++ b/cmd/werf/managed_images/rm/rm.go
@@ -73,6 +73,10 @@ func run(imageNames []string) error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	if err := image.Init(); err != nil {
 		return err
 	}

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -88,6 +88,10 @@ func runPurge() error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
 	if err := image.Init(); err != nil {
 		return err
 	}

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -129,8 +129,6 @@ func NewCmd() *cobra.Command {
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	
-	
 	common.SetupParallelOptions(&commonCmdData, cmd, common.DefaultBuildParallelTasksLimit)
 
 	common.SetupSkipBuild(&commonCmdData, cmd)
@@ -149,6 +147,10 @@ func runRender() error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := image.Init(); err != nil {

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -140,9 +140,6 @@ func NewCmd() *cobra.Command {
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	
-	
-
 	cmd.Flags().BoolVarP(&cmdData.Shell, "shell", "", false, "Use predefined docker options and command for debug")
 	cmd.Flags().BoolVarP(&cmdData.Bash, "bash", "", false, "Use predefined docker options and command for debug")
 	cmd.Flags().StringVarP(&cmdData.RawDockerOptions, "docker-options", "", os.Getenv("WERF_DOCKER_OPTIONS"), "Define docker run options (default $WERF_DOCKER_OPTIONS)")
@@ -210,6 +207,10 @@ func runMain() error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := image.Init(); err != nil {

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -80,9 +80,6 @@ func NewCmd() *cobra.Command {
 	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
 	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
 
-	
-	
-
 	return cmd
 }
 
@@ -91,6 +88,10 @@ func run(imageName string) error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	if err := image.Init(); err != nil {

--- a/cmd/werf/synchronization/main.go
+++ b/cmd/werf/synchronization/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/werf/kubedog/pkg/kube"
 
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/kubeutils"
 	"github.com/werf/werf/pkg/storage"
 	"github.com/werf/werf/pkg/storage/synchronization_server"
@@ -87,6 +88,10 @@ func runSynchronization() error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
 	}
 
 	host, port := cmdData.Host, cmdData.Port

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -254,12 +254,6 @@ func (c *Conveyor) AppendOnTerminateFunc(f func() error) {
 func (c *Conveyor) Terminate(ctx context.Context) error {
 	var terminateErrors []error
 
-	for gitRepoName, gitRepoCache := range c.GetGitRepoCaches() {
-		if err := gitRepoCache.Terminate(); err != nil {
-			terminateErrors = append(terminateErrors, fmt.Errorf("unable to terminate cache of git repo '%s': %s", gitRepoName, err))
-		}
-	}
-
 	for _, onTerminateFunc := range c.onTerminateFuncs {
 		if err := onTerminateFunc(); err != nil {
 			terminateErrors = append(terminateErrors, err)
@@ -825,15 +819,12 @@ func initStages(ctx context.Context, image *Image, imageInterfaceConfig config.S
 	}
 
 	gitArchiveStageOptions := &stage.NewGitArchiveStageOptions{
-		ArchivesDir:          getImageArchivesDir(imageName, c),
 		ScriptsDir:           getImageScriptsDir(imageName, c),
 		ContainerArchivesDir: getImageArchivesContainerDir(c),
 		ContainerScriptsDir:  getImageScriptsContainerDir(c),
 	}
 
 	gitPatchStageOptions := &stage.NewGitPatchStageOptions{
-		PatchesDir:           getImagePatchesDir(imageName, c),
-		ArchivesDir:          getImageArchivesDir(imageName, c),
 		ScriptsDir:           getImageScriptsDir(imageName, c),
 		ContainerPatchesDir:  getImagePatchesContainerDir(c),
 		ContainerArchivesDir: getImageArchivesContainerDir(c),
@@ -1084,9 +1075,7 @@ func baseGitMappingInit(local *config.GitLocalExport, imageName string, c *Conve
 
 	gitMapping := stage.NewGitMapping()
 
-	gitMapping.PatchesDir = getImagePatchesDir(imageName, c)
 	gitMapping.ContainerPatchesDir = getImagePatchesContainerDir(c)
-	gitMapping.ArchivesDir = getImageArchivesDir(imageName, c)
 	gitMapping.ContainerArchivesDir = getImageArchivesContainerDir(c)
 	gitMapping.ScriptsDir = getImageScriptsDir(imageName, c)
 	gitMapping.ContainerScriptsDir = getImageScriptsContainerDir(c)
@@ -1102,16 +1091,8 @@ func baseGitMappingInit(local *config.GitLocalExport, imageName string, c *Conve
 	return gitMapping
 }
 
-func getImagePatchesDir(imageName string, c *Conveyor) string {
-	return filepath.Join(c.tmpDir, imageName, "patch")
-}
-
 func getImagePatchesContainerDir(c *Conveyor) string {
 	return path.Join(c.containerWerfDir, "patch")
-}
-
-func getImageArchivesDir(imageName string, c *Conveyor) string {
-	return filepath.Join(c.tmpDir, imageName, "archive")
 }
 
 func getImageArchivesContainerDir(c *Conveyor) string {

--- a/pkg/build/stage/git_archive.go
+++ b/pkg/build/stage/git_archive.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/werf/werf/pkg/git_repo"
+
 	"github.com/werf/werf/pkg/container_runtime"
 	"github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/util"
@@ -71,7 +73,7 @@ func (s *GitArchiveStage) PrepareImage(ctx context.Context, c Conveyor, prevBuil
 		}
 	}
 
-	image.Container().RunOptions().AddVolume(fmt.Sprintf("%s:%s:ro", s.ArchivesDir, s.ContainerArchivesDir))
+	image.Container().RunOptions().AddVolume(fmt.Sprintf("%s:%s:ro", git_repo.CommonGitDataManager.ArchivesCacheDir, s.ContainerArchivesDir))
 	image.Container().RunOptions().AddVolume(fmt.Sprintf("%s:%s:ro", s.ScriptsDir, s.ContainerScriptsDir))
 
 	return nil

--- a/pkg/build/stage/git_patch.go
+++ b/pkg/build/stage/git_patch.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/werf/werf/pkg/git_repo"
+
 	"github.com/werf/werf/pkg/container_runtime"
 )
 
 type NewGitPatchStageOptions struct {
-	PatchesDir           string
-	ArchivesDir          string
 	ScriptsDir           string
 	ContainerPatchesDir  string
 	ContainerArchivesDir string
@@ -18,8 +18,6 @@ type NewGitPatchStageOptions struct {
 
 func newGitPatchStage(name StageName, gitPatchStageOptions *NewGitPatchStageOptions, baseStageOptions *NewBaseStageOptions) *GitPatchStage {
 	s := &GitPatchStage{
-		PatchesDir:           gitPatchStageOptions.PatchesDir,
-		ArchivesDir:          gitPatchStageOptions.ArchivesDir,
 		ScriptsDir:           gitPatchStageOptions.ScriptsDir,
 		ContainerPatchesDir:  gitPatchStageOptions.ContainerPatchesDir,
 		ContainerArchivesDir: gitPatchStageOptions.ContainerArchivesDir,
@@ -32,8 +30,6 @@ func newGitPatchStage(name StageName, gitPatchStageOptions *NewGitPatchStageOpti
 type GitPatchStage struct {
 	*GitStage
 
-	PatchesDir           string
-	ArchivesDir          string
 	ScriptsDir           string
 	ContainerPatchesDir  string
 	ContainerArchivesDir string
@@ -89,8 +85,8 @@ func (s *GitPatchStage) prepareImage(ctx context.Context, c Conveyor, prevBuiltI
 		}
 	}
 
-	image.Container().RunOptions().AddVolume(fmt.Sprintf("%s:%s:ro", s.PatchesDir, s.ContainerPatchesDir))
-	image.Container().RunOptions().AddVolume(fmt.Sprintf("%s:%s:ro", s.ArchivesDir, s.ContainerArchivesDir))
+	image.Container().RunOptions().AddVolume(fmt.Sprintf("%s:%s:ro", git_repo.CommonGitDataManager.PatchesCacheDir, s.ContainerPatchesDir))
+	image.Container().RunOptions().AddVolume(fmt.Sprintf("%s:%s:ro", git_repo.CommonGitDataManager.ArchivesCacheDir, s.ContainerArchivesDir))
 	image.Container().RunOptions().AddVolume(fmt.Sprintf("%s:%s:ro", s.ScriptsDir, s.ContainerScriptsDir))
 
 	return nil

--- a/pkg/git_repo/git_data_manager.go
+++ b/pkg/git_repo/git_data_manager.go
@@ -1,34 +1,49 @@
 package git_repo
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/werf/werf/pkg/true_git"
+
+	"github.com/werf/werf/pkg/util"
+
+	"github.com/werf/lockgate"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/werf/werf/pkg/werf"
 )
 
 const (
-	GitDataCacheVersion = "1"
+	GitArchivesCacheVersion = "1"
+	GitPatchesCacheVersion  = "1"
 )
+
+var (
+	CommonGitDataManager *GitDataManager
+)
+
+func Init() error {
+	CommonGitDataManager = NewGitDataManager(
+		filepath.Join(werf.GetLocalCacheDir(), "git_archives", GitArchivesCacheVersion),
+		filepath.Join(werf.GetLocalCacheDir(), "git_patches", GitPatchesCacheVersion),
+		filepath.Join(werf.GetServiceDir(), "tmp", "git_data"),
+	)
+	return nil
+}
+
+func NewGitDataManager(archivesCacheDir, patchesCacheDir, tmpDir string) *GitDataManager {
+	return &GitDataManager{ArchivesCacheDir: archivesCacheDir, PatchesCacheDir: patchesCacheDir, TmpDir: tmpDir}
+}
 
 type GitDataManager struct {
 	ArchivesCacheDir string
 	PatchesCacheDir  string
 	TmpDir           string
-}
-
-func NewCommonGitDataManager() *GitDataManager {
-	return NewGitDataManager(
-		filepath.Join(werf.GetLocalCacheDir(), "git_data", GitDataCacheVersion, "archives"),
-		filepath.Join(werf.GetLocalCacheDir(), "git_data", GitDataCacheVersion, "patches"),
-		filepath.Join(werf.GetLocalCacheDir(), "git_data", GitDataCacheVersion, "tmp"),
-	)
-}
-
-func NewGitDataManager(archivesCacheDir, patchesCacheDir, tmpDir string) *GitDataManager {
-	return &GitDataManager{ArchivesCacheDir: archivesCacheDir, PatchesCacheDir: patchesCacheDir, TmpDir: tmpDir}
 }
 
 func (manager *GitDataManager) GC() error {
@@ -39,61 +54,183 @@ func (manager *GitDataManager) getArchiveCacheFilePath(repoID, commit string) st
 	return filepath.Join(manager.ArchivesCacheDir, repoID, fmt.Sprintf("%s.tar", commit))
 }
 
-func (manager *GitDataManager) NewTmpArchiveFile() (*ArchiveFile, error) {
-	path := filepath.Join(manager.TmpDir, fmt.Sprintf("%s.tar", uuid.NewV4().String()))
+func (manager *GitDataManager) NewTmpFile() (string, error) {
+	path := filepath.Join(manager.TmpDir, uuid.NewV4().String())
 	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
-		return nil, fmt.Errorf("unable to create dir %q: %s", filepath.Dir(path), err)
+		return "", fmt.Errorf("unable to create dir %q: %s", filepath.Dir(path), err)
 	}
-	return &ArchiveFile{FilePath: path}, nil
+	return path, nil
 }
 
-func (manager *GitDataManager) GetArchiveFile(repoID, commit string) (*ArchiveFile, error) {
-	path := manager.getArchiveCacheFilePath(repoID, commit)
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+func (manager *GitDataManager) GetArchiveFile(ctx context.Context, repoID string, opts ArchiveOptions) (*ArchiveFile, error) {
+	if lock, err := manager.lockGC(ctx, true); err != nil {
+		return nil, err
+	} else {
+		defer werf.ReleaseHostLock(lock)
+	}
+
+	metadataPath := filepath.Join(manager.ArchivesCacheDir, archiveMetadataFileName(repoID, opts))
+	if exists, err := util.FileExists(metadataPath); err != nil {
+		return nil, err
+	} else if !exists {
 		return nil, nil
-	} else if err != nil {
-		return nil, fmt.Errorf("stat file %q failed: %s", path, err)
 	}
-	return &ArchiveFile{FilePath: path}, nil
+
+	path := filepath.Join(manager.ArchivesCacheDir, archiveFileName(repoID, opts))
+	if exists, err := util.FileExists(path); err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, nil
+	}
+
+	if data, err := ioutil.ReadFile(metadataPath); err != nil {
+		return nil, fmt.Errorf("error reading %s: %s", metadataPath, err)
+	} else {
+		var desc *true_git.ArchiveDescriptor
+		if err := json.Unmarshal(data, &desc); err != nil {
+			return nil, fmt.Errorf("error unmarshalling json from %s: %s", metadataPath, err)
+		}
+
+		return &ArchiveFile{FilePath: path, Descriptor: desc}, nil
+	}
 }
 
-func (manager *GitDataManager) PutArchiveFile(repoID, commit string, archiveFile *ArchiveFile) error {
-	path := manager.getArchiveCacheFilePath(repoID, commit)
-	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
-		return fmt.Errorf("unable to create dir %q: %s", filepath.Dir(path), err)
+func (manager *GitDataManager) lockGC(ctx context.Context, readOnly bool) (lockgate.LockHandle, error) {
+	_, handle, err := werf.AcquireHostLock(ctx, "git_data_manager", lockgate.AcquireOptions{NonBlocking: readOnly})
+	return handle, err
+}
+
+func (manager *GitDataManager) CreateArchiveFile(ctx context.Context, repoID string, opts ArchiveOptions, tmpPath string, desc *true_git.ArchiveDescriptor) (*ArchiveFile, error) {
+	if lock, err := manager.lockGC(ctx, true); err != nil {
+		return nil, err
+	} else {
+		defer werf.ReleaseHostLock(lock)
 	}
-	// TODO: put into cache, use lock for gc and another puts
-	return nil
+
+	if _, lock, err := werf.AcquireHostLock(ctx, fmt.Sprintf("git_archive.%s_%s", repoID, util.ObjectToHashKey(opts)), lockgate.AcquireOptions{}); err != nil {
+		return nil, err
+	} else {
+		defer werf.ReleaseHostLock(lock)
+	}
+
+	if archiveFile, err := manager.GetArchiveFile(ctx, repoID, opts); err != nil {
+		return nil, err
+	} else if archiveFile != nil {
+		return archiveFile, nil
+	}
+
+	if err := os.MkdirAll(manager.ArchivesCacheDir, 0777); err != nil {
+		return nil, fmt.Errorf("unable to create dir %q: %s", manager.ArchivesCacheDir, err)
+	}
+
+	metadataPath := filepath.Join(manager.ArchivesCacheDir, archiveMetadataFileName(repoID, opts))
+	if metadata, err := json.Marshal(desc); err != nil {
+		return nil, fmt.Errorf("error marshalling archive %s %s metadata json: %s", repoID, opts.Commit, err)
+	} else {
+		if err := ioutil.WriteFile(metadataPath, metadata, 0644); err != nil {
+			return nil, fmt.Errorf("error writing %s: %s", metadataPath, err)
+		}
+	}
+
+	path := filepath.Join(manager.ArchivesCacheDir, archiveFileName(repoID, opts))
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return nil, fmt.Errorf("unable to rename %s to %s: %s", tmpPath, path, err)
+	}
+
+	return &ArchiveFile{FilePath: path, Descriptor: desc}, nil
 }
 
 func (manager *GitDataManager) getPatchesCacheFilePath(repoID, fromCommit, toCommit string) string {
 	return filepath.Join(manager.PatchesCacheDir, repoID, fmt.Sprintf("%s_%s.patch", fromCommit, toCommit))
 }
 
-func (manager *GitDataManager) NewTmpPatchFile() (*PatchFile, error) {
-	path := filepath.Join(manager.TmpDir, fmt.Sprintf("%s.patch", uuid.NewV4().String()))
-	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
-		return nil, fmt.Errorf("unable to create dir %q: %s", filepath.Dir(path), err)
+func (manager *GitDataManager) GetPatchFile(ctx context.Context, repoID string, opts PatchOptions) (*PatchFile, error) {
+	if lock, err := manager.lockGC(ctx, true); err != nil {
+		return nil, err
+	} else {
+		defer werf.ReleaseHostLock(lock)
 	}
 
-	return &PatchFile{FilePath: path}, nil
-}
-
-func (manager *GitDataManager) GetPatchFile(repoID, fromCommit, toCommit string) (*PatchFile, error) {
-	path := manager.getPatchesCacheFilePath(repoID, fromCommit, toCommit)
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	metadataPath := filepath.Join(manager.PatchesCacheDir, patchMetadataFileName(repoID, opts))
+	if exists, err := util.FileExists(metadataPath); err != nil {
+		return nil, err
+	} else if !exists {
 		return nil, nil
-	} else if err != nil {
-		return nil, fmt.Errorf("stat file %q failed: %s", path, err)
 	}
-	return &PatchFile{FilePath: path}, nil
+
+	path := filepath.Join(manager.PatchesCacheDir, patchFileName(repoID, opts))
+	if exists, err := util.FileExists(path); err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, nil
+	}
+
+	if data, err := ioutil.ReadFile(metadataPath); err != nil {
+		return nil, fmt.Errorf("error reading %s: %s", metadataPath, err)
+	} else {
+		var desc *true_git.PatchDescriptor
+		if err := json.Unmarshal(data, &desc); err != nil {
+			return nil, fmt.Errorf("error unmarshalling json from %s: %s", metadataPath, err)
+		}
+
+		return &PatchFile{FilePath: path, Descriptor: desc}, nil
+	}
 }
 
-func (manager *GitDataManager) PutPatchFile(repoID, fromCommit, toCommit string, patchFile *PatchFile) error {
-	path := manager.getPatchesCacheFilePath(repoID, fromCommit, toCommit)
-	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
-		return fmt.Errorf("unable to create dir %q: %s", filepath.Dir(path), err)
+func (manager *GitDataManager) CreatePatchFile(ctx context.Context, repoID string, opts PatchOptions, tmpPath string, desc *true_git.PatchDescriptor) (*PatchFile, error) {
+	if lock, err := manager.lockGC(ctx, true); err != nil {
+		return nil, err
+	} else {
+		defer werf.ReleaseHostLock(lock)
 	}
-	// TODO: put into cache, use lock for gc and another puts
-	return nil
+
+	if _, lock, err := werf.AcquireHostLock(ctx, fmt.Sprintf("git_patch.%s_%s", repoID, util.ObjectToHashKey(opts)), lockgate.AcquireOptions{}); err != nil {
+		return nil, err
+	} else {
+		defer werf.ReleaseHostLock(lock)
+	}
+
+	if patchFile, err := manager.GetPatchFile(ctx, repoID, opts); err != nil {
+		return nil, err
+	} else if patchFile != nil {
+		return patchFile, nil
+	}
+
+	if err := os.MkdirAll(manager.PatchesCacheDir, 0777); err != nil {
+		return nil, fmt.Errorf("unable to create dir %q: %s", manager.PatchesCacheDir, err)
+	}
+
+	metadataPath := filepath.Join(manager.PatchesCacheDir, patchMetadataFileName(repoID, opts))
+	if metadata, err := json.Marshal(desc); err != nil {
+		return nil, fmt.Errorf("error marshalling patch %s %s %s metadata json: %s", repoID, opts.FromCommit, opts.ToCommit, err)
+	} else {
+		if err := ioutil.WriteFile(metadataPath, append(metadata, '\n'), 0644); err != nil {
+			return nil, fmt.Errorf("error writing %s: %s", metadataPath, err)
+		}
+	}
+
+	path := filepath.Join(manager.PatchesCacheDir, patchFileName(repoID, opts))
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return nil, fmt.Errorf("unable to rename %s to %s: %s", tmpPath, path, err)
+	}
+
+	return &PatchFile{FilePath: path, Descriptor: desc}, nil
+}
+
+func patchMetadataFileName(repoID string, opts PatchOptions) string {
+	return fmt.Sprintf("%s_%s.meta.json", repoID, util.ObjectToHashKey(opts))
+}
+
+func patchFileName(repoID string, opts PatchOptions) string {
+	return fmt.Sprintf("%s_%s.patch", repoID, util.ObjectToHashKey(opts))
+}
+
+func archiveMetadataFileName(repoID string, opts ArchiveOptions) string {
+	return fmt.Sprintf("%s_%s.meta.json", repoID, util.ObjectToHashKey(opts))
+}
+
+func archiveFileName(repoID string, opts ArchiveOptions) string {
+	return fmt.Sprintf("%s_%s.tar", repoID, util.ObjectToHashKey(opts))
 }

--- a/pkg/git_repo/local.go
+++ b/pkg/git_repo/local.go
@@ -25,7 +25,7 @@ type Local struct {
 	GitDir string
 }
 
-func OpenLocalRepo(name string, path string) (*Local, error) {
+func OpenLocalRepo(name, path string) (*Local, error) {
 	_, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{EnableDotGitCommonDir: true})
 	if err != nil {
 		if err == git.ErrRepositoryNotExists {
@@ -40,7 +40,7 @@ func OpenLocalRepo(name string, path string) (*Local, error) {
 		return nil, fmt.Errorf("unable to get real git repo dir for %s: %s", path, err)
 	}
 
-	localRepo := &Local{Base: Base{Name: name, GitDataManager: NewCommonGitDataManager()}, Path: path, GitDir: gitDir}
+	localRepo := &Local{Base: Base{Name: name}, Path: path, GitDir: gitDir}
 
 	return localRepo, nil
 }

--- a/pkg/git_repo/patch_file.go
+++ b/pkg/git_repo/patch_file.go
@@ -1,22 +1,12 @@
 package git_repo
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"github.com/werf/werf/pkg/true_git"
-	"github.com/werf/werf/pkg/werf"
-	uuid "github.com/satori/go.uuid"
 )
 
 type PatchFile struct {
 	FilePath   string
 	Descriptor *true_git.PatchDescriptor
-}
-
-func NewTmpPatchFile() *PatchFile {
-	path := filepath.Join(werf.GetTmpDir(), fmt.Sprintf("werf-%s.patch", uuid.NewV4().String()))
-	return &PatchFile{FilePath: path}
 }
 
 func (p *PatchFile) GetFilePath() string {

--- a/pkg/git_repo/remote.go
+++ b/pkg/git_repo/remote.go
@@ -31,7 +31,7 @@ type Remote struct {
 
 func OpenRemoteRepo(name, url string) (*Remote, error) {
 	repo := &Remote{
-		Base: Base{Name: name, GitDataManager: NewCommonGitDataManager()},
+		Base: Base{Name: name},
 		Url:  url,
 	}
 	return repo, repo.ValidateEndpoint()

--- a/pkg/util/hashsum.go
+++ b/pkg/util/hashsum.go
@@ -2,8 +2,11 @@ package util
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/werf/lockgate/pkg/util"
 
 	"github.com/spaolacci/murmur3"
 	"golang.org/x/crypto/sha3"
@@ -28,4 +31,12 @@ func Sha256Hash(args ...string) string {
 
 func prepareHashArgs(args ...string) string {
 	return strings.Join(args, ":::")
+}
+
+func ObjectToHashKey(obj interface{}) string {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		panic(fmt.Sprintf("unable to marshal object %#v: %s", obj, err))
+	}
+	return util.Sha256Hash(string(data))
 }

--- a/playground/synchronization_client/main.go
+++ b/playground/synchronization_client/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/werf/logboek"
 
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 
 	"github.com/werf/werf/pkg/storage/synchronization_server"
@@ -14,6 +15,10 @@ import (
 
 func doMain() error {
 	if err := werf.Init("", ""); err != nil {
+		return err
+	}
+
+	if err := git_repo.Init(); err != nil {
 		return err
 	}
 

--- a/playground/synchronization_server/main.go
+++ b/playground/synchronization_server/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/werf/logboek"
 
+	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/werf"
 
 	"github.com/werf/werf/pkg/storage"
@@ -18,6 +19,10 @@ import (
 
 func doMain() error {
 	if err := werf.Init("", ""); err != nil {
+		return err
+	}
+
+	if err := git_repo.Init(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Also rework build/stage/git_mapping to use patches and archives from GitDataManager directly without hardlinking to separate patches tmp-dir.