### PR TITLE
[v1.2] Ignore BLOB_UNKNOWN registry errors

### DIFF
--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -59,7 +59,13 @@ func (api *api) IsRepoImageExists(ctx context.Context, reference string) (bool, 
 
 func (api *api) TryGetRepoImage(ctx context.Context, reference string) (*image.Info, error) {
 	if imgInfo, err := api.GetRepoImage(ctx, reference); err != nil {
-		if IsManifestUnknownError(err) || IsNameUnknownError(err) {
+		if IsBlobUnknownError(err) || IsManifestUnknownError(err) {
+			// TODO: Delete such images in werf-cleanup then enable warnings
+			// logboek.Context(ctx).Warn().LogF("WARNING: Got an error when inspecting repo image %q: %s\n", reference, err)
+			return nil, nil
+		}
+
+		if IsNameUnknownError(err) {
 			return nil, nil
 		}
 		return imgInfo, err

--- a/pkg/docker_registry/default.go
+++ b/pkg/docker_registry/default.go
@@ -45,6 +45,10 @@ func IsManifestUnknownError(err error) bool {
 	return strings.Contains(err.Error(), "MANIFEST_UNKNOWN")
 }
 
+func IsBlobUnknownError(err error) bool {
+	return strings.Contains(err.Error(), "BLOB_UNKNOWN")
+}
+
 func IsNameUnknownError(err error) bool {
 	return strings.Contains(err.Error(), "NAME_UNKNOWN")
 }


### PR DESCRIPTION
Ignore silently without warnings until werf-cleanup does not delete these broken images.