### PR TITLE
[giterminism] Change helm giterministic files loader logic for subcharts

### DIFF
--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/werf/werf/pkg/deploy/helm/command_helpers"
+
 	"helm.sh/helm/v3/pkg/getter"
 
 	"github.com/werf/werf/pkg/config"
@@ -330,7 +332,7 @@ func runExport() error {
 		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
 			return werf_chart.NewWerfChart(ctx, nil, projectDir, werf_chart.WerfChartOptions{})
 		},
-		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir),
+		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir, cmd_helm.Settings, command_helpers.BuildChartDependenciesOptions{}),
 		LocateChartFunc: common.MakeLocateChartFunc(ctx, localGitRepo, projectDir),
 		ReadFileFunc:    common.MakeHelmReadFileFunc(ctx, localGitRepo, projectDir),
 	}

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -15,6 +15,7 @@ import (
 	"github.com/werf/werf/pkg/werf/global_warnings"
 
 	"github.com/werf/werf/pkg/deploy/helm"
+	"github.com/werf/werf/pkg/deploy/helm/command_helpers"
 
 	"github.com/werf/werf/pkg/deploy"
 	"github.com/werf/werf/pkg/deploy/secret"
@@ -340,7 +341,7 @@ func runPublish() error {
 		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
 			return werf_chart.NewWerfChart(ctx, nil, projectDir, werf_chart.WerfChartOptions{})
 		},
-		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir),
+		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir, cmd_helm.Settings, command_helpers.BuildChartDependenciesOptions{}),
 		LocateChartFunc: common.MakeLocateChartFunc(ctx, localGitRepo, projectDir),
 		ReadFileFunc:    common.MakeHelmReadFileFunc(ctx, localGitRepo, projectDir),
 	}

--- a/cmd/werf/common/deploy_params.go
+++ b/cmd/werf/common/deploy_params.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/werf/werf/pkg/deploy/helm/command_helpers"
+
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
 
@@ -198,12 +200,12 @@ func StubImageInfoGetters(werfConfig *config.WerfConfig) (list []*image.InfoGett
 	return list
 }
 
-func MakeChartDirLoadFunc(ctx context.Context, localGitRepo git_repo.Local, projectDir string) func(dir string) ([]*loader.BufferedFile, error) {
+func MakeChartDirLoadFunc(ctx context.Context, localGitRepo git_repo.Local, projectDir string, helmEnvSettings *cli.EnvSettings, buildChartDependenciesOpts command_helpers.BuildChartDependenciesOptions) func(dir string) ([]*loader.BufferedFile, error) {
 	if giterminism_inspector.LooseGiterminism {
 		return nil
 	}
 	return func(dir string) ([]*loader.BufferedFile, error) {
-		return werf_chart.GiterministicFilesLoader(ctx, localGitRepo, projectDir, dir)
+		return werf_chart.GiterministicFilesLoader(ctx, localGitRepo, projectDir, dir, helmEnvSettings, buildChartDependenciesOpts)
 	}
 }
 

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/werf/werf/pkg/deploy/helm/command_helpers"
+
 	cmd_helm "helm.sh/helm/v3/cmd/helm"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -385,7 +387,7 @@ func run(ctx context.Context, projectDir string) error {
 		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
 			return werf_chart.NewWerfChart(ctx, nil, projectDir, werf_chart.WerfChartOptions{})
 		},
-		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir),
+		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir, cmd_helm.Settings, command_helpers.BuildChartDependenciesOptions{}),
 		LocateChartFunc: common.MakeLocateChartFunc(ctx, localGitRepo, projectDir),
 		ReadFileFunc:    common.MakeHelmReadFileFunc(ctx, localGitRepo, projectDir),
 	}

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/werf/werf/pkg/deploy/helm/command_helpers"
+
 	"github.com/spf13/cobra"
 
 	cmd_helm "helm.sh/helm/v3/cmd/helm"
@@ -359,7 +361,7 @@ func runRender() error {
 		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
 			return werf_chart.NewWerfChart(ctx, nil, projectDir, werf_chart.WerfChartOptions{})
 		},
-		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir),
+		LoadDirFunc:     common.MakeChartDirLoadFunc(ctx, localGitRepo, projectDir, cmd_helm.Settings, command_helpers.BuildChartDependenciesOptions{}),
 		LocateChartFunc: common.MakeLocateChartFunc(ctx, localGitRepo, projectDir),
 		ReadFileFunc:    common.MakeHelmReadFileFunc(ctx, localGitRepo, projectDir),
 	}

