### PR TITLE
[giterminism] Improve feedback and manager logic 

### DIFF
--- a/integration/suites/giterminism/config_dockerfile_test.go
+++ b/integration/suites/giterminism/config_dockerfile_test.go
@@ -155,7 +155,7 @@ config:
 					addDockerfile:               true,
 					commitDockerfile:            true,
 					changeDockerfileAfterCommit: true,
-					expectedErrSubstring:        `unable to read dockerfile "Dockerfile": the file "Dockerfile" changes must be committed`,
+					expectedErrSubstring:        `unable to read dockerfile "Dockerfile": the file "Dockerfile" must be committed`,
 				}),
 				Entry(`config.dockerfile.allowUncommitted (Dockerfile) covers the uncommitted dockerfile "Dockerfile"`, entry{
 					configDockerfileAllowUncommittedGlob: "Dockerfile",
@@ -280,7 +280,7 @@ config:
 						"Dockerfile": "a",
 						"a":          dockerfilePath,
 					},
-					expectedErrSubstring: `unable to read dockerfile "Dockerfile": the file "dir/Dockerfile" must be committed`,
+					expectedErrSubstring: `unable to read dockerfile "Dockerfile": symlink "Dockerfile" check failed: the file "dir/Dockerfile" must be committed`,
 				}),
 				Entry("the symlink to the config file changed after commit: werf.yaml (changed) -> a -> dir/werf.yaml", entry{
 					commitDockerfile: true,
@@ -292,7 +292,7 @@ config:
 					changeSymlinksAfterCommit: map[string]string{
 						"Dockerfile": dockerfilePath,
 					},
-					expectedErrSubstring: `unable to read dockerfile "Dockerfile": the file "Dockerfile" changes must be committed`,
+					expectedErrSubstring: `unable to read dockerfile "Dockerfile": the file "Dockerfile" must be committed`,
 				}),
 				Entry("config.allowUncommitted (Dockerfile) does not cover uncommitted files", entry{
 					skipOnWindows:         true,
@@ -302,7 +302,7 @@ config:
 						"Dockerfile": "a",
 						"a":          dockerfilePath,
 					},
-					expectedErrSubstring: `unable to read dockerfile "Dockerfile": the file "Dockerfile" must be committed`,
+					expectedErrSubstring: `unable to read dockerfile "Dockerfile": accepted symlink "Dockerfile" check failed: the link target "a" should be also accepted by giterminism config`,
 				}),
 				Entry("config.allowUncommitted (Dockerfile, a) does not cover uncommitted files", entry{
 					skipOnWindows:         true,
@@ -312,7 +312,7 @@ config:
 						"Dockerfile": "a",
 						"a":          dockerfilePath,
 					},
-					expectedErrSubstring: `unable to read dockerfile "Dockerfile": the file "Dockerfile" must be committed`,
+					expectedErrSubstring: `unable to read dockerfile "Dockerfile": accepted symlink "Dockerfile" check failed: the link target "dir/Dockerfile" should be also accepted by giterminism config`,
 				}),
 				Entry("config.allowUncommitted (Dockerfile, a, dir/Dockerfile) covers uncommitted files", entry{
 					skipOnWindows:         true,
@@ -400,7 +400,7 @@ config:
 				addDockerignore:               true,
 				commitDockerignore:            true,
 				changeDockerignoreAfterCommit: true,
-				expectedErrSubstring:          `unable to read dockerignore file ".dockerignore": the file ".dockerignore" changes must be committed`,
+				expectedErrSubstring:          `unable to read dockerignore file ".dockerignore": the file ".dockerignore" must be committed`,
 			}),
 			Entry(`config.dockerfile.allowUncommittedDockerignoreFiles (.dockerignore) covers the uncommitted dockerignore ".dockerignore"`, entry{
 				configDockerfileAllowUncommittedDockerignoreFilesGlob: ".dockerignore",

--- a/integration/suites/giterminism/config_go_template_test.go
+++ b/integration/suites/giterminism/config_go_template_test.go
@@ -94,7 +94,7 @@ config:
 					addFiles:               []string{".werf/file"},
 					commitFiles:            []string{".werf/file"},
 					changeFilesAfterCommit: []string{".werf/file"},
-					expectedErrSubstring:   `error calling Get: {{ .Files.Get ".werf/file" }}: the file ".werf/file" changes must be committed`,
+					expectedErrSubstring:   `error calling Get: {{ .Files.Get ".werf/file" }}: the file ".werf/file" must be committed`,
 				}),
 			)
 		})
@@ -152,7 +152,7 @@ config:
 						addFiles:               []string{".werf/file1"},
 						commitFiles:            []string{".werf/file1"},
 						changeFilesAfterCommit: []string{".werf/file1"},
-						expectedErrSubstring:   `error calling Glob: {{ .Files.Glob ".werf/file1" }}: the file ".werf/file1" changes must be committed`,
+						expectedErrSubstring:   `error calling Glob: {{ .Files.Glob ".werf/file1" }}: the file ".werf/file1" must be committed`,
 					},
 				}),
 				Entry("config.goTemplateRendering.allowUncommittedFiles (.werf/file1) covers the not committed file", entry{
@@ -225,15 +225,14 @@ config:
 				allowEnvVariablesRegexp: "NAME",
 				addEnvName:              "NAME",
 			}),
