### PR TITLE
[BLOB_UNKNOWN] Completely ignore images with BLOB_UNKNOWN errors from the registry

### DIFF
--- a/pkg/cleaning/images_cleanup.go
+++ b/pkg/cleaning/images_cleanup.go
@@ -3,7 +3,6 @@ package cleaning
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -161,11 +160,6 @@ func (m *imagesCleanupManager) initImageCommitHashImageMetadata(ctx context.Cont
 		commitImageMetadata := map[plumbing.Hash]*storage.ImageMetadata{}
 		if err := m.StorageManager.ForEachGetImageMetadataByCommit(ctx, m.ProjectName, imageName, func(commit string, imageMetadata *storage.ImageMetadata, err error) error {
 			if err != nil {
-				if os.Getenv("WERF_EXPERIMENTAL_IGNORE_IMAGE_METADATA_BY_COMMIT_BLOB_UNKNOWN") == "1" {
-					if strings.Contains(err.Error(), "BLOB_UNKNOWN") {
-						return nil
-					}
-				}
 				return err
 			}
 

--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -59,7 +59,12 @@ func (api *api) IsRepoImageExists(ctx context.Context, reference string) (bool, 
 
 func (api *api) TryGetRepoImage(ctx context.Context, reference string) (*image.Info, error) {
 	if imgInfo, err := api.GetRepoImage(ctx, reference); err != nil {
-		if IsManifestUnknownError(err) || IsNameUnknownError(err) {
+		if IsBlobUnknownError(err) || IsManifestUnknownError(err) {
+			logboek.Context(ctx).Warn().LogF("WARNING: Got an error when inspecting repo image %q: %s", reference, err)
+			return nil, nil
+		}
+
+		if IsNameUnknownError(err) {
 			return nil, nil
 		}
 		return imgInfo, err

--- a/pkg/docker_registry/default.go
+++ b/pkg/docker_registry/default.go
@@ -56,6 +56,10 @@ func IsManifestUnknownError(err error) bool {
 	return strings.Contains(err.Error(), "MANIFEST_UNKNOWN")
 }
 
+func IsBlobUnknownError(err error) bool {
+	return strings.Contains(err.Error(), "BLOB_UNKNOWN")
+}
+
 func IsNameUnknownError(err error) bool {
 	return strings.Contains(err.Error(), "NAME_UNKNOWN")
 }


### PR DESCRIPTION
 - Consider image is not exists in that case.
 - Log warnings on BLOB_UNKNOWN and MANIFEST_UNKNOWN for default docker registry impl.
