### PR TITLE
[giterminism] Support subcharts loading from the local filesystem in the giterminism mode

### DIFF
--- a/cmd/werf/common/deploy_params.go
+++ b/cmd/werf/common/deploy_params.go
@@ -200,9 +200,8 @@ func MakeChartDirLoadFunc(ctx context.Context, localGitRepo *git_repo.Local, pro
 	if giterminism_inspector.LooseGiterminism || localGitRepo == nil {
 		return nil
 	}
-
 	return func(dir string) ([]*loader.BufferedFile, error) {
-		return werf_chart.LoadFilesFromGit(ctx, localGitRepo, projectDir, dir)
+		return werf_chart.GiterministicFilesLoader(ctx, localGitRepo, projectDir, dir)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9 // indirect
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prashantv/gostub v1.0.0
 	github.com/rodaine/table v1.0.0
 	github.com/satori/go.uuid v1.2.0
@@ -108,4 +109,4 @@ replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402
 
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible
 
-replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201204131657-147592495d8e
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201207143115-ea7631bd21e6

--- a/go.sum
+++ b/go.sum
@@ -1176,6 +1176,8 @@ github.com/werf/helm/v3 v3.0.0-20201204115118-294006439ce9 h1:vsSP8EN8ZQXmf5B7tx
 github.com/werf/helm/v3 v3.0.0-20201204115118-294006439ce9/go.mod h1:MeRlXlmCr5CWYKvqIPgXrSmcIXJpv7qcsKV3uTvcZSM=
 github.com/werf/helm/v3 v3.0.0-20201204131657-147592495d8e h1:ePn5jGrZH8liyz64uZBAU4K8TNEmnGfaFWEygEv8RKU=
 github.com/werf/helm/v3 v3.0.0-20201204131657-147592495d8e/go.mod h1:MeRlXlmCr5CWYKvqIPgXrSmcIXJpv7qcsKV3uTvcZSM=
+github.com/werf/helm/v3 v3.0.0-20201207143115-ea7631bd21e6 h1:RuZRrDBRgyUYRYKhebJSP/GDWAxkpNPhU1qKDpiP9IE=
+github.com/werf/helm/v3 v3.0.0-20201207143115-ea7631bd21e6/go.mod h1:MeRlXlmCr5CWYKvqIPgXrSmcIXJpv7qcsKV3uTvcZSM=
 github.com/werf/kubedog v0.4.1-0.20200923112210-4079add7a93c h1:aM9Gs5CF9YuCFs25mCNfZKTx+3dNe97YGQGKLIumW5U=
 github.com/werf/kubedog v0.4.1-0.20200923112210-4079add7a93c/go.mod h1:b/5MyrNDmxXtr68uucMmZCZmWS3h7cfAcgqtQbHsw5o=
 github.com/werf/kubedog v0.4.1-0.20201125180623-08ad3ea6f58c h1:caA8J/bf3AQgcjo0RCSKdY3blSSswMH47pDcnmsNxPg=

--- a/pkg/deploy/werf_chart/git_loader.go
+++ b/pkg/deploy/werf_chart/git_loader.go
@@ -4,14 +4,75 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/werf/logboek"
+	"helm.sh/helm/v3/pkg/chart"
+	"sigs.k8s.io/yaml"
 
 	"github.com/werf/werf/pkg/util"
 
 	"github.com/werf/werf/pkg/git_repo"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
+
+func GiterministicFilesLoader(ctx context.Context, localGitRepo *git_repo.Local, projectDir, loadDir string) ([]*loader.BufferedFile, error) {
+	var res []*loader.BufferedFile
+	var lock *chart.Lock
+
+	if gitFiles, err := LoadFilesFromGit(ctx, localGitRepo, projectDir, loadDir); err != nil {
+		return nil, err
+	} else {
+		for _, f := range gitFiles {
+			switch {
+			case f.Name == "Chart.lock":
+				lock = new(chart.Lock)
+				if err := yaml.Unmarshal(f.Data, &lock); err != nil {
+					return nil, errors.Wrap(err, "cannot load Chart.lock")
+				}
+				break
+			case f.Name == "requirements.lock":
+				lock = new(chart.Lock)
+				if err := yaml.Unmarshal(f.Data, &lock); err != nil {
+					return nil, errors.Wrap(err, "cannot load requirements.lock")
+				}
+				break
+			}
+		}
+
+		res = gitFiles
+	}
+
+	localFiles, err := loader.GetFilesFromLocalFilesystem(loadDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if lock != nil {
+		localSubchartsFiles := make(map[string][]*loader.BufferedFile)
+
+		for _, f := range localFiles {
+			switch {
+			case strings.HasPrefix(f.Name, "charts/"):
+				fname := strings.TrimPrefix(f.Name, "charts/")
+				cname := strings.SplitN(fname, "/", 2)[0]
+				localSubchartsFiles[cname] = append(localSubchartsFiles[cname], f)
+				logboek.Context(ctx).Debug().LogF("-- GiterministicFilesLoader: local subchart %q: found file %q\n", cname, f.Name)
+			}
+		}
+
+		for _, dep := range lock.Dependencies {
+			fullDepName := fmt.Sprintf("%s-%s.tgz", dep.Name, dep.Version)
+			if files, hasKey := localSubchartsFiles[fullDepName]; hasKey {
+				logboek.Context(ctx).Debug().LogF("-- GiterministicFilesLoader: using subchart %q from the local filesystem\n", fullDepName)
+				res = append(res, files...)
+			}
+		}
+	}
+
+	return res, nil
+}
 
 func LoadFilesFromGit(ctx context.Context, localGitRepo *git_repo.Local, projectDir, loadDir string) ([]*loader.BufferedFile, error) {
 	commit, err := localGitRepo.HeadCommit(ctx)
@@ -25,6 +86,8 @@ func LoadFilesFromGit(ctx context.Context, localGitRepo *git_repo.Local, project
 	if err != nil {
 		return nil, fmt.Errorf("unable to get local repo paths for commit %s: %s", commit, err)
 	}
+
+	// FIXME: .helmignore
 
 	relativeLoadDir := util.GetRelativeToBaseFilepath(projectDir, loadDir)
 


### PR DESCRIPTION
 - Read committed dependencies lock file (requirements.lock or Chart.lock).
 - Scan local filesystem for the charts specified in the lock-file and use these charts in the giterminism mode.

No auto `werf helm dependency build` yet.