-			Entry("config.goTemplateRendering.allowEnvVariables (NA*) does not cover the env name", entry{
-				allowEnvVariablesRegexp: "NA*",
+			Entry("config.goTemplateRendering.allowEnvVariables (NA.*) does not cover the env name", entry{
+				allowEnvVariablesRegexp: "NA.*",
 				addEnvName:              "NAME",
 				expectedErrSubstring:    `error calling env: the configuration with external dependency found in the werf config: env name "NAME" not allowed`,
 			}),
-			Entry("config.goTemplateRendering.allowEnvVariables (NA*) does not cover the env name", entry{
-				allowEnvVariablesRegexp: "NA*",
+			Entry("config.goTemplateRendering.allowEnvVariables (/NA.*/) covers the env name", entry{
+				allowEnvVariablesRegexp: "/NA.*/",
 				addEnvName:              "NAME",
-				expectedErrSubstring:    `error calling env: the configuration with external dependency found in the werf config: env name "NAME" not allowed`,
 			}),
 		)
 	})

--- a/integration/suites/giterminism/config_templates_dir_test.go
+++ b/integration/suites/giterminism/config_templates_dir_test.go
@@ -99,7 +99,7 @@ config:
 			addTemplate1:               true,
 			commitTemplate1:            true,
 			changeTemplate1AfterCommit: true,
-			expectedErrSubstring:       `unable to read werf config templates: the file ".werf/templates/1.tmpl" changes must be committed`,
+			expectedErrSubstring:       `unable to read werf config templates: the file ".werf/templates/1.tmpl" must be committed`,
 		}),
 		Entry("config.allowUncommittedTemplates has .werf/templates/1.tmpl, the template file not committed", entry{
 			allowUncommittedTemplate1: true,

--- a/integration/suites/giterminism/config_test.go
+++ b/integration/suites/giterminism/config_test.go
@@ -87,7 +87,7 @@ config:
 				addConfig:               true,
 				commitConfig:            true,
 				changeConfigAfterCommit: true,
-				expectedErrSubstring:    `unable to read werf config: the file "werf.yaml" changes must be committed`,
+				expectedErrSubstring:    `unable to read werf config: the file "werf.yaml" must be committed`,
 			}),
 			Entry("config.allowUncommitted allows not committed config file", entry{
 				allowUncommitted: true,
@@ -183,7 +183,7 @@ config:
 					"werf.yaml": "a",
 					"a":         configFilePath,
 				},
-				expectedErrSubstring: `unable to read werf config: the file "dir/werf.yaml" must be committed`,
+				expectedErrSubstring: `unable to read werf config: symlink "werf.yaml" check failed: the file "dir/werf.yaml" must be committed`,
 			}),
 			Entry("the symlink to the config file not committed: werf.yaml (not committed) -> a (not committed) -> dir/werf.yaml", entry{
 				addConfigFile:    true,
@@ -204,7 +204,7 @@ config:
 				addSymlinks: map[string]string{
 					"a": configFilePath,
 				},
-				expectedErrSubstring: ` unable to read werf config: the file "a" must be committed`,
+				expectedErrSubstring: ` unable to read werf config: symlink "werf.yaml" check failed: the file "a" must be committed`,
 			}),
 			Entry("the symlink to the config file changed after commit: werf.yaml (changed) -> a -> dir/werf.yaml", entry{
 				addConfigFile:    true,
@@ -216,7 +216,7 @@ config:
 				changeSymlinksAfterCommit: map[string]string{
 					"werf.yaml": configFilePath,
 				},
-				expectedErrSubstring: `unable to read werf config: the file "werf.yaml" changes must be committed`,
+				expectedErrSubstring: `unable to read werf config: the file "werf.yaml" must be committed`,
 			}),
 			Entry("config.allowUncommitted allows not committed config file", entry{
 				skipOnWindows:        true,
@@ -233,18 +233,18 @@ config:
 			}),
 			Entry("the broken symlink in fs: werf.yaml -> werf.yaml", entry{
 				skipOnWindows:        true,
-				addAndCommitSymlinks: map[string]string{"werf.yaml": "werf.yaml"},
-				expectedErrSubstring: `unable to read werf config: unable to resolve file path "werf.yaml": too many levels of symbolic links`,
+				allowUncommitted:     true,
+				addSymlinks:          map[string]string{"werf.yaml": "werf.yaml"},
+				expectedErrSubstring: `unable to read werf config: accepted symlink "werf.yaml" check failed: too many levels of symbolic links`,
 			}),
 			Entry("the broken symlink in commit: werf.yaml -> werf.yaml", entry{
-				addAndCommitSymlinks:      map[string]string{"werf.yaml": "werf.yaml"},
-				changeSymlinksAfterCommit: map[string]string{"werf.yaml": configFilePath},
-				expectedErrSubstring:      `unable to read werf config: unable to resolve commit file path "werf.yaml": too many levels of symbolic links`,
+				addAndCommitSymlinks: map[string]string{"werf.yaml": "werf.yaml"},
+				expectedErrSubstring: `unable to read werf config: symlink "werf.yaml" check failed: too many levels of symbolic links`,
 			}),
 			Entry("the linked file outside the project repository: werf.yaml -> a -> ../../../werf.yaml", entry{
 				skipOnWindows:        true,
 				addAndCommitSymlinks: map[string]string{"werf.yaml": "a", "a": "../../../werf.yaml"},
-				expectedErrSubstring: `unable to read werf config: the file "werf.yaml" not found in the project git repository`,
+				expectedErrSubstring: `unable to read werf config: symlink "werf.yaml" check failed: commit tree entry "../../../werf.yaml" not found in the repository`,
 			}),
 		)
 	})

--- a/integration/suites/giterminism/giterminism_config_test.go
+++ b/integration/suites/giterminism/giterminism_config_test.go
@@ -63,7 +63,7 @@ var _ = Describe("giterminism config", func() {
 			addConfig:               true,
 			commitConfig:            true,
 			changeConfigAfterCommit: true,
-			expectedErrSubstring:    `unable to read werf giterminism config: the file "werf-giterminism.yaml" changes must be committed`,
+			expectedErrSubstring:    `unable to read werf giterminism config: the file "werf-giterminism.yaml" must be committed`,
 		}),
 	)
 })

