### PR TITLE
[helm] Fix disable-determinism flag is not added to commands 

### DIFF
--- a/cmd/werf/helm/werf_chart.go
+++ b/cmd/werf/helm/werf_chart.go
@@ -17,6 +17,8 @@ func SetupWerfChartParams(cmd *cobra.Command, commonCmdData *cmd_werf_common.Cmd
 	cmd_werf_common.SetupTmpDir(commonCmdData, cmd)
 	cmd_werf_common.SetupHomeDir(commonCmdData, cmd)
 
+	cmd_werf_common.SetupDisableDeterminism(commonCmdData, cmd)
+
 	cmd_werf_common.SetupAddAnnotations(commonCmdData, cmd)
 	cmd_werf_common.SetupAddLabels(commonCmdData, cmd)
 

--- a/docs/_includes/documentation/reference/cli/werf_helm_install.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_install.md
@@ -106,6 +106,10 @@ werf helm install [NAME] [CHART] [flags] [options]
       --devel=false
             use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set,   
             this is ignored
+      --disable-determinism=false
+            Disable werf determinism mode (more info                                                
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_DISABLE_DETERMINISM)
       --disable-openapi-validation=false
             if set, the installation process will not validate rendered templates against the       
             Kubernetes OpenAPI Schema

--- a/docs/_includes/documentation/reference/cli/werf_helm_template.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_template.md
@@ -49,6 +49,10 @@ werf helm template [NAME] [CHART] [flags] [options]
       --devel=false
             use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set,   
             this is ignored
+      --disable-determinism=false
+            Disable werf determinism mode (more info                                                
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_DISABLE_DETERMINISM)
       --disable-openapi-validation=false
             if set, the installation process will not validate rendered templates against the       
             Kubernetes OpenAPI Schema

--- a/docs/_includes/documentation/reference/cli/werf_helm_upgrade.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_upgrade.md
@@ -66,6 +66,10 @@ werf helm upgrade [RELEASE] [CHART] [flags] [options]
       --devel=false
             use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set,   
             this is ignored
+      --disable-determinism=false
+            Disable werf determinism mode (more info                                                
+            https://werf.io/documentation/advanced/configuration/determinism.html, default          
+            $WERF_DISABLE_DETERMINISM)
       --disable-openapi-validation=false
             if set, the upgrade process will not validate rendered templates against the Kubernetes 
             OpenAPI Schema


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x20445eb]

goroutine 1 [running]:
github.com/werf/werf/cmd/werf/helm.InitWerfChartParams(0x2ba0b20, 0xc0007d9470, 0x3f81d80, 0xc00059fee0, 0x7ffc81549e21, 0x1e, 0x7ffc81549e21, 0x1e)
        /home/user/workspace/werf/cmd/werf/helm/werf_chart.go:46 +0x21b