### PR TITLE
Fix werf-helm-template and werf-helm-lint commands try to load kube config; fix werf-render command excess options

### DIFF
--- a/cmd/werf/bundle/apply/apply.go
+++ b/cmd/werf/bundle/apply/apply.go
@@ -121,16 +121,9 @@ func runApply() error {
 		return err
 	}
 
-	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
-	}}); err != nil {
-		return fmt.Errorf("cannot initialize kube: %s", err)
-	}
-
-	if err := common.InitKubedog(ctx); err != nil {
-		return fmt.Errorf("cannot init kubedog: %s", err)
+	common.SetupOndemandKubeInitializer(*commonCmdData.KubeContext, *commonCmdData.KubeConfig, *commonCmdData.KubeConfigBase64)
+	if err := common.GetOndemandKubeInitializer().Init(ctx); err != nil {
+		return err
 	}
 
 	userExtraAnnotations, err := common.GetUserExtraAnnotations(&commonCmdData)
@@ -151,7 +144,7 @@ func runApply() error {
 	cmd_helm.Settings.Debug = *commonCmdData.LogDebug
 
 	actionConfig := new(action.Configuration)
-	if err := helm.InitActionConfig(ctx, *commonCmdData.Namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{
+	if err := helm.InitActionConfig(ctx, common.GetOndemandKubeInitializer(), *commonCmdData.Namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{
 		StatusProgressPeriod:      time.Duration(*commonCmdData.StatusProgressPeriodSeconds) * time.Second,
 		HooksStatusProgressPeriod: time.Duration(*commonCmdData.HooksStatusProgressPeriodSeconds) * time.Second,
 		KubeConfigOptions: kube.KubeConfigOptions{

--- a/cmd/werf/bundle/download/download.go
+++ b/cmd/werf/bundle/download/download.go
@@ -96,7 +96,7 @@ func runApply() error {
 	cmd_helm.Settings.Debug = *commonCmdData.LogDebug
 
 	actionConfig := new(action.Configuration)
-	if err := helm.InitActionConfig(ctx, "", cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{}); err != nil {
+	if err := helm.InitActionConfig(ctx, nil, "", cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{}); err != nil {
 		return err
 	}
 

--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -315,7 +315,7 @@ func runExport() error {
 	}
 
 	actionConfig := new(action.Configuration)
-	if err := helm.InitActionConfig(ctx, "", cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{}); err != nil {
+	if err := helm.InitActionConfig(ctx, nil, "", cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{}); err != nil {
 		return err
 	}
 

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -325,7 +325,7 @@ func runPublish() error {
 	}
 
 	actionConfig := new(action.Configuration)
-	if err := helm.InitActionConfig(ctx, "", cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{}); err != nil {
+	if err := helm.InitActionConfig(ctx, nil, "", cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{}); err != nil {
 		return err
 	}
 

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/werf/kubedog/pkg/kube"
 	"github.com/werf/logboek"
 
 	"github.com/werf/werf/cmd/werf/common"
@@ -122,16 +121,9 @@ func runCleanup() error {
 	}
 	ctx = ctxWithDockerCli
 
-	if err := kube.Init(kube.InitOptions{KubeConfigOptions: kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
-	}}); err != nil {
-		return fmt.Errorf("cannot initialize kube: %s", err)
-	}
-
-	if err := common.InitKubedog(ctx); err != nil {
-		return fmt.Errorf("cannot init kubedog: %s", err)
+	common.SetupOndemandKubeInitializer(*commonCmdData.KubeContext, *commonCmdData.KubeConfig, *commonCmdData.KubeConfigBase64)
+	if err := common.GetOndemandKubeInitializer().Init(ctx); err != nil {
+		return err
 	}
 
 	projectDir, err := common.GetProjectDir(&commonCmdData)

--- a/cmd/werf/common/ondemand_kube_initializer.go
+++ b/cmd/werf/common/ondemand_kube_initializer.go
@@ -1,0 +1,52 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/werf/kubedog/pkg/kube"
+)
+
+var ondemandKubeInitializer *OndemandKubeInitializer
+
+type OndemandKubeInitializer struct {
+	KubeContext      string
+	KubeConfig       string
+	KubeConfigBase64 string
+
+	initialized bool
+}
+
+func SetupOndemandKubeInitializer(kubeContext, kubeConfig, kubeConfigBase64 string) {
+	ondemandKubeInitializer = &OndemandKubeInitializer{
+		KubeContext:      kubeContext,
+		KubeConfig:       kubeConfig,
+		KubeConfigBase64: kubeConfigBase64,
+	}
+}
+
+func GetOndemandKubeInitializer() *OndemandKubeInitializer {
+	return ondemandKubeInitializer
+}
+
+func (initializer *OndemandKubeInitializer) Init(ctx context.Context) error {
+	if initializer.initialized {
+		return nil
+	}
+
+	if err := kube.Init(kube.InitOptions{KubeConfigOptions: kube.KubeConfigOptions{
+		Context:          initializer.KubeContext,
+		ConfigPath:       initializer.KubeConfig,
+		ConfigDataBase64: initializer.KubeConfigBase64,
+	}}); err != nil {
+		return fmt.Errorf("cannot initialize kube: %s", err)
+	}
+
+	if err := InitKubedog(ctx); err != nil {
+		return fmt.Errorf("cannot init kubedog: %s", err)
+	}
+
+	initializer.initialized = true
+
+	return nil
+}

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -197,16 +197,9 @@ func runMain(ctx context.Context) error {
 		}
 	}()
 
-	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
-	}}); err != nil {
-		return fmt.Errorf("cannot initialize kube: %s", err)
-	}
-
-	if err := common.InitKubedog(ctx); err != nil {
-		return fmt.Errorf("cannot init kubedog: %s", err)
+	common.SetupOndemandKubeInitializer(*commonCmdData.KubeContext, *commonCmdData.KubeConfig, *commonCmdData.KubeConfigBase64)
+	if err := common.GetOndemandKubeInitializer().Init(ctx); err != nil {
+		return err
 	}
 
 	if *commonCmdData.Follow {
@@ -369,7 +362,7 @@ func run(ctx context.Context, projectDir string) error {
 	}
 
 	actionConfig := new(action.Configuration)
-	if err := helm.InitActionConfig(ctx, namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{
+	if err := helm.InitActionConfig(ctx, common.GetOndemandKubeInitializer(), namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{
 		StatusProgressPeriod:      time.Duration(*commonCmdData.StatusProgressPeriodSeconds) * time.Second,
 		HooksStatusProgressPeriod: time.Duration(*commonCmdData.HooksStatusProgressPeriodSeconds) * time.Second,
 		KubeConfigOptions: kube.KubeConfigOptions{

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -158,17 +158,9 @@ func runDismiss() error {
 	}
 	logboek.LogOptionalLn()
 
-	err = kube.Init(kube.InitOptions{kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
-	}})
-	if err != nil {
-		return fmt.Errorf("cannot initialize kube: %s", err)
-	}
-
-	if err := common.InitKubedog(ctx); err != nil {
-		return fmt.Errorf("cannot init kubedog: %s", err)
+	common.SetupOndemandKubeInitializer(*commonCmdData.KubeContext, *commonCmdData.KubeConfig, *commonCmdData.KubeConfigBase64)
+	if err := common.GetOndemandKubeInitializer().Init(ctx); err != nil {
+		return err
 	}
 
 	releaseName, err := common.GetHelmRelease(*commonCmdData.Release, *commonCmdData.Environment, werfConfig)
@@ -200,7 +192,7 @@ func runDismiss() error {
 	}
 
 	actionConfig := new(action.Configuration)
-	if err := helm.InitActionConfig(ctx, namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{
+	if err := helm.InitActionConfig(ctx, common.GetOndemandKubeInitializer(), namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{
 		StatusProgressPeriod:      time.Duration(*commonCmdData.StatusProgressPeriodSeconds) * time.Second,
 		HooksStatusProgressPeriod: time.Duration(*commonCmdData.HooksStatusProgressPeriodSeconds) * time.Second,
 		KubeConfigOptions: kube.KubeConfigOptions{

--- a/cmd/werf/helm/helm.go
+++ b/cmd/werf/helm/helm.go
@@ -138,7 +138,9 @@ func NewCmd() *cobra.Command {
 					return err
 				}
 
-				helm.InitActionConfig(ctx, namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{
+				common.SetupOndemandKubeInitializer(*_commonCmdData.KubeContext, *_commonCmdData.KubeConfig, *_commonCmdData.KubeConfigBase64)
+
+				helm.InitActionConfig(ctx, common.GetOndemandKubeInitializer(), namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{
 					StatusProgressPeriod:      time.Duration(*_commonCmdData.StatusProgressPeriodSeconds) * time.Second,
 					HooksStatusProgressPeriod: time.Duration(*_commonCmdData.HooksStatusProgressPeriodSeconds) * time.Second,
 					KubeConfigOptions: kube.KubeConfigOptions{
@@ -148,19 +150,6 @@ func NewCmd() *cobra.Command {
 					},
 					ReleasesHistoryMax: *_commonCmdData.ReleasesHistoryMax,
 				})
-
-				// FIXME: not all `werf helm *` commands may need a kubernetes connection
-				if err := kube.Init(kube.InitOptions{KubeConfigOptions: kube.KubeConfigOptions{
-					Context:          *_commonCmdData.KubeContext,
-					ConfigPath:       *_commonCmdData.KubeConfig,
-					ConfigDataBase64: *_commonCmdData.KubeConfigBase64,
-				}}); err != nil {
-					return fmt.Errorf("cannot initialize kube: %s", err)
-				}
-
-				if err := common.InitKubedog(ctx); err != nil {
-					return fmt.Errorf("cannot init kubedog: %s", err)
-				}
 
 				if oldRun != nil {
 					oldRun(cmd, args)

--- a/cmd/werf/helm/install.go
+++ b/cmd/werf/helm/install.go
@@ -29,6 +29,10 @@ func NewInstallCmd(actionConfig *action.Configuration, wc *werf_chart.WerfChart)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := common.BackgroundContext()
 
+		if err := common.GetOndemandKubeInitializer().Init(ctx); err != nil {
+			return err
+		}
+
 		if releaseName, chartDir, err := helmAction.NameAndChart(args); err != nil {
 			return err
 		} else {

--- a/cmd/werf/helm/upgrade.go
+++ b/cmd/werf/helm/upgrade.go
@@ -26,6 +26,10 @@ func NewUpgradeCmd(actionConfig *action.Configuration, wc *werf_chart.WerfChart)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := common.BackgroundContext()
 
+		if err := common.GetOndemandKubeInitializer().Init(ctx); err != nil {
+			return err
+		}
+
 		if chartDir, err := helmAction.ChartPathOptions.LocateChart(args[1], cmd_helm.Settings); err != nil {
 			return err
 		} else {

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -14,7 +13,6 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli/values"
 
-	"github.com/werf/kubedog/pkg/kube"
 	"github.com/werf/logboek"
 	"github.com/werf/logboek/pkg/level"
 
@@ -99,14 +97,6 @@ func NewCmd() *cobra.Command {
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupSynchronization(&commonCmdData, cmd)
-
-	common.SetupKubeConfig(&commonCmdData, cmd)
-	common.SetupKubeConfigBase64(&commonCmdData, cmd)
-	common.SetupKubeContext(&commonCmdData, cmd)
-
-	common.SetupStatusProgressPeriod(&commonCmdData, cmd)
-	common.SetupHooksStatusProgressPeriod(&commonCmdData, cmd)
-	common.SetupReleasesHistoryMax(&commonCmdData, cmd)
 
 	common.SetupRelease(&commonCmdData, cmd)
 	common.SetupNamespace(&commonCmdData, cmd)
@@ -341,15 +331,7 @@ func runRender() error {
 	}
 
 	actionConfig := new(action.Configuration)
-	if err := helm.InitActionConfig(ctx, namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{
-		StatusProgressPeriod:      time.Duration(*commonCmdData.StatusProgressPeriodSeconds) * time.Second,
-		HooksStatusProgressPeriod: time.Duration(*commonCmdData.HooksStatusProgressPeriodSeconds) * time.Second,
-		KubeConfigOptions: kube.KubeConfigOptions{
-			Context:          *commonCmdData.KubeContext,
-			ConfigPath:       *commonCmdData.KubeConfig,
-			ConfigDataBase64: *commonCmdData.KubeConfigBase64,
-		},
-	}); err != nil {
+	if err := helm.InitActionConfig(ctx, nil, namespace, cmd_helm.Settings, actionConfig, helm.InitActionConfigOptions{}); err != nil {
 		return err
 	}
 

--- a/docs/_data/sidebars/_cli.yml
+++ b/docs/_data/sidebars/_cli.yml
@@ -21,6 +21,12 @@ cli: &cli
       - title: werf bundle apply
         url: /documentation/reference/cli/werf_bundle_apply.html
 
+      - title: werf bundle download
+        url: /documentation/reference/cli/werf_bundle_download.html
+
+      - title: werf bundle export
+        url: /documentation/reference/cli/werf_bundle_export.html
+
       - title: werf bundle publish
         url: /documentation/reference/cli/werf_bundle_publish.html
 

--- a/docs/_data/sidebars/documentation.yml
+++ b/docs/_data/sidebars/documentation.yml
@@ -26,6 +26,12 @@ cli: &cli
       - title: werf bundle apply
         url: /documentation/reference/cli/werf_bundle_apply.html
 
+      - title: werf bundle download
+        url: /documentation/reference/cli/werf_bundle_download.html
+
+      - title: werf bundle export
+        url: /documentation/reference/cli/werf_bundle_export.html
+
       - title: werf bundle publish
         url: /documentation/reference/cli/werf_bundle_publish.html
 

--- a/docs/_includes/documentation/reference/cli/werf_bundle_download.md
+++ b/docs/_includes/documentation/reference/cli/werf_bundle_download.md
@@ -1,0 +1,88 @@
+{% if include.header %}
+{% assign header = include.header %}
+{% else %}
+{% assign header = "###" %}
+{% endif %}
+Take latest bundle from the specified container registry using specified version tag or version     
+mask and unpack it into provided directory (or into directory named as a resulting chart in the     
+current working directory).
+
+{{ header }} Syntax
+
+```shell
+werf bundle download [options]
+```
+
+{{ header }} Environments
+
+```shell
+  $WERF_DEBUG_ANSIBLE_ARGS  Pass specified cli args to ansible ($ANSIBLE_ARGS)
+  $WERF_SECRET_KEY          Use specified secret key to extract secrets for the deploy. Recommended 
+                            way to set secret key in CI-system. 
+                            
+                            Secret key also can be defined in files:
+                            * ~/.werf/global_secret_key (globally),
+                            * .werf_secret_key (per project)
+```
+
+{{ header }} Options
+
+```shell
+  -d, --destination=''
+            Download bundle into the provided directory ($WERF_DESTINATION or chart-name by default)
+      --home-dir=''
+            Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-registry=false
+            Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
+      --log-color-mode='auto'
+            Set log color mode.
+            Supported on, off and auto (based on the stdout’s file descriptor referring to a        
+            terminal) modes.
+            Default $WERF_LOG_COLOR_MODE or auto mode.
+      --log-debug=false
+            Enable debug (default $WERF_LOG_DEBUG).
+      --log-pretty=true
+            Enable emojis, auto line wrapping and log process border (default $WERF_LOG_PRETTY or   
+            true).
+      --log-project-dir=false
+            Print current project directory path (default $WERF_LOG_PROJECT_DIR)
+      --log-quiet=false
+            Disable explanatory output (default $WERF_LOG_QUIET).
+      --log-terminal-width=-1
+            Set log terminal width.
+            Defaults to:
+            * $WERF_LOG_TERMINAL_WIDTH
+            * interactive terminal width or 140
+      --log-verbose=false
+            Enable verbose output (default $WERF_LOG_VERBOSE).
+      --repo=''
+            Docker Repo to store stages (default $WERF_REPO)
+      --repo-docker-hub-password=''
+            Docker Hub password (default $WERF_REPO_DOCKER_HUB_PASSWORD)
+      --repo-docker-hub-token=''
+            Docker Hub token (default $WERF_REPO_DOCKER_HUB_TOKEN)
+      --repo-docker-hub-username=''
+            Docker Hub username (default $WERF_REPO_DOCKER_HUB_USERNAME)
+      --repo-github-token=''
+            GitHub token (default $WERF_REPO_GITHUB_TOKEN)
+      --repo-harbor-password=''
+            Harbor password (default $WERF_REPO_HARBOR_PASSWORD)
+      --repo-harbor-username=''
+            Harbor username (default $WERF_REPO_HARBOR_USERNAME)
+      --repo-implementation=''
+            Choose repo implementation.
+            The following docker registry implementations are supported: ecr, acr, default,         
+            dockerhub, gcr, github, gitlab, harbor, quay.
+            Default $WERF_REPO_IMPLEMENTATION or auto mode (detect implementation by a registry).
+      --repo-quay-token=''
+            quay.io token (default $WERF_REPO_QUAY_TOKEN)
+      --skip-tls-verify-registry=false
+            Skip TLS certificate validation when accessing a registry (default                      
+            $WERF_SKIP_TLS_VERIFY_REGISTRY)
+      --tag='latest'
+            Provide exact tag version or semver-based pattern, werf will install or upgrade to the  
+            latest version of the specified bundle ($WERF_TAG or latest by default)
+      --tmp-dir=''
+            Use specified dir to store tmp files and dirs (default $WERF_TMP_DIR or system tmp dir)
+```
+

--- a/docs/_includes/documentation/reference/cli/werf_bundle_download.short.md
+++ b/docs/_includes/documentation/reference/cli/werf_bundle_download.short.md
@@ -1,0 +1,1 @@
+download published bundle into directory

--- a/docs/_includes/documentation/reference/cli/werf_bundle_export.md
+++ b/docs/_includes/documentation/reference/cli/werf_bundle_export.md
@@ -3,13 +3,15 @@
 {% else %}
 {% assign header = "###" %}
 {% endif %}
-Render Kubernetes templates. This command will calculate digests and build (if needed) all images   
-defined in the werf.yaml.
+Export bundle into the provided directory (or into directory named as a resulting chart in the      
+current working directory). Werf bundle contains built images defined in the werf.yaml, helm chart, 
+service values which contain built images tags, any custom values and set values params provided    
+during publish invocation, werf addon templates (like werf_image).
 
 {{ header }} Syntax
 
 ```shell
-werf render [options]
+werf bundle export [options]
 ```
 
 {{ header }} Environments
@@ -38,17 +40,13 @@ werf render [options]
             Format: labelName=labelValue.
             Also, can be specified with $WERF_ADD_LABEL* (e.g.                                      
             $WERF_ADD_LABEL_1=labelName1=labelValue1", $WERF_ADD_LABEL_2=labelName2=labelValue2")
-      --atomic=false
-            Enable auto rollback of the failed release to the previous deployed release version     
-            when current deploy process have failed ($WERF_ATOMIC by default)
-  -R, --auto-rollback=false
-            Enable auto rollback of the failed release to the previous deployed release version     
-            when current deploy process have failed ($WERF_AUTO_ROLLBACK by default)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
             Custom configuration templates directory (default $WERF_CONFIG_TEMPLATES_DIR or .werf   
             in working directory)
+  -d, --destination=''
+            Export bundle into the provided directory ($WERF_DESTINATION or chart-name by default)
       --dev=false
             Enable developer mode (default $WERF_DEV)
       --dir=''
@@ -98,7 +96,7 @@ werf render [options]
             true).
       --log-project-dir=false
             Print current project directory path (default $WERF_LOG_PROJECT_DIR)
-      --log-quiet=true
+      --log-quiet=false
             Disable explanatory output (default $WERF_LOG_QUIET).
       --log-terminal-width=-1
             Set log terminal width.
@@ -112,24 +110,15 @@ werf render [options]
             more info                                                                               
             https://werf.io/v1.2-alpha/documentation/advanced/configuration/giterminism.html,       
             default $WERF_LOOSE_GITERMINISM)
-      --namespace=''
-            Use specified Kubernetes namespace (default [[ project ]]-[[ env ]] template or         
-            deploy.namespace custom template from werf.yaml or $WERF_NAMESPACE)
       --non-strict-giterminism-inspection=false
             Change some errors to warnings during giterminism inspection (more info                 
             https://werf.io/v1.2-alpha/documentation/advanced/configuration/giterminism.html,       
             default $WERF_NON_STRICT_GITERMINISM_INSPECTION)
-      --output=''
-            Write render output to the specified file instead of stdout ($WERF_RENDER_OUTPUT by     
-            default)
   -p, --parallel=true
             Run in parallel (default $WERF_PARALLEL)
       --parallel-tasks-limit=5
             Parallel tasks limit, set -1 to remove the limitation (default                          
             $WERF_PARALLEL_TASKS_LIMIT or 5)
-      --release=''
-            Use specified Helm release name (default [[ project ]]-[[ env ]] template or            
-            deploy.helmRelease custom template from werf.yaml or $WERF_RELEASE)
       --repo=''
             Docker Repo to store stages (default $WERF_REPO)
       --repo-docker-hub-password=''
@@ -219,8 +208,6 @@ werf render [options]
             
             The same address should be specified for all werf processes that work with a single     
             repo. :local address allows execution of werf processes from a single host only
-  -t, --timeout=0
-            Resources tracking timeout in seconds
       --tmp-dir=''
             Use specified dir to store tmp files and dirs (default $WERF_TMP_DIR or system tmp dir)
       --values=[]

--- a/docs/_includes/documentation/reference/cli/werf_bundle_export.short.md
+++ b/docs/_includes/documentation/reference/cli/werf_bundle_export.short.md
@@ -1,0 +1,1 @@
+export bundle

--- a/docs/pages/documentation/reference/cli/werf_bundle_download.md
+++ b/docs/pages/documentation/reference/cli/werf_bundle_download.md
@@ -1,0 +1,7 @@
+---
+title: werf bundle download
+sidebar: documentation
+permalink: documentation/reference/cli/werf_bundle_download.html
+---
+
+{% include /documentation/reference/cli/werf_bundle_download.md %}

--- a/docs/pages/documentation/reference/cli/werf_bundle_export.md
+++ b/docs/pages/documentation/reference/cli/werf_bundle_export.md
@@ -1,0 +1,7 @@
+---
+title: werf bundle export
+sidebar: documentation
+permalink: documentation/reference/cli/werf_bundle_export.html
+---
+
+{% include /documentation/reference/cli/werf_bundle_export.md %}

--- a/pkg/deploy/helm/init.go
+++ b/pkg/deploy/helm/init.go
@@ -30,7 +30,7 @@ type InitActionConfigOptions struct {
 	ReleasesHistoryMax        int
 }
 
-func InitActionConfig(ctx context.Context, namespace string, envSettings *cli.EnvSettings, actionConfig *action.Configuration, opts InitActionConfigOptions) error {
+func InitActionConfig(ctx context.Context, kubeInitializer KubeInitializer, namespace string, envSettings *cli.EnvSettings, actionConfig *action.Configuration, opts InitActionConfigOptions) error {
 	*envSettings.GetNamespaceP() = namespace
 
 	if opts.KubeConfigOptions.Context != "" {
@@ -54,7 +54,7 @@ func InitActionConfig(ctx context.Context, namespace string, envSettings *cli.En
 	}
 
 	kubeClient := actionConfig.KubeClient.(*helm_kube.Client)
-	kubeClient.ResourcesWaiter = NewResourcesWaiter(kubeClient, time.Now(), opts.StatusProgressPeriod, opts.HooksStatusProgressPeriod)
+	kubeClient.ResourcesWaiter = NewResourcesWaiter(kubeInitializer, kubeClient, time.Now(), opts.StatusProgressPeriod, opts.HooksStatusProgressPeriod)
 
 	if registryClient, err := helm_v3.NewRegistryClient(logboek.Context(ctx).Debug().IsAccepted(), logboek.Context(ctx).ProxyOutStream()); err != nil {
 		return fmt.Errorf("unable to create registry client: %s", err)

--- a/pkg/deploy/helm/kube_initializer.go
+++ b/pkg/deploy/helm/kube_initializer.go
@@ -1,0 +1,7 @@
+package helm
+
+import "context"
+
+type KubeInitializer interface {
+	Init(ctx context.Context) error
+}


### PR DESCRIPTION
 - Added OndemandKubeInitializer interface and object to init kubernetes ondemand only for 'werf helm *' commands.
 - Removed usage of kube-config and resources-waiter related options for the werf-render command.
 
NOTE:  OndemandKubeInitializer is not a perfect solution to the service initialization problem, but we need it due to the way helm commands are initialized.