### PR TITLE
[cli] Fix --non-strict-determinism-inspection is not defined for command

### DIFF
--- a/cmd/werf/helm/secret/decrypt/decrypt.go
+++ b/cmd/werf/helm/secret/decrypt/decrypt.go
@@ -54,6 +54,8 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	cmd.Flags().StringVarP(&cmdData.OutputFilePath, "output-file-path", "o", "", "Write to file instead of stdout")

--- a/cmd/werf/helm/secret/encrypt/encrypt.go
+++ b/cmd/werf/helm/secret/encrypt/encrypt.go
@@ -53,6 +53,8 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	cmd.Flags().StringVarP(&cmdData.OutputFilePath, "output-file-path", "o", "", "Write to file instead of stdout")

--- a/cmd/werf/helm/secret/file/decrypt/decrypt.go
+++ b/cmd/werf/helm/secret/file/decrypt/decrypt.go
@@ -64,6 +64,8 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	cmd.Flags().StringVarP(&CmdData.OutputFilePath, "output-file-path", "o", "", "Write to file instead of stdout")

--- a/cmd/werf/helm/secret/file/edit/edit.go
+++ b/cmd/werf/helm/secret/file/edit/edit.go
@@ -45,6 +45,8 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/helm/secret/file/encrypt/encrypt.go
+++ b/cmd/werf/helm/secret/file/encrypt/encrypt.go
@@ -60,6 +60,8 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	cmd.Flags().StringVarP(&cmdData.OutputFilePath, "output-file-path", "o", "", "Write to file instead of stdout")

--- a/cmd/werf/helm/secret/values/decrypt/decrypt.go
+++ b/cmd/werf/helm/secret/values/decrypt/decrypt.go
@@ -69,6 +69,8 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	cmd.Flags().StringVarP(&cmdData.OutputFilePath, "output-file-path", "o", "", "Write to file instead of stdout")

--- a/cmd/werf/helm/secret/values/edit/edit.go
+++ b/cmd/werf/helm/secret/values/edit/edit.go
@@ -45,6 +45,8 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/helm/secret/values/encrypt/encrypt.go
+++ b/cmd/werf/helm/secret/values/encrypt/encrypt.go
@@ -60,6 +60,8 @@ Encryption key should be in $WERF_SECRET_KEY or .werf_secret_key file`),
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	cmd.Flags().StringVarP(&cmdData.OutputFilePath, "output-file-path", "o", "", "Write to file instead of stdout")

--- a/cmd/werf/host/cleanup/cleanup.go
+++ b/cmd/werf/host/cleanup/cleanup.go
@@ -55,6 +55,8 @@ It is safe to run this command periodically by automated cleanup job in parallel
 	common.SetupHomeDir(&commonCmdData, cmd)
 	common.SetupDockerConfig(&commonCmdData, cmd, "")
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	common.SetupDryRun(&commonCmdData, cmd)

--- a/cmd/werf/host/project/list/list.go
+++ b/cmd/werf/host/project/list/list.go
@@ -47,6 +47,8 @@ func NewCmd() *cobra.Command {
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "")

--- a/cmd/werf/host/project/purge/purge.go
+++ b/cmd/werf/host/project/purge/purge.go
@@ -67,6 +67,8 @@ func NewCmd() *cobra.Command {
 	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupDryRun(&commonCmdData, cmd)
 	cmd.Flags().BoolVarP(&cmdData.Force, "force", "", false, common.CleaningCommandsForceOptionDescription)
 

--- a/cmd/werf/host/purge/purge.go
+++ b/cmd/werf/host/purge/purge.go
@@ -60,6 +60,8 @@ WARNING: Do not run this command during any other werf command is working on the
 
 	common.SetupLogOptions(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupDryRun(&commonCmdData, cmd)
 	cmd.Flags().BoolVarP(&cmdData.Force, "force", "", false, common.CleaningCommandsForceOptionDescription)
 

--- a/cmd/werf/synchronization/main.go
+++ b/cmd/werf/synchronization/main.go
@@ -64,6 +64,8 @@ func NewCmd() *cobra.Command {
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
+	common.SetupNonStrictDeterminismInspection(&commonCmdData, cmd)
+
 	common.SetupLogOptions(&commonCmdData, cmd)
 
 	common.SetupKubeConfig(&commonCmdData, cmd)

--- a/docs/_includes/documentation/reference/cli/werf_helm_secret_decrypt.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_secret_decrypt.md
@@ -43,6 +43,10 @@ werf helm secret decrypt [options]
             Use custom working directory (default $WERF_DIR or current directory)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
   -o, --output-file-path=''
             Write to file instead of stdout
       --tmp-dir=''

--- a/docs/_includes/documentation/reference/cli/werf_helm_secret_encrypt.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_secret_encrypt.md
@@ -42,6 +42,10 @@ werf helm secret encrypt [options]
             Use custom working directory (default $WERF_DIR or current directory)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
   -o, --output-file-path=''
             Write to file instead of stdout
       --tmp-dir=''

--- a/docs/_includes/documentation/reference/cli/werf_helm_secret_file_decrypt.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_secret_file_decrypt.md
@@ -41,6 +41,10 @@ werf helm secret file decrypt [FILE_PATH] [options]
             Use custom working directory (default $WERF_DIR or current directory)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
   -o, --output-file-path=''
             Write to file instead of stdout
       --tmp-dir=''

--- a/docs/_includes/documentation/reference/cli/werf_helm_secret_file_edit.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_secret_file_edit.md
@@ -37,6 +37,10 @@ werf helm secret file edit FILE_PATH [options]
             Use custom working directory (default $WERF_DIR or current directory)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
       --tmp-dir=''
             Use specified dir to store tmp files and dirs (default $WERF_TMP_DIR or system tmp dir)
 ```

