### PR TITLE
[giterminism] Fix broken symlinks are processed incorrectly

### DIFF
--- a/pkg/giterminism_manager/inspector/build_context.go
+++ b/pkg/giterminism_manager/inspector/build_context.go
@@ -37,5 +37,5 @@ func (i Inspector) InspectBuildContextFiles(ctx context.Context, matcher path_ma
 		)
 	}
 
-	return i.fileReader.ExtraWindowsCheckFilesModifiedLocally(ctx, relativeToProjectDirPathList...)
+	return i.fileReader.ExtraCheckFilesModifiedLocally(ctx, relativeToProjectDirPathList...)
 }

--- a/pkg/giterminism_manager/inspector/inspector.go
+++ b/pkg/giterminism_manager/inspector/inspector.go
@@ -29,7 +29,7 @@ type giterminismConfig interface {
 
 type fileReader interface {
 	HandleValidateSubmodulesErr(err error) error
-	ExtraWindowsCheckFilesModifiedLocally(ctx context.Context, relPath ...string) error
+	ExtraCheckFilesModifiedLocally(ctx context.Context, relPath ...string) error
 }
 
 type sharedOptions interface {


### PR DESCRIPTION
А few words on the issue:
```
$ git status
On branch master
nothing to commit, working tree clean

$ werf build
...
Running time 1.05 seconds
Error: phase build on image x stage gitArchive handler failed: the file "broken_symlink" must be committed

You might also be interested in developer mode (activated with --dev option) that allows you to work with staged changes without doing redundant commits. Just use "git add <file>..." to include the changes that should be used.

To provide a strong guarantee of reproducibility, werf reads the configuration and build's context files from the project git repository and eliminates external dependencies. We strongly recommend to follow this approach. But if necessary, you can allow the reading of specific files directly from the file system and enable the features that require careful use. Read more about giterminism and how to manage it here: https://werf.io/v1.2-alpha/documentation/advanced/configuration/giterminism.html.
```

rel https://github.com/go-git/go-git/issues/253