### PR TITLE
[determinism] Read values-related helm data from the local git repo and some fixes

### DIFF
--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -179,7 +179,7 @@ func runDismiss() error {
 		lockManager = m
 	}
 
-	wc := werf_chart.NewWerfChart(werf_chart.WerfChartOptions{
+	wc := werf_chart.NewWerfChart(ctx, localGitRepo, *commonCmdData.DisableDeterminism, werf_chart.WerfChartOptions{
 		ReleaseName: releaseName,
 		LockManager: lockManager,
 	})

--- a/cmd/werf/helm/helm.go
+++ b/cmd/werf/helm/helm.go
@@ -37,6 +37,8 @@ import (
 var _commonCmdData cmd_werf_common.CmdData
 
 func NewCmd() *cobra.Command {
+	ctx := common.BackgroundContext()
+
 	var namespace string
 	actionConfig := new(action.Configuration)
 
@@ -75,8 +77,10 @@ func NewCmd() *cobra.Command {
 		cmd_helm.NewSearchCmd(os.Stdout),
 		cmd_helm.NewShowCmd(os.Stdout, cmd_helm.ShowCmdOptions{
 			LoadOptions: loader.LoadOptions{
-				ChartExtender:               werf_chart.NewWerfChart(werf_chart.WerfChartOptions{}),
-				SubchartExtenderFactoryFunc: func() chart.ChartExtender { return werf_chart.NewWerfChart(werf_chart.WerfChartOptions{}) },
+				ChartExtender: werf_chart.NewWerfChart(ctx, nil, false, werf_chart.WerfChartOptions{}),
+				SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+					return werf_chart.NewWerfChart(ctx, nil, false, werf_chart.WerfChartOptions{})
+				},
 			},
 		}),
 		cmd_helm.NewStatusCmd(actionConfig, os.Stdout),

--- a/cmd/werf/helm/install.go
+++ b/cmd/werf/helm/install.go
@@ -1,7 +1,6 @@
 package helm
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/werf/werf/pkg/deploy/werf_chart"
 
 	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/common"
 	cmd_werf_common "github.com/werf/werf/cmd/werf/common"
 
 	"helm.sh/helm/v3/pkg/action"
@@ -24,12 +24,14 @@ import (
 var installCmdData cmd_werf_common.CmdData
 
 func NewInstallCmd(actionConfig *action.Configuration) *cobra.Command {
-	wc := werf_chart.NewWerfChart(werf_chart.WerfChartOptions{})
+	ctx := common.BackgroundContext()
+
+	wc := werf_chart.NewWerfChart(ctx, nil, false, werf_chart.WerfChartOptions{})
 
 	cmd, helmAction := cmd_helm.NewInstallCmd(actionConfig, os.Stdout, cmd_helm.InstallCmdOptions{
 		LoadOptions: loader.LoadOptions{
 			ChartExtender:               wc,
-			SubchartExtenderFactoryFunc: func() chart.ChartExtender { return werf_chart.NewWerfChart(werf_chart.WerfChartOptions{}) },
+			SubchartExtenderFactoryFunc: func() chart.ChartExtender { return werf_chart.NewWerfChart(ctx, nil, false, werf_chart.WerfChartOptions{}) },
 		},
 		PostRenderer: wc.ExtraAnnotationsAndLabelsPostRenderer,
 	})
@@ -53,17 +55,17 @@ func NewInstallCmd(actionConfig *action.Configuration) *cobra.Command {
 			wc.ChartDir = chartDir
 		}
 
-		if err := InitWerfChartParams(&installCmdData, wc, wc.ChartDir); err != nil {
+		if err := InitWerfChartParams(ctx, &installCmdData, wc, wc.ChartDir); err != nil {
 			return fmt.Errorf("unable to init werf chart: %s", err)
 		}
 
-		if vals, err := werf_chart.GetServiceValues(context.Background(), "PROJECT", "REPO", "NAMESPACE", nil, werf_chart.ServiceValuesOptions{IsStub: true}); err != nil {
+		if vals, err := werf_chart.GetServiceValues(ctx, "PROJECT", "REPO", "NAMESPACE", nil, werf_chart.ServiceValuesOptions{IsStub: true}); err != nil {
 			return fmt.Errorf("error creating service values: %s", err)
 		} else if err := wc.SetServiceValues(vals); err != nil {
 			return err
 		}
 
-		return wc.WrapInstall(context.Background(), func() error {
+		return wc.WrapInstall(ctx, func() error {
 			return oldRunE(cmd, args)
 		})
 	}

--- a/cmd/werf/helm/upgrade.go
+++ b/cmd/werf/helm/upgrade.go
@@ -1,7 +1,6 @@
 package helm
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/werf/werf/pkg/deploy/werf_chart"
 
 	"github.com/spf13/cobra"
+	"github.com/werf/werf/cmd/werf/common"
 	cmd_werf_common "github.com/werf/werf/cmd/werf/common"
 	cmd_helm "helm.sh/helm/v3/cmd/helm"
 	"helm.sh/helm/v3/pkg/action"
@@ -22,12 +22,14 @@ import (
 var upgradeCmdData cmd_werf_common.CmdData
 
 func NewUpgradeCmd(actionConfig *action.Configuration) *cobra.Command {
-	wc := werf_chart.NewWerfChart(werf_chart.WerfChartOptions{})
+	ctx := common.BackgroundContext()
+
+	wc := werf_chart.NewWerfChart(ctx, nil, false, werf_chart.WerfChartOptions{})
 
 	cmd, helmAction := cmd_helm.NewUpgradeCmd(actionConfig, os.Stdout, cmd_helm.UpgradeCmdOptions{
 		LoadOptions: loader.LoadOptions{
 			ChartExtender:               wc,
-			SubchartExtenderFactoryFunc: func() chart.ChartExtender { return werf_chart.NewWerfChart(werf_chart.WerfChartOptions{}) },
+			SubchartExtenderFactoryFunc: func() chart.ChartExtender { return werf_chart.NewWerfChart(ctx, nil, false, werf_chart.WerfChartOptions{}) },
 		},
 		PostRenderer: wc.ExtraAnnotationsAndLabelsPostRenderer,
 	})
@@ -51,17 +53,17 @@ func NewUpgradeCmd(actionConfig *action.Configuration) *cobra.Command {
 		}
 		wc.ReleaseName = args[0]
 
-		if err := InitWerfChartParams(&upgradeCmdData, wc, wc.ChartDir); err != nil {
+		if err := InitWerfChartParams(ctx, &upgradeCmdData, wc, wc.ChartDir); err != nil {
 			return fmt.Errorf("unable to init werf chart: %s", err)
 		}
 
-		if vals, err := werf_chart.GetServiceValues(context.Background(), "PROJECT", "REPO", "NAMESPACE", nil, werf_chart.ServiceValuesOptions{IsStub: true}); err != nil {
+		if vals, err := werf_chart.GetServiceValues(ctx, "PROJECT", "REPO", "NAMESPACE", nil, werf_chart.ServiceValuesOptions{IsStub: true}); err != nil {
 			return fmt.Errorf("error creating service values: %s", err)
 		} else if err := wc.SetServiceValues(vals); err != nil {
 			return err
 		}
 
-		return wc.WrapUpgrade(context.Background(), func() error {
+		return wc.WrapUpgrade(ctx, func() error {
 			return oldRunE(cmd, args)
 		})
 	}

--- a/cmd/werf/helm/werf_chart.go
+++ b/cmd/werf/helm/werf_chart.go
@@ -24,7 +24,7 @@ func SetupWerfChartParams(cmd *cobra.Command, commonCmdData *cmd_werf_common.Cmd
 	cmd_werf_common.SetupIgnoreSecretKey(commonCmdData, cmd)
 }
 
-func InitWerfChartParams(commonCmdData *cmd_werf_common.CmdData, wc *werf_chart.WerfChart, chartDir string) error {
+func InitWerfChartParams(ctx context.Context, commonCmdData *cmd_werf_common.CmdData, wc *werf_chart.WerfChart, chartDir string) error {
 	wc.SecretValueFiles = *commonCmdData.SecretValues
 
 	if extraAnnotations, err := cmd_werf_common.GetUserExtraAnnotations(commonCmdData); err != nil {
@@ -41,7 +41,7 @@ func InitWerfChartParams(commonCmdData *cmd_werf_common.CmdData, wc *werf_chart.
 
 	// NOTE: project-dir is the same as chart-dir for werf helm install/upgrade commands
 	// NOTE: project-dir is werf-project dir only for werf converge/dismiss commands
-	if m, err := deploy.GetSafeSecretManager(context.Background(), chartDir, chartDir, *commonCmdData.SecretValues, *commonCmdData.IgnoreSecretKey); err != nil {
+	if m, err := deploy.GetSafeSecretManager(ctx, chartDir, chartDir, *commonCmdData.SecretValues, wc.LocalGitRepo, *commonCmdData.DisableDeterminism, *commonCmdData.IgnoreSecretKey); err != nil {
 		return err
 	} else {
 		wc.SecretsManager = m

--- a/go.mod
+++ b/go.mod
@@ -144,4 +144,4 @@ replace github.com/containerd/containerd => github.com/containerd/containerd v1.
 
 replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
 
-replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201113193039-e8103b38e3e8
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201124163146-c2bd249981df

--- a/go.sum
+++ b/go.sum
@@ -1417,6 +1417,8 @@ github.com/werf/helm/v3 v3.0.0-20201112095157-718e2f06aa35 h1:b4FW3d+onjlu6EKLiJ
 github.com/werf/helm/v3 v3.0.0-20201112095157-718e2f06aa35/go.mod h1:jbfz/BoYmpJ3njhHBdH7F3kR8CNUGeRueliFtOhQK+M=
 github.com/werf/helm/v3 v3.0.0-20201113193039-e8103b38e3e8 h1:fGbJLRZb+YDi2odWhVBAWoC7VDi2uY37aMZlMOXhyRI=
 github.com/werf/helm/v3 v3.0.0-20201113193039-e8103b38e3e8/go.mod h1:jbfz/BoYmpJ3njhHBdH7F3kR8CNUGeRueliFtOhQK+M=
+github.com/werf/helm/v3 v3.0.0-20201124163146-c2bd249981df h1:yFBmvH2BZc8B+1M7keoPpWpeyS51IuDBm8kh5n6/V3s=
+github.com/werf/helm/v3 v3.0.0-20201124163146-c2bd249981df/go.mod h1:jbfz/BoYmpJ3njhHBdH7F3kR8CNUGeRueliFtOhQK+M=
 github.com/werf/kubedog v0.4.1-0.20200818145659-3aa022a95c07 h1:pKU78lxdl5Ck4zkWzwH74FOnAC3uf/5u5rbS8SRcXwk=
 github.com/werf/kubedog v0.4.1-0.20200818145659-3aa022a95c07/go.mod h1:b/5MyrNDmxXtr68uucMmZCZmWS3h7cfAcgqtQbHsw5o=
 github.com/werf/kubedog v0.4.1-0.20200907160731-10aec4300377 h1:bQgmFAC6Q7FEVR0Xa8I875LgTTxlHnWM/qGtHAK3OZQ=

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -1167,7 +1167,7 @@ func prepareImageBasedOnImageFromDockerfile(ctx context.Context, imageFromDocker
 		return nil, fmt.Errorf("unsupported dockerfile: %s", err)
 	}
 
-	exists, err := localGitRepo.IsFileExists(headCommit, imageFromDockerfileConfig.Dockerfile)
+	exists, err := localGitRepo.IsFileExists(ctx, headCommit, imageFromDockerfileConfig.Dockerfile)
 	if err != nil {
 		return nil, fmt.Errorf("unable to check file %s existence in local git repository: %s", imageFromDockerfileConfig.Dockerfile, err)
 	} else if !exists {
@@ -1180,7 +1180,7 @@ func prepareImageBasedOnImageFromDockerfile(ctx context.Context, imageFromDocker
 	}
 
 	var dockerignorePatterns []string
-	exists, err = localGitRepo.IsFileExists(headCommit, ".dockerignore")
+	exists, err = localGitRepo.IsFileExists(ctx, headCommit, ".dockerignore")
 	if err != nil {
 		return nil, fmt.Errorf("unable to check file .dockerignore existence in local git repository: %s", err)
 	} else if exists {
@@ -1279,9 +1279,9 @@ func checkPathRelativity(projectDir string, path string) error {
 }
 
 func getFileDataFromGitAndCompareWithLocal(ctx context.Context, projectDir string, localGitRepo *git_repo.Local, commit, relPath string) ([]byte, error) {
-	data, isDataIdentical, err := git_repo.ReadGitRepoFileAndCompareWithProjectFile(localGitRepo, commit, projectDir, relPath)
+	data, isDataIdentical, err := git_repo.ReadGitRepoFileAndCompareWithProjectFile(ctx, localGitRepo, commit, projectDir, relPath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read local git repo file %s and compare with project file: %s", relPath, err)
+		return nil, err
 	}
 
 	if !isDataIdentical {

--- a/pkg/deploy/secret_manager.go
+++ b/pkg/deploy/secret_manager.go
@@ -2,22 +2,46 @@ package deploy
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/werf/werf/pkg/deploy/werf_chart"
+	"github.com/werf/werf/pkg/git_repo"
+
 	"github.com/werf/logboek"
 	"github.com/werf/werf/pkg/deploy/secret"
-	"github.com/werf/werf/pkg/deploy/werf_chart"
 )
 
-func GetSafeSecretManager(ctx context.Context, projectDir, helmChartDir string, secretValues []string, ignoreSecretKey bool) (secret.Manager, error) {
+func GetSafeSecretManager(ctx context.Context, projectDir, helmChartDir string, secretValues []string, localGitRepo *git_repo.Local, disableDeterminism bool, ignoreSecretKey bool) (secret.Manager, error) {
 	isSecretsExists := false
-	if _, err := os.Stat(filepath.Join(helmChartDir, werf_chart.SecretDirName)); !os.IsNotExist(err) {
-		isSecretsExists = true
+
+	if disableDeterminism || localGitRepo == nil {
+		if _, err := os.Stat(filepath.Join(helmChartDir, werf_chart.SecretDirName)); !os.IsNotExist(err) {
+			isSecretsExists = true
+		}
+		if _, err := os.Stat(filepath.Join(helmChartDir, werf_chart.DefaultSecretValuesFileName)); !os.IsNotExist(err) {
+			isSecretsExists = true
+		}
+	} else {
+		commit, err := localGitRepo.HeadCommit(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get local repo head commit: %s", err)
+		}
+
+		if exists, err := localGitRepo.IsDirectoryExists(ctx, filepath.Join(helmChartDir, werf_chart.SecretDirName), commit); err != nil {
+			return nil, fmt.Errorf("error checking existance of the directory %q in the local git repo commit %s: %s", filepath.Join(helmChartDir, werf_chart.SecretDirName), err)
+		} else if exists {
+			isSecretsExists = true
+		}
+
+		if exists, err := localGitRepo.IsFileExists(ctx, commit, filepath.Join(helmChartDir, werf_chart.DefaultSecretValuesFileName)); err != nil {
+			return nil, fmt.Errorf("error checking existance of the file %q in the local git repo commit %s: %s", filepath.Join(helmChartDir, werf_chart.DefaultSecretValuesFileName), err)
+		} else if exists {
+			isSecretsExists = true
+		}
 	}
-	if _, err := os.Stat(filepath.Join(helmChartDir, werf_chart.DefaultSecretValuesFileName)); !os.IsNotExist(err) {
-		isSecretsExists = true
-	}
+
 	if len(secretValues) > 0 {
 		isSecretsExists = true
 	}

--- a/pkg/deploy/werf_chart/git_loader.go
+++ b/pkg/deploy/werf_chart/git_loader.go
@@ -27,14 +27,23 @@ func LoadFilesFromGit(ctx context.Context, localGitRepo *git_repo.Local, project
 
 	relativeLoadDir := util.GetRelativeToBaseFilepath(projectDir, loadDir)
 
+	if isSymlink, linkDest, err := localGitRepo.CheckAndReadSymlink(ctx, relativeLoadDir, commit); err != nil {
+		return nil, fmt.Errorf("error checking %s is symlink in the local git repo commit %s: %s", relativeLoadDir, commit, err)
+	} else if isSymlink {
+		logboek.Context(ctx).Debug().LogF("-- LoadFilesFromGit: load dir %q is symlink to %q\n", relativeLoadDir, linkDest)
+		relativeLoadDir = string(linkDest)
+	}
+
 	var res []*loader.BufferedFile
 
 	for _, repoPath := range repoPaths {
 		if util.IsSubpathOfBasePath(relativeLoadDir, repoPath) {
-			data, isDataIdentical, err := git_repo.ReadGitRepoFileAndCompareWithProjectFile(localGitRepo, commit, projectDir, repoPath)
+			data, isDataIdentical, err := git_repo.ReadGitRepoFileAndCompareWithProjectFile(ctx, localGitRepo, commit, projectDir, repoPath)
 			if err != nil {
-				return nil, fmt.Errorf("unable to read local git repo file %s and compare with project file: %s", repoPath, err)
+				return nil, err
 			}
+
+			logboek.Context(ctx).Debug().LogF("-- LoadFilesFromGit commit=%s loaded file %s:\n%s\n", commit, repoPath, data)
 
 			if !isDataIdentical {
 				logboek.Context(ctx).Warn().LogF("WARNING: In deterministic mode uncommitted file %s was not taken into account\n", repoPath)

--- a/pkg/deploy/werf_chart/secret_values.go
+++ b/pkg/deploy/werf_chart/secret_values.go
@@ -1,17 +1,44 @@
 package werf_chart
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
+
+	"github.com/werf/werf/pkg/git_repo"
 
 	"github.com/werf/werf/pkg/deploy/secret"
 	"sigs.k8s.io/yaml"
 )
 
-func DecodeSecretValuesFile(path string, m secret.Manager) (map[string]interface{}, error) {
-	data, err := ioutil.ReadFile(path)
+func DecodeSecretValuesFileFromGitCommit(ctx context.Context, path string, commit string, localGitRepo *git_repo.Local, m secret.Manager) (map[string]interface{}, error) {
+	var data []byte
+	if d, err := localGitRepo.ReadFile(ctx, commit, path); err != nil {
+		return nil, fmt.Errorf("error reading %q from the local git repo commit %s: %s", path, commit, err)
+	} else {
+		data = d
+	}
+
+	decodedData, err := m.DecryptYamlData(data)
 	if err != nil {
+		return nil, fmt.Errorf("cannot decode file %q secret data: %s", path, err)
+	}
+
+	rawValues := map[string]interface{}{}
+	if err := yaml.Unmarshal(decodedData, &rawValues); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal secret values file %s: %s", path, err)
+	}
+
+	return rawValues, nil
+}
+
+func DecodeSecretValuesFileFromFilesystem(ctx context.Context, path string, m secret.Manager) (map[string]interface{}, error) {
+	var data []byte
+
+	if d, err := ioutil.ReadFile(path); err != nil {
 		return nil, fmt.Errorf("cannot read file %q: %s", path, err)
+	} else {
+		data = d
 	}
 
 	decodedData, err := m.DecryptYamlData(data)

--- a/pkg/deploy/werf_chart/werf_chart.go
+++ b/pkg/deploy/werf_chart/werf_chart.go
@@ -11,11 +11,14 @@ import (
 	"text/template"
 	"unicode"
 
-	"github.com/Masterminds/sprig"
+	"github.com/werf/logboek"
+
 	"github.com/werf/werf/pkg/config"
 	"github.com/werf/werf/pkg/deploy/helm"
 	"github.com/werf/werf/pkg/deploy/lock_manager"
 	"github.com/werf/werf/pkg/deploy/secret"
+	"github.com/werf/werf/pkg/git_repo"
+	"github.com/werf/werf/pkg/util"
 	"github.com/werf/werf/pkg/util/secretvalues"
 	"github.com/werf/werf/pkg/werf"
 	"helm.sh/helm/v3/pkg/chart"
@@ -39,8 +42,11 @@ type WerfChartOptions struct {
 	SecretsManager secret.Manager
 }
 
-func NewWerfChart(opts WerfChartOptions) *WerfChart {
+func NewWerfChart(ctx context.Context, localGitRepo *git_repo.Local, disableDeterminism bool, opts WerfChartOptions) *WerfChart {
 	wc := &WerfChart{
+		Ctx:                ctx,
+		DisableDeterminism: disableDeterminism,
+
 		ReleaseName: opts.ReleaseName,
 		ChartDir:    opts.ChartDir,
 
@@ -52,6 +58,7 @@ func NewWerfChart(opts WerfChartOptions) *WerfChart {
 
 		LockManager:    opts.LockManager,
 		SecretsManager: opts.SecretsManager,
+		LocalGitRepo:   localGitRepo,
 
 		decodedSecretFilesData: make(map[string]string, 0),
 	}
@@ -62,7 +69,9 @@ func NewWerfChart(opts WerfChartOptions) *WerfChart {
 }
 
 type WerfChart struct {
-	HelmChart *chart.Chart
+	Ctx                context.Context
+	DisableDeterminism bool
+	HelmChart          *chart.Chart
 
 	ReleaseName      string
 	ChartDir         string
@@ -71,6 +80,7 @@ type WerfChart struct {
 	ExtraAnnotationsAndLabelsPostRenderer *helm.ExtraAnnotationsAndLabelsPostRenderer
 	LockManager                           *lock_manager.LockManager
 	SecretsManager                        secret.Manager
+	LocalGitRepo                          *git_repo.Local
 
 	chartMetadataFromWerfConfig *chart.Metadata
 	decodedSecretValues         map[string]interface{}
@@ -84,7 +94,7 @@ func (wc *WerfChart) SetupChart(c *chart.Chart) error {
 	return nil
 }
 
-func (wc *WerfChart) AfterLoad() error {
+func (wc *WerfChart) loadSecretsFromFilesystem() error {
 	secretValuesFiles := []string{}
 	defaultSecretValuesFile := filepath.Join(wc.ChartDir, DefaultSecretValuesFileName)
 	if _, err := os.Stat(defaultSecretValuesFile); !os.IsNotExist(err) {
@@ -94,7 +104,7 @@ func (wc *WerfChart) AfterLoad() error {
 		secretValuesFiles = append(secretValuesFiles, path)
 	}
 	for _, path := range secretValuesFiles {
-		if decodedValues, err := DecodeSecretValuesFile(path, wc.SecretsManager); err != nil {
+		if decodedValues, err := DecodeSecretValuesFileFromFilesystem(wc.Ctx, path, wc.SecretsManager); err != nil {
 			return fmt.Errorf("unable to decode secret values file %q: %s", path, err)
 		} else {
 			wc.decodedSecretValues = chartutil.CoalesceTables(decodedValues, wc.decodedSecretValues)
@@ -134,6 +144,111 @@ func (wc *WerfChart) AfterLoad() error {
 			return nil
 		}); err != nil {
 			return fmt.Errorf("unable to read secrets from %s directory: %s", secretDir, err)
+		}
+	}
+
+	return nil
+}
+
+func (wc *WerfChart) loadSecretsFromLocalGitRepo() error {
+	var secretValuesFiles []string
+
+	commit, err := wc.LocalGitRepo.HeadCommit(wc.Ctx)
+	if err != nil {
+		return fmt.Errorf("unable to get local repo head commit: %s", err)
+	}
+
+	var chartDir string
+	if isSymlink, linkDest, err := wc.LocalGitRepo.CheckAndReadSymlink(wc.Ctx, wc.ChartDir, commit); err != nil {
+		return fmt.Errorf("error checking %q is symlink in the local git repo commit %s: %s", wc.ChartDir, commit, err)
+	} else if isSymlink {
+		chartDir = string(linkDest)
+	} else {
+		chartDir = wc.ChartDir
+	}
+
+	defaultSecretValuesFile := filepath.Join(chartDir, DefaultSecretValuesFileName)
+	if exists, err := wc.LocalGitRepo.IsFileExists(wc.Ctx, commit, defaultSecretValuesFile); err != nil {
+		return fmt.Errorf("error checking existance of the file %q in the local git repo commit %s: %s", defaultSecretValuesFile, err)
+	} else if exists {
+		logboek.Context(wc.Ctx).Debug().LogF("Check %s exists in the local git repo commit %s: FOUND\n", defaultSecretValuesFile, commit)
+		secretValuesFiles = append(secretValuesFiles, defaultSecretValuesFile)
+	} else {
+		logboek.Context(wc.Ctx).Debug().LogF("Check %s exists in the local git repo commit %s: NOT FOUND\n", defaultSecretValuesFile, commit)
+	}
+
+	for _, path := range wc.SecretValueFiles {
+		secretValuesFiles = append(secretValuesFiles, path)
+	}
+
+	for _, path := range secretValuesFiles {
+		logboek.Context(wc.Ctx).Debug().LogF("Decoding secret values file %q\n", path)
+
+		var decodedValues map[string]interface{}
+
+		commit, err := wc.LocalGitRepo.HeadCommit(wc.Ctx)
+		if err != nil {
+			return fmt.Errorf("unable to get local repo head commit: %s", err)
+		}
+
+		if vals, err := DecodeSecretValuesFileFromGitCommit(wc.Ctx, path, commit, wc.LocalGitRepo, wc.SecretsManager); err != nil {
+			return fmt.Errorf("unable to decode secret values file %q: %s", path, err)
+		} else {
+			decodedValues = vals
+		}
+
+		wc.decodedSecretValues = chartutil.CoalesceTables(decodedValues, wc.decodedSecretValues)
+		wc.secretValuesToMask = append(wc.secretValuesToMask, secretvalues.ExtractSecretValuesFromMap(decodedValues)...)
+	}
+
+	secretDir := filepath.Join(wc.ChartDir, SecretDirName)
+	if exists, err := wc.LocalGitRepo.IsDirectoryExists(wc.Ctx, secretDir, commit); err != nil {
+		return fmt.Errorf("error checking existance of directory %s in the local git repo commit %s: %s", secretDir, commit, err)
+	} else if exists {
+		var secretFilesToDecode []string
+
+		if paths, err := wc.LocalGitRepo.GetFilePathList(wc.Ctx, commit); err != nil {
+			return fmt.Errorf("error getting file path list for the local git repo commit %s: %s", commit, err)
+		} else {
+			for _, path := range paths {
+				if util.IsSubpathOfBasePath(secretDir, path) {
+					secretFilesToDecode = append(secretFilesToDecode, path)
+				}
+			}
+		}
+
+		for _, path := range secretFilesToDecode {
+			data, err := wc.LocalGitRepo.ReadFile(wc.Ctx, commit, path)
+			if err != nil {
+				return fmt.Errorf("error reading file %s from the local git repo commit %s: %s", path, commit, err)
+			}
+
+			decodedData, err := wc.SecretsManager.Decrypt([]byte(strings.TrimRightFunc(string(data), unicode.IsSpace)))
+			if err != nil {
+				return fmt.Errorf("error decoding %s: %s", path, err)
+			}
+
+			relativePath, err := filepath.Rel(secretDir, path)
+			if err != nil {
+				panic(err)
+			}
+
+			wc.decodedSecretFilesData[filepath.ToSlash(relativePath)] = string(decodedData)
+			wc.secretValuesToMask = append(wc.secretValuesToMask, string(decodedData))
+		}
+	}
+
+	return nil
+}
+
+func (wc *WerfChart) AfterLoad() error {
+	if wc.DisableDeterminism || wc.LocalGitRepo == nil {
+		if err := wc.loadSecretsFromFilesystem(); err != nil {
+			return err
+		}
+	} else {
+		if err := wc.loadSecretsFromLocalGitRepo(); err != nil {
+			return err
 		}
 	}
 
@@ -186,10 +301,6 @@ func (wc *WerfChart) SetupTemplateFuncs(t *template.Template, funcMap template.F
 
 	for _, name := range []string{"werf_image"} {
 		setupIncludeWrapperFunc(name)
-	}
-
-	for _, name := range []string{"env", "expandenv"} {
-		funcMap[name] = sprig.TxtFuncMap()[name]
 	}
 }
 

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -1,13 +1,9 @@
 package git_repo
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"io/ioutil"
 	"path/filepath"
 
-	"github.com/werf/werf/pkg/util"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -84,49 +80,4 @@ type Checksum interface {
 
 func GetGitRepoCacheDir() string {
 	return filepath.Join(werf.GetLocalCacheDir(), "git_repos", GitRepoCacheVersion)
-}
-
-func ReadGitRepoFileAndCompareWithProjectFile(localGitRepo *Local, commit, projectDir, relPath string) ([]byte, bool, error) {
-	repoData, err := localGitRepo.ReadFile(commit, relPath)
-	if err != nil {
-		return nil, false, fmt.Errorf("unable to read file %s in local git repository: %s", relPath, err)
-	}
-
-	isDataIdentical, err := compareGitRepoFileWithProjectFile(repoData, projectDir, relPath)
-	if err != nil {
-		return nil, false, err
-	}
-
-	return repoData, isDataIdentical, err
-}
-
-func CompareLocalGitRepoFileWithProjectFile(localGitRepo *Local, commit, projectDir, relPath string) (bool, error) {
-	repoData, err := localGitRepo.ReadFile(commit, relPath)
-	if err != nil {
-		return false, fmt.Errorf("unable to read file %s in local git repository: %s", relPath, err)
-	}
-
-	return compareGitRepoFileWithProjectFile(repoData, projectDir, relPath)
-}
-
-func compareGitRepoFileWithProjectFile(repoFileData []byte, projectDir, relPath string) (bool, error) {
-	var localData []byte
-	absPath := filepath.Join(projectDir, relPath)
-	exist, err := util.FileExists(absPath)
-	if err != nil {
-		return false, fmt.Errorf("unable to check file existance: %s", err)
-	} else if exist {
-		localData, err = ioutil.ReadFile(absPath)
-		if err != nil {
-			return false, fmt.Errorf("unable to read file: %s", err)
-		}
-	}
-
-	isDataIdentical := bytes.Equal(repoFileData, localData)
-	localDataWithForcedUnixLineBreak := bytes.ReplaceAll(localData, []byte("\r\n"), []byte("\n"))
-	if !isDataIdentical {
-		isDataIdentical = bytes.Equal(repoFileData, localDataWithForcedUnixLineBreak)
-	}
-
-	return isDataIdentical, nil
 }


### PR DESCRIPTION
 - Read `--values`, `--secret-values`, `--set-file` and `.helm/secret/*` files from the local git repo in the determinism mode.
 - Implement git_repo ReadFile and IsFileExists operations so that it automatically resolve symlinks. Implement git_repo CheckAndReadSymlink operation.
 - Fixed deterministic chart loader for the werf-render command.
 - Fix some grammar in errors.

Refs https://github.com/werf/werf/issues/2874
