### PR TITLE
[config] .Files.Glob fails with an error instead of a warning message if no matches found

### DIFF
--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -317,7 +317,7 @@ func (f files) doGlob(ctx context.Context, pattern string) (map[string]interface
 	}
 
 	if len(res) == 0 {
-		logboek.Context(f.ctx).Warn().LogF("WARNING: No matches found for {{ .Files.Glob %q }}\n", pattern)
+		return nil, fmt.Errorf("{{ .Files.Glob %q }}: no matches found", pattern)
 	}
 
 	return res, nil


### PR DESCRIPTION
```
Error: unable to load werf config: template: werfConfig:8:9: executing "werfConfig" at <.Files.Glob>: error calling Glob: {{ .Files.Glob "path" }}: no matches found
```