### PR TITLE
[cleanup] Fix goroutine stack exceeds limit

### DIFF
--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -740,6 +740,17 @@ func findStageByImageID(stages []*image.StageDescription, imageID string) *image
 
 func (m *cleanupManager) excludeStageAndRelativesByStage(stages []*image.StageDescription, stage *image.StageDescription) ([]*image.StageDescription, []*image.StageDescription) {
 	var excludedStages []*image.StageDescription
+	currentStage := stage
+	for {
+		stages = excludeStages(stages, currentStage)
+		excludedStages = append(excludedStages, currentStage)
+
+		currentStage = findStageByImageID(stages, currentStage.Info.ParentID)
+		if currentStage == nil {
+			break
+		}
+	}
+
 	for label, checksum := range stage.Info.Labels {
 		if strings.HasPrefix(label, image.WerfImportChecksumLabelPrefix) {
 			sourceImageIDs, ok := m.checksumSourceImageIDs[checksum]
@@ -750,17 +761,6 @@ func (m *cleanupManager) excludeStageAndRelativesByStage(stages []*image.StageDe
 					excludedStages = append(excludedStages, excludedImportStages...)
 				}
 			}
-		}
-	}
-
-	currentStage := stage
-	for {
-		stages = excludeStages(stages, currentStage)
-		excludedStages = append(excludedStages, currentStage)
-
-		currentStage = findStageByImageID(stages, currentStage.Info.ParentID)
-		if currentStage == nil {
-			break
 		}
 	}
 


### PR DESCRIPTION
One checksum can be associated with many stages, so it is necessary to exclude the stage itself before processing linked imports