### PR TITLE
[giterminism] Improve feedback if a related submodule is not clean or has changes

### DIFF
--- a/pkg/git_repo/status/status.go
+++ b/pkg/git_repo/status/status.go
@@ -127,6 +127,7 @@ func status(ctx context.Context, repository *git.Repository, repositoryAbsFilepa
 
 			submoduleResult.SubmoduleStatus = submoduleStatus
 			submoduleResult.Result = sResult
+			submoduleResult.SubmodulePath = submodulePath
 
 			result.submoduleResults = append(result.submoduleResults, submoduleResult)
 		}

--- a/pkg/giterminism_manager/file_reader/errors.go
+++ b/pkg/giterminism_manager/file_reader/errors.go
@@ -38,18 +38,22 @@ func (r FileReader) NewFileNotFoundInProjectRepositoryError(relPath string) erro
 	return FileNotFoundInProjectRepositoryError{errors.NewError(fmt.Sprintf("the file %q not found in the project git repository", filepath.ToSlash(relPath)))}
 }
 
-func (r FileReader) NewUncommittedSubmoduleChangesError(submodulePath string) error {
-	errorMsg := fmt.Sprintf("the submodule %q has modified files and these changes must be committed or discarded. Do not forget to push new changes to the submodule remote", filepath.ToSlash(submodulePath))
-
+func (r FileReader) NewUncommittedSubmoduleChangesError(submodulePath string, filePathList []string) error {
+	errorMsg := fmt.Sprintf("the submodule %q has modified files and these changes must be committed (do not forget to push new changes to the submodule remote) or discarded:\n\n%s", filepath.ToSlash(submodulePath), prepareListOfFilesString(filePathList))
 	return errors.NewError(errorMsg)
 }
 
-func (r FileReader) NewUncleanSubmoduleError(submodulePath string) error {
+func (r FileReader) NewUncleanSubmoduleError(submodulePath, headCommit, currentCommit, expectedCommit string) error {
 	expectedAction := "must be committed"
 	if r.sharedOptions.Dev() {
 		expectedAction = "must be staged"
 	}
-	errorMsg := fmt.Sprintf("the submodule %q is not clean and %s. Do not forget to push a new commit to the submodule remote If this commit exists only locally", filepath.ToSlash(submodulePath), expectedAction)
+	errorMsg := fmt.Sprintf(`the submodule %q is not clean and %s. Do not forget to push the current commit to the submodule remote If this commit exists only locally
+
+Details:
+  commit:                 %q
+  currentWorktreeCommit:  %q
+  expectedWorktreeCommit: %q`, filepath.ToSlash(submodulePath), expectedAction, headCommit, currentCommit, expectedCommit)
 
 	return r.newUncommittedFilesErrorBase(errorMsg, filepath.ToSlash(submodulePath))
 }

--- a/pkg/giterminism_manager/inspector/inspector.go
+++ b/pkg/giterminism_manager/inspector/inspector.go
@@ -27,6 +27,7 @@ type giterminismConfig interface {
 }
 
 type fileReader interface {
+	HandleValidateSubmodulesErr(err error) error
 	ExtraWindowsCheckFilesModifiedLocally(ctx context.Context, relPath ...string) error
 }
 


### PR DESCRIPTION
- Ignore user work tree submodule directory if a submodule ".git" directory not found

- Return a detailed error if a work tree submodule directory is not clean:
```
the submodule "<submodule path>" is not clean and must be committed. Do not forget to push the current commit to the submodule remote If this commit exists only locally

Details:
  commit:                 "0000000000000000000000000000000000000000"
  currentWorktreeCommit:  "d9243a9a45b10e6b7d985322b8108897626a25a6"
  expectedWorktreeCommit: "d9243a9a45b10e6b7d985322b8108897626a25a6"

You might also be interested in developer mode (activated with --dev option) that allows you to work with staged changes without doing redundant commits. Just use "git add <file>..." to include the changes that should be used.
```

- Return a detailed error if a work tree submodule directory has changes:
```
the submodule "<submodule path>" has modified files and these changes must be committed (do not forget to push new changes to the submodule remote) or discarded:

 - file1
 - file2
```