### PR TITLE
[stapel, git] Fix adding a broken symlink does not work

### DIFF
--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -8,7 +8,7 @@ import (
 
 // FileExists returns true if path exists
 func FileExists(path string) (bool, error) {
-	_, err := os.Stat(path)
+	_, err := os.Lstat(path)
 	if err != nil {
 		if isNotExistError(err) {
 			return false, nil
@@ -21,7 +21,7 @@ func FileExists(path string) (bool, error) {
 }
 
 func RegularFileExists(path string) (bool, error) {
-	fileInfo, err := os.Stat(path)
+	fileInfo, err := os.Lstat(path)
 	if err != nil {
 		if isNotExistError(err) {
 			return false, nil
@@ -34,7 +34,7 @@ func RegularFileExists(path string) (bool, error) {
 }
 
 func DirExists(path string) (bool, error) {
-	fileInfo, err := os.Stat(path)
+	fileInfo, err := os.Lstat(path)
 	if err != nil {
 		if isNotExistError(err) {
 			return false, nil


### PR DESCRIPTION
А few words on the issue:

```
$ werf build
...
Error: phase build on image x stage gitArchive handler failed: error preparing stage gitArchive: error creating archive for commit "9ddc6d4ad22f4745e958864b2fded5dcf42a8fea": base path broken_symlink entry not found repo

$ cat werf.yaml
project: broken_symlink
configVersion: 1
---
image: test
from: alpine
git:
  - add: /broken_symlink
    to: /link
```

When adding a file to an assembly container, it doesn't matter which file the symlink points to.