### PR TITLE
[config] Fix naming for the user template

### DIFF
--- a/pkg/giterminism/file_reader/config_templates.go
+++ b/pkg/giterminism/file_reader/config_templates.go
@@ -40,6 +40,12 @@ func (r FileReader) ReadConfigTemplateFiles(ctx context.Context, customDirRelPat
 		return r.readCommitConfigTemplateFile(ctx, relPath)
 	}
 
+	tmplFuncWrapperFunc := func(relPath string, data []byte, err error) error {
+		templatePathInsideDir := util.GetRelativeToBaseFilepath(templatesDirRelPath, relPath)
+		readFileBeforeHookFunc(relPath)
+		return tmplFunc(templatePathInsideDir, data, err)
+	}
+
 	templateRelPathListFromFS, err := r.configTemplateFileRelPathListFromFS(templatesDirRelPath)
 	if err != nil {
 		return err
@@ -48,7 +54,7 @@ func (r FileReader) ReadConfigTemplateFiles(ctx context.Context, customDirRelPat
 	if r.manager.LooseGiterminism() {
 		for _, templateRelPath := range templateRelPathListFromFS {
 			data, err := readFileFunc(templateRelPath)
-			if err := tmplFunc(templateRelPath, data, err); err != nil {
+			if err := tmplFuncWrapperFunc(templateRelPath, data, err); err != nil {
 				return err
 			}
 		}
@@ -69,7 +75,7 @@ func (r FileReader) ReadConfigTemplateFiles(ctx context.Context, customDirRelPat
 		}
 
 		data, err := readCommitFileFunc(templateRelPath)
-		if err := tmplFunc(templateRelPath, data, err); err != nil {
+		if err := tmplFuncWrapperFunc(templateRelPath, data, err); err != nil {
 			return err
 		}
 	}
@@ -89,7 +95,7 @@ func (r FileReader) ReadConfigTemplateFiles(ctx context.Context, customDirRelPat
 		}
 
 		data, err := readFileFunc(templateRelPath)
-		if err := tmplFunc(templateRelPath, data, err); err != nil {
+		if err := tmplFuncWrapperFunc(templateRelPath, data, err); err != nil {
 			return err
 		}
 	}

--- a/pkg/giterminism/interface.go
+++ b/pkg/giterminism/interface.go
@@ -21,7 +21,7 @@ type Manager interface {
 
 type FileReader interface {
 	ReadConfig(ctx context.Context, customRelPath string) ([]byte, error)
-	ReadConfigTemplateFiles(ctx context.Context, customRelDirPath string, tmplFunc func(relPath string, data []byte, err error) error) error
+	ReadConfigTemplateFiles(ctx context.Context, customRelDirPath string, tmplFunc func(templatePathInsideDir string, data []byte, err error) error) error
 }
 
 type Config interface {


### PR DESCRIPTION
The template name is the path relative to the templates directory.
{{ include ".werf/templates/1.tmpl" . }} => {{ include "templates/1.tmpl" . }}