### PR TITLE
[docs] Fix quickstart minikube setup guides for MacOS and Windows

### DIFF
--- a/docs/_includes/en/installation/multiwerf_windows.md
+++ b/docs/_includes/en/installation/multiwerf_windows.md
@@ -30,9 +30,9 @@ set MULTIWERF_BIN_PATH="C:\ProgramData\multiwerf\bin"
 mkdir %MULTIWERF_BIN_PATH%
 bitsadmin.exe /transfer "multiwerf" https://flant.bintray.com/multiwerf/v1.3.0/multiwerf-windows-amd64-v1.3.0.exe %MULTIWERF_BIN_PATH%\multiwerf.exe
 setx /M PATH "%PATH%;%MULTIWERF_BIN_PATH%"
-
-# after that open new cmd.exe session and start using multiwerf
 ```
+
+Next it is required to open **new cmd.exe session** to start using werf.
 
 ###### Using werf in the current shell
 

--- a/docs/_includes/installation/binary_windows.md
+++ b/docs/_includes/installation/binary_windows.md
@@ -21,6 +21,4 @@ set WERF_BIN_PATH="C:\ProgramData\werf\bin"
 mkdir %WERF_BIN_PATH%
 bitsadmin.exe /transfer "werf" https://dl.bintray.com/flant/werf/v1.1.21+fix22/werf-windows-amd64-v1.1.21+fix22.exe %WERF_BIN_PATH%\werf.exe
 setx /M PATH "%PATH%;%WERF_BIN_PATH%"
-
-# open new cmd.exe session and start using werf
 ```

--- a/docs/_includes/ru/installation/multiwerf_windows.md
+++ b/docs/_includes/ru/installation/multiwerf_windows.md
@@ -32,7 +32,7 @@ bitsadmin.exe /transfer "multiwerf" https://flant.bintray.com/multiwerf/v1.3.0/m
 setx /M PATH "%PATH%;%MULTIWERF_BIN_PATH%"
 ```
 
-После этого можно открыть новую сессию `cmd.exe` и начать пользоваться multiwerf.
+После этого **необходимо открыть новую сессию `cmd.exe`**, чтобы начать пользоваться werf.
 
 ###### Использование werf в текущей сессии shell
 


### PR DESCRIPTION
 - Make a separate instructions list for Windows, MacOS and Linux OS in the quickstart guide.
 - Require for werf dependencies installation explicitly.