--- a/pkg/deploy/helm/command_helpers/build_chart_dependencies.go
+++ b/pkg/deploy/helm/command_helpers/build_chart_dependencies.go
@@ -1,0 +1,69 @@
+package command_helpers
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"helm.sh/helm/v3/pkg/chart/loader"
+
+	"github.com/werf/logboek"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/downloader"
+	"helm.sh/helm/v3/pkg/getter"
+)
+
+type BuildChartDependenciesOptions struct {
+	Keyring    string
+	SkipUpdate bool
+	Verify     downloader.VerificationStrategy
+}
+
+func BuildChartDependenciesInDir(ctx context.Context, lockFileData []byte, chartFileData []byte, targetDir string, helmEnvSettings *cli.EnvSettings, opts BuildChartDependenciesOptions) error {
+	logboek.Context(ctx).Debug().LogF("-- BuildChartDependenciesInDir\n")
+
+	if err := os.MkdirAll(targetDir, os.ModePerm); err != nil {
+		return fmt.Errorf("error creating dir %q: %s", targetDir, err)
+	}
+
+	lockFilePath := filepath.Join(targetDir, "Chart.lock")
+	if err := ioutil.WriteFile(lockFilePath, lockFileData, 0644); err != nil {
+		return fmt.Errorf("error writing %q: %s", lockFilePath)
+	}
+
+	chartFilePath := filepath.Join(targetDir, "Chart.yaml")
+	if err := ioutil.WriteFile(chartFilePath, chartFileData, 0644); err != nil {
+		return fmt.Errorf("error writing %q: %s", chartFilePath)
+	}
+
+	man := &downloader.Manager{
+		Out:        logboek.ProxyOutStream(),
+		ChartPath:  targetDir,
+		Keyring:    opts.Keyring,
+		SkipUpdate: opts.SkipUpdate,
+		Verify:     opts.Verify,
+
+		Getters:          getter.All(helmEnvSettings),
+		RepositoryConfig: helmEnvSettings.RepositoryConfig,
+		RepositoryCache:  helmEnvSettings.RepositoryCache,
+		Debug:            helmEnvSettings.Debug,
+	}
+
+	currentLoaderOptions := loader.GlobalLoadOptions
+	loader.GlobalLoadOptions = &loader.LoadOptions{
+		ChartExtender:               currentLoaderOptions.ChartExtender,
+		SubchartExtenderFactoryFunc: currentLoaderOptions.SubchartExtenderFactoryFunc,
+	}
+	defer func() {
+		loader.GlobalLoadOptions = currentLoaderOptions
+	}()
+
+	err := man.Build()
+	if e, ok := err.(downloader.ErrRepoNotFound); ok {
+		return fmt.Errorf("%s. Please add the missing repos via 'helm repo add'", e.Error())
+	}
+
+	return nil
+}

--- a/pkg/deploy/werf_chart/git_loader.go
+++ b/pkg/deploy/werf_chart/git_loader.go
@@ -3,90 +3,169 @@ package werf_chart
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/werf/werf/pkg/giterminism_inspector"
+	"github.com/werf/werf/pkg/deploy/helm/command_helpers"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/werf/lockgate"
+
+	"helm.sh/helm/v3/pkg/cli"
 
 	"github.com/pkg/errors"
-	"github.com/werf/logboek"
+	"github.com/werf/werf/pkg/werf"
 	"helm.sh/helm/v3/pkg/chart"
 	"sigs.k8s.io/yaml"
 
+	"github.com/werf/logboek"
 	"github.com/werf/werf/pkg/util"
 
 	"github.com/werf/werf/pkg/git_repo"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
