### PR TITLE
[bundle] Export and download bundle commands

### DIFF
--- a/cmd/werf/bundle/download/download.go
+++ b/cmd/werf/bundle/download/download.go
@@ -1,0 +1,131 @@
+package download
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/werf/werf/pkg/werf/global_warnings"
+
+	"github.com/werf/werf/pkg/deploy/helm"
+
+	cmd_helm "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart/loader"
+
+	"github.com/spf13/cobra"
+
+	"github.com/werf/logboek"
+	"github.com/werf/logboek/pkg/level"
+
+	"github.com/werf/werf/cmd/werf/common"
+	"github.com/werf/werf/pkg/werf"
+)
+
+var cmdData struct {
+	Tag         string
+	Destination string
+}
+
+var commonCmdData common.CmdData
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "download",
+		Short:                 "Download published bundle into directory",
+		Long:                  common.GetLongCommandDescription(`Take latest bundle from the specified container registry using specified version tag or version mask and unpack it into provided directory (or into directory named as a resulting chart in the current working directory).`),
+		DisableFlagsInUseLine: true,
+		Annotations: map[string]string{
+			common.CmdEnvAnno: common.EnvsDescription(common.WerfDebugAnsibleArgs, common.WerfSecretKey),
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			defer global_warnings.PrintGlobalWarnings(common.BackgroundContext())
+
+			logboek.Streams().Mute()
+			logboek.SetAcceptedLevel(level.Error)
+
+			if err := common.ProcessLogOptionsDefaultQuiet(&commonCmdData); err != nil {
+				common.PrintHelp(cmd)
+				return err
+			}
+
+			common.LogVersion()
+
+			return common.LogRunningTime(func() error {
+				return runApply()
+			})
+		},
+	}
+
+	common.SetupTmpDir(&commonCmdData, cmd)
+	common.SetupHomeDir(&commonCmdData, cmd)
+
+	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
+
+	common.SetupStagesStorageOptions(&commonCmdData, cmd) // FIXME
+
+	common.SetupLogOptions(&commonCmdData, cmd)
+	common.SetupLogProjectDir(&commonCmdData, cmd)
+
+	defaultTag := os.Getenv("WERF_TAG")
+	if defaultTag == "" {
+		defaultTag = "latest"
+	}
+	cmd.Flags().StringVarP(&cmdData.Tag, "tag", "", defaultTag, "Provide exact tag version or semver-based pattern, werf will install or upgrade to the latest version of the specified bundle ($WERF_TAG or latest by default)")
+	cmd.Flags().StringVarP(&cmdData.Destination, "destination", "d", os.Getenv("WERF_DESTINATION"), "Download bundle into the provided directory ($WERF_DESTINATION or chart-name by default)")
+
+	return cmd
+}
+
+func runApply() error {
+	ctx := common.BackgroundContext()
+
+	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
+		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := common.DockerRegistryInit(&commonCmdData); err != nil {
+		return err
+	}
+
+	repoAddress, err := common.GetStagesStorageAddress(&commonCmdData)
+	if err != nil {
+		return err
+	}
+
+	cmd_helm.Settings.Debug = *commonCmdData.LogDebug
+
+	actionConfig := new(action.Configuration)
+	if err := helm.InitActionConfig(ctx, "", cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{}); err != nil {
+		return err
+	}
+
+	loader.GlobalLoadOptions = &loader.LoadOptions{}
+
+	// FIXME: support semver-pattern
+	bundleRef := fmt.Sprintf("%s:%s", repoAddress, cmdData.Tag)
+
+	if err := logboek.Context(ctx).LogProcess("Pulling bundle %q", bundleRef).DoError(func() error {
+		if cmd := cmd_helm.NewChartPullCmd(actionConfig, logboek.ProxyOutStream()); cmd != nil {
+			if err := cmd.RunE(cmd, []string{bundleRef}); err != nil {
+				return fmt.Errorf("error saving bundle to the local chart helm cache: %s", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := logboek.Context(ctx).LogProcess("Saving bundle into directory").DoError(func() error {
+		if cmd := cmd_helm.NewChartExportCmd(actionConfig, logboek.ProxyOutStream(), cmd_helm.ChartExportCmdOptions{Destination: cmdData.Destination}); cmd != nil {
+			if err := cmd.RunE(cmd, []string{bundleRef}); err != nil {
+				return fmt.Errorf("error saving bundle to the directory: %s", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -1,0 +1,364 @@
+package export
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"helm.sh/helm/v3/pkg/getter"
+
+	"github.com/werf/werf/pkg/config"
+	"github.com/werf/werf/pkg/git_repo"
+	"github.com/werf/werf/pkg/giterminism_inspector"
+	"github.com/werf/werf/pkg/werf/global_warnings"
+
+	"github.com/werf/werf/pkg/deploy/helm"
+
+	"github.com/werf/werf/pkg/deploy"
+	"github.com/werf/werf/pkg/deploy/secret"
+
+	"github.com/werf/werf/pkg/deploy/werf_chart"
+	cmd_helm "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/cli/values"
+
+	"github.com/spf13/cobra"
+
+	"github.com/werf/logboek"
+	"github.com/werf/logboek/pkg/level"
+
+	"github.com/werf/werf/cmd/werf/common"
+	"github.com/werf/werf/pkg/build"
+	"github.com/werf/werf/pkg/container_runtime"
+	"github.com/werf/werf/pkg/docker"
+	"github.com/werf/werf/pkg/image"
+	"github.com/werf/werf/pkg/ssh_agent"
+	"github.com/werf/werf/pkg/storage/manager"
+	"github.com/werf/werf/pkg/tmp_manager"
+	"github.com/werf/werf/pkg/true_git"
+	"github.com/werf/werf/pkg/werf"
+)
+
+var cmdData struct {
+	Destination string
+}
+
+var commonCmdData common.CmdData
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "export",
+		Short:                 "Export bundle",
+		Long:                  common.GetLongCommandDescription(`Export bundle into the provided directory. Werf bundle contains built images defined in the werf.yaml, helm chart, service values which contain built images tags, any custom values and set values params provided during publish invocation, werf addon templates (like werf_image).`),
+		DisableFlagsInUseLine: true,
+		Annotations: map[string]string{
+			common.CmdEnvAnno: common.EnvsDescription(common.WerfDebugAnsibleArgs, common.WerfSecretKey),
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			defer global_warnings.PrintGlobalWarnings(common.BackgroundContext())
+
+			logboek.Streams().Mute()
+			logboek.SetAcceptedLevel(level.Error)
+
+			if err := common.ProcessLogOptionsDefaultQuiet(&commonCmdData); err != nil {
+				common.PrintHelp(cmd)
+				return err
+			}
+
+			common.LogVersion()
+
+			return common.LogRunningTime(func() error {
+				return runExport()
+			})
+		},
+	}
+
+	common.SetupDir(&commonCmdData, cmd)
+	common.SetupGiterminismInspectorOptions(&commonCmdData, cmd)
+	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+	common.SetupEnvironment(&commonCmdData, cmd)
+
+	common.SetupTmpDir(&commonCmdData, cmd)
+	common.SetupHomeDir(&commonCmdData, cmd)
+	common.SetupSSHKey(&commonCmdData, cmd)
+
+	common.SetupIntrospectAfterError(&commonCmdData, cmd)
+	common.SetupIntrospectBeforeError(&commonCmdData, cmd)
+	common.SetupIntrospectStage(&commonCmdData, cmd)
+
+	common.SetupSecondaryStagesStorageOptions(&commonCmdData, cmd)
+	common.SetupStagesStorageOptions(&commonCmdData, cmd)
+
+	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified repo and to pull base images")
+	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
+
+	common.SetupLogOptions(&commonCmdData, cmd)
+	common.SetupLogProjectDir(&commonCmdData, cmd)
+
+	common.SetupSynchronization(&commonCmdData, cmd)
+
+	common.SetupAddAnnotations(&commonCmdData, cmd)
+	common.SetupAddLabels(&commonCmdData, cmd)
+
+	common.SetupSet(&commonCmdData, cmd)
+	common.SetupSetString(&commonCmdData, cmd)
+	common.SetupSetFile(&commonCmdData, cmd)
+	common.SetupValues(&commonCmdData, cmd)
+	common.SetupSecretValues(&commonCmdData, cmd)
+	common.SetupIgnoreSecretKey(&commonCmdData, cmd)
+
+	common.SetupReportPath(&commonCmdData, cmd)
+	common.SetupReportFormat(&commonCmdData, cmd)
+
+	common.SetupVirtualMerge(&commonCmdData, cmd)
+	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
+	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
+	common.SetupParallelOptions(&commonCmdData, cmd, common.DefaultBuildParallelTasksLimit)
+
+	common.SetupSkipBuild(&commonCmdData, cmd)
+
+	cmd.Flags().StringVarP(&cmdData.Destination, "destination", "d", os.Getenv("WERF_DESTINATION"), "Export bundle into the provided directory ($WERF_DESTINATION or chart-name by default)")
+
+	return cmd
+}
+
+func runExport() error {
+	ctx := common.BackgroundContext()
+
+	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
+		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := giterminism_inspector.Init(giterminism_inspector.InspectionOptions{LooseGiterminism: *commonCmdData.LooseGiterminism, NonStrict: *commonCmdData.NonStrictGiterminismInspection}); err != nil {
+		return err
+	}
+
+	if err := git_repo.Init(); err != nil {
+		return err
+	}
+
+	if err := image.Init(); err != nil {
+		return err
+	}
+
+	if err := true_git.Init(true_git.Options{LiveGitOutput: *commonCmdData.LogVerbose || *commonCmdData.LogDebug}); err != nil {
+		return err
+	}
+
+	if err := common.DockerRegistryInit(&commonCmdData); err != nil {
+		return err
+	}
+
+	if err := docker.Init(ctx, *commonCmdData.DockerConfig, *commonCmdData.LogVerbose, *commonCmdData.LogDebug); err != nil {
+		return err
+	}
+
+	ctxWithDockerCli, err := docker.NewContext(ctx)
+	if err != nil {
+		return err
+	}
+	ctx = ctxWithDockerCli
+
+	projectDir, err := common.GetProjectDir(&commonCmdData)
+	if err != nil {
+		return fmt.Errorf("getting project dir failed: %s", err)
+	}
+
+	common.ProcessLogProjectDir(&commonCmdData, projectDir)
+
+	localGitRepo, err := git_repo.OpenLocalRepo("own", projectDir, giterminism_inspector.DevMode)
+	if err != nil {
+		return fmt.Errorf("unable to open local repo %s: %s", projectDir, err)
+	}
+
+	werfConfig, err := common.GetRequiredWerfConfig(ctx, projectDir, &commonCmdData, localGitRepo, config.WerfConfigOptions{LogRenderedFilePath: true, Env: *commonCmdData.Environment})
+	if err != nil {
+		return fmt.Errorf("unable to load werf config: %s", err)
+	}
+
+	projectName := werfConfig.Meta.Project
+
+	chartDir, err := common.GetHelmChartDir(projectDir, &commonCmdData, werfConfig)
+	if err != nil {
+		return fmt.Errorf("getting helm chart dir failed: %s", err)
+	}
+
+	projectTmpDir, err := tmp_manager.CreateProjectDir(ctx)
+	if err != nil {
+		return fmt.Errorf("getting project tmp dir failed: %s", err)
+	}
+	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
+
+	if err := ssh_agent.Init(ctx, *commonCmdData.SSHKeys); err != nil {
+		return fmt.Errorf("cannot initialize ssh agent: %s", err)
+	}
+	defer func() {
+		err := ssh_agent.Terminate()
+		if err != nil {
+			logboek.Warn().LogF("WARNING: ssh agent termination failed: %s\n", err)
+		}
+	}()
+
+	userExtraAnnotations, err := common.GetUserExtraAnnotations(&commonCmdData)
+	if err != nil {
+		return err
+	}
+
+	userExtraLabels, err := common.GetUserExtraLabels(&commonCmdData)
+	if err != nil {
+		return err
+	}
+
+	buildOptions, err := common.GetBuildOptions(&commonCmdData, werfConfig)
+	if err != nil {
+		return err
+	}
+
+	logboek.LogOptionalLn()
+
+	repoAddress, err := common.GetStagesStorageAddress(&commonCmdData)
+	if err != nil {
+		return err
+	}
+
+	var imagesInfoGetters []*image.InfoGetter
+	var imagesRepository string
+
+	if len(werfConfig.StapelImages) != 0 || len(werfConfig.ImagesFromDockerfile) != 0 {
+		containerRuntime := &container_runtime.LocalDockerServerRuntime{} // TODO
+		stagesStorage, err := common.GetStagesStorage(repoAddress, containerRuntime, &commonCmdData)
+		if err != nil {
+			return err
+		}
+		synchronization, err := common.GetSynchronization(ctx, &commonCmdData, projectName, stagesStorage)
+		if err != nil {
+			return err
+		}
+		stagesStorageCache, err := common.GetStagesStorageCache(synchronization)
+		if err != nil {
+			return err
+		}
+		storageLockManager, err := common.GetStorageLockManager(ctx, synchronization)
+		if err != nil {
+			return err
+		}
+		secondaryStagesStorageList, err := common.GetSecondaryStagesStorageList(stagesStorage, containerRuntime, &commonCmdData)
+		if err != nil {
+			return err
+		}
+
+		storageManager := manager.NewStorageManager(projectName, stagesStorage, secondaryStagesStorageList, storageLockManager, stagesStorageCache)
+
+		imagesRepository = storageManager.StagesStorage.String()
+
+		conveyorOptions, err := common.GetConveyorOptionsWithParallel(&commonCmdData, buildOptions)
+		if err != nil {
+			return err
+		}
+
+		conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, localGitRepo, nil, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, storageManager, storageLockManager, conveyorOptions)
+		defer conveyorWithRetry.Terminate()
+
+		if err := conveyorWithRetry.WithRetryBlock(ctx, func(c *build.Conveyor) error {
+			if *commonCmdData.SkipBuild {
+				if err := c.ShouldBeBuilt(ctx); err != nil {
+					return err
+				}
+			} else {
+				if err := c.Build(ctx, buildOptions); err != nil {
+					return err
+				}
+			}
+
+			imagesInfoGetters = c.GetImageInfoGetters()
+
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		logboek.LogOptionalLn()
+	}
+
+	var secretsManager secret.Manager
+	if m, err := deploy.GetSafeSecretManager(ctx, projectDir, chartDir, *commonCmdData.SecretValues, localGitRepo, *commonCmdData.IgnoreSecretKey); err != nil {
+		return err
+	} else {
+		secretsManager = m
+	}
+
+	wc := werf_chart.NewWerfChart(ctx, localGitRepo, projectDir, werf_chart.WerfChartOptions{
+		ReleaseName: "RELEASE",
+		ChartDir:    chartDir,
+
+		SecretValueFiles: *commonCmdData.SecretValues,
+		ExtraAnnotations: userExtraAnnotations,
+		ExtraLabels:      userExtraLabels,
+
+		SecretsManager: secretsManager,
+	})
+	if err := wc.SetEnv(*commonCmdData.Environment); err != nil {
+		return err
+	}
+	if err := wc.SetWerfConfig(werfConfig); err != nil {
+		return err
+	}
+	if vals, err := werf_chart.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, werf_chart.ServiceValuesOptions{Env: *commonCmdData.Environment}); err != nil {
+		return fmt.Errorf("error creating service values: %s", err)
+	} else if err := wc.SetServiceValues(vals); err != nil {
+		return err
+	}
+
+	actionConfig := new(action.Configuration)
+	if err := helm.InitActionConfig(ctx, "", cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{}); err != nil {
+		return err
+	}
+
+	cmd_helm.Settings.Debug = *commonCmdData.LogDebug
+
+	loader.GlobalLoadOptions = &loader.LoadOptions{
+		ChartExtender: wc,
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return werf_chart.NewWerfChart(ctx, nil, projectDir, werf_chart.WerfChartOptions{})
+		},
+		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir),
+		LocateChartFunc: common.MakeLocateChartFunc(ctx, localGitRepo, projectDir),
+		ReadFileFunc:    common.MakeHelmReadFileFunc(ctx, localGitRepo, projectDir),
+	}
+
+	valueOpts := &values.Options{
+		ValueFiles:   *commonCmdData.Values,
+		StringValues: *commonCmdData.SetString,
+		Values:       *commonCmdData.Set,
+		FileValues:   *commonCmdData.SetFile,
+	}
+
+	helmTemplateCmd, _ := cmd_helm.NewTemplateCmd(actionConfig, ioutil.Discard, cmd_helm.TemplateCmdOptions{
+		PostRenderer: wc.ExtraAnnotationsAndLabelsPostRenderer,
+		ValueOpts:    valueOpts,
+	})
+	if err := wc.WrapTemplate(ctx, func() error {
+		return helmTemplateCmd.RunE(helmTemplateCmd, []string{"RELEASE", chartDir})
+	}); err != nil {
+		return err
+	}
+
+	destinationDir := cmdData.Destination
+	if destinationDir == "" {
+		destinationDir = wc.HelmChart.Metadata.Name
+	}
+
+	p := getter.All(cmd_helm.Settings)
+	if vals, err := valueOpts.MergeValues(p, loader.GlobalLoadOptions.ReadFileFunc); err != nil {
+		return err
+	} else if _, err := wc.CreateNewBundle(ctx, destinationDir, vals); err != nil {
+		return fmt.Errorf("unable to create bundle: %s", err)
+	}
+
+	return nil
+}

--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -51,7 +51,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "export",
 		Short:                 "Export bundle",
-		Long:                  common.GetLongCommandDescription(`Export bundle into the provided directory. Werf bundle contains built images defined in the werf.yaml, helm chart, service values which contain built images tags, any custom values and set values params provided during publish invocation, werf addon templates (like werf_image).`),
+		Long:                  common.GetLongCommandDescription(`Export bundle into the provided directory (or into directory named as a resulting chart in the current working directory). Werf bundle contains built images defined in the werf.yaml, helm chart, service values which contain built images tags, any custom values and set values params provided during publish invocation, werf addon templates (like werf_image).`),
 		DisableFlagsInUseLine: true,
 		Annotations: map[string]string{
 			common.CmdEnvAnno: common.EnvsDescription(common.WerfDebugAnsibleArgs, common.WerfSecretKey),

--- a/cmd/werf/main.go
+++ b/cmd/werf/main.go
@@ -33,6 +33,7 @@ import (
 	host_purge "github.com/werf/werf/cmd/werf/host/purge"
 
 	bundle_apply "github.com/werf/werf/cmd/werf/bundle/apply"
+	bundle_download "github.com/werf/werf/cmd/werf/bundle/download"
 	bundle_export "github.com/werf/werf/cmd/werf/bundle/export"
 	bundle_publish "github.com/werf/werf/cmd/werf/bundle/publish"
 
@@ -161,6 +162,7 @@ func bundleCmd() *cobra.Command {
 		bundle_publish.NewCmd(),
 		bundle_apply.NewCmd(),
 		bundle_export.NewCmd(),
+		bundle_download.NewCmd(),
 	)
 
 	return cmd

--- a/cmd/werf/main.go
+++ b/cmd/werf/main.go
@@ -33,6 +33,7 @@ import (
 	host_purge "github.com/werf/werf/cmd/werf/host/purge"
 
 	bundle_apply "github.com/werf/werf/cmd/werf/bundle/apply"
+	bundle_export "github.com/werf/werf/cmd/werf/bundle/export"
 	bundle_publish "github.com/werf/werf/cmd/werf/bundle/publish"
 
 	config_list "github.com/werf/werf/cmd/werf/config/list"
@@ -159,6 +160,7 @@ func bundleCmd() *cobra.Command {
 	cmd.AddCommand(
 		bundle_publish.NewCmd(),
 		bundle_apply.NewCmd(),
+		bundle_export.NewCmd(),
 	)
 
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -109,4 +109,4 @@ replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402
 
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible
 
-replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201218191930-00bc897eeee5
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20201221121807-8e8bbbf1f374

--- a/go.sum
+++ b/go.sum
@@ -1182,6 +1182,8 @@ github.com/werf/helm/v3 v3.0.0-20201217130132-273559fb7084 h1:OpPyCSBK58njtzqzah
 github.com/werf/helm/v3 v3.0.0-20201217130132-273559fb7084/go.mod h1:MeRlXlmCr5CWYKvqIPgXrSmcIXJpv7qcsKV3uTvcZSM=
 github.com/werf/helm/v3 v3.0.0-20201218191930-00bc897eeee5 h1:91yhgBJ34LZLvbnGvVTMFJZ8w2hGdDU+3GcBc2OtUWI=
 github.com/werf/helm/v3 v3.0.0-20201218191930-00bc897eeee5/go.mod h1:MeRlXlmCr5CWYKvqIPgXrSmcIXJpv7qcsKV3uTvcZSM=
+github.com/werf/helm/v3 v3.0.0-20201221121807-8e8bbbf1f374 h1:4jkojcSz0SKssyA5Am+HLTxTMwvIFntBpOFqU0tFwxk=
+github.com/werf/helm/v3 v3.0.0-20201221121807-8e8bbbf1f374/go.mod h1:MeRlXlmCr5CWYKvqIPgXrSmcIXJpv7qcsKV3uTvcZSM=
 github.com/werf/kubedog v0.4.1-0.20200923112210-4079add7a93c h1:aM9Gs5CF9YuCFs25mCNfZKTx+3dNe97YGQGKLIumW5U=
 github.com/werf/kubedog v0.4.1-0.20200923112210-4079add7a93c/go.mod h1:b/5MyrNDmxXtr68uucMmZCZmWS3h7cfAcgqtQbHsw5o=
 github.com/werf/kubedog v0.4.1-0.20201125180623-08ad3ea6f58c h1:caA8J/bf3AQgcjo0RCSKdY3blSSswMH47pDcnmsNxPg=


### PR DESCRIPTION
`werf bundle export` — creates resulting bundle chart directory without publishing this chart into the docker registry.
`werf bundle download` — downloads previously published chart into the directory without applying it into the kubernetes.