--- a/docs/_includes/documentation/reference/cli/werf_helm_secret_file_encrypt.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_secret_file_encrypt.md
@@ -37,6 +37,10 @@ werf helm secret file encrypt [FILE_PATH] [options]
             Use custom working directory (default $WERF_DIR or current directory)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
   -o, --output-file-path=''
             Write to file instead of stdout
       --tmp-dir=''

--- a/docs/_includes/documentation/reference/cli/werf_helm_secret_values_decrypt.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_secret_values_decrypt.md
@@ -46,6 +46,10 @@ werf helm secret values decrypt [FILE_PATH] [options]
             Use custom working directory (default $WERF_DIR or current directory)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
   -o, --output-file-path=''
             Write to file instead of stdout
       --tmp-dir=''

--- a/docs/_includes/documentation/reference/cli/werf_helm_secret_values_edit.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_secret_values_edit.md
@@ -37,6 +37,10 @@ werf helm secret values edit FILE_PATH [options]
             Use custom working directory (default $WERF_DIR or current directory)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
       --tmp-dir=''
             Use specified dir to store tmp files and dirs (default $WERF_TMP_DIR or system tmp dir)
 ```

--- a/docs/_includes/documentation/reference/cli/werf_helm_secret_values_encrypt.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_secret_values_encrypt.md
@@ -37,6 +37,10 @@ werf helm secret values encrypt [FILE_PATH] [options]
             Use custom working directory (default $WERF_DIR or current directory)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
   -o, --output-file-path=''
             Write to file instead of stdout
       --tmp-dir=''

--- a/docs/_includes/documentation/reference/cli/werf_host_cleanup.md
+++ b/docs/_includes/documentation/reference/cli/werf_host_cleanup.md
@@ -50,6 +50,10 @@ werf host cleanup [options]
             * interactive terminal width or 140
       --log-verbose=false
             Enable verbose output (default $WERF_LOG_VERBOSE).
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
       --tmp-dir=''
             Use specified dir to store tmp files and dirs (default $WERF_TMP_DIR or system tmp dir)
 ```

--- a/docs/_includes/documentation/reference/cli/werf_host_project_list.md
+++ b/docs/_includes/documentation/reference/cli/werf_host_project_list.md
@@ -40,6 +40,10 @@ werf host project list [options]
             Enable verbose output (default $WERF_LOG_VERBOSE).
   -q, --names-only=false
             Only show project names
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
       --tmp-dir=''
             Use specified dir to store tmp files and dirs (default $WERF_TMP_DIR or system tmp dir)
 ```

--- a/docs/_includes/documentation/reference/cli/werf_host_project_purge.md
+++ b/docs/_includes/documentation/reference/cli/werf_host_project_purge.md
@@ -56,6 +56,10 @@ werf host project purge [PROJECT_NAME ...] [options]
             * interactive terminal width or 140
       --log-verbose=false
             Enable verbose output (default $WERF_LOG_VERBOSE).
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
       --repo=''
             Docker Repo to store stages (default $WERF_REPO)
       --repo-docker-hub-password=''

--- a/docs/_includes/documentation/reference/cli/werf_host_purge.md
+++ b/docs/_includes/documentation/reference/cli/werf_host_purge.md
@@ -53,6 +53,10 @@ werf host purge [options]
             * interactive terminal width or 140
       --log-verbose=false
             Enable verbose output (default $WERF_LOG_VERBOSE).
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
       --tmp-dir=''
             Use specified dir to store tmp files and dirs (default $WERF_TMP_DIR or system tmp dir)
 ```

--- a/docs/_includes/documentation/reference/cli/werf_synchronization.md
+++ b/docs/_includes/documentation/reference/cli/werf_synchronization.md
@@ -61,6 +61,10 @@ werf synchronization [options]
             * interactive terminal width or 140
       --log-verbose=false
             Enable verbose output (default $WERF_LOG_VERBOSE).
+      --non-strict-determinism-inspection=false
+            Change some errors to warnings during determinism inspection (more info                 
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_NON_STRICT_DETERMINISM_INSPECTION)
       --port=''
             Bind synchronization server to the specified port (default 55581 or $WERF_PORT)
       --tmp-dir=''


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x2bd88e3]

goroutine 1 [running]:
github.com/werf/werf/cmd/werf/helm/secret/file/encrypt.runSecretEncrypt(0xc0001220b0, 0x6, 0x0, 0x3528840)
	.../werf/cmd/werf/helm/secret/file/encrypt/encrypt.go:75 +0xe3