### PR TITLE
Update deprecation warning for fromArtifact directive

### DIFF
--- a/pkg/config/stapel_image_base.go
+++ b/pkg/config/stapel_image_base.go
@@ -103,7 +103,7 @@ func (c *StapelImageBase) validate(giterminismManager giterminism_manager.Interf
 	}
 
 	if c.raw.FromArtifact != "" {
-		logboek.Context(context.Background()).Warn().LogLn("DEPRECATION WARNING: The directive `fromArtifact` will be removed in v1.3. Use `fromImage` or `import` directive instead!")
+		logboek.Context(context.Background()).Warn().LogLn("WARNING: Do not use artifacts as a base for other images and artifacts. The feature is deprecated, and the directive 'fromArtifact' will be completely removed in version v1.3.\n\nCareless use of artifacts may lead to difficult to trace issues that may arise long after the configuration has been written. The artifact image is cached after the first build and ignores any changes in the project git repository unless the user has explicitly specified stage dependencies. As found, this behavior is completely unexpected for users despite the fact that it is absolutely correct in the werf logic.")
 	}
 
 	// TODO: валидацию формата `From`


### PR DESCRIPTION
```
WARNING: Do not use artifacts as a base for other images and artifacts. The feature is deprecated, and the directive 'fromArtifact' will be completely removed in version v1.3.

Careless use of artifacts may lead to difficult to trace issues that may arise long after the configuration has been written. The artifact image is cached after the first build and ignores any changes in the project git repository unless the user has explicitly specified stage dependencies. As found, this behavior is completely unexpected for users despite the fact that it is absolutely correct in the werf logic.
```