-func GiterministicFilesLoader(ctx context.Context, localGitRepo git_repo.Local, projectDir, loadDir string) ([]*loader.BufferedFile, error) {
-	var res []*loader.BufferedFile
-	var lock *chart.Lock
+func GetChartDependenciesCacheDir(lockDigest string) string {
+	return filepath.Join(werf.GetLocalCacheDir(), "helm_chart_dependencies", lockDigest)
+}
 
+func LoadMetadata(files []*loader.BufferedFile) (*chart.Metadata, error) {
+	var metadata *chart.Metadata
+
+	for _, f := range files {
+		if f.Name == "Chart.yaml" {
+			metadata = new(chart.Metadata)
+
+			if err := yaml.Unmarshal(f.Data, metadata); err != nil {
+				return nil, errors.Wrap(err, "cannot load Chart.yaml")
+			}
+
+			if metadata.APIVersion == "" {
+				metadata.APIVersion = chart.APIVersionV1
+			}
+
+			break
+		}
+	}
+
+	for _, f := range files {
+		if f.Name == "requirements.yaml" {
+			if err := yaml.Unmarshal(f.Data, metadata); err != nil {
+				return nil, errors.Wrap(err, "cannot load requirements.yaml")
+			}
+			break
+		}
+	}
+
+	return metadata, nil
+}
+
+func LoadLock(files []*loader.BufferedFile) (*chart.Lock, *loader.BufferedFile, error) {
+	var lock *chart.Lock
+	var lockFile *loader.BufferedFile
+
+	for _, f := range files {
+		switch {
+		case f.Name == "Chart.lock":
+			lock = new(chart.Lock)
+			if err := yaml.Unmarshal(f.Data, &lock); err != nil {
+				return nil, nil, errors.Wrap(err, "cannot load Chart.lock")
+			}
+			lockFile = f
+			break
+		case f.Name == "requirements.lock":
+			lock = new(chart.Lock)
+			if err := yaml.Unmarshal(f.Data, &lock); err != nil {
+				return nil, nil, errors.Wrap(err, "cannot load requirements.lock")
+			}
+			lockFile = f
+			break
+		}
+	}
+
+	return lock, lockFile, nil
+}
+
+func GetPreparedChartDependenciesDir(ctx context.Context, lockDigest string, lockFileData []byte, chartFileData []byte, helmEnvSettings *cli.EnvSettings, buildChartDependenciesOpts command_helpers.BuildChartDependenciesOptions) (string, error) {
+	depsDir := GetChartDependenciesCacheDir(lockDigest)
+
+	if _, err := os.Stat(depsDir); os.IsNotExist(err) {
+		if err := logboek.Context(ctx).Default().LogProcess("Building chart dependencies").DoError(func() error {
+			logboek.Context(ctx).Default().LogF("Using chart dependencies directory: %s\n", depsDir)
+			if _, lock, err := werf.AcquireHostLock(ctx, depsDir, lockgate.AcquireOptions{}); err != nil {
+				return fmt.Errorf("error acquiring lock for %q: %s", depsDir, err)
+			} else {
+				defer werf.ReleaseHostLock(lock)
+			}
+
+			tmpDepsDir := fmt.Sprintf("%s.tmp.%s", depsDir, uuid.NewV4().String())
+
+			if err := command_helpers.BuildChartDependenciesInDir(ctx, lockFileData, chartFileData, tmpDepsDir, helmEnvSettings, buildChartDependenciesOpts); err != nil {
+				return fmt.Errorf("error building chart dependencies: %s", err)
+			}
+
+			if err := os.Rename(tmpDepsDir, depsDir); err != nil {
+				return fmt.Errorf("error renaming %q to %q: %s", tmpDepsDir, depsDir, err)
+			}
+
+			return nil
+		}); err != nil {
+			return "", err
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("error accessing %q: %s", depsDir, err)
+	} else {
+		logboek.Context(ctx).Default().LogF("Using cached chart dependencies directory: %s\n", depsDir)
+	}
+
+	return depsDir, nil
+}
+
+func GiterministicFilesLoader(ctx context.Context, localGitRepo git_repo.Local, projectDir, loadDir string, helmEnvSettings *cli.EnvSettings, buildChartDependenciesOpts command_helpers.BuildChartDependenciesOptions) ([]*loader.BufferedFile, error) {
 	gitFiles, err := LoadFilesFromGit(ctx, localGitRepo, projectDir, loadDir)
 	if err != nil {
 		return nil, err
 	}
 
+	var chartFile *loader.BufferedFile
 	for _, f := range gitFiles {
-		switch {
-		case f.Name == "Chart.lock":
-			lock = new(chart.Lock)
-			if err := yaml.Unmarshal(f.Data, &lock); err != nil {
-				return nil, errors.Wrap(err, "cannot load Chart.lock")
-			}
-			break
-		case f.Name == "requirements.lock":
-			lock = new(chart.Lock)
-			if err := yaml.Unmarshal(f.Data, &lock); err != nil {
-				return nil, errors.Wrap(err, "cannot load requirements.lock")
-			}
-			break
-		}
-	}
-
-	res = gitFiles
-
-	localFiles, err := loader.GetFilesFromLocalFilesystem(loadDir)
-	if err != nil {
-		return nil, err
-	}
-
-CheckUncommittedChartYaml:
-	for _, f := range localFiles {
 		if f.Name == "Chart.yaml" {
-			for _, gf := range gitFiles {
-				if gf.Name == "Chart.yaml" {
-					break CheckUncommittedChartYaml
-				}
-			}
-
-			if err := giterminism_inspector.ReportUntrackedFile(ctx, filepath.Join(loadDir, f.Name)); err != nil {
-				return nil, err
-			}
-
-			break CheckUncommittedChartYaml
+			chartFile = f
+			break
 		}
 	}
 
-	if lock != nil {
-		localSubchartsFiles := make(map[string][]*loader.BufferedFile)
+	res := gitFiles
 
-		for _, f := range localFiles {
-			switch {
-			case strings.HasPrefix(f.Name, "charts/"):
-				fname := strings.TrimPrefix(f.Name, "charts/")
-				cname := strings.SplitN(fname, "/", 2)[0]
-				localSubchartsFiles[cname] = append(localSubchartsFiles[cname], f)
-				logboek.Context(ctx).Debug().LogF("-- GiterministicFilesLoader: local subchart %q: found file %q\n", cname, f.Name)
+	if chartFile != nil {
+		if lock, lockFile, err := LoadLock(gitFiles); err != nil {
+			return nil, fmt.Errorf("error loading chart lock file: %s", err)
+		} else if lock == nil {
+			if metadata, err := LoadMetadata(gitFiles); err != nil {
+				return nil, fmt.Errorf("error loading chart metadata file: %s", err)
+			} else if len(metadata.Dependencies) > 0 {
+				logboek.Context(ctx).Error().LogLn("Cannot build chart dependencies and preload charts without lock file (.helm/Chart.lock or .helm/requirements.lock)")
+				logboek.Context(ctx).Error().LogLn("It is recommended to add Chart.lock file to your project repository or remove chart dependencies.")
+				logboek.Context(ctx).Error().LogLn()
+				logboek.Context(ctx).Error().LogLn("To generate a lock file run 'werf helm dependency update .helm' and commit resulting .helm/Chart.lock (it is not required to commit whole .helm/charts directory).")
+				logboek.Context(ctx).Error().LogLn()
 			}
-		}
+		} else {
+			if depsDir, err := GetPreparedChartDependenciesDir(ctx, lock.Digest, lockFile.Data, chartFile.Data, helmEnvSettings, buildChartDependenciesOpts); err != nil {
+				return nil, fmt.Errorf("")
+			} else {
+				localFiles, err := loader.GetFilesFromLocalFilesystem(depsDir)
+				if err != nil {
+					return nil, err
+				}
 
-		for _, dep := range lock.Dependencies {
-			fullDepName := fmt.Sprintf("%s-%s.tgz", dep.Name, dep.Version)
-			if files, hasKey := localSubchartsFiles[fullDepName]; hasKey {
-				logboek.Context(ctx).Debug().LogF("-- GiterministicFilesLoader: using subchart %q from the local filesystem\n", fullDepName)
-				res = append(res, files...)
+				for _, f := range localFiles {
+					if strings.HasPrefix(f.Name, "charts/") {
+						res = append(res, f)
+						logboek.Context(ctx).Debug().LogF("-- GiterministicFilesLoader: loading subchart %q from dependencies dir %s\n", f.Name, depsDir)
+					}
+				}
 			}
 		}
 	}
@@ -107,7 +186,7 @@ func LoadFilesFromGit(ctx context.Context, localGitRepo git_repo.Local, projectD
 		return nil, fmt.Errorf("unable to get local repo paths for commit %s: %s", commit, err)
 	}
 
-	// FIXME: .helmignore
+	// TODO: Add .helmignore someday
 
 	relativeLoadDir := util.GetRelativeToBaseFilepath(projectDir, loadDir)
 


### PR DESCRIPTION
 - automatically perform dependency build operation for provided Chart.lock;
 - the result of dependency build is cached by the Chart.lock's digest;
 - load standard `.helm/charts` dir and charts dir using dependency build operation result.
