### PR TITLE
[config] Fix werf config templates reading (.werf/**/*.tmpl)

### DIFF
--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -365,7 +366,14 @@ func getWerfConfigTemplatesLocalGitRepo(ctx context.Context, localGitRepo git_re
 			continue
 		}
 
-		templatesPathList = append(templatesPathList, relPath)
+		matched, err := filepath.Match("*.tmpl", path.Base(relPath))
+		if err != nil {
+			return nil, err
+		}
+
+		if matched {
+			templatesPathList = append(templatesPathList, relPath)
+		}
 	}
 
 	return templatesPathList, nil


### PR DESCRIPTION
All files in the werf config templates directory (.werf by default) were treated as templates.
The template file must have `.tmpl` extension.