### PR TITLE
[win][git] Fix CRLF issues and patch-does-not-apply errors

### DIFF
--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -157,7 +157,7 @@ func (gm *GitMapping) applyPatchCommand(patchFile *ContainerFileDescriptor, arch
 	))
 
 	gitCommand := fmt.Sprintf(
-		"%s %s apply --whitespace=nowarn --directory=\"%s\" --unsafe-paths %s",
+		"%s %s apply --ignore-whitespace --whitespace=nowarn --directory=\"%s\" --unsafe-paths %s",
 		stapel.OptionalSudoCommand(gm.Owner, gm.Group),
 		stapel.GitBinPath(),
 		applyPatchDirectory,

--- a/pkg/git_repo/git_data_manager.go
+++ b/pkg/git_repo/git_data_manager.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	GitArchivesCacheVersion = "1"
-	GitPatchesCacheVersion  = "1"
+	GitArchivesCacheVersion = "2"
+	GitPatchesCacheVersion  = "2"
 )
 
 var (

--- a/pkg/git_repo/work_tree.go
+++ b/pkg/git_repo/work_tree.go
@@ -6,7 +6,7 @@ import (
 	"github.com/werf/werf/pkg/werf"
 )
 
-const GitWorkTreeCacheVersion = "7"
+const GitWorkTreeCacheVersion = "8"
 
 func GetWorkTreeCacheDir() string {
 	return filepath.Join(werf.GetLocalCacheDir(), "git_worktrees", GitWorkTreeCacheVersion)

--- a/pkg/true_git/common.go
+++ b/pkg/true_git/common.go
@@ -22,3 +22,7 @@ func setCommandRecordingLiveOutput(ctx context.Context, cmd *exec.Cmd) *bytes.Bu
 
 	return recorder
 }
+
+func getCommonGitOptions() []string {
+	return []string{"-c", "core.autocrlf=false"}
+}

--- a/pkg/true_git/dev_branch.go
+++ b/pkg/true_git/dev_branch.go
@@ -114,7 +114,8 @@ type runGitCmdOptions struct {
 }
 
 func runGitCmd(ctx context.Context, args []string, dir string, opts runGitCmdOptions) (*bytes.Buffer, error) {
-	cmd := exec.Command("git", args...)
+	allArgs := append(getCommonGitOptions(), args...)
+	cmd := exec.Command("git", allArgs...)
 	cmd.Dir = dir
 
 	if opts.stdin != nil {

--- a/pkg/true_git/dot_git.go
+++ b/pkg/true_git/dot_git.go
@@ -41,7 +41,7 @@ func IsValidWorkTree(workTree string) (bool, error) {
 }
 
 func IsValidGitDir(gitDir string) (bool, error) {
-	gitArgs := []string{"--git-dir", gitDir, "rev-parse"}
+	gitArgs := append(getCommonGitOptions(), []string{"--git-dir", gitDir, "rev-parse"}...)
 
 	cmd := exec.Command("git", gitArgs...)
 

--- a/pkg/true_git/merge.go
+++ b/pkg/true_git/merge.go
@@ -50,7 +50,7 @@ func CreateDetachedMergeCommit(ctx context.Context, gitDir, workTreeCacheDir, co
 				return fmt.Errorf("unable to remove %s: %s", currentCommitPath, err)
 			}
 
-			cmd = exec.Command("git", "-c", "user.email=werf@werf.io", "-c", "user.name=werf", "merge", "--no-edit", "--no-ff", commitToMerge)
+			cmd = exec.Command("git", append(getCommonGitOptions(), "-c", "user.email=werf@werf.io", "-c", "user.name=werf", "merge", "--no-edit", "--no-ff", commitToMerge)...)
 			cmd.Dir = workTreeDir
 			output = setCommandRecordingLiveOutput(ctx, cmd)
 			err = cmd.Run()
@@ -61,7 +61,7 @@ func CreateDetachedMergeCommit(ctx context.Context, gitDir, workTreeCacheDir, co
 				fmt.Printf("[DEBUG MERGE] %s\n%s\n", strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " "), output)
 			}
 
-			cmd = exec.Command("git", "rev-parse", "HEAD")
+			cmd = exec.Command("git", append(getCommonGitOptions(), "rev-parse", "HEAD")...)
 			cmd.Dir = workTreeDir
 			output = setCommandRecordingLiveOutput(ctx, cmd)
 			err = cmd.Run()

--- a/pkg/true_git/merge_base.go
+++ b/pkg/true_git/merge_base.go
@@ -7,7 +7,7 @@ import (
 )
 
 func IsAncestor(ancestorCommit, descendantCommit string, gitDir string) (bool, error) {
-	gitArgs := []string{"-C", gitDir, "merge-base", "--is-ancestor", ancestorCommit, descendantCommit}
+	gitArgs := append(getCommonGitOptions(), "-C", gitDir, "merge-base", "--is-ancestor", ancestorCommit, descendantCommit)
 	cmd := exec.Command("git", gitArgs...)
 
 	output, err := cmd.CombinedOutput()

--- a/pkg/true_git/patch.go
+++ b/pkg/true_git/patch.go
@@ -69,10 +69,10 @@ func writePatch(ctx context.Context, out io.Writer, gitDir, workTreeCacheDir str
 		return nil, fmt.Errorf("provide work tree cache directory to enable submodules!")
 	}
 
-	commonGitOpts := []string{
+	commonGitOpts := append(getCommonGitOptions(),
 		"-c", "diff.renames=false",
 		"-c", "core.quotePath=false",
-	}
+	)
 	if opts.WithEntireFileContext {
 		commonGitOpts = append(commonGitOpts, "-c", "diff.context=999999999")
 	}

--- a/pkg/true_git/repository.go
+++ b/pkg/true_git/repository.go
@@ -29,7 +29,7 @@ type FetchOptions struct {
 
 func Fetch(ctx context.Context, path string, options FetchOptions) error {
 	command := "git"
-	commandArgs := []string{"-C", path, "fetch"}
+	commandArgs := append(getCommonGitOptions(), "-C", path, "fetch")
 
 	if options.Unshallow {
 		commandArgs = append(commandArgs, "--unshallow")

--- a/pkg/true_git/show_ref.go
+++ b/pkg/true_git/show_ref.go
@@ -25,7 +25,7 @@ type ShowRefResult struct {
 }
 
 func ShowRef(repoDir string) (*ShowRefResult, error) {
-	gitArgs := []string{"-C", repoDir, "show-ref", "--head"}
+	gitArgs := append(getCommonGitOptions(), "-C", repoDir, "show-ref", "--head")
 
 	cmd := exec.Command("git", gitArgs...)
 

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -12,10 +12,7 @@ import (
 func syncSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 	logProcessMsg := fmt.Sprintf("Sync submodules in work tree %q", workTreeDir)
 	return logboek.Context(ctx).Info().LogProcess(logProcessMsg).DoError(func() error {
-		cmd := exec.Command(
-			"git", "-c", "core.autocrlf=false",
-			"submodule", "sync", "--recursive",
-		)
+		cmd := exec.Command("git", append(getCommonGitOptions(), "submodule", "sync", "--recursive")...)
 
 		cmd.Dir = workTreeDir // required for `git submodule` to work
 
@@ -38,8 +35,8 @@ func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 	logProcessMsg := fmt.Sprintf("Update submodules in work tree %q", workTreeDir)
 	return logboek.Context(ctx).Info().LogProcess(logProcessMsg).DoError(func() error {
 		cmd := exec.Command(
-			"git", "-c", "core.autocrlf=false",
-			"submodule", "update", "--checkout", "--force", "--init", "--recursive",
+			"git", append(getCommonGitOptions(),
+				"submodule", "update", "--checkout", "--force", "--init", "--recursive")...,
 		)
 
 		cmd.Dir = workTreeDir // required for `git submodule` to work


### PR DESCRIPTION
The root of the issue: werf have added file converted from LF to CRLF into built image under windows due to some local git autocrlf settings. Then werf cannot apply patch to the file with CRLF's inside the build container.

 1. Fix werf to always add files into image from git without any conversions from LF to CRLF, or from CRLF to LF. Take files from the git as-is.
 2. Fix patches applier for files with CRLF already added into the built images for some reason (images built with an older werf version with this bug).