### PR TITLE
[deploy] werf_image and nameless image deprecation fix

### DIFF
--- a/pkg/deploy/helm/chart_extender/chart_template_helpers.go
+++ b/pkg/deploy/helm/chart_extender/chart_template_helpers.go
@@ -8,7 +8,7 @@ var ChartTemplateHelpers = `{{- define "_werf_image" -}}
 {{-     if not $context.Values.werf.is_nameless_image -}}
 {{-       required "No image specified for template" nil -}}
 {{-     end -}}
-{{      $context.Values.werf.image }}
+{{      $context.Values.werf.nameless_image }}
 {{-   end -}}
 {{- end -}}
 

--- a/pkg/deploy/helm/chart_extender/service_values.go
+++ b/pkg/deploy/helm/chart_extender/service_values.go
@@ -44,7 +44,7 @@ func GetServiceValues(ctx context.Context, projectName string, repo string, imag
 	for _, imageInfoGetter := range imageInfoGetters {
 		if imageInfoGetter.IsNameless() {
 			werfInfo["is_nameless_image"] = true
-			werfInfo["image"] = imageInfoGetter.GetName()
+			werfInfo["nameless_image"] = imageInfoGetter.GetName()
 		} else {
 			werfInfo["image"].(map[string]interface{})[imageInfoGetter.GetWerfImageName()] = imageInfoGetter.GetName()
 		}


### PR DESCRIPTION
Pass nameless image as .Values.werf.nameless_image instead of .Values.werf.image.

.Values.werf.image is always map[string]string and will only contain named images names.

As nameless image is being deprecated in the v1.2 there is no "normal" way to get nameless image from values, that's why we use "special" value .Values.werf.nameless_image for now. In the v1.3 nameless images will be completely removed.