### PR TITLE
Fix deadline-exceeded when hook job took more than 5 min

### DIFF
--- a/cmd/werf/bundle/apply/apply.go
+++ b/cmd/werf/bundle/apply/apply.go
@@ -228,7 +228,7 @@ func runApply() error {
 		Install:         common.NewBool(true),
 		Wait:            common.NewBool(true),
 		Atomic:          common.NewBool(cmdData.AutoRollback),
-		Timeout:         common.NewDuration(time.Duration(cmdData.Timeout)),
+		Timeout:         common.NewDuration(time.Duration(cmdData.Timeout) * time.Second),
 	})
 
 	/*

--- a/cmd/werf/common/helpers.go
+++ b/cmd/werf/common/helpers.go
@@ -3,12 +3,9 @@ package common
 import "time"
 
 func NewDuration(value time.Duration) *time.Duration {
-	if value != 0 {
-		res := new(time.Duration)
-		*res = value
-		return res
-	}
-	return nil
+	res := new(time.Duration)
+	*res = value
+	return res
 }
 
 func NewBool(value bool) *bool {

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -397,7 +397,7 @@ func run(ctx context.Context, projectDir string) error {
 		Install:         common.NewBool(true),
 		Wait:            common.NewBool(true),
 		Atomic:          common.NewBool(cmdData.AutoRollback),
-		Timeout:         common.NewDuration(time.Duration(cmdData.Timeout)),
+		Timeout:         common.NewDuration(time.Duration(cmdData.Timeout) * time.Second),
 	})
 	return wc.WrapUpgrade(ctx, func() error {
 		return helmUpgradeCmd.RunE(helmUpgradeCmd, []string{releaseName, chartDir})


### PR DESCRIPTION
 - Fix default helm 5 min timeout => infinite.
 - Fix any timeout other than default results in 'context deadline' error.
