### PR TITLE
[config] Cast a user regexp value to full match regexp

### DIFF
--- a/pkg/config/raw_meta_cleanup.go
+++ b/pkg/config/raw_meta_cleanup.go
@@ -166,10 +166,11 @@ func (c *rawMetaCleanupKeepPolicyReferences) processRegexpString(name, configVal
 		value = strings.TrimPrefix(configValue, "/")
 		value = strings.TrimSuffix(value, "/")
 	} else {
-		value = fmt.Sprintf("^%s$", regexp.QuoteMeta(configValue))
+		value = regexp.QuoteMeta(configValue)
 	}
 
-	regex, err := regexp.Compile(value)
+	expr := fmt.Sprintf("^%s$", value)
+	regex, err := regexp.Compile(expr)
 	if err != nil {
 		return nil, newDetailedConfigError(fmt.Sprintf("invalid value '%s' for `%s: string|REGEX`!", configValue, name), c, c.rawMetaCleanup.rawMeta.doc)
 	}


### PR DESCRIPTION
After that, each user regexp value will be wrapped with `^` and `$`.

The change affects the following directives:
- werf.yaml: 
  - `cleanup.keepPolicies.[*].references.branch`
  - `cleanup.keepPolicies.[*].references.tag`
- werf-giterminism.yaml: 
  - `config.allowUncommittedTemplates`
  - `config.goTemplateRendering.allowEnvVariables`
  - `config.dockerfile.allowUncommitted`
  - `config.dockerfile.allowUncommittedDockerignoreFiles`
  - `helm.allowUncommittedFiles`