--- a/integration/suites/giterminism/helm_test.go
+++ b/integration/suites/giterminism/helm_test.go
@@ -94,13 +94,13 @@ helm:
 				addFiles:               []string{".helm/templates/template1.yaml"},
 				commitFiles:            []string{".helm/templates/template1.yaml"},
 				changeFilesAfterCommit: []string{".helm/templates/template1.yaml"},
-				expectedErrSubstring:   `unable to locate chart directory: the file ".helm/templates/template1.yaml" changes must be committed`,
+				expectedErrSubstring:   `unable to locate chart directory: the file ".helm/templates/template1.yaml" must be committed`,
 			}),
 			Entry("the template files changed after commit", entry{
 				addFiles:               []string{".helm/templates/template1.yaml", ".helm/templates/template2.yaml", ".helm/templates/template3.yaml"},
 				commitFiles:            []string{".helm/templates/template1.yaml", ".helm/templates/template2.yaml", ".helm/templates/template3.yaml"},
 				changeFilesAfterCommit: []string{".helm/templates/template1.yaml", ".helm/templates/template2.yaml", ".helm/templates/template3.yaml"},
-				expectedErrSubstring: `unable to locate chart directory: the following files changes must be committed:
+				expectedErrSubstring: `unable to locate chart directory: the following files must be committed:
 
  - .helm/templates/template1.yaml
  - .helm/templates/template2.yaml
@@ -211,7 +211,7 @@ helm:
 				addSymlinks: map[string]string{
 					".helm/templates": "../dir/.helm/templates",
 				},
-				expectedErrSubstring: `unable to locate chart directory: the file ".helm/templates/template1.yaml" must be committed`,
+				expectedErrSubstring: `unable to locate chart directory: accepted symlink ".helm/templates/template1.yaml" check failed: the link target "dir/.helm/templates" should be also accepted by giterminism config`,
 			}),
 			Entry("helm.allowUncommittedFiles (.helm, dir) covers uncommitted files", entry{
 				skipOnWindows:              true,

--- a/pkg/git_repo/local.go
+++ b/pkg/git_repo/local.go
@@ -325,6 +325,16 @@ type IsFileModifiedLocally struct {
 	WorktreeOnly bool
 }
 
+func (repo *Local) CheckIfFilePathInsideSubmodule(ctx context.Context, path string) (bool, bool, string, error) {
+	statusResult, err := repo.getMainStatusResult(ctx)
+	if err != nil {
+		return false, false, "", err
+	}
+
+	inside, unclean, submodulePath := statusResult.CheckIfFilePathInsideSubmodule(path)
+	return inside, unclean, submodulePath, nil
+}
+
 // IsFileModifiedLocally checks if the file has worktree or staged changes
 func (repo *Local) IsFileModifiedLocally(ctx context.Context, path string, options IsFileModifiedLocally) (bool, error) {
 	statusResult, err := repo.getMainStatusResult(ctx)

--- a/pkg/git_repo/local.go
+++ b/pkg/git_repo/local.go
@@ -393,7 +393,7 @@ func (repo *Local) WalkCommitFiles(ctx context.Context, commit string, dir strin
 
 	resolvedDir, err := repo.ResolveCommitFilePath(ctx, commit, dir)
 	if err != nil {
-		return fmt.Errorf("unable to resolve commit file path %q: %s", dir, err)
+		return fmt.Errorf("unable to resolve commit file %q: %s", dir, err)
 	}
 
 	result, err := repo.LsTree(ctx, path_matcher.NewSimplePathMatcher(resolvedDir, []string{}, true), LsTreeOptions{
@@ -405,7 +405,7 @@ func (repo *Local) WalkCommitFiles(ctx context.Context, commit string, dir strin
 	}
 
 	return result.Walk(func(lsTreeEntry *ls_tree.LsTreeEntry) error {
-		notResolvedPath := strings.Replace(filepath.ToSlash(lsTreeEntry.FullFilepath), resolvedDir, dir, -1)
+		notResolvedPath := strings.Replace(filepath.ToSlash(lsTreeEntry.FullFilepath), resolvedDir, dir, 1)
 
 		if debugGiterminismManager() {
 			logboek.Context(ctx).Debug().LogF("-- %q %q\n", notResolvedPath, lsTreeEntry.Mode.String())
@@ -464,7 +464,7 @@ func (repo *Local) ReadCommitFile(ctx context.Context, commit, path string) (dat
 func (repo *Local) readCommitFile(ctx context.Context, commit, path string) ([]byte, error) {
 	resolvedPath, err := repo.ResolveCommitFilePath(ctx, commit, path)
 	if err != nil {
-		return nil, fmt.Errorf("unable to resolve commit file path %q: %s", path, err)
+		return nil, fmt.Errorf("unable to resolve commit file %q: %s", path, err)
 	}
 
 	return repo.ReadCommitTreeEntryContent(ctx, commit, resolvedPath)
@@ -526,7 +526,7 @@ func (repo *Local) checkCommitFileMode(ctx context.Context, commit string, path 
 			return false, nil
 		}
 
-		return false, fmt.Errorf("unable to resolve commit file path %q: %s", path, err)
+		return false, fmt.Errorf("unable to resolve commit file %q: %s", path, err)
 	}
 
 	lsTreeEntry, err := repo.getCommitTreeEntry(ctx, commit, resolvedPath)
@@ -543,8 +543,8 @@ func (repo *Local) checkCommitFileMode(ctx context.Context, commit string, path 
 	return false, nil
 }
 
-// ResolveAndCheckCommitFilePath does ResolveCommitFilePath with an additional check for each resolved path.
-func (repo *Local) ResolveAndCheckCommitFilePath(ctx context.Context, commit, path string, checkFunc func(resolvedPath string) error) (resolvedPath string, err error) {
+// ResolveAndCheckCommitFilePath does ResolveCommitFilePath with an additional check for each resolved link target.
+func (repo *Local) ResolveAndCheckCommitFilePath(ctx context.Context, commit, path string, checkSymlinkTargetFunc func(resolvedPath string) error) (resolvedPath string, err error) {
 	logboek.Context(ctx).Debug().
 		LogBlock("ResolveAndCheckCommitFilePath %q %q", commit, path).
 		Options(func(options types.LogBlockOptionsInterface) {
@@ -562,7 +562,7 @@ func (repo *Local) ResolveAndCheckCommitFilePath(ctx context.Context, commit, pa
 						}
 					}).
 					DoError(func() error {
-						err := checkFunc(resolvedPath)
+						err := checkSymlinkTargetFunc(resolvedPath)
 
 						if debugGiterminismManager() {
 							logboek.Context(ctx).Debug().LogF("err: %q\n", err)
@@ -582,23 +582,8 @@ func (repo *Local) ResolveAndCheckCommitFilePath(ctx context.Context, commit, pa
 	return
 }
 
-func (repo *Local) resolveAndCheckCommitFilePath(ctx context.Context, commit, path string, checkFunc func(relPath string) error) (resolvedPath string, err error) {
-	if err := checkFunc(path); err != nil {
-		return "", err
-	}
-
-	resolvedPath, err = repo.resolveCommitFilePath(ctx, commit, path, 0, checkFunc)
-	if err != nil {
-		return "", err
-	}
-
-	if resolvedPath != path {
-		if err := checkFunc(resolvedPath); err != nil {
-			return "", err
-		}
-	}
-
-	return resolvedPath, nil
+func (repo *Local) resolveAndCheckCommitFilePath(ctx context.Context, commit, path string, checkSymlinkTargetFunc func(relPath string) error) (resolvedPath string, err error) {
+	return repo.resolveCommitFilePath(ctx, commit, path, 0, checkSymlinkTargetFunc)
 }
 
 // ResolveCommitFilePath follows symbolic links and returns the resolved path if there is a corresponding tree entry in the repo.
@@ -634,7 +619,7 @@ func IsTreeEntryNotFoundInRepoErr(err error) bool {
 	}
 }
 
-func (repo *Local) resolveCommitFilePath(ctx context.Context, commit, path string, depth int, checkFunc func(resolvedPath string) error) (string, error) {
+func (repo *Local) resolveCommitFilePath(ctx context.Context, commit, path string, depth int, checkSymlinkTargetFunc func(resolvedPath string) error) (string, error) {
 	if depth > 1000 {
 		return "", fmt.Errorf("too many levels of symbolic links")
 	}
@@ -675,7 +660,7 @@ func (repo *Local) resolveCommitFilePath(ctx context.Context, commit, path strin
 		mode := lsTreeEntry.Mode
 		switch {
 		case mode.IsMalformed():
-			return "", treeEntryNotFoundInRepoErr{fmt.Errorf("commit tree entry %q not found in the repo", pathToResolve)}
+			return "", treeEntryNotFoundInRepoErr{fmt.Errorf("commit tree entry %q not found in the repository", pathToResolve)}
 		case mode == filemode.Symlink:
 			data, err := repo.ReadCommitTreeEntryContent(ctx, commit, pathToResolve)
 			if err != nil {
@@ -684,21 +669,21 @@ func (repo *Local) resolveCommitFilePath(ctx context.Context, commit, path strin
 
 			link := string(data)
 			if pathPkg.IsAbs(link) {
-				return "", treeEntryNotFoundInRepoErr{fmt.Errorf("commit tree entry %q not found in the repo", pathToResolve)}
+				return "", treeEntryNotFoundInRepoErr{fmt.Errorf("commit tree entry %q not found in the repository", link)}
 			}
 
 			resolvedLink := pathPkg.Join(pathPkg.Dir(pathToResolve), link)
 			if resolvedLink == ".." || strings.HasPrefix(resolvedLink, "../") {
-				return "", treeEntryNotFoundInRepoErr{fmt.Errorf("commit tree entry %q not found in the repo", pathToResolve)}
+				return "", treeEntryNotFoundInRepoErr{fmt.Errorf("commit tree entry %q not found in the repository", link)}
 			}
 
-			if checkFunc != nil {
-				if err := checkFunc(resolvedLink); err != nil {
+			if checkSymlinkTargetFunc != nil {
+				if err := checkSymlinkTargetFunc(resolvedLink); err != nil {
 					return "", err
 				}
 			}
 
-			resolvedTarget, err := repo.resolveCommitFilePath(ctx, commit, resolvedLink, depth, checkFunc)
+			resolvedTarget, err := repo.resolveCommitFilePath(ctx, commit, resolvedLink, depth, checkSymlinkTargetFunc)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/giterminism_manager/config/config.go
+++ b/pkg/giterminism_manager/config/config.go
@@ -116,16 +116,26 @@ type goTemplateRendering struct {
 
 func (r goTemplateRendering) IsEnvNameAccepted(name string) (bool, error) {
 	for _, pattern := range r.AllowEnvVariables {
-		if strings.HasPrefix(pattern, "/") && strings.HasSuffix(pattern, "/") {
-			expr := fmt.Sprintf("^%s$", pattern[1:len(pattern)-1])
-			r, err := regexp.Compile(expr)
-			if err != nil {
-				return false, err
-			}
+		match, err := func() (bool, error) {
+			if strings.HasPrefix(pattern, "/") && strings.HasSuffix(pattern, "/") {
+				expr := fmt.Sprintf("^%s$", pattern[1:len(pattern)-1])
+				r, err := regexp.Compile(expr)
+				if err != nil {
+					return false, err
+				}
 
-			return r.MatchString(name), nil
-		} else {
-			return pattern == name, nil
+				return r.MatchString(name), nil
+			} else {
+				return pattern == name, nil
+			}
+		}()
+
+		if err != nil {
+			return false, err
+		}
+
+		if match {
+			return true, nil
 		}
 	}
 

--- a/pkg/giterminism_manager/file_reader/config_go_template.go
+++ b/pkg/giterminism_manager/file_reader/config_go_template.go
@@ -31,11 +31,7 @@ func (r FileReader) ConfigGoTemplateFilesGlob(ctx context.Context, glob string) 
 }
 
 func (r FileReader) ConfigGoTemplateFilesGet(ctx context.Context, relPath string) ([]byte, error) {
-	if err := r.CheckConfigurationFileExistence(ctx, relPath, r.giterminismConfig.IsUncommittedConfigGoTemplateRenderingFileAccepted); err != nil {
-		return nil, fmt.Errorf("{{ .Files.Get %q }}: %s", relPath, err)
-	}
-
-	data, err := r.ReadAndValidateConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedConfigGoTemplateRenderingFileAccepted)
+	data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedConfigGoTemplateRenderingFileAccepted)
 	if err != nil {
 		return nil, fmt.Errorf("{{ .Files.Get %q }}: %s", relPath, err)
 	}

--- a/pkg/giterminism_manager/file_reader/configuration.go
+++ b/pkg/giterminism_manager/file_reader/configuration.go
@@ -2,19 +2,18 @@ package file_reader
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/werf/logboek"
 	"github.com/werf/logboek/pkg/types"
 
-	"github.com/werf/werf/pkg/git_repo"
+	"github.com/werf/werf/pkg/util"
 )
 
 // WalkConfigurationFilesWithGlob reads the configuration files taking into account the giterminism config.
 // The result paths are relative to the passed directory, the method does reverse resolving for symlinks.
 func (r FileReader) WalkConfigurationFilesWithGlob(ctx context.Context, dir, glob string, isFileAcceptedCheckFunc func(relPath string) (bool, error), handleFileFunc func(notResolvedPath string, data []byte, err error) error) (err error) {
 	logboek.Context(ctx).Debug().
-		LogBlock("ConfigurationFilesGlob %q %q", dir, glob).
+		LogBlock("WalkConfigurationFilesWithGlob %q %q", dir, glob).
 		Options(func(options types.LogBlockOptionsInterface) {
 			if !debug() {
 				options.Mute()
@@ -32,26 +31,6 @@ func (r FileReader) WalkConfigurationFilesWithGlob(ctx context.Context, dir, glo
 }
 
 func (r FileReader) walkConfigurationFilesWithGlob(ctx context.Context, dir, glob string, isFileAcceptedCheckFunc func(relPath string) (bool, error), handleFileFunc func(notResolvedPath string, data []byte, err error) error) (err error) {
-	processedFiles := map[string]bool{}
-
-	isFileProcessedFunc := func(relPath string) bool {
-		return processedFiles[filepath.ToSlash(relPath)]
-	}
-
-	readFileBeforeHookFunc := func(relPath string) {
-		processedFiles[filepath.ToSlash(relPath)] = true
-	}
-
-	readFileFunc := func(relPath string) ([]byte, error) {
-		readFileBeforeHookFunc(relPath)
-		return r.ReadFile(ctx, relPath)
-	}
-
-	readCommitFileWrapperFunc := func(relPath string) ([]byte, error) {
-		readFileBeforeHookFunc(relPath)
-		return r.ReadAndValidateCommitFile(ctx, relPath)
-	}
-
 	fileRelPathListFromFS, err := r.ListFilesWithGlob(ctx, dir, glob)
 	if err != nil {
 		return err
@@ -59,7 +38,7 @@ func (r FileReader) walkConfigurationFilesWithGlob(ctx context.Context, dir, glo
 
 	if r.sharedOptions.LooseGiterminism() {
 		for _, relPath := range fileRelPathListFromFS {
-			data, err := readFileFunc(relPath)
+			data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, isFileAcceptedCheckFunc)
 			if err := handleFileFunc(relPath, data, err); err != nil {
 				return err
 			}
@@ -73,46 +52,19 @@ func (r FileReader) walkConfigurationFilesWithGlob(ctx context.Context, dir, glo
 		return err
 	}
 
-	var relPathListWithUncommittedFilesChanges []string
-	for _, relPath := range fileRelPathListFromCommit {
-		if accepted, err := r.IsFilePathAccepted(ctx, relPath, isFileAcceptedCheckFunc); err != nil {
-			return err
-		} else if accepted {
-			continue
-		}
+	relPathList := util.AddNewStringsToStringArray(fileRelPathListFromFS, fileRelPathListFromCommit...)
 
-		data, err := readCommitFileWrapperFunc(relPath)
-		if err := handleFileFunc(relPath, data, err); err != nil {
-			if isUncommittedFilesChangesError(err) {
-				relPathListWithUncommittedFilesChanges = append(relPathListWithUncommittedFilesChanges, relPath)
+	var relPathListWithUncommittedFiles []string
+	for _, relPath := range relPathList {
+		data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, isFileAcceptedCheckFunc)
+		err = handleFileFunc(relPath, data, err)
+		if err != nil {
+			switch err.(type) {
+			case UncommittedFilesError:
+				relPathListWithUncommittedFiles = append(relPathListWithUncommittedFiles, relPath)
 				continue
 			}
 
-			return err
-		}
-	}
-
-	if len(relPathListWithUncommittedFilesChanges) != 0 {
-		return r.NewUncommittedFilesChangesError(relPathListWithUncommittedFilesChanges...)
-	}
-
-	var relPathListWithUncommittedFiles []string
-	for _, relPath := range fileRelPathListFromFS {
-		accepted, err := r.IsFilePathAccepted(ctx, relPath, isFileAcceptedCheckFunc)
-		if err != nil {
-			return err
-		}
-
-		if !accepted {
-			if !isFileProcessedFunc(relPath) {
-				relPathListWithUncommittedFiles = append(relPathListWithUncommittedFiles, relPath)
-			}
-
-			continue
-		}
-
-		data, err := readFileFunc(relPath)
-		if err := handleFileFunc(relPath, data, err); err != nil {
 			return err
 		}
 	}
@@ -124,16 +76,17 @@ func (r FileReader) walkConfigurationFilesWithGlob(ctx context.Context, dir, glo
 	return nil
 }
 
-func (r FileReader) ReadAndValidateConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (data []byte, err error) {
+// ReadAndCheckConfigurationFile does CheckConfigurationFileExistenceAndAcceptance and ReadConfigurationFile.
+func (r FileReader) ReadAndCheckConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (data []byte, err error) {
 	logboek.Context(ctx).Debug().
-		LogBlock("ReadAndValidateConfigurationFile %q", relPath).
+		LogBlock("ReadAndCheckConfigurationFile %q", relPath).
 		Options(func(options types.LogBlockOptionsInterface) {
 			if !debug() {
 				options.Mute()
 			}
 		}).
 		Do(func() {
-			data, err = r.readAndValidateConfigurationFile(ctx, relPath, isFileAcceptedCheckFunc)
+			data, err = r.readAndCheckConfigurationFile(ctx, relPath, isFileAcceptedCheckFunc)
 
 			if debug() {
 				logboek.Context(ctx).Debug().LogF("dataLength: %v\nerr: %q\n", len(data), err)
@@ -143,30 +96,58 @@ func (r FileReader) ReadAndValidateConfigurationFile(ctx context.Context, relPat
 	return
 }
 
-func (r FileReader) readAndValidateConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) ([]byte, error) {
-	existAndAccepted, err := r.IsRegularFileExistAndAccepted(ctx, relPath, isFileAcceptedCheckFunc)
-	if err != nil {
+func (r FileReader) readAndCheckConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) ([]byte, error) {
+	if err := r.CheckConfigurationFileExistenceAndAcceptance(ctx, relPath, isFileAcceptedCheckFunc); err != nil {
 		return nil, err
 	}
 
-	if existAndAccepted {
-		return r.ReadFile(ctx, relPath)
-	}
-
-	return r.ReadAndValidateCommitFile(ctx, relPath)
+	return r.ReadConfigurationFile(ctx, relPath, isFileAcceptedCheckFunc)
 }
 
-// CheckConfigurationFileExistence returns an error if there are not the file in the project repository commit and an accepted file by the giteminism config in the project directory.
-func (r FileReader) CheckConfigurationFileExistence(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (err error) {
+// ReadConfigurationFile does ReadFile or ReadCommitFile depending on the giterminism config.
+func (r FileReader) ReadConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (data []byte, err error) {
 	logboek.Context(ctx).Debug().
-		LogBlock("CheckConfigurationFileExistence %q", relPath).
+		LogBlock("ReadConfigurationFile %q", relPath).
 		Options(func(options types.LogBlockOptionsInterface) {
 			if !debug() {
 				options.Mute()
 			}
 		}).
 		Do(func() {
-			err = r.checkConfigurationFileExistence(ctx, relPath, isFileAcceptedCheckFunc)
+			data, err = r.readConfigurationFile(ctx, relPath, isFileAcceptedCheckFunc)
+
+			if debug() {
+				logboek.Context(ctx).Debug().LogF("dataLength: %v\nerr: %q\n", len(data), err)
+			}
+		})
+
+	return
+}
+
+func (r FileReader) readConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) ([]byte, error) {
+	shouldFileBeReadFromFS, err := r.ShouldFileBeRead(ctx, relPath, isFileAcceptedCheckFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	if shouldFileBeReadFromFS {
+		return r.ReadFile(ctx, relPath)
+	} else {
+		return r.ReadCommitFile(ctx, relPath)
+	}
+}
+
+// CheckConfigurationFileExistenceAndAcceptance does CheckFileExistenceAndAcceptance or CheckCommitFileExistenceAndLocalChanges depending on the giterminism config.
+func (r FileReader) CheckConfigurationFileExistenceAndAcceptance(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (err error) {
+	logboek.Context(ctx).Debug().
+		LogBlock("CheckConfigurationFileExistenceAndAcceptance %q", relPath).
+		Options(func(options types.LogBlockOptionsInterface) {
+			if !debug() {
+				options.Mute()
+			}
+		}).
+		Do(func() {
+			err = r.checkConfigurationFileExistenceAndAcceptance(ctx, relPath, isFileAcceptedCheckFunc)
 
 			if debug() {
 				logboek.Context(ctx).Debug().LogF("err: %q\n", err)
@@ -176,53 +157,20 @@ func (r FileReader) CheckConfigurationFileExistence(ctx context.Context, relPath
 	return
 }
 
-func (r FileReader) checkConfigurationFileExistence(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) error {
-	existInFS, err := r.IsRegularFileExist(ctx, relPath)
+func (r FileReader) checkConfigurationFileExistenceAndAcceptance(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) error {
+	shouldFileBeReadFromFS, err := r.ShouldFileBeRead(ctx, relPath, isFileAcceptedCheckFunc)
 	if err != nil {
 		return err
 	}
 
-	if existInFS {
-		if r.sharedOptions.LooseGiterminism() {
-			return nil
-		}
-
-		accepted, err := r.IsFilePathAccepted(ctx, relPath, isFileAcceptedCheckFunc)
-		if err != nil {
-			return err
-		}
-
-		if accepted {
-			return nil
-		}
+	if shouldFileBeReadFromFS {
+		return r.CheckFileExistenceAndAcceptance(ctx, relPath, isFileAcceptedCheckFunc)
 	}
 
-	if r.sharedOptions.LooseGiterminism() {
-		return r.NewFilesNotFoundInProjectDirectoryError(relPath)
-	}
-
-	exist, err := r.IsCommitFileExist(ctx, relPath)
-	if err != nil {
-		return err
-	}
-
-	if exist {
-		return nil
-	}
-
-	if existInFS {
-		err := r.ValidateCommitFilePath(ctx, relPath)
-		if git_repo.IsTreeEntryNotFoundInRepoErr(err) {
-			return r.NewUncommittedFilesError(relPath)
-		} else {
-			return err
-		}
-	} else {
-		return r.NewFilesNotFoundInProjectGitRepositoryError(relPath)
-	}
+	return r.CheckCommitFileExistenceAndLocalChanges(ctx, relPath)
 }
 
-// IsConfigurationFileExistAnywhere checks the configuration file existence in the project directory and the project repository.
+// IsConfigurationFileExistAnywhere returns true if the configuration file exists in the project directory or in the project repository.
 func (r FileReader) IsConfigurationFileExistAnywhere(ctx context.Context, relPath string) (exist bool, err error) {
 	logboek.Context(ctx).Debug().
 		LogBlock("IsConfigurationFileExistAnywhere %q", relPath).
@@ -260,7 +208,7 @@ func (r FileReader) isConfigurationFileExistAnywhere(ctx context.Context, relPat
 }
 
 // IsConfigurationFileExist checks the configuration file existence taking into account the giterminism config.
-// The method applies isFileAcceptedCheckFunc for each resolved path.
+// The method does not check acceptance for each symlink target if the configuration file is symlink.
 func (r FileReader) IsConfigurationFileExist(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (exist bool, err error) {
 	logboek.Context(ctx).Debug().
 		LogBlock("IsConfigurationFileExist %q", relPath).
@@ -281,17 +229,13 @@ func (r FileReader) IsConfigurationFileExist(ctx context.Context, relPath string
 }
 
 func (r FileReader) isConfigurationFileExist(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (bool, error) {
-	exist, err := r.IsRegularFileExistAndAccepted(ctx, relPath, isFileAcceptedCheckFunc)
+	shouldFileBeReadFromFS, err := r.ShouldFileBeRead(ctx, relPath, isFileAcceptedCheckFunc)
 	if err != nil {
 		return false, err
 	}
 
-	if exist {
-		return true, nil
-	}
-
-	if r.sharedOptions.LooseGiterminism() {
-		return false, nil
+	if shouldFileBeReadFromFS {
+		return r.IsRegularFileExist(ctx, relPath)
 	} else {
 		return r.IsCommitFileExist(ctx, relPath)
 	}

--- a/pkg/giterminism_manager/file_reader/dockerfile.go
+++ b/pkg/giterminism_manager/file_reader/dockerfile.go
@@ -52,11 +52,7 @@ func (r FileReader) ReadDockerfile(ctx context.Context, relPath string) (data []
 }
 
 func (r FileReader) readDockerfile(ctx context.Context, relPath string) ([]byte, error) {
-	if err := r.CheckConfigurationFileExistence(ctx, relPath, r.giterminismConfig.IsUncommittedDockerfileAccepted); err != nil {
-		return nil, err
-	}
-
-	return r.ReadAndValidateConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedDockerfileAccepted)
+	return r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedDockerfileAccepted)
 }
 
 func (r FileReader) ReadDockerignore(ctx context.Context, relPath string) (data []byte, err error) {
@@ -83,9 +79,5 @@ func (r FileReader) ReadDockerignore(ctx context.Context, relPath string) (data 
 }
 
 func (r FileReader) readDockerignore(ctx context.Context, relPath string) ([]byte, error) {
-	if err := r.CheckConfigurationFileExistence(ctx, relPath, r.giterminismConfig.IsUncommittedDockerignoreAccepted); err != nil {
-		return nil, err
-	}
-
-	return r.ReadAndValidateConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedDockerignoreAccepted)
+	return r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedDockerignoreAccepted)
 }

--- a/pkg/giterminism_manager/file_reader/errors.go
+++ b/pkg/giterminism_manager/file_reader/errors.go
@@ -8,67 +8,41 @@ import (
 	"github.com/werf/werf/pkg/giterminism_manager/errors"
 )
 
-type FilesNotFoundInProjectDirectoryError struct {
-	error
-}
-type FilesNotFoundInTheProjectGitRepositoryError struct {
-	error
-}
 type UncommittedFilesError struct {
 	error
 }
-type UncommittedFilesChangesError struct {
+type FileNotAcceptedError struct {
+	error
+}
+type FileNotFoundInProjectDirectoryError struct {
+	error
+}
+type FileNotFoundInProjectRepositoryError struct {
 	error
 }
 
-func isUncommittedFilesChangesError(err error) bool {
+func IsFileNotFoundInProjectDirectoryError(err error) bool {
 	switch err.(type) {
-	case UncommittedFilesChangesError:
+	case FileNotFoundInProjectDirectoryError:
 		return true
 	default:
 		return false
 	}
 }
 
-func (r FileReader) NewFilesNotFoundInProjectDirectoryError(relPaths ...string) error {
-	var errorMsg string
-	if len(relPaths) == 1 {
-		errorMsg = fmt.Sprintf("the file %q not found in the project directory", filepath.ToSlash(relPaths[0]))
-	} else if len(relPaths) > 1 {
-		errorMsg = fmt.Sprintf("the following files not found in the project directory:\n\n%s", prepareListOfFilesString(relPaths))
-	} else {
-		panic("unexpected condition")
-	}
-
-	return FilesNotFoundInProjectDirectoryError{errors.NewError(errorMsg)}
+func (r FileReader) NewFileNotFoundInProjectDirectoryError(relPath string) error {
+	return FileNotFoundInProjectDirectoryError{errors.NewError(fmt.Sprintf("the file %q not found in the project directory", filepath.ToSlash(relPath)))}
 }
 
-func (r FileReader) NewFilesNotFoundInProjectGitRepositoryError(relPaths ...string) error {
-	var errorMsg string
-	if len(relPaths) == 1 {
-		errorMsg = fmt.Sprintf("the file %q not found in the project git repository", filepath.ToSlash(relPaths[0]))
-	} else if len(relPaths) > 1 {
-		errorMsg = fmt.Sprintf("the following files not found in the project git repository:\n\n%s", prepareListOfFilesString(relPaths))
-	} else {
-		panic("unexpected condition")
-	}
+func (r FileReader) NewFileNotFoundInProjectRepositoryError(relPath string) error {
+	return FileNotFoundInProjectRepositoryError{errors.NewError(fmt.Sprintf("the file %q not found in the project git repository", filepath.ToSlash(relPath)))}
+}
 
-	return FilesNotFoundInTheProjectGitRepositoryError{errors.NewError(errorMsg)}
+func (r FileReader) NewSymlinkResolveFailedError(link string, resolveErr error) error {
+	return errors.NewError(fmt.Sprintf("accepted symlink %q check failed: %s", filepath.ToSlash(link), resolveErr))
 }
 
 func (r FileReader) NewUncommittedFilesError(relPaths ...string) error {
-	return UncommittedFilesError{r.newUncommittedFilesErrorBase("", relPaths...)}
-}
-
-func (r FileReader) NewUncommittedFilesChangesError(relPaths ...string) error {
-	return UncommittedFilesChangesError{UncommittedFilesError{r.newUncommittedFilesErrorBase("changes", relPaths...)}}
-}
-
-func (r FileReader) newUncommittedFilesErrorBase(specificFileProperty string, relPaths ...string) error {
-	if specificFileProperty != "" {
-		specificFileProperty = " " + specificFileProperty
-	}
-
 	expectedAction := "must be committed"
 	if r.sharedOptions.Dev() {
 		expectedAction = "must be staged"
@@ -76,9 +50,9 @@ func (r FileReader) newUncommittedFilesErrorBase(specificFileProperty string, re
 
 	var errorMsg string
 	if len(relPaths) == 1 {
-		errorMsg = fmt.Sprintf("the file %q%s %s", filepath.ToSlash(relPaths[0]), specificFileProperty, expectedAction)
+		errorMsg = fmt.Sprintf("the file %q %s", filepath.ToSlash(relPaths[0]), expectedAction)
 	} else if len(relPaths) > 1 {
-		errorMsg = fmt.Sprintf("the following files%s %s:\n\n%s", specificFileProperty, expectedAction, prepareListOfFilesString(relPaths))
+		errorMsg = fmt.Sprintf("the following files %s:\n\n%s", expectedAction, prepareListOfFilesString(relPaths))
 	} else {
 		panic("unexpected condition")
 	}
@@ -93,7 +67,7 @@ To stage the changes use the following command: "git add %s".`, errorMsg, string
 You might also be interested in developer mode (activated with --dev option) that allows you to work with staged changes without doing redundant commits. Just use "git add <file>..." to include the changes that should be used.`, errorMsg)
 	}
 
-	return UncommittedFilesChangesError{errors.NewError(errorMsg)}
+	return UncommittedFilesError{errors.NewError(errorMsg)}
 }
 
 func prepareListOfFilesString(paths []string) string {

--- a/pkg/giterminism_manager/file_reader/giterminism_config.go
+++ b/pkg/giterminism_manager/file_reader/giterminism_config.go
@@ -53,13 +53,7 @@ func (r FileReader) ReadGiterminismConfig(ctx context.Context) (data []byte, err
 }
 
 func (r FileReader) readGiterminismConfig(ctx context.Context) ([]byte, error) {
-	if err := r.CheckConfigurationFileExistence(ctx, GiterminismConfigName, func(relPath string) (bool, error) {
-		return false, nil
-	}); err != nil {
-		return nil, err
-	}
-
-	return r.ReadAndValidateConfigurationFile(ctx, GiterminismConfigName, func(relPath string) (bool, error) {
+	return r.ReadAndCheckConfigurationFile(ctx, GiterminismConfigName, func(relPath string) (bool, error) {
 		return false, nil
 	})
 }

--- a/pkg/giterminism_manager/file_reader/helm_chart_extender.go
+++ b/pkg/giterminism_manager/file_reader/helm_chart_extender.go
@@ -47,11 +47,7 @@ func (r FileReader) ReadChartFile(ctx context.Context, path string) ([]byte, err
 }
 
 func (r FileReader) readChartFile(ctx context.Context, relPath string) ([]byte, error) {
-	if err := r.CheckConfigurationFileExistence(ctx, relPath, r.giterminismConfig.IsUncommittedHelmFileAccepted); err != nil {
-		return nil, err
-	}
-
-	return r.ReadAndValidateConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedHelmFileAccepted)
+	return r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedHelmFileAccepted)
 }
 
 func (r FileReader) LoadChartDir(ctx context.Context, chartDir string) ([]*chart.ChartExtenderBufferedFile, error) {


### PR DESCRIPTION
- Read the configuration file from fs if not resolved path accepted by giterminism config:
  - the file must exist in the project git work tree directory;
  - the path must be fully accepted by giterminism config (each resolved symlink target must be accepted).

- Read the configuration file from commit:
  - the file must exist in the current commit;
  - the path must not have any uncommitted changes locally (each symlink target).

Improve resolve symlink failed error messages:
  - fs symlink:
    - `unable to read <config type>: accepted symlink "<symlink path>" check failed: too many levels of symbolic links`
    - `unable to read <config type>: accepted symlink "<symlink path>" check failed: the link target "<target path>" should be also accepted by giterminism config`
  - commit symlink:
  	- `unable to read <config type>: symlink "<symlink path>" check failed: commit tree entry "<target path>" not found in the repository`
  	- `unable to read <config type>: symlink "<symlink path>" check failed: the file "<target path>" must be committed`