### PR TITLE
small cleanups and fixes

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -1208,6 +1209,94 @@ func prepareImageBasedOnImageFromDockerfile(ctx context.Context, imageFromDocker
 	logboek.Context(ctx).Info().LogFDetails("Using stage %s\n", dockerfileStage.Name())
 
 	return img, nil
+}
+
+func getDockerfileData(ctx context.Context, imageFromDockerfileConfig *config.ImageFromDockerfile, c *Conveyor, localGitRepo git_repo.Local, headCommit string) ([]byte, error) {
+	var dockerfileData []byte
+	relDockerfilePath := filepath.Join(imageFromDockerfileConfig.Context, imageFromDockerfileConfig.Dockerfile)
+	if isAccepted, err := giterminism_inspector.IsUncommittedDockerfileAccepted(relDockerfilePath); err != nil {
+		return nil, err
+	} else if isAccepted {
+		absDockerfilePath := filepath.Join(c.projectDir, relDockerfilePath)
+
+		exist, err := util.FileExists(absDockerfilePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check existence of file %s: %s", absDockerfilePath, err)
+		}
+		if !exist {
+			return nil, fmt.Errorf("dockerfile '%s' was not found", absDockerfilePath)
+		}
+
+		dockerfileData, err = ioutil.ReadFile(absDockerfilePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read file %s: %s", absDockerfilePath, err)
+		}
+	} else {
+		exists, err := localGitRepo.IsCommitFileExists(ctx, headCommit, relDockerfilePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check file %s existence in the local git repo commit %s: %s", relDockerfilePath, headCommit, err)
+		}
+		if !exists {
+			return nil, fmt.Errorf("dockerfile '%s' was not found in the local git repo commit %s", relDockerfilePath, headCommit)
+		}
+
+		dockerfileData, err = getFileDataFromGitAndCompareWithLocal(ctx, c.projectDir, localGitRepo, headCommit, relDockerfilePath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return dockerfileData, nil
+}
+
+func getDockerignorePatterns(ctx context.Context, imageFromDockerfileConfig *config.ImageFromDockerfile, c *Conveyor, localGitRepo git_repo.Local, headCommit string) ([]string, error) {
+	var dockerignorePatterns []string
+	relDockerignorePath := filepath.Join(imageFromDockerfileConfig.Context, ".dockerignore")
+	if isAccepted, err := giterminism_inspector.IsUncommittedDockerignoreAccepted(relDockerignorePath); err != nil {
+		return nil, err
+	} else if isAccepted {
+		absDockerfileignorePath := filepath.Join(c.projectDir, relDockerignorePath)
+
+		exist, err := util.FileExists(absDockerfileignorePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check existence of file %s: %s", absDockerfileignorePath, err)
+		}
+
+		if exist {
+			data, err := ioutil.ReadFile(absDockerfileignorePath)
+			if err != nil {
+				return nil, fmt.Errorf("unable to read file %s: %s", absDockerfileignorePath, err)
+			}
+
+			r := bytes.NewReader(data)
+			dockerignorePatterns, err = dockerignore.ReadAll(r)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		exist, err := localGitRepo.IsCommitFileExists(ctx, headCommit, relDockerignorePath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check file .dockerignore existence in the local git repo commit %s: %s", headCommit, err)
+		} else if exist {
+			data, err := getFileDataFromGitAndCompareWithLocal(ctx, c.projectDir, localGitRepo, headCommit, relDockerignorePath)
+			if err != nil {
+				return nil, err
+			}
+
+			r := bytes.NewReader(data)
+			dockerignorePatterns, err = dockerignore.ReadAll(r)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return dockerignorePatterns, nil
+}
+
+func getFileDataFromGitAndCompareWithLocal(ctx context.Context, projectDir string, localGitRepo git_repo.Local, commit, relPath string) ([]byte, error) {
+	return git_repo.ReadCommitFileAndCompareWithProjectFile(ctx, localGitRepo, commit, projectDir, relPath)
 }
 
 func resolveDockerStagesFromValue(stages []instructions.Stage) {

--- a/pkg/deploy/lock_manager/lock_manager.go
+++ b/pkg/deploy/lock_manager/lock_manager.go
@@ -36,7 +36,7 @@ func NewLockManager(namespace string) (*LockManager, error) {
 			Resource: "configmaps",
 		}, configMapName, namespace,
 	)
-	lockerWithRetry := locker_with_retry.NewLockerWithRetry(nil, locker, locker_with_retry.LockerWithRetryOptions{MaxAcquireAttempts: 10, MaxReleaseAttempts: 10})
+	lockerWithRetry := locker_with_retry.NewLockerWithRetry(context.Background(), locker, locker_with_retry.LockerWithRetryOptions{MaxAcquireAttempts: 10, MaxReleaseAttempts: 10})
 
 	return &LockManager{
 		Namespace:       namespace,

--- a/pkg/path_matcher/git_mapping.go
+++ b/pkg/path_matcher/git_mapping.go
@@ -63,9 +63,8 @@ func (f *GitMappingPathMatcher) ProcessDirOrSubmodulePath(path string) (bool, bo
 	isMatched, shouldGoThrough := f.processDirOrSubmodulePath(formatPath(path))
 	if f.isGreedySearchOn {
 		return false, isMatched || shouldGoThrough
-	} else {
-		return isMatched, shouldGoThrough
 	}
+	return isMatched, shouldGoThrough
 }
 
 func (f *GitMappingPathMatcher) processDirOrSubmodulePath(path string) (bool, bool) {
@@ -75,11 +74,14 @@ func (f *GitMappingPathMatcher) processDirOrSubmodulePath(path string) (bool, bo
 	if isPathRelativeToBasePath || path == f.basePath {
 		if len(f.includePaths) == 0 && len(f.excludePaths) == 0 {
 			return true, false
-		} else if hasUniversalGlob(f.excludePaths) {
+		}
+		if hasUniversalGlob(f.excludePaths) {
 			return false, false
-		} else if hasUniversalGlob(f.includePaths) {
+		}
+		if hasUniversalGlob(f.includePaths) {
 			return true, false
-		} else if path == f.basePath {
+		}
+		if path == f.basePath {
 			return false, true
 		}
 	} else if isBasePathRelativeToPath {
@@ -90,8 +92,8 @@ func (f *GitMappingPathMatcher) processDirOrSubmodulePath(path string) (bool, bo
 
 	relPath := rel(path, f.basePath)
 	relPathParts := util.SplitFilepath(relPath)
-	inProgressIncludePaths := f.includePaths[:]
-	inProgressExcludePaths := f.excludePaths[:]
+	inProgressIncludePaths := f.includePaths
+	inProgressExcludePaths := f.excludePaths
 	var matchedIncludePaths, matchedExcludePaths []string
 
 	for _, pathPart := range relPathParts {
@@ -118,19 +120,20 @@ func (f *GitMappingPathMatcher) processDirOrSubmodulePath(path string) (bool, bo
 
 	if len(inProgressExcludePaths) != 0 {
 		return false, !hasUniversalGlob(inProgressExcludePaths)
-	} else if len(inProgressIncludePaths) != 0 {
+	}
+	if len(inProgressIncludePaths) != 0 {
 		if hasUniversalGlob(inProgressIncludePaths) {
 			return true, false
-		} else {
-			return false, true
 		}
-	} else if len(matchedExcludePaths) != 0 {
-		return false, false
-	} else if len(matchedIncludePaths) != 0 {
-		return true, false
-	} else {
+		return false, true
+	}
+	if len(matchedExcludePaths) != 0 {
 		return false, false
 	}
+	if len(matchedIncludePaths) != 0 {
+		return true, false
+	}
+	return false, false
 }
 
 func matchGlobs(pathPart string, globs []string) (inProgressGlobs []string, matchedGlobs []string) {
@@ -152,16 +155,16 @@ func matchGlob(pathPart string, glob string) (inProgressGlob, matchedGlob string
 	if err != nil {
 		panic(err)
 	}
-
 	if !isMatched {
 		return "", ""
-	} else if strings.Contains(globParts[0], "**") {
-		return glob, ""
-	} else if len(globParts) > 1 {
-		return filepath.Join(globParts[1:]...), ""
-	} else {
-		return "", glob
 	}
+	if strings.Contains(globParts[0], "**") {
+		return glob, ""
+	}
+	if len(globParts) > 1 {
+		return filepath.Join(globParts[1:]...), ""
+	}
+	return "", glob
 }
 
 func hasUniversalGlob(globs []string) bool {

--- a/pkg/true_git/ls_tree/result.go
+++ b/pkg/true_git/ls_tree/result.go
@@ -67,6 +67,9 @@ func (r *Result) LsTree(ctx context.Context, pathMatcher path_matcher.PathMatche
 			}
 		} else {
 			entryLsTreeEntries, entrySubmodulesResults, err = lsTreeEntryMatch(ctx, r.repository, r.tree, r.repositoryFullFilepath, r.repositoryFullFilepath, lsTreeEntry, pathMatcher)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		res.lsTreeEntries = append(res.lsTreeEntries, entryLsTreeEntries...)


### PR DESCRIPTION
```
pkg/true_git/ls_tree/result.go:69:4: SA4006: this value of `err` is never used (staticcheck)
pkg/build/conveyor.go:1235:16: printf: Errorf format %s reads arg #4, but call has 3 args (govet)
pkg/deploy/lock_manager/lock_manager.go:39:58: SA1012: do not pass a nil Context, even if a function permits it; pass context.TODO if you are unsure about which Context to use (staticcheck)
pkg/path_matcher/git_mapping.go:93:28: unslice: could simplify f.includePaths[:] to f.includePaths (gocritic)
pkg/path_matcher/git_mapping.go:94:28: unslice: could simplify f.excludePaths[:] to f.excludePaths (gocritic)
```