### PR TITLE
Small changes for DEPRECATION WARNINGS

### DIFF
--- a/pkg/deploy/helm/chart_extender/common_template_funcs.go
+++ b/pkg/deploy/helm/chart_extender/common_template_funcs.go
@@ -22,7 +22,7 @@ func SetupIncludeWrapperFuncs(funcMap template.FuncMap) {
 
 func SetupWerfImageDeprecationFunc(ctx context.Context, funcMap template.FuncMap) {
 	funcMap["_print_werf_image_deprecation"] = func() (string, error) {
-		logboek.Context(ctx).Warn().LogF("DEPRECATION WARNING: Usage of werf_image is deprecated, use .Values.werf.image.IMAGE_NAME directly instead\n")
+		logboek.Context(ctx).Warn().LogF("DEPRECATION WARNING: Usage of werf_image is deprecated, use .Values.werf.image.IMAGE_NAME directly instead, werf_image template function will be removed in v1.3.\n")
 		return "", nil
 	}
 }

--- a/pkg/giterminism_manager/manager.go
+++ b/pkg/giterminism_manager/manager.go
@@ -26,7 +26,7 @@ func NewManager(ctx context.Context, projectDir string, localGitRepo git_repo.Lo
 	}
 
 	if options.LooseGiterminism {
-		err := errors.NewError(`WARNING: The --loose-giterminism option (and WERF_LOOSE_GITERMINISM env variable) is forbidden and will be removed soon!
+		err := errors.NewError(`DEPRECATION WARNING: The --loose-giterminism option (and WERF_LOOSE_GITERMINISM env variable) is forbidden and will be removed in v1.2!
 Please use werf-giterminism.yaml config instead to loosen giterminism restrictions if needed.`)
 		logboek.Context(ctx).Warn().LogLn(err)
 	}


### PR DESCRIPTION
 - werf_image will be removed in the v1.3;
 - DEPRECATION WARNING instead of WARNING for --loose-giterminism, will be removed in the v1.2.