### PR TITLE
Implement fine-grained giterminism config (part 1)

### DIFF
--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -134,7 +134,7 @@ func runExport() error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
-	if err := giterminism_inspector.Init(giterminism_inspector.InspectionOptions{LooseGiterminism: *commonCmdData.LooseGiterminism, NonStrict: *commonCmdData.NonStrictGiterminismInspection}); err != nil {
+	if err := common.InitGiterminismInspector(&commonCmdData); err != nil {
 		return err
 	}
 

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -144,7 +144,7 @@ func runPublish() error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
-	if err := giterminism_inspector.Init(giterminism_inspector.InspectionOptions{LooseGiterminism: *commonCmdData.LooseGiterminism, NonStrict: *commonCmdData.NonStrictGiterminismInspection}); err != nil {
+	if err := common.InitGiterminismInspector(&commonCmdData); err != nil {
 		return err
 	}
 

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -963,7 +963,12 @@ func GetWerfConfigOptions(cmdData *CmdData, LogRenderedFilePath bool) config.Wer
 }
 
 func InitGiterminismInspector(cmdData *CmdData) error {
-	return giterminism_inspector.Init(giterminism_inspector.InspectionOptions{
+	projectPath, err := GetProjectDir(cmdData)
+	if err != nil {
+		return fmt.Errorf("unable to get project dir: %s", err)
+	}
+
+	return giterminism_inspector.Init(projectPath, giterminism_inspector.InspectionOptions{
 		LooseGiterminism: *cmdData.LooseGiterminism,
 		NonStrict:        *cmdData.NonStrictGiterminismInspection,
 		DevMode:          *cmdData.Dev,

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -921,7 +921,7 @@ func GetWerfConfigPath(projectDir string, customConfigPath string, required bool
 
 	var commit string
 	for _, werfConfigPath := range configPathToCheck {
-		if giterminism_inspector.LooseGiterminism || localGitRepo == nil {
+		if giterminism_inspector.LooseGiterminism || localGitRepo == nil || giterminism_inspector.IsUncommittedConfigAccepted() {
 			if exists, err := util.FileExists(werfConfigPath); err != nil {
 				return "", err
 			} else if exists {

--- a/cmd/werf/common/deploy_params.go
+++ b/cmd/werf/common/deploy_params.go
@@ -156,6 +156,8 @@ func renderDeployParamTemplate(templateName, templateText string, environmentOpt
 	tmpl := template.New(templateName).Delims("[[", "]]")
 
 	funcMap := sprig.TxtFuncMap()
+	delete(funcMap, "env")
+	delete(funcMap, "expandenv")
 
 	funcMap["project"] = func() string {
 		return werfConfig.Meta.Project

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,9 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.1.1-0.20200721083337-cded5b685b8a
+	github.com/go-openapi/spec v0.19.3
+	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/validate v0.19.5
 	github.com/gofrs/uuid v3.3.0+incompatible // indirect
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/golang/example v0.0.0-20170904185048-46695d81d1fa
@@ -33,6 +36,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gosuri/uitable v0.0.4
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/jinzhu/gorm v1.9.12 // indirect

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/werf/werf/pkg/config"
 	"github.com/werf/werf/pkg/container_runtime"
 	"github.com/werf/werf/pkg/git_repo"
+	"github.com/werf/werf/pkg/giterminism_inspector"
 	"github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/logging"
 	"github.com/werf/werf/pkg/path_matcher"
@@ -1128,7 +1129,12 @@ func prepareImageBasedOnImageFromDockerfile(ctx context.Context, imageFromDocker
 	}
 
 	for _, contextAddFile := range imageFromDockerfileConfig.ContextAddFile {
-		absContextAddFile := filepath.Join(c.projectDir, imageFromDockerfileConfig.Context, contextAddFile)
+		relContextAddFile := filepath.Join(imageFromDockerfileConfig.Context, contextAddFile)
+		if err := giterminism_inspector.ReportConfigDockerfileContextAddFile(ctx, relContextAddFile); err != nil {
+			return nil, err
+		}
+
+		absContextAddFile := filepath.Join(c.projectDir, relContextAddFile)
 		exist, err := util.FileExists(absContextAddFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to check existence of file %s: %s", absContextAddFile, err)

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -1145,35 +1146,14 @@ func prepareImageBasedOnImageFromDockerfile(ctx context.Context, imageFromDocker
 		}
 	}
 
-	relDockerfilePath := filepath.Join(imageFromDockerfileConfig.Context, imageFromDockerfileConfig.Dockerfile)
-	exists, err := localGitRepo.IsCommitFileExists(ctx, headCommit, relDockerfilePath)
-	if err != nil {
-		return nil, fmt.Errorf("unable to check file %s existence in local git repository: %s", relDockerfilePath, err)
-	} else if !exists {
-		return nil, fmt.Errorf("dockerfile '%s' was not found in local git repository", relDockerfilePath)
-	}
-
-	dockerfileData, err := getFileDataFromGitAndCompareWithLocal(ctx, c.projectDir, localGitRepo, headCommit, relDockerfilePath)
+	dockerfileData, err := getDockerfileData(ctx, imageFromDockerfileConfig, c, localGitRepo, headCommit)
 	if err != nil {
 		return nil, err
 	}
 
-	relDockerignorePath := filepath.Join(imageFromDockerfileConfig.Context, ".dockerignore")
-	var dockerignorePatterns []string
-	exists, err = localGitRepo.IsCommitFileExists(ctx, headCommit, relDockerignorePath)
+	dockerignorePatterns, err := getDockerignorePatterns(ctx, imageFromDockerfileConfig, c, localGitRepo, headCommit)
 	if err != nil {
-		return nil, fmt.Errorf("unable to check file .dockerignore existence in local git repository: %s", err)
-	} else if exists {
-		dockerignoreData, err := getFileDataFromGitAndCompareWithLocal(ctx, c.projectDir, localGitRepo, headCommit, relDockerignorePath)
-		if err != nil {
-			return nil, err
-		}
-
-		r := bytes.NewReader(dockerignoreData)
-		dockerignorePatterns, err = dockerignore.ReadAll(r)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	dockerignorePatternMatcher, err := fileutils.NewPatternMatcher(dockerignorePatterns)
@@ -1247,6 +1227,90 @@ func prepareImageBasedOnImageFromDockerfile(ctx context.Context, imageFromDocker
 	logboek.Context(ctx).Info().LogFDetails("Using stage %s\n", dockerfileStage.Name())
 
 	return img, nil
+}
+
+func getDockerfileData(ctx context.Context, imageFromDockerfileConfig *config.ImageFromDockerfile, c *Conveyor, localGitRepo *git_repo.Local, headCommit string) ([]byte, error) {
+	var dockerfileData []byte
+	relDockerfilePath := filepath.Join(imageFromDockerfileConfig.Context, imageFromDockerfileConfig.Dockerfile)
+	if isAccepted, err := giterminism_inspector.IsUncommittedDockerfileAccepted(relDockerfilePath); err != nil {
+		return nil, err
+	} else if isAccepted {
+		absDockerfilePath := filepath.Join(c.projectDir, relDockerfilePath)
+
+		exist, err := util.FileExists(absDockerfilePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check existence of file %s: %s", absDockerfilePath, err)
+		}
+
+		if !exist {
+			return nil, fmt.Errorf("dockerfile '%s' was not found", absDockerfilePath)
+		}
+
+		dockerfileData, err = ioutil.ReadFile(absDockerfilePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read file %s: %s", absDockerfilePath, err)
+		}
+	} else {
+		exists, err := localGitRepo.IsCommitFileExists(ctx, headCommit, relDockerfilePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check file %s existence in the local git repo commit %s %s: %s", relDockerfilePath, headCommit, err)
+		} else if !exists {
+			return nil, fmt.Errorf("dockerfile '%s' was not found in the local git repo commit %s", relDockerfilePath, headCommit)
+		}
+
+		dockerfileData, err = getFileDataFromGitAndCompareWithLocal(ctx, c.projectDir, localGitRepo, headCommit, relDockerfilePath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return dockerfileData, nil
+}
+
+func getDockerignorePatterns(ctx context.Context, imageFromDockerfileConfig *config.ImageFromDockerfile, c *Conveyor, localGitRepo *git_repo.Local, headCommit string) ([]string, error) {
+	var dockerignorePatterns []string
+	relDockerignorePath := filepath.Join(imageFromDockerfileConfig.Context, ".dockerignore")
+	if isAccepted, err := giterminism_inspector.IsUncommittedDockerignoreAccepted(relDockerignorePath); err != nil {
+		return nil, err
+	} else if isAccepted {
+		absDockerfileignorePath := filepath.Join(c.projectDir, relDockerignorePath)
+
+		exist, err := util.FileExists(absDockerfileignorePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check existence of file %s: %s", absDockerfileignorePath, err)
+		}
+
+		if exist {
+			data, err := ioutil.ReadFile(absDockerfileignorePath)
+			if err != nil {
+				return nil, fmt.Errorf("unable to read file %s: %s", absDockerfileignorePath, err)
+			}
+
+			r := bytes.NewReader(data)
+			dockerignorePatterns, err = dockerignore.ReadAll(r)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		exist, err := localGitRepo.IsCommitFileExists(ctx, headCommit, relDockerignorePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check file .dockerignore existence in the local git repo commit %s: %s", headCommit, err)
+		} else if exist {
+			data, err := getFileDataFromGitAndCompareWithLocal(ctx, c.projectDir, localGitRepo, headCommit, relDockerignorePath)
+			if err != nil {
+				return nil, err
+			}
+
+			r := bytes.NewReader(data)
+			dockerignorePatterns, err = dockerignore.ReadAll(r)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return dockerignorePatterns, nil
 }
 
 func getFileDataFromGitAndCompareWithLocal(ctx context.Context, projectDir string, localGitRepo *git_repo.Local, commit, relPath string) ([]byte, error) {

--- a/pkg/config/mount.go
+++ b/pkg/config/mount.go
@@ -17,8 +17,14 @@ type Mount struct {
 
 func (c *Mount) validate() error {
 	if !giterminism_inspector.LooseGiterminism {
-		if err := giterminism_inspector.ReportMountDirectiveUsage(context.Background()); err != nil {
-			return err
+		if c.raw.FromPath != "" {
+			if err := giterminism_inspector.ReportConfigStapelMountFromPath(context.Background(), c.raw.FromPath); err != nil {
+				return err
+			}
+		} else if c.Type == "build_dir" {
+			if err := giterminism_inspector.ReportConfigStapelMountBuildDir(context.Background()); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -222,8 +222,7 @@ func renderWerfConfigYaml(ctx context.Context, projectDir, werfConfigPath, werfC
 	}
 
 	var data []byte
-
-	if giterminism_inspector.LooseGiterminism || localGitRepo == nil {
+	if giterminism_inspector.LooseGiterminism || localGitRepo == nil || giterminism_inspector.IsUncommittedConfigAccepted() {
 		if d, err := ioutil.ReadFile(werfConfigPath); err != nil {
 			return "", fmt.Errorf("error reading %q: %s", werfConfigPath, err)
 		} else {
@@ -241,7 +240,6 @@ func renderWerfConfigYaml(ctx context.Context, projectDir, werfConfigPath, werfC
 	tmpl.Funcs(funcMap(tmpl))
 
 	var werfConfigsTemplates []string
-
 	if giterminism_inspector.LooseGiterminism || localGitRepo == nil {
 		if templates, err := getWerfConfigTemplatesFromFilesystem(werfConfigTemplatesDir); err != nil {
 			return "", err

--- a/pkg/giterminism_inspector/config/config.go
+++ b/pkg/giterminism_inspector/config/config.go
@@ -1,9 +1,53 @@
 package config
 
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/bmatcuk/doublestar"
+)
+
 type GiterminismConfig struct {
 	Config config `json:"config"`
 }
 
 type config struct {
-	AllowUncommitted bool `json:"allowUncommitted"`
+	AllowUncommitted bool   `json:"allowUncommitted"`
+	Stapel           stapel `json:"stapel"`
+}
+
+type stapel struct {
+	Mount mount `json:"mount"`
+}
+
+type mount struct {
+	AllowBuildDir  bool     `json:"allowBuildDir"`
+	AllowFromPaths []string `json:"allowFromPaths"`
+}
+
+func (m mount) IsFromPathAccepted(path string) (bool, error) {
+	return isPathMatched(m.AllowFromPaths, path, true)
+}
+
+func isPathMatched(patterns []string, path string, withGlobs bool) (bool, error) {
+	path = filepath.ToSlash(path)
+	for _, pattern := range patterns {
+		pattern = filepath.ToSlash(pattern)
+		var matchFunc func(string, string) (bool, error)
+		if withGlobs {
+			matchFunc = doublestar.Match
+		} else {
+			matchFunc = func(pattern string, path string) (bool, error) {
+				return pattern == path, nil
+			}
+		}
+
+		if matched, err := matchFunc(pattern, path); err != nil {
+			return false, fmt.Errorf("unable to match path (pattern: %s, path %s): %s", pattern, path, err)
+		} else if matched {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/giterminism_inspector/config/config.go
+++ b/pkg/giterminism_inspector/config/config.go
@@ -1,0 +1,3 @@
+package config
+
+type GiterminismConfig struct{}

--- a/pkg/giterminism_inspector/config/config.go
+++ b/pkg/giterminism_inspector/config/config.go
@@ -1,3 +1,9 @@
 package config
 
-type GiterminismConfig struct{}
+type GiterminismConfig struct {
+	Config config `json:"config"`
+}
+
+type config struct {
+	AllowUncommitted bool `json:"allowUncommitted"`
+}

--- a/pkg/giterminism_inspector/config/config.go
+++ b/pkg/giterminism_inspector/config/config.go
@@ -17,6 +17,7 @@ type config struct {
 	AllowUncommitted    bool                `json:"allowUncommitted"`
 	GoTemplateRendering goTemplateRendering `json:"goTemplateRendering"`
 	Stapel              stapel              `json:"stapel"`
+	Dockerfile          dockerfile          `json:"dockerfile"`
 }
 
 type goTemplateRendering struct {
@@ -55,6 +56,18 @@ type mount struct {
 
 func (m mount) IsFromPathAccepted(path string) (bool, error) {
 	return isPathMatched(m.AllowFromPaths, path, true)
+}
+
+type dockerfile struct {
+	AllowContextAddFile []string `json:"allowContextAddFile"`
+}
+
+func (d dockerfile) IsContextAddFileAccepted(path string) (bool, error) {
+	return isPathMatched(d.AllowContextAddFile, path, true)
+}
+
+type helm struct {
+	AllowUncommittedFiles []string `json:"allowUncommittedFiles"`
 }
 
 func isPathMatched(patterns []string, path string, withGlobs bool) (bool, error) {

--- a/pkg/giterminism_inspector/config/main.go
+++ b/pkg/giterminism_inspector/config/main.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/werf/werf/pkg/util"
+)
+
+func PrepareConfig(projectPath string) (c GiterminismConfig, err error) {
+	configPath := filepath.Join(projectPath, "werf-giterminism.yaml")
+
+	var data []byte
+	if exist, err := util.RegularFileExists(configPath); err != nil {
+		return c, err
+	} else if !exist {
+		data = []byte("giterminismConfigVersion: \"1\"")
+	} else {
+		data, err = ioutil.ReadFile(configPath)
+		if err != nil {
+			return c, fmt.Errorf("unable to read file %s: %s", configPath, err)
+		}
+	}
+
+	err = processWithOpenAPISchema(&data)
+	if err != nil {
+		return c, fmt.Errorf("%s validation failed: %s", configPath, err)
+	}
+
+	if err := json.Unmarshal(data, &c); err != nil {
+		panic(fmt.Sprint("unexpected error: ", err))
+	}
+
+	return c, err
+}

--- a/pkg/giterminism_inspector/config/openapi_spec.go
+++ b/pkg/giterminism_inspector/config/openapi_spec.go
@@ -35,6 +35,8 @@ definitions:
         $ref: '#/definitions/ConfigGoTemplateRendering'
       stapel:
         $ref: '#/definitions/ConfigStapel'
+      dockerfile:
+        $ref: '#/definitions/ConfigDockerfile'
   ConfigGoTemplateRendering:
     type: object
     additionalProperties: {}
@@ -56,6 +58,14 @@ definitions:
       allowBuildDir:
         type: boolean
       allowFromPaths:
+        type: array
+        items:
+          type: string
+  ConfigDockerfile:
+    type: object
+    additionalProperties: {}
+    properties:
+      allowContextAddFile:
         type: array
         items:
           type: string

--- a/pkg/giterminism_inspector/config/openapi_spec.go
+++ b/pkg/giterminism_inspector/config/openapi_spec.go
@@ -31,8 +31,18 @@ definitions:
     properties:
       allowUncommitted:
         type: boolean
+      goTemplateRendering:
+        $ref: '#/definitions/ConfigGoTemplateRendering'
       stapel:
         $ref: '#/definitions/ConfigStapel'
+  ConfigGoTemplateRendering:
+    type: object
+    additionalProperties: {}
+    properties:
+      allowEnvVariables:
+        type: array
+        items:
+          type: string
   ConfigStapel:
     type: object
     additionalProperties: {}

--- a/pkg/giterminism_inspector/config/openapi_spec.go
+++ b/pkg/giterminism_inspector/config/openapi_spec.go
@@ -22,6 +22,15 @@ properties:
   giterminismConfigVersion:
     type: string
     enum: ["1"]
+  config:
+    $ref: '#/definitions/Config'
+definitions:
+  Config:
+    type: object
+    additionalProperties: {}
+    properties:
+      allowUncommitted:
+        type: boolean
 `
 )
 

--- a/pkg/giterminism_inspector/config/openapi_spec.go
+++ b/pkg/giterminism_inspector/config/openapi_spec.go
@@ -24,6 +24,8 @@ properties:
     enum: ["1"]
   config:
     $ref: '#/definitions/Config'
+  helm:
+    $ref: '#/definitions/Helm'
 definitions:
   Config:
     type: object
@@ -65,7 +67,23 @@ definitions:
     type: object
     additionalProperties: {}
     properties:
+      allowUncommitted:
+        type: array
+        items:
+          type: string
+      allowUncommittedDockerignoreFiles:
+        type: array
+        items:
+          type: string
       allowContextAddFile:
+        type: array
+        items:
+          type: string
+  Helm:
+    type: object
+    additionalProperties: {}
+    properties:
+      allowUncommittedFiles:
         type: array
         items:
           type: string

--- a/pkg/giterminism_inspector/config/openapi_spec.go
+++ b/pkg/giterminism_inspector/config/openapi_spec.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
+	"github.com/go-openapi/validate/post"
+	"github.com/hashicorp/go-multierror"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	// TODO: use embedded file openapi_spec.yaml instead
+	schemaYaml = `type: object
+required:
+- giterminismConfigVersion
+additionalProperties: {}
+properties:
+  giterminismConfigVersion:
+    type: string
+    enum: ["1"]
+`
+)
+
+func openAPISchema() *spec.Schema {
+	hash := map[string]interface{}{}
+	if err := yaml.UnmarshalStrict([]byte(schemaYaml), &hash); err != nil {
+		panic(fmt.Sprint("unexpected error: ", err))
+	}
+
+	data, err := json.Marshal(hash)
+	if err != nil {
+		panic(fmt.Sprint("unexpected error: ", err))
+	}
+
+	schema := &spec.Schema{}
+	if err := json.Unmarshal(data, schema); err != nil {
+		panic(fmt.Sprint("unexpected error: ", err))
+	}
+
+	err = spec.ExpandSchema(schema, schema, nil)
+	if err != nil {
+		panic(fmt.Sprint("unexpected error: ", err))
+	}
+
+	return schema
+}
+
+func processWithOpenAPISchema(dataObj *[]byte) error {
+	validator := validate.NewSchemaValidator(openAPISchema(), nil, "", strfmt.Default)
+
+	var blank map[string]interface{}
+	err := yaml.Unmarshal(*dataObj, &blank)
+	if err != nil {
+		return err
+	}
+
+	result := validator.Validate(blank)
+	if result.IsValid() {
+		post.ApplyDefaults(result)
+		*dataObj, err = json.Marshal(result.Data())
+		if err != nil {
+			panic(fmt.Sprint("unexpected error: ", err))
+		}
+
+		return nil
+	}
+
+	var allErrs *multierror.Error
+	allErrs = multierror.Append(allErrs, result.Errors...)
+
+	return allErrs.ErrorOrNil()
+}

--- a/pkg/giterminism_inspector/config/openapi_spec.go
+++ b/pkg/giterminism_inspector/config/openapi_spec.go
@@ -31,6 +31,24 @@ definitions:
     properties:
       allowUncommitted:
         type: boolean
+      stapel:
+        $ref: '#/definitions/ConfigStapel'
+  ConfigStapel:
+    type: object
+    additionalProperties: {}
+    properties:
+      mount:
+        $ref: '#/definitions/ConfigStapelMount'
+  ConfigStapelMount:
+    type: object
+    additionalProperties: {}
+    properties:
+      allowBuildDir:
+        type: boolean
+      allowFromPaths:
+        type: array
+        items:
+          type: string
 `
 )
 

--- a/pkg/giterminism_inspector/config/openapi_spec.yaml
+++ b/pkg/giterminism_inspector/config/openapi_spec.yaml
@@ -15,8 +15,18 @@ definitions:
     properties:
       allowUncommitted:
         type: boolean
+      goTemplateRendering:
+        $ref: '#/definitions/ConfigGoTemplateRendering'
       stapel:
         $ref: '#/definitions/ConfigStapel'
+  ConfigGoTemplateRendering:
+    type: object
+    additionalProperties: {}
+    properties:
+      allowEnvVariables:
+        type: array
+        items:
+          type: string
   ConfigStapel:
     type: object
     additionalProperties: {}

--- a/pkg/giterminism_inspector/config/openapi_spec.yaml
+++ b/pkg/giterminism_inspector/config/openapi_spec.yaml
@@ -15,3 +15,21 @@ definitions:
     properties:
       allowUncommitted:
         type: boolean
+      stapel:
+        $ref: '#/definitions/ConfigStapel'
+  ConfigStapel:
+    type: object
+    additionalProperties: {}
+    properties:
+      mount:
+        $ref: '#/definitions/ConfigStapelMount'
+  ConfigStapelMount:
+    type: object
+    additionalProperties: {}
+    properties:
+      allowBuildDir:
+        type: boolean
+      allowFromPaths:
+        type: array
+        items:
+          type: string

--- a/pkg/giterminism_inspector/config/openapi_spec.yaml
+++ b/pkg/giterminism_inspector/config/openapi_spec.yaml
@@ -1,0 +1,8 @@
+type: object
+required:
+  - giterminismConfigVersion
+additionalProperties: {}
+properties:
+  giterminismConfigVersion:
+    type: string
+    enum: ["1"]

--- a/pkg/giterminism_inspector/config/openapi_spec.yaml
+++ b/pkg/giterminism_inspector/config/openapi_spec.yaml
@@ -8,6 +8,8 @@ properties:
     enum: ["1"]
   config:
     $ref: '#/definitions/Config'
+  helm:
+    $ref: '#/definitions/Helm'
 definitions:
   Config:
     type: object
@@ -49,7 +51,23 @@ definitions:
     type: object
     additionalProperties: {}
     properties:
+      allowUncommitted:
+        type: array
+        items:
+          type: string
+      allowUncommittedDockerignoreFiles:
+        type: array
+        items:
+          type: string
       allowContextAddFile:
+        type: array
+        items:
+          type: string
+  Helm:
+    type: object
+    additionalProperties: {}
+    properties:
+      allowUncommittedFiles:
         type: array
         items:
           type: string

--- a/pkg/giterminism_inspector/config/openapi_spec.yaml
+++ b/pkg/giterminism_inspector/config/openapi_spec.yaml
@@ -6,3 +6,12 @@ properties:
   giterminismConfigVersion:
     type: string
     enum: ["1"]
+  config:
+    $ref: '#/definitions/Config'
+definitions:
+  Config:
+    type: object
+    additionalProperties: {}
+    properties:
+      allowUncommitted:
+        type: boolean

--- a/pkg/giterminism_inspector/config/openapi_spec.yaml
+++ b/pkg/giterminism_inspector/config/openapi_spec.yaml
@@ -19,6 +19,8 @@ definitions:
         $ref: '#/definitions/ConfigGoTemplateRendering'
       stapel:
         $ref: '#/definitions/ConfigStapel'
+      dockerfile:
+        $ref: '#/definitions/ConfigDockerfile'
   ConfigGoTemplateRendering:
     type: object
     additionalProperties: {}
@@ -40,6 +42,14 @@ definitions:
       allowBuildDir:
         type: boolean
       allowFromPaths:
+        type: array
+        items:
+          type: string
+  ConfigDockerfile:
+    type: object
+    additionalProperties: {}
+    properties:
+      allowContextAddFile:
         type: array
         items:
           type: string

--- a/pkg/giterminism_inspector/giterminism_inspector.go
+++ b/pkg/giterminism_inspector/giterminism_inspector.go
@@ -94,6 +94,16 @@ func ReportConfigStapelMountFromPath(_ context.Context, fromPath string) error {
 	return fmt.Errorf("'mount { fromPath: %s, ... }' is forbidden due to enabled giterminism mode (more info %s), it is recommended to avoid this directive", fromPath, giterminismDocPageURL)
 }
 
+func ReportConfigDockerfileContextAddFile(_ context.Context, contextAddFile string) error {
+	if isAccepted, err := giterminismConfig.Config.Dockerfile.IsContextAddFileAccepted(contextAddFile); err != nil {
+		return err
+	} else if isAccepted {
+		return nil
+	}
+
+	return fmt.Errorf("'contextAddFile %s' is forbidden due to enabled giterminism mode (more info %s), it is recommended to avoid this directive", contextAddFile, giterminismDocPageURL)
+}
+
 func ReportConfigGoTemplateRenderingEnv(_ context.Context, envName string) error {
 	if isAccepted, err := giterminismConfig.Config.GoTemplateRendering.IsEnvNameAccepted(envName); err != nil {
 		return err

--- a/pkg/giterminism_inspector/giterminism_inspector.go
+++ b/pkg/giterminism_inspector/giterminism_inspector.go
@@ -3,8 +3,9 @@ package giterminism_inspector
 import (
 	"context"
 	"fmt"
-
 	"github.com/werf/logboek"
+
+	"github.com/werf/werf/pkg/giterminism_inspector/config"
 )
 
 const giterminismDocPageURL = "https://werf.io/v1.2-alpha/documentation/advanced/configuration/giterminism.html"
@@ -15,6 +16,8 @@ var (
 	DevMode                  bool
 	ReportedUncommittedPaths []string
 	ReportedUntrackedPaths   []string
+
+	giterminismConfig config.GiterminismConfig
 )
 
 type InspectionOptions struct {
@@ -23,10 +26,17 @@ type InspectionOptions struct {
 	DevMode          bool
 }
 
-func Init(opts InspectionOptions) error {
+func Init(projectPath string, opts InspectionOptions) error {
 	LooseGiterminism = opts.LooseGiterminism
 	NonStrict = opts.NonStrict
 	DevMode = opts.DevMode
+
+	if c, err := config.PrepareConfig(projectPath); err != nil {
+		return err
+	} else {
+		giterminismConfig = c
+	}
+
 	return nil
 }
 

--- a/pkg/giterminism_inspector/giterminism_inspector.go
+++ b/pkg/giterminism_inspector/giterminism_inspector.go
@@ -94,8 +94,14 @@ func ReportConfigStapelMountFromPath(_ context.Context, fromPath string) error {
 	return fmt.Errorf("'mount { fromPath: %s, ... }' is forbidden due to enabled giterminism mode (more info %s), it is recommended to avoid this directive", fromPath, giterminismDocPageURL)
 }
 
-func ReportGoTemplateEnvFunctionUsage(ctx context.Context, functionName string) error {
-	return fmt.Errorf("go templates function %q is forbidden due to enabled giterminism mode (more info %s)", functionName, giterminismDocPageURL)
+func ReportConfigGoTemplateRenderingEnv(_ context.Context, envName string) error {
+	if isAccepted, err := giterminismConfig.Config.GoTemplateRendering.IsEnvNameAccepted(envName); err != nil {
+		return err
+	} else if isAccepted {
+		return nil
+	}
+
+	return fmt.Errorf("env name %s is forbidden due to enabled giterminism mode (more info %s)", envName, giterminismDocPageURL)
 }
 
 func PrintInspectionDebrief(ctx context.Context) {

--- a/pkg/giterminism_inspector/giterminism_inspector.go
+++ b/pkg/giterminism_inspector/giterminism_inspector.go
@@ -3,8 +3,8 @@ package giterminism_inspector
 import (
 	"context"
 	"fmt"
-	"github.com/werf/logboek"
 
+	"github.com/werf/logboek"
 	"github.com/werf/werf/pkg/giterminism_inspector/config"
 )
 
@@ -76,8 +76,22 @@ func ReportUncommittedFile(ctx context.Context, path string) error {
 	}
 }
 
-func ReportMountDirectiveUsage(ctx context.Context) error {
-	return fmt.Errorf("'mount' directive is forbidden due to enabled giterminism mode (more info %s), it is recommended to avoid this directive", giterminismDocPageURL)
+func ReportConfigStapelMountBuildDir(_ context.Context) error {
+	if giterminismConfig.Config.Stapel.Mount.AllowBuildDir {
+		return nil
+	}
+
+	return fmt.Errorf("'mount { from: build_dir, ... }' is forbidden due to enabled giterminism mode (more info %s), it is recommended to avoid this directive", giterminismDocPageURL)
+}
+
+func ReportConfigStapelMountFromPath(_ context.Context, fromPath string) error {
+	if isAccepted, err := giterminismConfig.Config.Stapel.Mount.IsFromPathAccepted(fromPath); err != nil {
+		return err
+	} else if isAccepted {
+		return nil
+	}
+
+	return fmt.Errorf("'mount { fromPath: %s, ... }' is forbidden due to enabled giterminism mode (more info %s), it is recommended to avoid this directive", fromPath, giterminismDocPageURL)
 }
 
 func ReportGoTemplateEnvFunctionUsage(ctx context.Context, functionName string) error {

--- a/pkg/giterminism_inspector/giterminism_inspector.go
+++ b/pkg/giterminism_inspector/giterminism_inspector.go
@@ -44,6 +44,14 @@ func IsUncommittedConfigAccepted() bool {
 	return giterminismConfig.Config.AllowUncommitted
 }
 
+func IsUncommittedDockerfileAccepted(path string) (bool, error) {
+	return giterminismConfig.Config.Dockerfile.IsUncommittedAccepted(path)
+}
+
+func IsUncommittedDockerignoreAccepted(path string) (bool, error) {
+	return giterminismConfig.Config.Dockerfile.IsUncommittedDockerignoreAccepted(path)
+}
+
 func ReportUntrackedFile(ctx context.Context, path string) error {
 	for _, p := range ReportedUntrackedPaths {
 		if p == path {

--- a/pkg/giterminism_inspector/giterminism_inspector.go
+++ b/pkg/giterminism_inspector/giterminism_inspector.go
@@ -40,6 +40,10 @@ func Init(projectPath string, opts InspectionOptions) error {
 	return nil
 }
 
+func IsUncommittedConfigAccepted() bool {
+	return giterminismConfig.Config.AllowUncommitted
+}
+
 func ReportUntrackedFile(ctx context.Context, path string) error {
 	for _, p := range ReportedUntrackedPaths {
 		if p == path {


### PR DESCRIPTION
werf-giterminism.yaml
```
giterminismConfigVersion: 1
config:
  allowUncommitted: true
  goTemplateRendering:
    allowEnvVariables:
      - VARIABLE_X
      - /CI_*/
  stapel:
    mount:
      allowBuildDir: true 
      allowFromPaths:     
        - PATH1
        - /**/*/
  dockerfile:
    allowUncommitted:
      - Dockerfile
      - /**/*/
    allowUncommittedDockerignoreFiles:
      - .dockerignore
      - /**/*/
    allowContextAddFile:
      - aaa
```

rel https://github.com/werf/werf/issues/3046