### PR TITLE
[giterminism] Refactoring: simplify error messages and the corresponding code

### DIFF
--- a/integration/suites/giterminism/config_dockerfile_test.go
+++ b/integration/suites/giterminism/config_dockerfile_test.go
@@ -137,11 +137,11 @@ FROM alpine
 				}
 			},
 			Entry("the dockerfile not found", entry{
-				expectedErrSubstring: `the dockerfile "Dockerfile" not found in the project git repository`,
+				expectedErrSubstring: `unable to read dockerfile "Dockerfile": the file "Dockerfile" not found in the project git repository`,
 			}),
 			Entry("the dockerfile not committed", entry{
 				addDockerfile:        true,
-				expectedErrSubstring: `the uncommitted configuration found in the project git work tree: the dockerfile "Dockerfile" must be committed`,
+				expectedErrSubstring: `unable to read dockerfile "Dockerfile": the file "Dockerfile" must be committed`,
 			}),
 			Entry("the dockerfile committed", entry{
 				addDockerfile:    true,
@@ -151,7 +151,7 @@ FROM alpine
 				addDockerfile:               true,
 				commitDockerfile:            true,
 				changeDockerfileAfterCommit: true,
-				expectedErrSubstring:        `the uncommitted configuration found in the project git work tree: the dockerfile "Dockerfile" changes must be committed`,
+				expectedErrSubstring:        `unable to read dockerfile "Dockerfile": the file "Dockerfile" changes must be committed`,
 			}),
 			Entry(`config.dockerfile.allowUncommitted (Dockerfile) covers the uncommitted dockerfile "Dockerfile"`, entry{
 				configDockerfileAllowUncommittedGlob: "Dockerfile",
@@ -169,13 +169,13 @@ FROM alpine
 			Entry(`config.dockerfile.allowUncommitted (docker*) does not cover the dockerfile "Dockerfile"`, entry{
 				configDockerfileAllowUncommittedGlob: "docker*",
 				addDockerfile:                        true,
-				expectedErrSubstring:                 `the uncommitted configuration found in the project git work tree: the dockerfile "Dockerfile" must be committed`,
+				expectedErrSubstring:                 `unable to read dockerfile "Dockerfile": the file "Dockerfile" must be committed`,
 			}),
 			Entry(`config.dockerfile.allowContextAddFiles (Dockerfile) does not cover the dockerfile "Dockerfile" inside context "context"`, entry{
 				configDockerfileAllowUncommittedGlob: "Dockerfile",
 				context:                              "context",
 				addDockerfile:                        true,
-				expectedErrSubstring:                 `the uncommitted configuration found in the project git work tree: the dockerfile "context/Dockerfile" must be committed`,
+				expectedErrSubstring:                 `unable to read dockerfile "context/Dockerfile": the file "context/Dockerfile" must be committed`,
 			}),
 			Entry(`config.dockerfile.allowContextAddFiles (context/Dockerfile) covers the dockerfile "Dockerfile" inside context "context"`, entry{
 				configDockerfileAllowUncommittedGlob: "context/Dockerfile",
@@ -250,7 +250,7 @@ config:
 			Entry("the dockerignore not found", entry{}),
 			Entry("the dockerignore not committed", entry{
 				addDockerignore:      true,
-				expectedErrSubstring: `the uncommitted configuration found in the project git work tree: the dockerignore file ".dockerignore" must be committed`,
+				expectedErrSubstring: `unable to read dockerignore file ".dockerignore": the file ".dockerignore" must be committed`,
 			}),
 			Entry("the dockerignore committed", entry{
 				addDockerignore:    true,
@@ -260,7 +260,7 @@ config:
 				addDockerignore:               true,
 				commitDockerignore:            true,
 				changeDockerignoreAfterCommit: true,
-				expectedErrSubstring:          `the uncommitted configuration found in the project git work tree: the dockerignore file ".dockerignore" changes must be committed`,
+				expectedErrSubstring:          `unable to read dockerignore file ".dockerignore": the file ".dockerignore" changes must be committed`,
 			}),
 			Entry(`config.dockerfile.allowUncommittedDockerignoreFiles (.dockerignore) covers the uncommitted dockerignore ".dockerignore"`, entry{
 				configDockerfileAllowUncommittedDockerignoreFilesGlob: ".dockerignore",
@@ -278,13 +278,13 @@ config:
 			Entry(`config.dockerfile.allowUncommittedDockerignoreFiles (docker*) does not cover the dockerignore ".dockerignore"`, entry{
 				configDockerfileAllowUncommittedDockerignoreFilesGlob: "docker*",
 				addDockerignore:      true,
-				expectedErrSubstring: `the uncommitted configuration found in the project git work tree: the dockerignore file ".dockerignore" must be committed`,
+				expectedErrSubstring: `unable to read dockerignore file ".dockerignore": the file ".dockerignore" must be committed`,
 			}),
 			Entry(`config.dockerignore.allowContextAddFiles (.dockerignore) does not cover the dockerignore ".dockerignore" inside context "context"`, entry{
 				configDockerfileAllowUncommittedDockerignoreFilesGlob: ".dockerignore",
 				context:              "context",
 				addDockerignore:      true,
-				expectedErrSubstring: `the uncommitted configuration found in the project git work tree: the dockerignore file "context/.dockerignore" must be committed`,
+				expectedErrSubstring: `unable to read dockerignore file "context/.dockerignore": the file "context/.dockerignore" must be committed`,
 			}),
 			Entry(`config.dockerignore.allowContextAddFiles (context/.dockerignore) covers the dockerignore ".dockerignore" inside context "context"`, entry{
 				configDockerfileAllowUncommittedDockerignoreFilesGlob: "context/.dockerignore",

--- a/integration/suites/giterminism/config_go_template_test.go
+++ b/integration/suites/giterminism/config_go_template_test.go
@@ -75,7 +75,7 @@ config:
 				}),
 				Entry("the file not committed", entryBase{
 					addFiles:             []string{".werf/file"},
-					expectedErrSubstring: `error calling Get: {{ .Files.Get ".werf/file" }}: the uncommitted configuration found in the project git work tree: the file ".werf/file" must be committed`,
+					expectedErrSubstring: `error calling Get: {{ .Files.Get ".werf/file" }}: the file ".werf/file" must be committed`,
 				}),
 				Entry("the file committed", entryBase{
 					addFiles:    []string{".werf/file"},
@@ -94,7 +94,7 @@ config:
 					addFiles:               []string{".werf/file"},
 					commitFiles:            []string{".werf/file"},
 					changeFilesAfterCommit: []string{".werf/file"},
-					expectedErrSubstring:   `error calling Get: {{ .Files.Get ".werf/file" }}: the uncommitted configuration found in the project git work tree: the file ".werf/file" changes must be committed`,
+					expectedErrSubstring:   `error calling Get: {{ .Files.Get ".werf/file" }}: the file ".werf/file" changes must be committed`,
 				}),
 			)
 		})
@@ -121,14 +121,14 @@ config:
 					filesGlob: ".werf/file1",
 					entryBase: entryBase{
 						addFiles:             []string{".werf/file1"},
-						expectedErrSubstring: `error calling Glob: {{ .Files.Glob ".werf/file1" }}: the uncommitted configuration found in the project git work tree: the file ".werf/file1" must be committed`,
+						expectedErrSubstring: `error calling Glob: {{ .Files.Glob ".werf/file1" }}: the file ".werf/file1" must be committed`,
 					},
 				}),
 				Entry("the files not committed", entry{
 					filesGlob: ".werf/*",
 					entryBase: entryBase{
 						addFiles: []string{".werf/file1", ".werf/file2", ".werf/file3"},
-						expectedErrSubstring: `error calling Glob: {{ .Files.Glob ".werf/*" }}: the uncommitted configuration found in the project git work tree: the following files must be committed:
+						expectedErrSubstring: `error calling Glob: {{ .Files.Glob ".werf/*" }}: the following files must be committed:
 
  - .werf/file1
  - .werf/file2
@@ -150,7 +150,7 @@ config:
 						addFiles:               []string{".werf/file1"},
 						commitFiles:            []string{".werf/file1"},
 						changeFilesAfterCommit: []string{".werf/file1"},
-						expectedErrSubstring:   `error calling Glob: {{ .Files.Glob ".werf/file1" }}: the uncommitted configuration found in the project git work tree: the file ".werf/file1" changes must be committed`,
+						expectedErrSubstring:   `error calling Glob: {{ .Files.Glob ".werf/file1" }}: the file ".werf/file1" changes must be committed`,
 					},
 				}),
 				Entry("config.goTemplateRendering.allowUncommittedFiles (.werf/file1) covers the not committed file", entry{

--- a/integration/suites/giterminism/config_templates_dir_test.go
+++ b/integration/suites/giterminism/config_templates_dir_test.go
@@ -1,8 +1,6 @@
 package giterminism_test
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -23,7 +21,7 @@ var _ = Describe("config templates dir", func() {
 		expectedErrSubstring         string
 	}
 
-	DescribeTable("allowUncommittedTemplates",
+	DescribeTable("config.allowUncommittedTemplates",
 		func(e entry) {
 			tmpl1RelPath := ".werf/templates/1.tmpl"
 			tmpl2RelPath := ".werf/templates/2.tmpl"
@@ -89,9 +87,9 @@ config:
 				}
 			}
 		},
-		Entry(".werf/templates/1.tmpl not found in commit", entry{
+		Entry(".werf/templates/1.tmpl not committed", entry{
 			addTemplate1:         true,
-			expectedErrSubstring: fmt.Sprintf("the uncommitted configuration found in the project git work tree: the werf config template %q must be committed", ".werf/templates/1.tmpl"),
+			expectedErrSubstring: `unable to read werf config templates: the file ".werf/templates/1.tmpl" must be committed`,
 		}),
 		Entry(".werf/templates/1.tmpl committed", entry{
 			addTemplate1:    true,
@@ -101,7 +99,7 @@ config:
 			addTemplate1:               true,
 			commitTemplate1:            true,
 			changeTemplate1AfterCommit: true,
-			expectedErrSubstring:       `the uncommitted configuration found in the project git work tree: the werf config template ".werf/templates/1.tmpl" changes must be committed`,
+			expectedErrSubstring:       `unable to read werf config templates: the file ".werf/templates/1.tmpl" changes must be committed`,
 		}),
 		Entry("config.allowUncommittedTemplates has .werf/templates/1.tmpl, the template file not committed", entry{
 			allowUncommittedTemplate1: true,
@@ -117,7 +115,7 @@ config:
 			addTemplate1:              true,
 			addTemplate2:              true,
 			commitTemplate1:           true,
-			expectedErrSubstring:      `the uncommitted configuration found in the project git work tree: the werf config template ".werf/templates/2.tmpl" must be committed`,
+			expectedErrSubstring:      `unable to read werf config templates: the file ".werf/templates/2.tmpl" must be committed`,
 		}),
 		Entry("config.allowUncommittedTemplates has .werf/**/*.tmpl", entry{
 			allowUncommittedAllTemplates: true,

--- a/integration/suites/giterminism/config_test.go
+++ b/integration/suites/giterminism/config_test.go
@@ -68,11 +68,11 @@ project: none
 			}
 		},
 		Entry("werf.yaml not found", entry{
-			expectedErrSubstring: `the werf config "werf.yaml" not found in the project git repository`,
+			expectedErrSubstring: `unable to read werf config: the file "werf.yaml" not found in the project git repository`,
 		}),
 		Entry("werf.yaml not committed", entry{
 			addConfig:            true,
-			expectedErrSubstring: `the uncommitted configuration found in the project git work tree: the werf config "werf.yaml" must be committed`,
+			expectedErrSubstring: `unable to read werf config: the file "werf.yaml" must be committed`,
 		}),
 		Entry("werf.yaml committed", entry{
 			addConfig:    true,
@@ -82,7 +82,7 @@ project: none
 			addConfig:               true,
 			commitConfig:            true,
 			changeConfigAfterCommit: true,
-			expectedErrSubstring:    `the uncommitted configuration found in the project git work tree: the werf config "werf.yaml" changes must be committed`,
+			expectedErrSubstring:    `unable to read werf config: the file "werf.yaml" changes must be committed`,
 		}),
 		Entry("config.allowUncommitted is true, werf.yaml not committed", entry{
 			allowUncommitted: true,

--- a/integration/suites/giterminism/giterminism_config_test.go
+++ b/integration/suites/giterminism/giterminism_config_test.go
@@ -53,7 +53,7 @@ var _ = Describe("giterminism config", func() {
 		Entry("the giterminism config not exist", entry{}),
 		Entry("the giterminism config not committed", entry{
 			addConfig:            true,
-			expectedErrSubstring: "the uncommitted configuration found in the project git work tree: the giterminism config \"werf-giterminism.yaml\" must be committed",
+			expectedErrSubstring: `unable to read werf giterminism config: the file "werf-giterminism.yaml" must be committed`,
 		}),
 		Entry("the giterminism config committed", entry{
 			addConfig:    true,
@@ -63,7 +63,7 @@ var _ = Describe("giterminism config", func() {
 			addConfig:               true,
 			commitConfig:            true,
 			changeConfigAfterCommit: true,
-			expectedErrSubstring:    "the uncommitted configuration found in the project git work tree: the giterminism config \"werf-giterminism.yaml\" changes must be committed",
+			expectedErrSubstring:    `unable to read werf giterminism config: the file "werf-giterminism.yaml" changes must be committed`,
 		}),
 	)
 })

--- a/integration/suites/giterminism/helm_test.go
+++ b/integration/suites/giterminism/helm_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/werf/werf/integration/pkg/utils"
 )
 
-var _ = Describe("config", func() {
+var _ = Describe("helm chart files", func() {
 	BeforeEach(func() {
 		gitInit()
 		utils.CopyIn(utils.FixturePath("default"), SuiteData.TestDirPath)
@@ -67,16 +67,16 @@ helm:
 			}
 		},
 		Entry("the chart directory not found", entry{
-			expectedErrSubstring: `the chart directory ".helm" not found in the project git repository`,
+			expectedErrSubstring: `unable to locate chart directory: the directory ".helm" not found in the project git repository`,
 		}),
 		Entry(`the template file ".helm/templates/template1.yaml" not committed`, entry{
 			addFiles:             []string{".helm/templates/template1.yaml"},
-			expectedErrSubstring: `the uncommitted configuration found in the project git work tree: the chart file ".helm/templates/template1.yaml" must be committed`,
+			expectedErrSubstring: `unable to locate chart directory: the file ".helm/templates/template1.yaml" must be committed`,
 		}),
 		Entry("the template files not committed", entry{
 			addFiles:    []string{".helm/templates/template1.yaml", ".helm/templates/template2.yaml", ".helm/templates/template3.yaml"},
 			commitFiles: []string{".helm/templates/template1.yaml"},
-			expectedErrSubstring: `the uncommitted configuration found in the project git work tree: the following chart files must be committed:
+			expectedErrSubstring: `unable to locate chart directory: the following files must be committed:
 
  - .helm/templates/template2.yaml
  - .helm/templates/template3.yaml
@@ -91,13 +91,13 @@ helm:
 			addFiles:               []string{".helm/templates/template1.yaml"},
 			commitFiles:            []string{".helm/templates/template1.yaml"},
 			changeFilesAfterCommit: []string{".helm/templates/template1.yaml"},
-			expectedErrSubstring:   `the uncommitted configuration found in the project git work tree: the chart file ".helm/templates/template1.yaml" changes must be committed`,
+			expectedErrSubstring:   `unable to locate chart directory: the file ".helm/templates/template1.yaml" changes must be committed`,
 		}),
 		Entry("the template files changed after commit", entry{
 			addFiles:               []string{".helm/templates/template1.yaml", ".helm/templates/template2.yaml", ".helm/templates/template3.yaml"},
 			commitFiles:            []string{".helm/templates/template1.yaml", ".helm/templates/template2.yaml", ".helm/templates/template3.yaml"},
 			changeFilesAfterCommit: []string{".helm/templates/template1.yaml", ".helm/templates/template2.yaml", ".helm/templates/template3.yaml"},
-			expectedErrSubstring: `the uncommitted configuration found in the project git work tree: the following chart files changes must be committed:
+			expectedErrSubstring: `unable to locate chart directory: the following files changes must be committed:
 
  - .helm/templates/template1.yaml
  - .helm/templates/template2.yaml

--- a/pkg/giterminism_manager/file_reader/config_go_template.go
+++ b/pkg/giterminism_manager/file_reader/config_go_template.go
@@ -11,10 +11,8 @@ func (r FileReader) ConfigGoTemplateFilesGlob(ctx context.Context, pattern strin
 
 	if err := r.configurationFilesGlob(
 		ctx,
-		configGoTemplateErrorConfigType,
 		pattern,
 		r.giterminismConfig.IsUncommittedConfigGoTemplateRenderingFileAccepted,
-		r.readCommitConfigGoTemplateFile,
 		func(relPath string, data []byte, err error) error {
 			if err != nil {
 				return err
@@ -45,15 +43,9 @@ func (r FileReader) ConfigGoTemplateFilesGet(ctx context.Context, relPath string
 }
 
 func (r FileReader) checkConfigGoTemplateFileExistence(ctx context.Context, relPath string) error {
-	return r.checkConfigurationFileExistence(ctx, configGoTemplateErrorConfigType, relPath, r.giterminismConfig.IsUncommittedConfigGoTemplateRenderingFileAccepted)
+	return r.checkConfigurationFileExistence(ctx, relPath, r.giterminismConfig.IsUncommittedConfigGoTemplateRenderingFileAccepted)
 }
 
 func (r FileReader) readConfigGoTemplateFile(ctx context.Context, relPath string) ([]byte, error) {
-	return r.readConfigurationFile(ctx, configGoTemplateErrorConfigType, relPath, r.giterminismConfig.IsUncommittedConfigGoTemplateRenderingFileAccepted)
-}
-
-func (r FileReader) readCommitConfigGoTemplateFile(ctx context.Context, relPath string) ([]byte, error) {
-	return r.readCommitFile(ctx, relPath, func(ctx context.Context, relPath string) error {
-		return NewUncommittedFilesChangesError(configGoTemplateErrorConfigType, relPath)
-	})
+	return r.readConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedConfigGoTemplateRenderingFileAccepted)
 }

--- a/pkg/giterminism_manager/file_reader/config_templates.go
+++ b/pkg/giterminism_manager/file_reader/config_templates.go
@@ -2,6 +2,7 @@ package file_reader
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/werf/werf/pkg/util"
@@ -10,6 +11,15 @@ import (
 var DefaultWerfConfigTemplatesDirName = ".werf"
 
 func (r FileReader) ReadConfigTemplateFiles(ctx context.Context, customDirRelPath string, tmplFunc func(templatePathInsideDir string, data []byte, err error) error) error {
+	err := r.readConfigTemplateFiles(ctx, customDirRelPath, tmplFunc)
+	if err != nil {
+		return fmt.Errorf("unable to read werf config templates: %s", err)
+	}
+
+	return nil
+}
+
+func (r FileReader) readConfigTemplateFiles(ctx context.Context, customDirRelPath string, tmplFunc func(templatePathInsideDir string, data []byte, err error) error) error {
 	templatesDirRelPath := DefaultWerfConfigTemplatesDirName
 	if customDirRelPath != "" {
 		templatesDirRelPath = customDirRelPath
@@ -18,19 +28,11 @@ func (r FileReader) ReadConfigTemplateFiles(ctx context.Context, customDirRelPat
 	pattern := filepath.Join(templatesDirRelPath, "**", "*.tmpl")
 	return r.configurationFilesGlob(
 		ctx,
-		configTemplateErrorConfigType,
 		pattern,
 		r.giterminismConfig.IsUncommittedConfigTemplateFileAccepted,
-		r.readCommitConfigTemplateFile,
 		func(relPath string, data []byte, err error) error {
 			templatePathInsideDir := util.GetRelativeToBaseFilepath(templatesDirRelPath, relPath)
 			return tmplFunc(templatePathInsideDir, data, err)
 		},
 	)
-}
-
-func (r FileReader) readCommitConfigTemplateFile(ctx context.Context, relPath string) ([]byte, error) {
-	return r.readCommitFile(ctx, relPath, func(ctx context.Context, relPath string) error {
-		return NewUncommittedFilesChangesError(configTemplateErrorConfigType, relPath)
-	})
 }

--- a/pkg/giterminism_manager/file_reader/dockerfile.go
+++ b/pkg/giterminism_manager/file_reader/dockerfile.go
@@ -2,22 +2,25 @@ package file_reader
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 )
 
 func (r FileReader) ReadDockerfile(ctx context.Context, relPath string) ([]byte, error) {
-	if err := r.checkDockerfileExistence(ctx, relPath); err != nil {
-		return nil, err
+	data, err := r.readDockerfile(ctx, relPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read dockerfile %q: %s", filepath.ToSlash(relPath), err)
 	}
 
-	return r.readDockerfile(ctx, relPath)
+	return data, nil
 }
 
 func (r FileReader) readDockerfile(ctx context.Context, relPath string) ([]byte, error) {
-	return r.readConfigurationFile(ctx, dockerfileErrorConfigType, relPath, r.giterminismConfig.IsUncommittedDockerfileAccepted)
-}
+	if err := r.checkConfigurationFileExistence(ctx, relPath, r.giterminismConfig.IsUncommittedDockerfileAccepted); err != nil {
+		return nil, err
+	}
 
-func (r FileReader) checkDockerfileExistence(ctx context.Context, relPath string) error {
-	return r.checkConfigurationFileExistence(ctx, dockerfileErrorConfigType, relPath, r.giterminismConfig.IsUncommittedDockerfileAccepted)
+	return r.readConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedDockerfileAccepted)
 }
 
 func (r FileReader) IsDockerignoreExistAnywhere(ctx context.Context, relPath string) (bool, error) {
@@ -25,21 +28,22 @@ func (r FileReader) IsDockerignoreExistAnywhere(ctx context.Context, relPath str
 }
 
 func (r FileReader) ReadDockerignore(ctx context.Context, relPath string) ([]byte, error) {
-	if err := r.checkDockerignoreExistence(ctx, relPath); err != nil {
+	data, err := r.readDockerignore(ctx, relPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read dockerignore file %q: %s", filepath.ToSlash(relPath), err)
+	}
+
+	return data, nil
+}
+
+func (r FileReader) readDockerignore(ctx context.Context, relPath string) ([]byte, error) {
+	if err := r.checkConfigurationFileExistence(ctx, relPath, r.giterminismConfig.IsUncommittedDockerignoreAccepted); err != nil {
 		return nil, err
 	}
 
-	return r.readDockerignore(ctx, relPath)
-}
-
-func (r FileReader) checkDockerignoreExistence(ctx context.Context, relPath string) error {
-	return r.checkConfigurationFileExistence(ctx, dockerignoreErrorConfigType, relPath, r.giterminismConfig.IsUncommittedDockerignoreAccepted)
+	return r.readConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedDockerignoreAccepted)
 }
 
 func (r FileReader) isDockerignoreExist(ctx context.Context, relPath string) (bool, error) {
 	return r.isConfigurationFileExist(ctx, relPath, r.giterminismConfig.IsUncommittedDockerignoreAccepted)
-}
-
-func (r FileReader) readDockerignore(ctx context.Context, relPath string) ([]byte, error) {
-	return r.readConfigurationFile(ctx, dockerignoreErrorConfigType, relPath, r.giterminismConfig.IsUncommittedDockerignoreAccepted)
 }

--- a/pkg/giterminism_manager/file_reader/errors.go
+++ b/pkg/giterminism_manager/file_reader/errors.go
@@ -8,7 +8,7 @@ import (
 	"github.com/werf/werf/pkg/giterminism_manager/errors"
 )
 
-type FilesNotFoundInTheProjectDirectoryError struct {
+type FilesNotFoundInProjectDirectoryError struct {
 	error
 }
 type FilesNotFoundInTheProjectGitRepositoryError struct {
@@ -30,25 +30,25 @@ func isUncommittedFilesChangesError(err error) bool {
 	}
 }
 
-func NewFilesNotFoundInTheProjectDirectoryError(configType configType, relPaths ...string) error {
+func NewFilesNotFoundInProjectDirectoryError(relPaths ...string) error {
 	var errorMsg string
 	if len(relPaths) == 1 {
-		errorMsg = fmt.Sprintf("the %s %q not found in the project git repository", configType, filepath.ToSlash(relPaths[0]))
+		errorMsg = fmt.Sprintf("the file %q not found in the project directory", filepath.ToSlash(relPaths[0]))
 	} else if len(relPaths) > 1 {
-		errorMsg = fmt.Sprintf("the following %ss not found in the project git repository:\n\n%s", configType, prepareListOfFilesString(relPaths))
+		errorMsg = fmt.Sprintf("the following files not found in the project directory:\n\n%s", prepareListOfFilesString(relPaths))
 	} else {
 		panic("unexpected condition")
 	}
 
-	return FilesNotFoundInTheProjectDirectoryError{errors.NewError(errorMsg)}
+	return FilesNotFoundInProjectDirectoryError{errors.NewError(errorMsg)}
 }
 
-func NewFilesNotFoundInTheProjectGitRepositoryError(configType configType, relPaths ...string) error {
+func NewFilesNotFoundInProjectGitRepositoryError(relPaths ...string) error {
 	var errorMsg string
 	if len(relPaths) == 1 {
-		errorMsg = fmt.Sprintf("the %s %q not found in the project git repository", configType, filepath.ToSlash(relPaths[0]))
+		errorMsg = fmt.Sprintf("the file %q not found in the project git repository", filepath.ToSlash(relPaths[0]))
 	} else if len(relPaths) > 1 {
-		errorMsg = fmt.Sprintf("the following %ss not found in the project git repository:\n\n%s", configType, prepareListOfFilesString(relPaths))
+		errorMsg = fmt.Sprintf("the following files not found in the project git repository:\n\n%s", prepareListOfFilesString(relPaths))
 	} else {
 		panic("unexpected condition")
 	}
@@ -56,12 +56,12 @@ func NewFilesNotFoundInTheProjectGitRepositoryError(configType configType, relPa
 	return FilesNotFoundInTheProjectGitRepositoryError{errors.NewError(errorMsg)}
 }
 
-func NewUncommittedFilesError(configType configType, relPaths ...string) error {
-	errorMsg := "the uncommitted configuration found in the project git work tree"
+func NewUncommittedFilesError(relPaths ...string) error {
+	var errorMsg string
 	if len(relPaths) == 1 {
-		errorMsg = fmt.Sprintf("%s: the %s %q must be committed", errorMsg, configType, filepath.ToSlash(relPaths[0]))
+		errorMsg = fmt.Sprintf("the file %q must be committed", filepath.ToSlash(relPaths[0]))
 	} else if len(relPaths) > 1 {
-		errorMsg = fmt.Sprintf("%s: the following %ss must be committed:\n\n%s", errorMsg, configType, prepareListOfFilesString(relPaths))
+		errorMsg = fmt.Sprintf("the following files must be committed:\n\n%s", prepareListOfFilesString(relPaths))
 	} else {
 		panic("unexpected condition")
 	}
@@ -69,12 +69,12 @@ func NewUncommittedFilesError(configType configType, relPaths ...string) error {
 	return UncommittedFilesError{errors.NewError(errorMsg)}
 }
 
-func NewUncommittedFilesChangesError(configType configType, relPaths ...string) error {
-	errorMsg := "the uncommitted configuration found in the project git work tree"
+func NewUncommittedFilesChangesError(relPaths ...string) error {
+	var errorMsg string
 	if len(relPaths) == 1 {
-		errorMsg = fmt.Sprintf("%s: the %s %q changes must be committed", errorMsg, configType, filepath.ToSlash(relPaths[0]))
+		errorMsg = fmt.Sprintf("the file %q changes must be committed", filepath.ToSlash(relPaths[0]))
 	} else if len(relPaths) > 1 {
-		errorMsg = fmt.Sprintf("%s: the following %ss changes must be committed:\n\n%s", errorMsg, configType, prepareListOfFilesString(relPaths))
+		errorMsg = fmt.Sprintf("the following files changes must be committed:\n\n%s", prepareListOfFilesString(relPaths))
 	} else {
 		panic("unexpected condition")
 	}

--- a/pkg/giterminism_manager/file_reader/file_reader.go
+++ b/pkg/giterminism_manager/file_reader/file_reader.go
@@ -2,19 +2,6 @@ package file_reader
 
 import "github.com/werf/werf/pkg/git_repo"
 
-type configType string
-
-const (
-	giterminismConfigErrorConfigType configType = "giterminism config"
-	configErrorConfigType            configType = "werf config"
-	configTemplateErrorConfigType    configType = "werf config template"
-	configGoTemplateErrorConfigType  configType = "file"
-	dockerfileErrorConfigType        configType = "dockerfile"
-	dockerignoreErrorConfigType      configType = "dockerignore file"
-	chartFileErrorConfigType         configType = "chart file"
-	chartDirectoryErrorConfigType    configType = "chart directory"
-)
-
 type FileReader struct {
 	sharedOptions     sharedOptions
 	giterminismConfig giterminismConfig

--- a/pkg/giterminism_manager/file_reader/git.go
+++ b/pkg/giterminism_manager/file_reader/git.go
@@ -61,7 +61,7 @@ func (r FileReader) commitFilesGlob(ctx context.Context, pattern string) ([]stri
 	pattern = filepath.ToSlash(pattern)
 	for _, relToGitFilepath := range commitPathList {
 		relToGitPath := filepath.ToSlash(relToGitFilepath)
-		relPath := util.GetRelativeToBaseFilepath(r.relativeToGitWorkingDir(), relToGitPath)
+		relPath := filepath.ToSlash(util.GetRelativeToBaseFilepath(r.relativeToGitWorkingDir(), relToGitPath))
 
 		if matched, err := doublestar.Match(pattern, relPath); err != nil {
 			return nil, err

--- a/pkg/giterminism_manager/file_reader/git.go
+++ b/pkg/giterminism_manager/file_reader/git.go
@@ -73,7 +73,7 @@ func (r FileReader) commitFilesGlob(ctx context.Context, pattern string) ([]stri
 	return result, nil
 }
 
-func (r FileReader) readCommitFile(ctx context.Context, relPath string, handleUncommittedChangesFunc func(context.Context, string) error) ([]byte, error) {
+func (r FileReader) readCommitFile(ctx context.Context, relPath string) ([]byte, error) {
 	logboek.Context(ctx).Debug().LogF("-- giterminism_manager.FileReader.readCommitFile relPath=%q\n", relPath)
 
 	fileRepoPath := r.relativeToGitPath(filepath.ToSlash(relPath))
@@ -83,17 +83,13 @@ func (r FileReader) readCommitFile(ctx context.Context, relPath string, handleUn
 		return nil, fmt.Errorf("unable to read file %q from the local git repo commit %s: %s", relPath, r.sharedOptions.HeadCommit(), err)
 	}
 
-	if handleUncommittedChangesFunc == nil {
-		return repoData, nil
-	}
-
 	isDataIdentical, err := r.compareFileData(relPath, repoData)
 	if err != nil {
 		return nil, fmt.Errorf("unable to compare commit file %q with the local project file: %s", relPath, err)
 	}
 
 	if !isDataIdentical {
-		if err := handleUncommittedChangesFunc(ctx, filepath.FromSlash(relPath)); err != nil {
+		if err := NewUncommittedFilesChangesError(relPath); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/giterminism_manager/file_reader/giterminism_config.go
+++ b/pkg/giterminism_manager/file_reader/giterminism_config.go
@@ -1,6 +1,9 @@
 package file_reader
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 const GiterminismConfigName = "werf-giterminism.yaml"
 
@@ -9,17 +12,22 @@ func (r FileReader) IsGiterminismConfigExistAnywhere(ctx context.Context) (bool,
 }
 
 func (r FileReader) ReadGiterminismConfig(ctx context.Context) ([]byte, error) {
-	if err := r.checkConfigurationFileExistence(ctx, giterminismConfigErrorConfigType, GiterminismConfigName, func(relPath string) (bool, error) {
+	data, err := r.readGiterminismConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read werf giterminism config: %s", err)
+	}
+
+	return data, nil
+}
+
+func (r FileReader) readGiterminismConfig(ctx context.Context) ([]byte, error) {
+	if err := r.checkConfigurationFileExistence(ctx, GiterminismConfigName, func(relPath string) (bool, error) {
 		return false, nil
 	}); err != nil {
 		return nil, err
 	}
 
-	return r.readGiterminismConfig(ctx)
-}
-
-func (r FileReader) readGiterminismConfig(ctx context.Context) ([]byte, error) {
-	return r.readConfigurationFile(ctx, giterminismConfigErrorConfigType, GiterminismConfigName, func(relPath string) (bool, error) {
+	return r.readConfigurationFile(ctx, GiterminismConfigName, func(relPath string) (bool, error) {
 		return false, nil
 	})
 }

--- a/pkg/giterminism_manager/file_reader/helm_chart_extender.go
+++ b/pkg/giterminism_manager/file_reader/helm_chart_extender.go
@@ -15,26 +15,40 @@ import (
 func (r FileReader) LocateChart(ctx context.Context, relDir string, _ *cli.EnvSettings) (string, error) {
 	files, err := r.loadChartDir(ctx, relDir)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("unable to locate chart directory: %s", err)
 	}
 
 	if len(files) == 0 {
-		return "", NewFilesNotFoundInTheProjectGitRepositoryError(chartDirectoryErrorConfigType, relDir)
+		return "", NewFilesNotFoundInProjectGitRepositoryError(relDir)
 	}
 
 	return relDir, nil
 }
 
 func (r FileReader) ReadChartFile(ctx context.Context, relPath string) ([]byte, error) {
-	if err := r.checkChartFileExistence(ctx, relPath); err != nil {
+	data, err := r.readChartFile(ctx, relPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read chart file %q: %s", filepath.ToSlash(relPath), err)
+	}
+
+	return data, nil
+}
+
+func (r FileReader) readChartFile(ctx context.Context, relPath string) ([]byte, error) {
+	if err := r.checkConfigurationFileExistence(ctx, relPath, r.giterminismConfig.IsUncommittedHelmFileAccepted); err != nil {
 		return nil, err
 	}
 
-	return r.readChartFile(ctx, relPath)
+	return r.readConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedHelmFileAccepted)
 }
 
 func (r FileReader) LoadChartDir(ctx context.Context, relDir string) ([]*chart.ChartExtenderBufferedFile, error) {
-	return r.loadChartDir(ctx, relDir)
+	files, err := r.loadChartDir(ctx, relDir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load chart dir %q: %s", filepath.ToSlash(relDir), err)
+	}
+
+	return files, nil
 }
 
 // TODO helmignore support
@@ -44,7 +58,7 @@ func (r FileReader) loadChartDir(ctx context.Context, relDir string) ([]*chart.C
 	if exist, err := r.isConfigurationFileExistAnywhere(ctx, relDir); err != nil {
 		return nil, err
 	} else if !exist {
-		return nil, NewFilesNotFoundInTheProjectGitRepositoryError(chartDirectoryErrorConfigType, relDir)
+		return nil, fmt.Errorf("the directory %q not found in the project git repository", relDir)
 	}
 
 	// TODO configurationFilesGlob method must resolve symlinks properly
@@ -56,10 +70,8 @@ func (r FileReader) loadChartDir(ctx context.Context, relDir string) ([]*chart.C
 	pattern := filepath.Join(relDir, "**/*")
 	if err := r.configurationFilesGlob(
 		ctx,
-		chartFileErrorConfigType,
 		pattern,
 		r.giterminismConfig.IsUncommittedHelmFileAccepted,
-		r.readChartFile,
 		func(relPath string, data []byte, err error) error {
 			if err != nil {
 				return err
@@ -98,12 +110,4 @@ func (r FileReader) resolveChartDirectory(relDir string) (string, error) {
 	}
 
 	return util.GetRelativeToBaseFilepath(r.sharedOptions.ProjectDir(), link), nil
-}
-
-func (r FileReader) readChartFile(ctx context.Context, relPath string) ([]byte, error) {
-	return r.readConfigurationFile(ctx, chartFileErrorConfigType, relPath, r.giterminismConfig.IsUncommittedHelmFileAccepted)
-}
-
-func (r FileReader) checkChartFileExistence(ctx context.Context, relPath string) error {
-	return r.checkConfigurationFileExistence(ctx, chartFileErrorConfigType, relPath, r.giterminismConfig.IsUncommittedHelmFileAccepted)
 }


### PR DESCRIPTION
```
the <config type> '<path>' not found in the project git repository
=>
unable to read <config type>: the file "<path>" not found in the project git repository

the uncommitted configuration found in the project directory: the <config type> '<path>' must be committed
=>
unable to read <config type>: the file "<path>" must be committed
```