### PR TITLE
[config] The env function requires the set environment variable 

### DIFF
--- a/integration/suites/build/stapel_image/base_image/from_image_test.go
+++ b/integration/suites/build/stapel_image/base_image/from_image_test.go
@@ -62,13 +62,3 @@ var _ = XDescribe("fromImage", func() {
 		})
 	})
 })
-
-var _ = XDescribe("fromArtifact", func() {
-	BeforeEach(func() {
-		SuiteData.TestDirPath = utils.FixturePath("from_artifact")
-	})
-
-	It("should be rebuilt", func() {
-		fromImageItFunc("app", "fromArtifact", func(appConfigName, fromImageConfigName string) {})
-	})
-})

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -266,6 +266,12 @@ func funcMap(tmpl *template.Template, giterminismManager giterminism_manager.Int
 			return "", err
 		}
 
+		if !giterminismManager.LooseGiterminism() {
+			if _, exist := os.LookupEnv(envName); !exist {
+				return "", fmt.Errorf("the environment variable %q must be set", envName)
+			}
+		}
+
 		return envFunc(envName), nil
 	}
 

--- a/pkg/giterminism_manager/interface.go
+++ b/pkg/giterminism_manager/interface.go
@@ -18,6 +18,7 @@ type Interface interface {
 	HeadCommit() string
 	ProjectDir() string
 	RelativeToGitProjectDir() string
+	LooseGiterminism() bool
 	Dev() bool
 }
 


### PR DESCRIPTION
- The used environment variable can be empty but must be set (ENV_NAME="").
- Otherwise, an error `executing "werfConfig" at <env "test">: error calling env: the environment variable "<ENV_NAME>" must be set` will be returned