### PR TITLE
Fix auto generation of Chart.yaml during werf-converge; update helm to v3.4.1

### DIFF
--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -384,16 +384,17 @@ func run(ctx context.Context, projectDir string) error {
 		return err
 	}
 
-	helmUpgradeCmd, _ := cmd_helm.NewUpgradeCmd(actionConfig, logboek.ProxyOutStream(), cmd_helm.UpgradeCmdOptions{
-		LoadOptions: loader.LoadOptions{
-			ChartExtender: wc,
-			SubchartExtenderFactoryFunc: func() chart.ChartExtender {
-				return werf_chart.NewWerfChart(ctx, nil, *commonCmdData.DisableGitermenism, projectDir, werf_chart.WerfChartOptions{})
-			},
-			LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
-			LocateChartFunc: common.MakeLocateChartFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
-			ReadFileFunc:    common.MakeHelmReadFileFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
+	loader.GlobalLoadOptions = &loader.LoadOptions{
+		ChartExtender: wc,
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return werf_chart.NewWerfChart(ctx, nil, *commonCmdData.DisableGitermenism, projectDir, werf_chart.WerfChartOptions{})
 		},
+		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
+		LocateChartFunc: common.MakeLocateChartFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
+		ReadFileFunc:    common.MakeHelmReadFileFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
+	}
+
+	helmUpgradeCmd, _ := cmd_helm.NewUpgradeCmd(actionConfig, logboek.ProxyOutStream(), cmd_helm.UpgradeCmdOptions{
 		PostRenderer: wc.ExtraAnnotationsAndLabelsPostRenderer,
 		ValueOpts: &values.Options{
 			ValueFiles:   *commonCmdData.Values,

--- a/cmd/werf/helm/helm.go
+++ b/cmd/werf/helm/helm.go
@@ -47,6 +47,13 @@ func NewCmd() *cobra.Command {
 		Short: "Manage application deployment with helm",
 	}
 
+	loader.GlobalLoadOptions = &loader.LoadOptions{
+		ChartExtender: werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{}),
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{})
+		},
+	}
+
 	os.Setenv("HELM_EXPERIMENTAL_OCI", "1")
 
 	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", *cmd_helm.Settings.GetNamespaceP(), "namespace scope for this request")
@@ -76,14 +83,7 @@ func NewCmd() *cobra.Command {
 		cmd_helm.NewPluginCmd(os.Stdout),
 		cmd_helm.NewPullCmd(os.Stdout),
 		cmd_helm.NewSearchCmd(os.Stdout),
-		cmd_helm.NewShowCmd(os.Stdout, cmd_helm.ShowCmdOptions{
-			LoadOptions: loader.LoadOptions{
-				ChartExtender: werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{}),
-				SubchartExtenderFactoryFunc: func() chart.ChartExtender {
-					return werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{})
-				},
-			},
-		}),
+		cmd_helm.NewShowCmd(os.Stdout),
 		cmd_helm.NewStatusCmd(actionConfig, os.Stdout),
 		cmd_helm.NewTestCmd(actionConfig, os.Stdout),
 		cmd_helm.NewVerifyCmd(os.Stdout),

--- a/cmd/werf/helm/install.go
+++ b/cmd/werf/helm/install.go
@@ -28,11 +28,14 @@ func NewInstallCmd(actionConfig *action.Configuration) *cobra.Command {
 
 	wc := werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{})
 
-	cmd, helmAction := cmd_helm.NewInstallCmd(actionConfig, os.Stdout, cmd_helm.InstallCmdOptions{
-		LoadOptions: loader.LoadOptions{
-			ChartExtender:               wc,
-			SubchartExtenderFactoryFunc: func() chart.ChartExtender { return werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{}) },
+	loader.GlobalLoadOptions = &loader.LoadOptions{
+		ChartExtender: wc,
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{})
 		},
+	}
+
+	cmd, helmAction := cmd_helm.NewInstallCmd(actionConfig, os.Stdout, cmd_helm.InstallCmdOptions{
 		PostRenderer: wc.ExtraAnnotationsAndLabelsPostRenderer,
 	})
 

--- a/cmd/werf/helm/template.go
+++ b/cmd/werf/helm/template.go
@@ -28,11 +28,14 @@ func NewTemplateCmd(actionConfig *action.Configuration) *cobra.Command {
 
 	wc := werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{})
 
-	cmd, helmAction := cmd_helm.NewTemplateCmd(actionConfig, os.Stdout, cmd_helm.TemplateCmdOptions{
-		LoadOptions: loader.LoadOptions{
-			ChartExtender:               wc,
-			SubchartExtenderFactoryFunc: func() chart.ChartExtender { return werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{}) },
+	loader.GlobalLoadOptions = &loader.LoadOptions{
+		ChartExtender: wc,
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{})
 		},
+	}
+
+	cmd, helmAction := cmd_helm.NewTemplateCmd(actionConfig, os.Stdout, cmd_helm.TemplateCmdOptions{
 		PostRenderer: wc.ExtraAnnotationsAndLabelsPostRenderer,
 	})
 

--- a/cmd/werf/helm/upgrade.go
+++ b/cmd/werf/helm/upgrade.go
@@ -26,11 +26,14 @@ func NewUpgradeCmd(actionConfig *action.Configuration) *cobra.Command {
 
 	wc := werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{})
 
-	cmd, helmAction := cmd_helm.NewUpgradeCmd(actionConfig, os.Stdout, cmd_helm.UpgradeCmdOptions{
-		LoadOptions: loader.LoadOptions{
-			ChartExtender:               wc,
-			SubchartExtenderFactoryFunc: func() chart.ChartExtender { return werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{}) },
+	loader.GlobalLoadOptions = &loader.LoadOptions{
+		ChartExtender: wc,
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return werf_chart.NewWerfChart(ctx, nil, false, "", werf_chart.WerfChartOptions{})
 		},
+	}
+
+	cmd, helmAction := cmd_helm.NewUpgradeCmd(actionConfig, os.Stdout, cmd_helm.UpgradeCmdOptions{
 		PostRenderer: wc.ExtraAnnotationsAndLabelsPostRenderer,
 	})
 

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -373,16 +373,17 @@ func runRender() error {
 
 	cmd_helm.Settings.Debug = *commonCmdData.LogDebug
 
-	helmTemplateCmd, _ := cmd_helm.NewTemplateCmd(actionConfig, output, cmd_helm.TemplateCmdOptions{
-		LoadOptions: loader.LoadOptions{
-			ChartExtender: wc,
-			SubchartExtenderFactoryFunc: func() chart.ChartExtender {
-				return werf_chart.NewWerfChart(ctx, nil, *commonCmdData.DisableGitermenism, projectDir, werf_chart.WerfChartOptions{})
-			},
-			LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
-			LocateChartFunc: common.MakeLocateChartFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
-			ReadFileFunc:    common.MakeHelmReadFileFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
+	loader.GlobalLoadOptions = &loader.LoadOptions{
+		ChartExtender: wc,
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return werf_chart.NewWerfChart(ctx, nil, *commonCmdData.DisableGitermenism, projectDir, werf_chart.WerfChartOptions{})
 		},
+		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
+		LocateChartFunc: common.MakeLocateChartFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
+		ReadFileFunc:    common.MakeHelmReadFileFunc(ctx, localGitRepo, projectDir, *commonCmdData.DisableGitermenism),
+	}
+
+	helmTemplateCmd, _ := cmd_helm.NewTemplateCmd(actionConfig, output, cmd_helm.TemplateCmdOptions{
 		PostRenderer: wc.ExtraAnnotationsAndLabelsPostRenderer,
 		ValueOpts: &values.Options{
 			ValueFiles:   *commonCmdData.Values,

--- a/docs/_includes/documentation/reference/cli/werf_helm_dependency_build.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_dependency_build.md
@@ -25,6 +25,8 @@ werf helm dependency build CHART [flags] [options]
 ```shell
       --keyring='~/.gnupg/pubring.gpg'
             keyring containing public keys
+      --skip-refresh=false
+            do not refresh the local repository cache
       --verify=false
             verify the packages against signatures
 ```

--- a/go.mod
+++ b/go.mod
@@ -71,13 +71,13 @@ require (
 	gopkg.in/oleiade/reflections.v1 v1.0.0
 	gopkg.in/yaml.v2 v2.3.0
 	helm.sh/helm/v3 v3.2.4
-	k8s.io/api v0.19.2
-	k8s.io/apimachinery v0.19.2
-	k8s.io/cli-runtime v0.19.2
-	k8s.io/client-go v0.19.2
+	k8s.io/api v0.19.3
+	k8s.io/apimachinery v0.19.3
+	k8s.io/cli-runtime v0.19.3
+	k8s.io/client-go v0.19.3
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.2.0
-	k8s.io/kubectl v0.19.2
+	k8s.io/kubectl v0.19.3
 	mvdan.cc/xurls v1.1.0
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/yaml v1.2.0
@@ -108,4 +108,4 @@ replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402
 
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible
 
-replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201124163146-c2bd249981df
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201203170401-53f8eabe3f2e

--- a/go.sum
+++ b/go.sum
@@ -1168,6 +1168,8 @@ github.com/werf/helm/v3 v3.0.0-20201113193039-e8103b38e3e8 h1:fGbJLRZb+YDi2odWhV
 github.com/werf/helm/v3 v3.0.0-20201113193039-e8103b38e3e8/go.mod h1:jbfz/BoYmpJ3njhHBdH7F3kR8CNUGeRueliFtOhQK+M=
 github.com/werf/helm/v3 v3.0.0-20201124163146-c2bd249981df h1:yFBmvH2BZc8B+1M7keoPpWpeyS51IuDBm8kh5n6/V3s=
 github.com/werf/helm/v3 v3.0.0-20201124163146-c2bd249981df/go.mod h1:jbfz/BoYmpJ3njhHBdH7F3kR8CNUGeRueliFtOhQK+M=
+github.com/werf/helm/v3 v3.0.0-20201203170401-53f8eabe3f2e h1:TujJy4FfhGZ8s5tFEMUN83UgmH3XqE4qAY17wv9QsHE=
+github.com/werf/helm/v3 v3.0.0-20201203170401-53f8eabe3f2e/go.mod h1:MeRlXlmCr5CWYKvqIPgXrSmcIXJpv7qcsKV3uTvcZSM=
 github.com/werf/kubedog v0.4.1-0.20200923112210-4079add7a93c h1:aM9Gs5CF9YuCFs25mCNfZKTx+3dNe97YGQGKLIumW5U=
 github.com/werf/kubedog v0.4.1-0.20200923112210-4079add7a93c/go.mod h1:b/5MyrNDmxXtr68uucMmZCZmWS3h7cfAcgqtQbHsw5o=
 github.com/werf/kubedog v0.4.1-0.20201125180623-08ad3ea6f58c h1:caA8J/bf3AQgcjo0RCSKdY3blSSswMH47pDcnmsNxPg=


### PR DESCRIPTION
 - Take Chart.yaml from the repository if exists.
 - Override metadata.name field with werf project name from the werf.yaml.
 - Set metadata.version = 1.0.0 if not set.
 - Set custom werf-chart loader globally for all `werf helm *` commands.

This makes Chart.yaml optional, but werf will use it when it exists.

Refs https://github.com/werf/helm/pull/68.
Refs https://github.com/werf/helm/pull/69
