### PR TITLE
unlambda in cmd

### DIFF
--- a/cmd/werf/bundle/apply/apply.go
+++ b/cmd/werf/bundle/apply/apply.go
@@ -63,9 +63,7 @@ func NewCmd() *cobra.Command {
 
 			common.LogVersion()
 
-			return common.LogRunningTime(func() error {
-				return runApply()
-			})
+			return common.LogRunningTime(runApply)
 		},
 	}
 

--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -70,9 +70,7 @@ func NewCmd() *cobra.Command {
 
 			common.LogVersion()
 
-			return common.LogRunningTime(func() error {
-				return runExport()
-			})
+			return common.LogRunningTime(runExport)
 		},
 	}
 

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -75,7 +75,7 @@ Published into container registry bundle can be rolled out by the "werf bundle "
 
 			common.LogVersion()
 
-			return common.LogRunningTime(runPublish())
+			return common.LogRunningTime(runPublish)
 		},
 	}
 

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -75,9 +75,7 @@ Published into container registry bundle can be rolled out by the "werf bundle "
 
 			common.LogVersion()
 
-			return common.LogRunningTime(func() error {
-				return runPublish()
-			})
+			return common.LogRunningTime(runPublish())
 		},
 	}
 

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -43,9 +43,7 @@ It is safe to run this command periodically (daily is enough) by automated clean
 			}
 			common.LogVersion()
 
-			return common.LogRunningTime(func() error {
-				return runCleanup()
-			})
+			return common.LogRunningTime(runCleanup)
 		},
 	}
 

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -62,9 +62,7 @@ Read more info about Helm Release name, Kubernetes Namespace and how to change i
 			}
 			common.LogVersion()
 
-			return common.LogRunningTime(func() error {
-				return runDismiss()
-			})
+			return common.LogRunningTime(runDismiss)
 		},
 	}
 

--- a/cmd/werf/host/cleanup/cleanup.go
+++ b/cmd/werf/host/cleanup/cleanup.go
@@ -43,9 +43,7 @@ It is safe to run this command periodically by automated cleanup job in parallel
 			}
 			common.LogVersion()
 
-			return common.LogRunningTime(func() error {
-				return runGC()
-			})
+			return common.LogRunningTime(runGC)
 		},
 	}
 

--- a/cmd/werf/host/purge/purge.go
+++ b/cmd/werf/host/purge/purge.go
@@ -47,9 +47,7 @@ WARNING: Do not run this command during any other werf command is working on the
 			}
 			common.LogVersion()
 
-			return common.LogRunningTime(func() error {
-				return runReset()
-			})
+			return common.LogRunningTime(runReset)
 		},
 	}
 

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -44,9 +44,7 @@ WARNING: Do not run this command during any other werf command is working on the
 			}
 			common.LogVersion()
 
-			return common.LogRunningTime(func() error {
-				return runPurge()
-			})
+			return common.LogRunningTime(runPurge)
 		},
 	}
 

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -67,9 +67,7 @@ func NewCmd() *cobra.Command {
 
 			common.LogVersion()
 
-			return common.LogRunningTime(func() error {
-				return runRender()
-			})
+			return common.LogRunningTime(runRender)
 		},
 	}
 

--- a/cmd/werf/synchronization/main.go
+++ b/cmd/werf/synchronization/main.go
@@ -50,9 +50,7 @@ func NewCmd() *cobra.Command {
 
 			common.LogVersion()
 
-			return common.LogRunningTime(func() error {
-				return runSynchronization()
-			})
+			return common.LogRunningTime(runSynchronization)
 		},
 	}
 


### PR DESCRIPTION
Found by `gocritic`

```
cmd/werf/bundle/export/export.go:71:33: unlambda: replace `func() error {
	return runExport()
}` with `runExport` (gocritic)
cmd/werf/synchronization/main.go:53:33: unlambda: replace `func() error {
	return runSynchronization()
}` with `runSynchronization` (gocritic)
cmd/werf/bundle/download/download.go:53:33: unlambda: replace `func() error {
	return runApply()
}` with `runApply` (gocritic)
cmd/werf/dismiss/dismiss.go:65:33: unlambda: replace `func() error {
	return runDismiss()
}` with `runDismiss` (gocritic)
cmd/werf/purge/purge.go:47:33: unlambda: replace `func() error {
	return runPurge()
}` with `runPurge` (gocritic)
cmd/werf/cleanup/cleanup.go:46:33: unlambda: replace `func() error {
	return runCleanup()
}` with `runCleanup` (gocritic)
cmd/werf/bundle/apply/apply.go:66:33: unlambda: replace `func() error {
	return runApply()
}` with `runApply` (gocritic)
cmd/werf/bundle/publish/publish.go:77:33: unlambda: replace `func() error {
	return runPublish()
}` with `runPublish` (gocritic)
cmd/werf/host/cleanup/cleanup.go:46:33: unlambda: replace `func() error {
	return runGC()
}` with `runGC` (gocritic)
cmd/werf/host/purge/purge.go:50:33: unlambda: replace `func() error {
	return runReset()
}` with `runReset` (gocritic)
cmd/werf/render/render.go:68:33: unlambda: replace `func() error {
	return runRender()
}` with `runRender` (gocritic)
```