### PR TITLE
Introduce initial `werf bundle publish` command

### DIFF
--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -1,55 +1,63 @@
-package render
+package publish
 
 import (
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
-	"time"
+	"path/filepath"
 
-	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/getter"
 
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/werf/werf/pkg/config"
+	"github.com/werf/werf/pkg/git_repo"
+	"github.com/werf/werf/pkg/giterminism_inspector"
+	"github.com/werf/werf/pkg/werf/global_warnings"
+
+	"github.com/werf/werf/pkg/deploy/helm"
+
+	"github.com/werf/werf/pkg/deploy"
+	"github.com/werf/werf/pkg/deploy/secret"
+
+	"github.com/werf/werf/pkg/deploy/werf_chart"
 	cmd_helm "helm.sh/helm/v3/cmd/helm"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli/values"
 
-	"github.com/werf/kubedog/pkg/kube"
+	"github.com/spf13/cobra"
+
 	"github.com/werf/logboek"
 	"github.com/werf/logboek/pkg/level"
 
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/build"
 	"github.com/werf/werf/pkg/container_runtime"
-	"github.com/werf/werf/pkg/deploy"
-	"github.com/werf/werf/pkg/deploy/helm"
-	"github.com/werf/werf/pkg/deploy/secret"
-	"github.com/werf/werf/pkg/deploy/werf_chart"
 	"github.com/werf/werf/pkg/docker"
-	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/ssh_agent"
-	"github.com/werf/werf/pkg/storage"
 	"github.com/werf/werf/pkg/storage/manager"
 	"github.com/werf/werf/pkg/tmp_manager"
 	"github.com/werf/werf/pkg/true_git"
 	"github.com/werf/werf/pkg/werf"
-	"github.com/werf/werf/pkg/werf/global_warnings"
 )
 
 var cmdData struct {
-	Timeout      int
-	AutoRollback bool
-	RenderOutput string
+	Tag string
 }
 
 var commonCmdData common.CmdData
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "render",
-		Short:                 "Render Kubernetes templates",
-		Long:                  common.GetLongCommandDescription(`Render Kubernetes templates. This command will calculate digests and build (if needed) all images defined in the werf.yaml.`),
+		Use:   "publish",
+		Short: "Publish werf chart bundle",
+		Long: common.GetLongCommandDescription(`Publish werf bundle into the container registry. Werf bundle contains built images defined in the werf.yaml, helm chart, service values which contain built images tags, any custom values and set values params provided during publish invocation, werf addon templates (like werf_image).
+
+Published into container registry bundle can be rolled out by the "werf bundle " command.
+`),
 		DisableFlagsInUseLine: true,
 		Annotations: map[string]string{
 			common.CmdEnvAnno: common.EnvsDescription(common.WerfDebugAnsibleArgs, common.WerfSecretKey),
@@ -68,17 +76,16 @@ func NewCmd() *cobra.Command {
 			common.LogVersion()
 
 			return common.LogRunningTime(func() error {
-				return runRender()
+				return runPublish()
 			})
 		},
 	}
 
 	common.SetupDir(&commonCmdData, cmd)
+	common.SetupGiterminismInspectorOptions(&commonCmdData, cmd)
 	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
 	common.SetupConfigPath(&commonCmdData, cmd)
 	common.SetupEnvironment(&commonCmdData, cmd)
