### PR TITLE
[windows] Fix unable to rename archive

### DIFF
--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -281,6 +281,7 @@ func (repo *Base) createArchive(ctx context.Context, repoPath, gitDir, repoID, w
 	if err != nil {
 		return nil, fmt.Errorf("cannot open archive file: %s", err)
 	}
+	defer fileHandler.Close()
 
 	archiveOpts := true_git.ArchiveOptions{
 		Commit: opts.Commit,

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -303,6 +303,10 @@ func (repo *Base) createArchive(ctx context.Context, repoPath, gitDir, repoID, w
 		return nil, fmt.Errorf("error creating archive for commit `%s`: %s", opts.Commit, err)
 	}
 
+	if err := fileHandler.Close(); err != nil {
+		return nil, fmt.Errorf("unable to close file %s: %s", tmpPath, err)
+	}
+
 	if archive, err := CommonGitDataManager.CreateArchiveFile(ctx, repoID, opts, tmpPath, desc); err != nil {
 		return nil, err
 	} else {


### PR DESCRIPTION
Error: phase build on image ~ stage dockerfile handler failed: error preparing stage dockerfile: unable to create archive: unable to rename C:\Users\test\.werf\service\tmp\git_data\d236b334-bccb-470b-bec0-18f79384679e to C:\Users\test\.werf\local_cache\git_archives\1\700ddbcae629cc7d90c6dcfda2bd10ee2997fefcc8a5a0588b8cb74e0edb53a4_d3f909c8cb82d2c44976def5298d3373c5a37de5bae71de6cfbb1dc99e760931.tar: rename C:\Users\test\.werf\service\tmp\git_data\d236b334-bccb-470b-bec0-18f79384679e C:\Users\test\.werf\local_cache\git_archives\1\700ddbcae629cc7d90c6dcfda2bd10ee2997fefcc8a5a0588b8cb74e0edb53a4_d3f909c8cb82d2c44976def5298d3373c5a37de5bae71de6cfbb1dc99e760931.tar: The process cannot access the file because it is being used by another process.