### PR TITLE
Fix dockerfile-not-found error when running werf not from the root of the git work tree

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -1044,12 +1045,12 @@ func GetHelmChartDir(werfConfig *config.WerfConfig, giterminismManager gitermini
 		helmChartDir = ".helm"
 	}
 
-	absHelmChartDir := util.GetAbsoluteFilepath(helmChartDir)
+	absHelmChartDir := filepath.Join(giterminismManager.ProjectDir(), helmChartDir)
 	if !util.IsSubpathOfBasePath(giterminismManager.LocalGitRepo().WorkTreeDir, absHelmChartDir) {
-		return "", fmt.Errorf("the chart directory %q must be in the project git work tree %q", helmChartDir, giterminismManager.LocalGitRepo().WorkTreeDir)
+		return "", fmt.Errorf("the chart directory %s must be in the project git work tree %s", absHelmChartDir, giterminismManager.LocalGitRepo().WorkTreeDir)
 	}
 
-	return util.GetRelativeToBaseFilepath(giterminismManager.ProjectDir(), absHelmChartDir), nil
+	return absHelmChartDir, nil
 }
 
 func GetNamespace(cmdData *CmdData) string {

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -1020,8 +1020,6 @@ func GetWorkingDir(cmdData *CmdData) string {
 	return util.GetAbsoluteFilepath(workingDir)
 }
 
-// FIXME: this is simple working dir
-// FIXME: while git-work-tree can be renamed to project-work-tree or project-git-work-tree or project-git
 func GetProjectDir(cmdData *CmdData, gitWorkTree string) (string, error) {
 	var projectDir string
 	if *cmdData.Dir != "" {

--- a/pkg/build/stage/dockerfile.go
+++ b/pkg/build/stage/dockerfile.go
@@ -612,7 +612,7 @@ func (s *DockerfileStage) PrepareImage(ctx context.Context, c Conveyor, _, img c
 func (s *DockerfileStage) prepareContextArchive(ctx context.Context, giterminismManager giterminism_manager.Interface) (string, error) {
 	archive, err := giterminismManager.LocalGitRepo().CreateArchive(ctx, git_repo.ArchiveOptions{
 		FilterOptions: git_repo.FilterOptions{
-			BasePath: s.context,
+			BasePath: filepath.Join(giterminismManager.RelativeToGitProjectDir(), s.context),
 		},
 		Commit: giterminismManager.HeadCommit(),
 	})

--- a/pkg/giterminism_manager/file_reader/file_reader.go
+++ b/pkg/giterminism_manager/file_reader/file_reader.go
@@ -26,6 +26,7 @@ type giterminismConfig interface {
 
 type sharedOptions interface {
 	ProjectDir() string
+	RelativeToGitProjectDir() string
 	LocalGitRepo() *git_repo.Local
 	HeadCommit() string
 	LooseGiterminism() bool

--- a/pkg/giterminism_manager/file_reader/git.go
+++ b/pkg/giterminism_manager/file_reader/git.go
@@ -13,13 +13,8 @@ import (
 	"github.com/bmatcuk/doublestar"
 )
 
-func (r FileReader) relativeToGitWorkingDir() string {
-	workingDir := r.sharedOptions.ProjectDir() // FIXME: rename project-dir to working dir and work-tree-dir to project-git-work-tree or project-git or project-work-tree or ...
-	return util.GetRelativeToBaseFilepath(r.sharedOptions.LocalGitRepo().WorkTreeDir, workingDir)
-}
-
 func (r FileReader) relativeToGitPath(relPath string) string {
-	return filepath.Join(r.relativeToGitWorkingDir(), relPath)
+	return filepath.Join(r.sharedOptions.RelativeToGitProjectDir(), relPath)
 }
 
 func (r FileReader) isCommitDirectoryExist(ctx context.Context, relPath string) (bool, error) {
@@ -61,7 +56,7 @@ func (r FileReader) commitFilesGlob(ctx context.Context, pattern string) ([]stri
 	pattern = filepath.ToSlash(pattern)
 	for _, relToGitFilepath := range commitPathList {
 		relToGitPath := filepath.ToSlash(relToGitFilepath)
-		relPath := filepath.ToSlash(util.GetRelativeToBaseFilepath(r.relativeToGitWorkingDir(), relToGitPath))
+		relPath := filepath.ToSlash(util.GetRelativeToBaseFilepath(r.sharedOptions.RelativeToGitProjectDir(), relToGitPath))
 
 		if matched, err := doublestar.Match(pattern, relPath); err != nil {
 			return nil, err

--- a/pkg/giterminism_manager/interface.go
+++ b/pkg/giterminism_manager/interface.go
@@ -17,6 +17,7 @@ type Interface interface {
 	LocalGitRepo() *git_repo.Local
 	HeadCommit() string
 	ProjectDir() string
+	RelativeToGitProjectDir() string
 	Dev() bool
 }
 

--- a/pkg/giterminism_manager/manager.go
+++ b/pkg/giterminism_manager/manager.go
@@ -3,6 +3,8 @@ package giterminism_manager
 import (
 	"context"
 
+	"github.com/werf/werf/pkg/util"
+
 	"github.com/werf/logboek"
 	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/giterminism_manager/config"
@@ -78,6 +80,10 @@ type sharedOptions struct {
 
 func (s *sharedOptions) ProjectDir() string {
 	return s.projectDir
+}
+
+func (s *sharedOptions) RelativeToGitProjectDir() string {
+	return util.GetRelativeToBaseFilepath(s.LocalGitRepo().WorkTreeDir, s.projectDir)
 }
 
 func (s *sharedOptions) HeadCommit() string {


### PR DESCRIPTION
```
\# docs/werf.yaml
configVersion: 1
project: docs
---
image: docs
dockerfile: ./Dockerfile
```

When running werf from docs folder werf's dockerfile builder will use `docs` dir — project dir — as build dockerfile build context root for the context tar archive, not git work tree root.