### PR TITLE
[build] Remove stages_and_images read-only lock during build process

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -456,14 +456,6 @@ func (c *Conveyor) doDetermineStages(ctx context.Context) error {
 }
 
 func (c *Conveyor) runPhases(ctx context.Context, phases []Phase, logImages bool) error {
-	if lock, err := c.StorageLockManager.LockStagesAndImages(ctx, c.projectName(), storage.LockStagesAndImagesOptions{GetOrCreateImagesOnly: true}); err != nil {
-		return fmt.Errorf("unable to lock stages and images (to get or create stages and images only): %s", err)
-	} else {
-		c.AppendOnTerminateFunc(func() error {
-			return c.StorageLockManager.Unlock(ctx, lock)
-		})
-	}
-
 	for _, phase := range phases {
 		logProcess := logboek.Context(ctx).Debug().LogProcess("Phase %s -- BeforeImages()", phase.Name())
 		logProcess.Start()

--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -37,15 +37,7 @@ type CleanupOptions struct {
 }
 
 func Cleanup(ctx context.Context, projectName string, storageManager *manager.StorageManager, storageLockManager storage.LockManager, options CleanupOptions) error {
-	m := newCleanupManager(projectName, storageManager, options)
-
-	if lock, err := storageLockManager.LockStagesAndImages(ctx, projectName, storage.LockStagesAndImagesOptions{GetOrCreateImagesOnly: false}); err != nil {
-		return fmt.Errorf("unable to lock stages and images: %s", err)
-	} else {
-		defer storageLockManager.Unlock(ctx, lock)
-	}
-
-	return m.run(ctx)
+	return newCleanupManager(projectName, storageManager, options).run(ctx)
 }
 
 func newCleanupManager(projectName string, storageManager *manager.StorageManager, options CleanupOptions) *cleanupManager {

--- a/pkg/cleaning/purge.go
+++ b/pkg/cleaning/purge.go
@@ -2,7 +2,6 @@ package cleaning
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/werf/logboek"
 
@@ -17,15 +16,7 @@ type PurgeOptions struct {
 }
 
 func Purge(ctx context.Context, projectName string, storageManager *manager.StorageManager, storageLockManager storage.LockManager, options PurgeOptions) error {
-	m := newPurgeManager(projectName, storageManager, options)
-
-	if lock, err := storageLockManager.LockStagesAndImages(ctx, projectName, storage.LockStagesAndImagesOptions{GetOrCreateImagesOnly: false}); err != nil {
-		return fmt.Errorf("unable to lock stages and images: %s", err)
-	} else {
-		defer storageLockManager.Unlock(ctx, lock)
-	}
-
-	return m.run(ctx)
+	return newPurgeManager(projectName, storageManager, options).run(ctx)
 }
 
 func newPurgeManager(projectName string, storageManager *manager.StorageManager, options PurgeOptions) *purgeManager {

--- a/pkg/storage/generic_lock_manager.go
+++ b/pkg/storage/generic_lock_manager.go
@@ -28,16 +28,6 @@ func (manager *GenericLockManager) LockStageCache(ctx context.Context, projectNa
 	return LockHandle{LockgateHandle: lock, ProjectName: projectName}, err
 }
 
-func (manager *GenericLockManager) LockImage(ctx context.Context, projectName, imageName string) (LockHandle, error) {
-	_, lock, err := manager.Locker.Acquire(genericImageLockName(imageName), werf.SetupLockerDefaultOptions(ctx, lockgate.AcquireOptions{}))
-	return LockHandle{LockgateHandle: lock, ProjectName: projectName}, err
-}
-
-func (manager *GenericLockManager) LockStagesAndImages(ctx context.Context, projectName string, opts LockStagesAndImagesOptions) (LockHandle, error) {
-	_, lock, err := manager.Locker.Acquire(genericStagesAndImagesLockName(projectName), werf.SetupLockerDefaultOptions(ctx, lockgate.AcquireOptions{Shared: opts.GetOrCreateImagesOnly}))
-	return LockHandle{LockgateHandle: lock, ProjectName: projectName}, err
-}
-
 func (manager *GenericLockManager) Unlock(ctx context.Context, lock LockHandle) error {
 	err := manager.Locker.Release(lock.LockgateHandle)
 	if err != nil {
@@ -52,12 +42,4 @@ func genericStageLockName(projectName, digest string) string {
 
 func genericStageCacheLockName(projectName, digest string) string {
 	return fmt.Sprintf("%s.%s.cache", projectName, digest)
-}
-
-func genericImageLockName(imageName string) string {
-	return fmt.Sprintf("%s.image", imageName)
-}
-
-func genericStagesAndImagesLockName(projectName string) string {
-	return fmt.Sprintf("%s.stages_and_images", projectName)
 }

--- a/pkg/storage/kubernetes_lock_manager.go
+++ b/pkg/storage/kubernetes_lock_manager.go
@@ -84,24 +84,6 @@ func (manager *KuberntesLockManager) LockStageCache(ctx context.Context, project
 	}
 }
 
-func (manager *KuberntesLockManager) LockImage(ctx context.Context, projectName, imageName string) (LockHandle, error) {
-	if locker, err := manager.getLockerForProject(ctx, projectName); err != nil {
-		return LockHandle{}, err
-	} else {
-		_, lock, err := locker.Acquire(kuberntesImageLockName(projectName, imageName), werf.SetupLockerDefaultOptions(ctx, lockgate.AcquireOptions{}))
-		return LockHandle{LockgateHandle: lock, ProjectName: projectName}, err
-	}
-}
-
-func (manager *KuberntesLockManager) LockStagesAndImages(ctx context.Context, projectName string, opts LockStagesAndImagesOptions) (LockHandle, error) {
-	if locker, err := manager.getLockerForProject(ctx, projectName); err != nil {
-		return LockHandle{}, err
-	} else {
-		_, lock, err := locker.Acquire(kuberntesStagesAndImagesLockName(projectName), werf.SetupLockerDefaultOptions(ctx, lockgate.AcquireOptions{Shared: opts.GetOrCreateImagesOnly}))
-		return LockHandle{LockgateHandle: lock, ProjectName: projectName}, err
-	}
-}
-
 func (manager *KuberntesLockManager) Unlock(ctx context.Context, lock LockHandle) error {
 	if locker, err := manager.getLockerForProject(ctx, lock.ProjectName); err != nil {
 		return err
@@ -114,19 +96,10 @@ func (manager *KuberntesLockManager) Unlock(ctx context.Context, lock LockHandle
 	}
 }
 
-// FIXME: v1.2 use the same locks names as generic lock manager (include project name into lock name)
-func kubernetesStageLockName(_, digest string) string {
-	return fmt.Sprintf("stage/%s", digest)
+func kubernetesStageLockName(projectName, digest string) string {
+	return fmt.Sprintf("%s/stage/%s", projectName, digest)
 }
 
-func kubernetesStageCacheLockName(_, digest string) string {
-	return fmt.Sprintf("stage-cache/%s", digest)
-}
-
-func kuberntesImageLockName(_, imageName string) string {
-	return fmt.Sprintf("image/%s", imageName)
-}
-
-func kuberntesStagesAndImagesLockName(_ string) string {
-	return fmt.Sprintf("stages_and_images")
+func kubernetesStageCacheLockName(projectName, digest string) string {
+	return fmt.Sprintf("%s/stage-cache/%s", projectName, digest)
 }

--- a/pkg/storage/lock_manager.go
+++ b/pkg/storage/lock_manager.go
@@ -9,8 +9,6 @@ import (
 type LockManager interface {
 	LockStage(ctx context.Context, projectName, digest string) (LockHandle, error)
 	LockStageCache(ctx context.Context, projectName, digest string) (LockHandle, error)
-	LockImage(ctx context.Context, projectName, imageName string) (LockHandle, error)
-	LockStagesAndImages(ctx context.Context, projectName string, opts LockStagesAndImagesOptions) (LockHandle, error)
 	Unlock(ctx context.Context, lockHandle LockHandle) error
 }
 


### PR DESCRIPTION
 - stages_and_images read only lock is preventive measure against running cleanup and build commands at the same time;
 - this lock creates unnecessary load on the synchronization server, because this lock working all the time the build process is active for each build process;
 - it is mostly safe to just omit this lock completely;
 - also removed unused "image" lock from the lock manager (legacy from v1.1).
 - also renamed kubernetes-related stage and stage-cache locks to include project name (just for more correctness, incompatible with v1.1 change).