-
-	common.SetupGiterminismInspectorOptions(&commonCmdData, cmd)
 
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
@@ -95,21 +102,11 @@ func NewCmd() *cobra.Command {
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
-	common.SetupLogOptionsDefaultQuiet(&commonCmdData, cmd)
+	common.SetupLogOptions(&commonCmdData, cmd)
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
 
-	common.SetupKubeConfig(&commonCmdData, cmd)
-	common.SetupKubeConfigBase64(&commonCmdData, cmd)
-	common.SetupKubeContext(&commonCmdData, cmd)
-
-	common.SetupStatusProgressPeriod(&commonCmdData, cmd)
-	common.SetupHooksStatusProgressPeriod(&commonCmdData, cmd)
-	common.SetupReleasesHistoryMax(&commonCmdData, cmd)
-
-	common.SetupRelease(&commonCmdData, cmd)
-	common.SetupNamespace(&commonCmdData, cmd)
 	common.SetupAddAnnotations(&commonCmdData, cmd)
 	common.SetupAddLabels(&commonCmdData, cmd)
 
@@ -131,23 +128,23 @@ func NewCmd() *cobra.Command {
 
 	common.SetupSkipBuild(&commonCmdData, cmd)
 
-	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")
-	cmd.Flags().BoolVarP(&cmdData.AutoRollback, "auto-rollback", "R", common.GetBoolEnvironmentDefaultFalse("WERF_AUTO_ROLLBACK"), "Enable auto rollback of the failed release to the previous deployed release version when current deploy process have failed ($WERF_AUTO_ROLLBACK by default)")
-	cmd.Flags().BoolVarP(&cmdData.AutoRollback, "atomic", "", common.GetBoolEnvironmentDefaultFalse("WERF_ATOMIC"), "Enable auto rollback of the failed release to the previous deployed release version when current deploy process have failed ($WERF_ATOMIC by default)")
-
-	cmd.Flags().StringVarP(&cmdData.RenderOutput, "output", "", os.Getenv("WERF_RENDER_OUTPUT"), "Write render output to the specified file instead of stdout ($WERF_RENDER_OUTPUT by default)")
+	defaultTag := os.Getenv("WERF_TAG")
+	if defaultTag == "" {
+		defaultTag = "latest"
+	}
+	cmd.Flags().StringVarP(&cmdData.Tag, "tag", "", defaultTag, "Publish bundle into container registry repo by the provided tag ($WERF_TAG or latest by default)")
 
 	return cmd
 }
 
-func runRender() error {
+func runPublish() error {
 	ctx := common.BackgroundContext()
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
-	if err := common.InitGiterminismInspector(&commonCmdData); err != nil {
+	if err := giterminism_inspector.Init(giterminism_inspector.InspectionOptions{LooseGiterminism: *commonCmdData.LooseGiterminism, NonStrict: *commonCmdData.NonStrictGiterminismInspection}); err != nil {
 		return err
 	}
 
@@ -184,12 +181,12 @@ func runRender() error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	localGitRepo, err := common.OpenLocalGitRepo(projectDir)
+	localGitRepo, err := git_repo.OpenLocalRepo("own", projectDir, giterminism_inspector.DevMode)
 	if err != nil {
 		return fmt.Errorf("unable to open local repo %s: %s", projectDir, err)
 	}
 
-	werfConfig, err := common.GetRequiredWerfConfig(ctx, projectDir, &commonCmdData, localGitRepo, common.GetWerfConfigOptions(&commonCmdData, true))
+	werfConfig, err := common.GetRequiredWerfConfig(ctx, projectDir, &commonCmdData, localGitRepo, config.WerfConfigOptions{LogRenderedFilePath: true, Env: *commonCmdData.Environment})
 	if err != nil {
 		return fmt.Errorf("unable to load werf config: %s", err)
 	}
@@ -217,16 +214,6 @@ func runRender() error {
 		}
 	}()
 
-	releaseName, err := common.GetHelmRelease(*commonCmdData.Release, *commonCmdData.Environment, werfConfig)
-	if err != nil {
-		return err
-	}
-
-	namespace, err := common.GetKubernetesNamespace(*commonCmdData.Namespace, *commonCmdData.Environment, werfConfig)
-	if err != nil {
-		return err
-	}
-
 	userExtraAnnotations, err := common.GetUserExtraAnnotations(&commonCmdData)
 	if err != nil {
 		return err
@@ -244,71 +231,68 @@ func runRender() error {
 
 	logboek.LogOptionalLn()
 
+	repoAddress, err := common.GetStagesStorageAddress(&commonCmdData)
+	if err != nil {
+		return err
+	}
+
 	var imagesInfoGetters []*image.InfoGetter
 	var imagesRepository string
-	var isStub bool
 
 	if len(werfConfig.StapelImages) != 0 || len(werfConfig.ImagesFromDockerfile) != 0 {
-		stagesStorageAddress := common.GetOptionalStagesStorageAddress(&commonCmdData)
-
-		if stagesStorageAddress != storage.LocalStorageAddress {
-			containerRuntime := &container_runtime.LocalDockerServerRuntime{} // TODO
-			stagesStorage, err := common.GetStagesStorage(stagesStorageAddress, containerRuntime, &commonCmdData)
-			if err != nil {
-				return err
-			}
-			synchronization, err := common.GetSynchronization(ctx, &commonCmdData, projectName, stagesStorage)
-			if err != nil {
-				return err
-			}
-			stagesStorageCache, err := common.GetStagesStorageCache(synchronization)
-			if err != nil {
-				return err
-			}
-			storageLockManager, err := common.GetStorageLockManager(ctx, synchronization)
-			if err != nil {
-				return err
-			}
-			secondaryStagesStorageList, err := common.GetSecondaryStagesStorageList(stagesStorage, containerRuntime, &commonCmdData)
-			if err != nil {
-				return err
-			}
-
-			storageManager := manager.NewStorageManager(projectName, stagesStorage, secondaryStagesStorageList, storageLockManager, stagesStorageCache)
-
-			imagesRepository = storageManager.StagesStorage.String()
-
-			conveyorOptions, err := common.GetConveyorOptionsWithParallel(&commonCmdData, buildOptions)
-			if err != nil {
-				return err
-			}
-
-			conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, localGitRepo, nil, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, storageManager, storageLockManager, conveyorOptions)
-			defer conveyorWithRetry.Terminate()
-
-			if err := conveyorWithRetry.WithRetryBlock(ctx, func(c *build.Conveyor) error {
-				if *commonCmdData.SkipBuild {
-					if err := c.ShouldBeBuilt(ctx); err != nil {
-						return err
-					}
-				} else {
-					if err := c.Build(ctx, buildOptions); err != nil {
-						return err
-					}
-				}
-
-				imagesInfoGetters = c.GetImageInfoGetters()
-
-				return nil
-			}); err != nil {
-				return err
-			}
-
-			logboek.LogOptionalLn()
-		} else {
-			imagesRepository = "REPO"
-			isStub = true
+		containerRuntime := &container_runtime.LocalDockerServerRuntime{} // TODO
+		stagesStorage, err := common.GetStagesStorage(repoAddress, containerRuntime, &commonCmdData)
+		if err != nil {
+			return err
 		}
+		synchronization, err := common.GetSynchronization(ctx, &commonCmdData, projectName, stagesStorage)
+		if err != nil {
+			return err
+		}
+		stagesStorageCache, err := common.GetStagesStorageCache(synchronization)
+		if err != nil {
+			return err
+		}
+		storageLockManager, err := common.GetStorageLockManager(ctx, synchronization)
+		if err != nil {
+			return err
+		}
+		secondaryStagesStorageList, err := common.GetSecondaryStagesStorageList(stagesStorage, containerRuntime, &commonCmdData)
+		if err != nil {
+			return err
+		}
+
+		storageManager := manager.NewStorageManager(projectName, stagesStorage, secondaryStagesStorageList, storageLockManager, stagesStorageCache)
+
+		imagesRepository = storageManager.StagesStorage.String()
+
+		conveyorOptions, err := common.GetConveyorOptionsWithParallel(&commonCmdData, buildOptions)
+		if err != nil {
+			return err
+		}
+
+		conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, localGitRepo, nil, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, storageManager, storageLockManager, conveyorOptions)
+		defer conveyorWithRetry.Terminate()
+
+		if err := conveyorWithRetry.WithRetryBlock(ctx, func(c *build.Conveyor) error {
+			if *commonCmdData.SkipBuild {
+				if err := c.ShouldBeBuilt(ctx); err != nil {
+					return err
+				}
+			} else {
+				if err := c.Build(ctx, buildOptions); err != nil {
+					return err
+				}
+			}
+
+			imagesInfoGetters = c.GetImageInfoGetters()
+
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		logboek.LogOptionalLn()
 	}
 
 	var secretsManager secret.Manager
@@ -319,7 +303,7 @@ func runRender() error {
 	}
 
 	wc := werf_chart.NewWerfChart(ctx, localGitRepo, projectDir, werf_chart.WerfChartOptions{
-		ReleaseName: releaseName,
+		ReleaseName: "RELEASE",
 		ChartDir:    chartDir,
 
 		SecretValueFiles: *commonCmdData.SecretValues,
@@ -334,35 +318,15 @@ func runRender() error {
 	if err := wc.SetWerfConfig(werfConfig); err != nil {
 		return err
 	}
-	if vals, err := werf_chart.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, werf_chart.ServiceValuesOptions{Namespace: namespace, Env: *commonCmdData.Environment, IsStub: isStub}); err != nil {
+	if vals, err := werf_chart.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, werf_chart.ServiceValuesOptions{Env: *commonCmdData.Environment}); err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	} else if err := wc.SetServiceValues(vals); err != nil {
 		return err
 	}
 
 	actionConfig := new(action.Configuration)
-	if err := helm.InitActionConfig(ctx, namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{
-		StatusProgressPeriod:      time.Duration(*commonCmdData.StatusProgressPeriodSeconds) * time.Second,
-		HooksStatusProgressPeriod: time.Duration(*commonCmdData.HooksStatusProgressPeriodSeconds) * time.Second,
-		KubeConfigOptions: kube.KubeConfigOptions{
-			Context:          *commonCmdData.KubeContext,
-			ConfigPath:       *commonCmdData.KubeConfig,
-			ConfigDataBase64: *commonCmdData.KubeConfigBase64,
-		},
-	}); err != nil {
+	if err := helm.InitActionConfig(ctx, "", cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{}); err != nil {
 		return err
-	}
-
-	var output io.Writer
-	if cmdData.RenderOutput != "" {
-		if f, err := os.Create(cmdData.RenderOutput); err != nil {
-			return fmt.Errorf("unable to open file %q: %s", cmdData.RenderOutput, err)
-		} else {
-			defer f.Close()
-			output = f
-		}
-	} else {
-		output = os.Stdout
 	}
 
 	cmd_helm.Settings.Debug = *commonCmdData.LogDebug
@@ -377,16 +341,56 @@ func runRender() error {
 		ReadFileFunc:    common.MakeHelmReadFileFunc(ctx, localGitRepo, projectDir),
 	}
 
-	helmTemplateCmd, _ := cmd_helm.NewTemplateCmd(actionConfig, output, cmd_helm.TemplateCmdOptions{
+	valueOpts := &values.Options{
+		ValueFiles:   *commonCmdData.Values,
+		StringValues: *commonCmdData.SetString,
+		Values:       *commonCmdData.Set,
+		FileValues:   *commonCmdData.SetFile,
+	}
+
+	helmTemplateCmd, _ := cmd_helm.NewTemplateCmd(actionConfig, ioutil.Discard, cmd_helm.TemplateCmdOptions{
 		PostRenderer: wc.ExtraAnnotationsAndLabelsPostRenderer,
-		ValueOpts: &values.Options{
-			ValueFiles:   *commonCmdData.Values,
-			StringValues: *commonCmdData.SetString,
-			Values:       *commonCmdData.Set,
-			FileValues:   *commonCmdData.SetFile,
-		},
+		ValueOpts:    valueOpts,
 	})
-	return wc.WrapTemplate(ctx, func() error {
-		return helmTemplateCmd.RunE(helmTemplateCmd, []string{releaseName, chartDir})
-	})
+	if err := wc.WrapTemplate(ctx, func() error {
+		return helmTemplateCmd.RunE(helmTemplateCmd, []string{"RELEASE", chartDir})
+	}); err != nil {
+		return err
+	}
+
+	bundleTmpDir := filepath.Join(werf.GetServiceDir(), "tmp", "bundles", uuid.NewV4().String(), wc.HelmChart.Metadata.Name)
+	defer os.RemoveAll(bundleTmpDir)
+
+	p := getter.All(cmd_helm.Settings)
+	if vals, err := valueOpts.MergeValues(p, loader.GlobalLoadOptions.ReadFileFunc); err != nil {
+		return err
+	} else if bundle, err := wc.CreateNewBundle(ctx, bundleTmpDir, vals); err != nil {
+		return fmt.Errorf("unable to create bundle: %s", err)
+	} else {
+		loader.GlobalLoadOptions = &loader.LoadOptions{}
+
+		bundleRef := fmt.Sprintf("%s:%s", repoAddress, cmdData.Tag)
+
+		if err := logboek.Context(ctx).LogProcess("Saving bundle to the local chart helm cache").DoError(func() error {
+			helmChartSaveCmd := cmd_helm.NewChartSaveCmd(actionConfig, logboek.ProxyOutStream())
+			if err := helmChartSaveCmd.RunE(helmChartSaveCmd, []string{bundle.Dir, bundleRef}); err != nil {
+				return fmt.Errorf("error saving bundle to the local chart helm cache: %s", err)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		if err := logboek.Context(ctx).LogProcess("Pushing bundle %q", bundleRef).DoError(func() error {
+			helmChartPushCmd := cmd_helm.NewChartPushCmd(actionConfig, logboek.ProxyOutStream())
+			if err := helmChartPushCmd.RunE(helmChartPushCmd, []string{bundleRef}); err != nil {
+				return fmt.Errorf("error pushing bundle %q: %s", bundleRef, err)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -102,6 +102,8 @@ type CmdData struct {
 	VirtualMergeIntoCommit *string
 
 	ScanContextNamespaceOnly *bool
+
+	Tag *string
 }
 
 const (

--- a/cmd/werf/common/synchronization.go
+++ b/cmd/werf/common/synchronization.go
@@ -108,21 +108,6 @@ func checkSynchronizationKubernetesParamsForWarnings(cmdData *CmdData) {
 }
 
 func GetSynchronization(ctx context.Context, cmdData *CmdData, projectName string, stagesStorage storage.StagesStorage) (*SynchronizationParams, error) {
-	var defaultKubernetesSynchronization string
-	if *cmdData.Synchronization == "" {
-		defaultKubernetesSynchronization = storage.DefaultKubernetesStorageAddress
-
-		if *cmdData.KubeContext != "" {
-			defaultKubernetesSynchronization += fmt.Sprintf(":%s", *cmdData.KubeContext)
-		}
-
-		if *cmdData.KubeConfigBase64 != "" {
-			defaultKubernetesSynchronization += fmt.Sprintf("@base64:%s", *cmdData.KubeConfigBase64)
-		} else if *cmdData.KubeConfig != "" {
-			defaultKubernetesSynchronization += fmt.Sprintf("@%s", *cmdData.KubeConfig)
-		}
-	}
-
 	getKubeParamsFunc := func(address string) (*SynchronizationParams, error) {
 		res := &SynchronizationParams{}
 		res.SynchronizationType = KubernetesSynchronization

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -362,7 +362,7 @@ func run(ctx context.Context, projectDir string) error {
 	if err := wc.SetWerfConfig(werfConfig); err != nil {
 		return err
 	}
-	if vals, err := werf_chart.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, namespace, imagesInfoGetters, werf_chart.ServiceValuesOptions{Env: *commonCmdData.Environment}); err != nil {
+	if vals, err := werf_chart.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, werf_chart.ServiceValuesOptions{Namespace: namespace, Env: *commonCmdData.Environment}); err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	} else if err := wc.SetServiceValues(vals); err != nil {
 		return err

--- a/cmd/werf/helm/get_autogenerated_values.go
+++ b/cmd/werf/helm/get_autogenerated_values.go
@@ -210,7 +210,7 @@ func runGetServiceValues() error {
 		}
 	}
 
-	serviceValues, err := werf_chart.GetServiceValues(ctx, projectName, imagesRepository, namespace, imagesInfoGetters, werf_chart.ServiceValuesOptions{Env: environment})
+	serviceValues, err := werf_chart.GetServiceValues(ctx, projectName, imagesRepository, imagesInfoGetters, werf_chart.ServiceValuesOptions{Namespace: namespace, Env: environment})
 	if err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	}

--- a/cmd/werf/helm/helm.go
+++ b/cmd/werf/helm/helm.go
@@ -132,7 +132,7 @@ func NewCmd() *cobra.Command {
 
 				ctx := common.BackgroundContext()
 
-				if vals, err := werf_chart.GetServiceValues(ctx, "PROJECT", "REPO", namespace, nil, werf_chart.ServiceValuesOptions{IsStub: true}); err != nil {
+				if vals, err := werf_chart.GetServiceValues(ctx, "PROJECT", "REPO", nil, werf_chart.ServiceValuesOptions{Namespace: namespace, IsStub: true}); err != nil {
 					return fmt.Errorf("error creating service values: %s", err)
 				} else if err := wc.SetServiceValues(vals); err != nil {
 					return err

--- a/cmd/werf/main.go
+++ b/cmd/werf/main.go
@@ -32,6 +32,8 @@ import (
 	host_project_purge "github.com/werf/werf/cmd/werf/host/project/purge"
 	host_purge "github.com/werf/werf/cmd/werf/host/purge"
 
+	bundle_publish "github.com/werf/werf/cmd/werf/bundle/publish"
+
 	config_list "github.com/werf/werf/cmd/werf/config/list"
 	config_render "github.com/werf/werf/cmd/werf/config/render"
 	"github.com/werf/werf/cmd/werf/render"
@@ -85,6 +87,7 @@ Find more information at https://werf.io`),
 			Commands: []*cobra.Command{
 				converge.NewCmd(),
 				dismiss.NewCmd(),
+				bundleCmd(),
 			},
 		},
 		{
@@ -145,6 +148,18 @@ func dockerComposeCmd() *cobra.Command {
 
 	return cmd
 
+}
+
+func bundleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bundle",
+		Short: "Work with werf bundles: publish bundles into container registry and deploy bundles into Kubernetes cluster",
+	}
+	cmd.AddCommand(
+		bundle_publish.NewCmd(),
+	)
+
+	return cmd
 }
 
 func configCmd() *cobra.Command {

--- a/docs/_data/sidebars/_cli.yml
+++ b/docs/_data/sidebars/_cli.yml
@@ -15,6 +15,12 @@ cli: &cli
     - title: werf dismiss
       url: /documentation/reference/cli/werf_dismiss.html
 
+    - title: werf bundle
+      f:
+
+      - title: werf bundle publish
+        url: /documentation/reference/cli/werf_bundle_publish.html
+
   - title: Cleaning commands
     f:
 

--- a/docs/_data/sidebars/documentation.yml
+++ b/docs/_data/sidebars/documentation.yml
@@ -20,6 +20,12 @@ cli: &cli
     - title: werf dismiss
       url: /documentation/reference/cli/werf_dismiss.html
 
+    - title: werf bundle
+      f:
+
+      - title: werf bundle publish
+        url: /documentation/reference/cli/werf_bundle_publish.html
+
   - title: Cleaning commands
     f:
 

--- a/docs/_includes/documentation/reference/cli/werf_bundle.md
+++ b/docs/_includes/documentation/reference/cli/werf_bundle.md
@@ -1,0 +1,7 @@
+{% if include.header %}
+{% assign header = include.header %}
+{% else %}
+{% assign header = "###" %}
+{% endif %}
+Work with werf bundles: publish bundles into container registry and deploy bundles into Kubernetes cluster
+

--- a/docs/_includes/documentation/reference/cli/werf_bundle.short.md
+++ b/docs/_includes/documentation/reference/cli/werf_bundle.short.md
@@ -1,0 +1,1 @@
+work with werf bundles: publish bundles into container registry and deploy bundles into Kubernetes cluster

--- a/docs/_includes/documentation/reference/cli/werf_bundle_publish.md
+++ b/docs/_includes/documentation/reference/cli/werf_bundle_publish.md
@@ -1,0 +1,230 @@
+{% if include.header %}
+{% assign header = include.header %}
+{% else %}
+{% assign header = "###" %}
+{% endif %}
+Publish werf bundle into the container registry. Werf bundle contains built images defined in the   
+werf.yaml, helm chart, service values which contain built images tags, any custom values and set    
+values params provided during publish invocation, werf addon templates (like werf_image).
+
+Published into container registry bundle can be rolled out by the "werf bundle " command.
+
+
+{{ header }} Syntax
+
+```shell
+werf bundle publish [options]
+```
+
+{{ header }} Environments
+
+```shell
+  $WERF_DEBUG_ANSIBLE_ARGS  Pass specified cli args to ansible ($ANSIBLE_ARGS)
+  $WERF_SECRET_KEY          Use specified secret key to extract secrets for the deploy. Recommended 
+                            way to set secret key in CI-system. 
+                            
+                            Secret key also can be defined in files:
+                            * ~/.werf/global_secret_key (globally),
+                            * .werf_secret_key (per project)
+```
+
+{{ header }} Options
+
+```shell
+      --add-annotation=[]
+            Add annotation to deploying resources (can specify multiple).
+            Format: annoName=annoValue.
+            Also, can be specified with $WERF_ADD_ANNOTATION* (e.g.                                 
+            $WERF_ADD_ANNOTATION_1=annoName1=annoValue1",                                           
+            $WERF_ADD_ANNOTATION_2=annoName2=annoValue2")
+      --add-label=[]
+            Add label to deploying resources (can specify multiple).
+            Format: labelName=labelValue.
+            Also, can be specified with $WERF_ADD_LABEL* (e.g.                                      
+            $WERF_ADD_LABEL_1=labelName1=labelValue1", $WERF_ADD_LABEL_2=labelName2=labelValue2")
+      --config=''
+            Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
+      --config-templates-dir=''
+            Custom configuration templates directory (default $WERF_CONFIG_TEMPLATES_DIR or .werf   
+            in working directory)
+      --dev=false
+            Enable developer mode (default $WERF_DEV)
+      --dir=''
+            Use custom working directory (default $WERF_DIR or current directory)
+      --docker-config=''
+            Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
+            ~/.docker (in the order of priority)
+            Command needs granted permissions to read, pull and push images into the specified repo 
+            and to pull base images
+      --env=''
+            Use specified environment (default $WERF_ENV)
+      --home-dir=''
+            Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --ignore-secret-key=false
+            Disable secrets decryption (default $WERF_IGNORE_SECRET_KEY)
+      --insecure-registry=false
+            Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
+      --introspect-before-error=false
+            Introspect failed stage in the clean state, before running all assembly instructions of 
+            the stage
+      --introspect-error=false
+            Introspect failed stage in the state, right after running failed assembly instruction
+      --introspect-stage=[]
+            Introspect a specific stage. The option can be used multiple times to introspect        
+            several stages.
+            
+            There are the following formats to use:
+            * specify IMAGE_NAME/STAGE_NAME to introspect stage STAGE_NAME of either image or       
+            artifact IMAGE_NAME
+            * specify STAGE_NAME or */STAGE_NAME for the introspection of all existing stages with  
+            name STAGE_NAME
+            
+            IMAGE_NAME is the name of an image or artifact described in werf.yaml, the nameless     
+            image specified with ~.
+            STAGE_NAME should be one of the following: from, beforeInstall, importsBeforeInstall,   
+            gitArchive, install, importsAfterInstall, beforeSetup, importsBeforeSetup, setup,       
+            importsAfterSetup, gitCache, gitLatestPatch, dockerInstructions, dockerfile
+      --log-color-mode='auto'
+            Set log color mode.
+            Supported on, off and auto (based on the stdout’s file descriptor referring to a        
+            terminal) modes.
+            Default $WERF_LOG_COLOR_MODE or auto mode.
+      --log-debug=false
+            Enable debug (default $WERF_LOG_DEBUG).
+      --log-pretty=true
+            Enable emojis, auto line wrapping and log process border (default $WERF_LOG_PRETTY or   
+            true).
+      --log-project-dir=false
+            Print current project directory path (default $WERF_LOG_PROJECT_DIR)
+      --log-quiet=false
+            Disable explanatory output (default $WERF_LOG_QUIET).
+      --log-terminal-width=-1
+            Set log terminal width.
+            Defaults to:
+            * $WERF_LOG_TERMINAL_WIDTH
+            * interactive terminal width or 140
+      --log-verbose=false
+            Enable verbose output (default $WERF_LOG_VERBOSE).
+      --loose-giterminism=false
+            Loose werf giterminism mode restrictions (NOTE: not all restrictions can be removed,    
+            more info                                                                               
+            https://werf.io/v1.2-alpha/documentation/advanced/configuration/giterminism.html,       
+            default $WERF_LOOSE_GITERMINISM)
+      --non-strict-giterminism-inspection=false
+            Change some errors to warnings during giterminism inspection (more info                 
+            https://werf.io/v1.2-alpha/documentation/advanced/configuration/giterminism.html,       
+            default $WERF_NON_STRICT_GITERMINISM_INSPECTION)
+  -p, --parallel=true
+            Run in parallel (default $WERF_PARALLEL)
+      --parallel-tasks-limit=5
+            Parallel tasks limit, set -1 to remove the limitation (default                          
+            $WERF_PARALLEL_TASKS_LIMIT or 5)
+      --repo=''
+            Docker Repo to store stages (default $WERF_REPO)
+      --repo-docker-hub-password=''
+            Docker Hub password (default $WERF_REPO_DOCKER_HUB_PASSWORD)
+      --repo-docker-hub-token=''
+            Docker Hub token (default $WERF_REPO_DOCKER_HUB_TOKEN)
+      --repo-docker-hub-username=''
+            Docker Hub username (default $WERF_REPO_DOCKER_HUB_USERNAME)
+      --repo-github-token=''
+            GitHub token (default $WERF_REPO_GITHUB_TOKEN)
+      --repo-harbor-password=''
+            Harbor password (default $WERF_REPO_HARBOR_PASSWORD)
+      --repo-harbor-username=''
+            Harbor username (default $WERF_REPO_HARBOR_USERNAME)
+      --repo-implementation=''
+            Choose repo implementation.
+            The following docker registry implementations are supported: ecr, acr, default,         
+            dockerhub, gcr, github, gitlab, harbor, quay.
+            Default $WERF_REPO_IMPLEMENTATION or auto mode (detect implementation by a registry).
+      --repo-quay-token=''
+            quay.io token (default $WERF_REPO_QUAY_TOKEN)
+      --report-format='json'
+            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default)
+            json:
+            	{
+            	  "Images": {
+            		"<WERF_IMAGE_NAME>": {
+            			"WerfImageName": "<WERF_IMAGE_NAME>",
+            			"DockerRepo": "<REPO>",
+            			"DockerTag": "<TAG>"
+            			"DockerImageName": "<REPO>:<TAG>",
+            			"DockerImageID": "<SHA256>",
+            		},
+            		...
+            	  }
+            	}
+            envfile:
+            	WERF_<FORMATTED_WERF_IMAGE_NAME>_DOCKER_IMAGE_NAME=<REPO>:<TAG>
+            	...
+            <FORMATTED_WERF_IMAGE_NAME> is werf image name from werf.yaml modified according to the 
+            following rules:
+            - all characters are uppercase (app -> APP);
+            - charset /- is replaced with _ (dev/app-frontend -> DEV_APP_FRONTEND)
+      --report-path=''
+            Report save path ($WERF_REPORT_PATH by default)
+      --secondary-repo=[]
+            Specify one or multiple secondary read-only repo with images that will be used as a     
+            cache
+      --secret-values=[]
+            Specify helm secret values in a YAML file (can specify multiple).
+            Also, can be defined with $WERF_SECRET_VALUES* (e.g.                                    
+            $WERF_SECRET_VALUES_ENV=.helm/secret_values_test.yaml,                                  
+            $WERF_SECRET_VALUES=.helm/secret_values_db.yaml)
+      --set=[]
+            Set helm values on the command line (can specify multiple or separate values with       
+            commas: key1=val1,key2=val2).
+            Also, can be defined with $WERF_SET* (e.g. $WERF_SET_1=key1=val1, $WERF_SET_2=key2=val2)
+      --set-file=[]
+            Set values from respective files specified via the command line (can specify multiple   
+            or separate values with commas: key1=path1,key2=path2).
+            Also, can be defined with $WERF_SET_FILE* (e.g. $WERF_SET_FILE_1=key1=path1,            
+            $WERF_SET_FILE_2=key2=val2)
+      --set-string=[]
+            Set STRING helm values on the command line (can specify multiple or separate values     
+            with commas: key1=val1,key2=val2).
+            Also, can be defined with $WERF_SET_STRING* (e.g. $WERF_SET_STRING_1=key1=val1,         
+            $WERF_SET_STRING_2=key2=val2)
+  -Z, --skip-build=false
+            Disable building of docker images, cached images in the repo should exist in the repo   
+            if werf.yaml contains at least one image description (default $WERF_SKIP_BUILD)
+      --skip-tls-verify-registry=false
+            Skip TLS certificate validation when accessing a registry (default                      
+            $WERF_SKIP_TLS_VERIFY_REGISTRY)
+      --ssh-key=[]
+            Use only specific ssh key(s).
+            Can be specified with $WERF_SSH_KEY* (e.g. $WERF_SSH_KEY_REPO=~/.ssh/repo_rsa",         
+            $WERF_SSH_KEY_NODEJS=~/.ssh/nodejs_rsa").
+            Defaults to $WERF_SSH_KEY*, system ssh-agent or ~/.ssh/{id_rsa|id_dsa}, see             
+            https://werf.io/documentation/reference/toolbox/ssh.html
+  -S, --synchronization=''
+            Address of synchronizer for multiple werf processes to work with a single repo.
+            
+            Default:
+            * $WERF_SYNCHRONIZATION or
+            * :local if --repo is not specified or
+            * kubernetes://werf-synchronization if --repo is specified
+            
+            The same address should be specified for all werf processes that work with a single     
+            repo. :local address allows execution of werf processes from a single host only
+      --tag='latest'
+            Publish bundle into container registry repo by the provided tag ($WERF_TAG or latest by 
+            default)
+      --tmp-dir=''
+            Use specified dir to store tmp files and dirs (default $WERF_TMP_DIR or system tmp dir)
+      --values=[]
+            Specify helm values in a YAML file or a URL (can specify multiple).
+            Also, can be defined with $WERF_VALUES* (e.g. $WERF_VALUES_ENV=.helm/values_test.yaml,  
+            $WERF_VALUES_DB=.helm/values_db.yaml)
+      --virtual-merge=false
+            Enable virtual/ephemeral merge commit mode when building current application state      
+            ($WERF_VIRTUAL_MERGE by default)
+      --virtual-merge-from-commit=''
+            Commit hash for virtual/ephemeral merge commit with new changes introduced in the pull  
+            request ($WERF_VIRTUAL_MERGE_FROM_COMMIT by default)
+      --virtual-merge-into-commit=''
+            Commit hash for virtual/ephemeral merge commit which is base for changes introduced in  
+            the pull request ($WERF_VIRTUAL_MERGE_INTO_COMMIT by default)
+```
+

--- a/docs/_includes/documentation/reference/cli/werf_bundle_publish.short.md
+++ b/docs/_includes/documentation/reference/cli/werf_bundle_publish.short.md
@@ -1,0 +1,1 @@
+publish werf chart bundle

--- a/docs/pages/documentation/reference/cli/overview.md
+++ b/docs/pages/documentation/reference/cli/overview.md
@@ -8,6 +8,7 @@ toc: false
 Delivery commands:
  - [werf converge]({{ "/documentation/reference/cli/werf_converge.html" | relative_url }}) — {% include /documentation/reference/cli/werf_converge.short.md %}.
  - [werf dismiss]({{ "/documentation/reference/cli/werf_dismiss.html" | relative_url }}) — {% include /documentation/reference/cli/werf_dismiss.short.md %}.
+ - [werf bundle]({{ "/documentation/reference/cli/werf_bundle_publish.html" | relative_url }}) — {% include /documentation/reference/cli/werf_bundle_publish.short.md %}.
 
 Cleaning commands:
  - [werf cleanup]({{ "/documentation/reference/cli/werf_cleanup.html" | relative_url }}) — {% include /documentation/reference/cli/werf_cleanup.short.md %}.

--- a/docs/pages/documentation/reference/cli/werf_bundle.md
+++ b/docs/pages/documentation/reference/cli/werf_bundle.md
@@ -1,0 +1,7 @@
+---
+title: werf bundle
+sidebar: documentation
+permalink: documentation/reference/cli/werf_bundle.html
+---
+
+{% include /documentation/reference/cli/werf_bundle.md %}

--- a/docs/pages/documentation/reference/cli/werf_bundle_publish.md
+++ b/docs/pages/documentation/reference/cli/werf_bundle_publish.md
@@ -1,0 +1,7 @@
+---
+title: werf bundle publish
+sidebar: documentation
+permalink: documentation/reference/cli/werf_bundle_publish.html
+---
+
+{% include /documentation/reference/cli/werf_bundle_publish.md %}

--- a/go.mod
+++ b/go.mod
@@ -109,4 +109,4 @@ replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402
 
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible
 
-replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201207143115-ea7631bd21e6
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201217130132-273559fb7084

--- a/go.sum
+++ b/go.sum
@@ -1178,6 +1178,8 @@ github.com/werf/helm/v3 v3.0.0-20201204131657-147592495d8e h1:ePn5jGrZH8liyz64uZ
 github.com/werf/helm/v3 v3.0.0-20201204131657-147592495d8e/go.mod h1:MeRlXlmCr5CWYKvqIPgXrSmcIXJpv7qcsKV3uTvcZSM=
 github.com/werf/helm/v3 v3.0.0-20201207143115-ea7631bd21e6 h1:RuZRrDBRgyUYRYKhebJSP/GDWAxkpNPhU1qKDpiP9IE=
 github.com/werf/helm/v3 v3.0.0-20201207143115-ea7631bd21e6/go.mod h1:MeRlXlmCr5CWYKvqIPgXrSmcIXJpv7qcsKV3uTvcZSM=
+github.com/werf/helm/v3 v3.0.0-20201217130132-273559fb7084 h1:OpPyCSBK58njtzqzah+HKDGts6TsyXcrR8oPKS8WZ2s=
+github.com/werf/helm/v3 v3.0.0-20201217130132-273559fb7084/go.mod h1:MeRlXlmCr5CWYKvqIPgXrSmcIXJpv7qcsKV3uTvcZSM=
 github.com/werf/kubedog v0.4.1-0.20200923112210-4079add7a93c h1:aM9Gs5CF9YuCFs25mCNfZKTx+3dNe97YGQGKLIumW5U=
 github.com/werf/kubedog v0.4.1-0.20200923112210-4079add7a93c/go.mod h1:b/5MyrNDmxXtr68uucMmZCZmWS3h7cfAcgqtQbHsw5o=
 github.com/werf/kubedog v0.4.1-0.20201125180623-08ad3ea6f58c h1:caA8J/bf3AQgcjo0RCSKdY3blSSswMH47pDcnmsNxPg=

--- a/pkg/deploy/werf_chart/bundle.go
+++ b/pkg/deploy/werf_chart/bundle.go
@@ -1,0 +1,100 @@
+package werf_chart
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/werf/werf/pkg/deploy/helm"
+
+	"helm.sh/helm/v3/pkg/postrender"
+
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+/*
+ * Bundle object is chart.ChartExtender compatible object
+ * which could be used during helm install/upgrade process
+ */
+type Bundle struct {
+	Dir       string
+	HelmChart *chart.Chart
+}
+
+func NewBundle(dir string) *Bundle {
+	return &Bundle{
+		Dir: dir,
+	}
+}
+
+func (bundle *Bundle) GetPostRenderer() (postrender.PostRenderer, error) {
+	postRenderer := helm.NewExtraAnnotationsAndLabelsPostRenderer(nil, nil)
+
+	if dataMap, err := readBundleJsonMap(filepath.Join(bundle.Dir, "extra_annotations.json")); err != nil {
+		return nil, err
+	} else {
+		postRenderer.Add(dataMap, nil)
+	}
+
+	if dataMap, err := readBundleJsonMap(filepath.Join(bundle.Dir, "extra_labels.json")); err != nil {
+		return nil, err
+	} else {
+		postRenderer.Add(nil, dataMap)
+	}
+
+	return postRenderer, nil
+}
+
+func (bundle *Bundle) SetupChart(c *chart.Chart) error {
+	bundle.HelmChart = c
+	return nil
+}
+
+func (bundle *Bundle) AfterLoad() error {
+	return nil
+}
+
+func (bundle *Bundle) MakeValues(inputVals map[string]interface{}) (map[string]interface{}, error) {
+	return inputVals, nil
+}
+
+func (bundle *Bundle) SetupTemplateFuncs(t *template.Template, funcMap template.FuncMap) {
+	helmIncludeFunc := funcMap["include"].(func(name string, data interface{}) (string, error))
+	setupIncludeWrapperFunc := func(name string) {
+		funcMap[name] = func(data interface{}) (string, error) {
+			return helmIncludeFunc(name, data)
+		}
+	}
+
+	for _, name := range []string{"werf_image"} {
+		setupIncludeWrapperFunc(name)
+	}
+}
+
+func writeBundleJsonMap(dataMap map[string]string, path string) error {
+	if data, err := json.Marshal(dataMap); err != nil {
+		return fmt.Errorf("unable to prepare %q data: %s", path, err)
+	} else if err := ioutil.WriteFile(path, append(data, []byte("\n")...), os.ModePerm); err != nil {
+		return fmt.Errorf("unable to write %q: %s", path, err)
+	} else {
+		return nil
+	}
+}
+
+func readBundleJsonMap(path string) (map[string]string, error) {
+	var res map[string]string
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("error accessing %q: %s", path, err)
+	} else if data, err := ioutil.ReadFile(path); err != nil {
+		return nil, fmt.Errorf("error reading %q: %s", path, err)
+	} else if err := json.Unmarshal(data, res); err != nil {
+		return nil, fmt.Errorf("error unmarshalling json from %q: %s", path, err)
+	} else {
+		return res, nil
+	}
+}

--- a/pkg/deploy/werf_chart/service_values.go
+++ b/pkg/deploy/werf_chart/service_values.go
@@ -11,24 +11,28 @@ import (
 )
 
 type ServiceValuesOptions struct {
-	Env    string
-	IsStub bool
+	Namespace string
+	Env       string
+	IsStub    bool
 }
 
-func GetServiceValues(ctx context.Context, projectName string, repo, namespace string, imageInfoGetters []*image.InfoGetter, opts ServiceValuesOptions) (map[string]interface{}, error) {
+func GetServiceValues(ctx context.Context, projectName string, repo string, imageInfoGetters []*image.InfoGetter, opts ServiceValuesOptions) (map[string]interface{}, error) {
 	globalInfo := map[string]interface{}{
 		"env": opts.Env,
 	}
 
 	werfInfo := map[string]interface{}{
-		"name":      projectName,
-		"repo":      repo,
-		"namespace": namespace,
-		"is_stub":   opts.IsStub,
-		"env":       opts.Env,
+		"name": projectName,
+		"repo": repo,
+		"env":  opts.Env,
+	}
+
+	if opts.Namespace != "" {
+		werfInfo["namespace"] = opts.Namespace
 	}
 
 	if opts.IsStub {
+		werfInfo["is_stub"] = true
 		werfInfo["stub_image"] = fmt.Sprintf("%s:TAG", repo)
 	}
 


### PR DESCRIPTION
 - werf_chart.WerfChart is chart.ChartExtender compatible object, which could generate a werf_chart.Bundle object. This object will keep all custom values and templates, chart config file (Chart.yaml) and other data (extra annotations/labels, extra templates).
 - werf_chart.Bundle object is also chart.ChartExtender compatible object which could be deployed using the same helm install/upgrade procedure as for werf_chart.WerfChart.
 - werf_chart.Bundle is compatible with standard helm-chart files structure, but contains some extensions (extra labels and annotations are saved into chart for example — these will be used only when deploying bundle using werf and ignored if deploying bundle using default helm).
 - werf_chart.Bundle could be dumped into directory, packed, pushed into the container registry and pulled from the container registry.
 
 Refs https://github.com/werf/werf/issues/2712
 Refs https://github.com/werf/werf/issues/2694