### PR TITLE
[giterminism] Fix .gitignore rules are not fully supported

### DIFF
--- a/pkg/git_repo/local.go
+++ b/pkg/git_repo/local.go
@@ -768,6 +768,34 @@ func (repo *Local) ReadCommitTreeEntryContent(ctx context.Context, commit, relPa
 	return content, nil
 }
 
+func (repo *Local) IsCommitTreeEntryDirectory(ctx context.Context, commit, relPath string) (isDirectory bool, err error) {
+	logboek.Context(ctx).Debug().
+		LogBlock("IsCommitTreeEntryDirectory %q %q", commit, relPath).
+		Options(func(options types.LogBlockOptionsInterface) {
+			if !debugGiterminismManager() {
+				options.Mute()
+			}
+		}).
+		Do(func() {
+			isDirectory, err = repo.isCommitTreeEntryDirectory(ctx, commit, relPath)
+
+			if debugGiterminismManager() {
+				logboek.Context(ctx).Debug().LogF("isDirectory: %v\nerr: %q\n", isDirectory, err)
+			}
+		})
+
+	return
+}
+
+func (repo *Local) isCommitTreeEntryDirectory(ctx context.Context, commit, relPath string) (bool, error) {
+	entry, err := repo.getCommitTreeEntry(ctx, commit, relPath)
+	if err != nil {
+		return false, err
+	}
+
+	return entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule, nil
+}
+
 func (repo *Local) IsCommitTreeEntryExist(ctx context.Context, commit, relPath string) (exist bool, err error) {
 	logboek.Context(ctx).Debug().
 		LogBlock("IsCommitTreeEntryExist %q %q", commit, relPath).

--- a/pkg/git_repo/status/result.go
+++ b/pkg/git_repo/status/result.go
@@ -241,14 +241,14 @@ func (r *Result) ValidateSubmodules(repository *git.Repository, headCommit strin
 
 func (r *Result) IsFileModified(relPath string, options FilterOptions) bool {
 	for _, filePath := range r.filteredFilePathList(options) {
-		if path.Join(r.repositoryFullFilepath, filePath) == filepath.ToSlash(relPath) {
+		if path.Join(r.repositoryFullFilepath, filePath) == filepath.ToSlash(relPath) || util.IsSubpathOfBasePath(relPath, filePath) {
 			return true
 		}
 	}
 
 	if !options.IgnoreSubmodules {
 		for _, sr := range r.submoduleResults {
-			if util.IsSubpathOfBasePath(filepath.ToSlash(sr.repositoryFullFilepath), filepath.ToSlash(relPath)) {
+			if util.IsSubpathOfBasePath(sr.repositoryFullFilepath, relPath) {
 				if sr.submoduleStatus.Current != sr.submoduleStatus.Expected {
 					return true
 				}

--- a/pkg/giterminism_manager/file_reader/config.go
+++ b/pkg/giterminism_manager/file_reader/config.go
@@ -69,8 +69,8 @@ func (r FileReader) readConfig(ctx context.Context, customRelPath string) ([]byt
 	configRelPathList := r.configPathList(customRelPath)
 
 	for _, configPath := range configRelPathList {
-		data, err := r.ReadAndCheckConfigurationFile(ctx, configPath, func(_ string) (bool, error) {
-			return r.giterminismConfig.IsUncommittedConfigAccepted(), nil
+		data, err := r.ReadAndCheckConfigurationFile(ctx, configPath, func(_ string) bool {
+			return r.giterminismConfig.IsUncommittedConfigAccepted()
 		})
 
 		if err != nil {

--- a/pkg/giterminism_manager/file_reader/config_go_template.go
+++ b/pkg/giterminism_manager/file_reader/config_go_template.go
@@ -13,7 +13,7 @@ func (r FileReader) ConfigGoTemplateFilesGlob(ctx context.Context, glob string) 
 		ctx,
 		"",
 		glob,
-		r.giterminismConfig.IsUncommittedConfigGoTemplateRenderingFileAccepted,
+		r.giterminismConfig.UncommittedConfigGoTemplateRenderingFilePathMatcher().MatchPath,
 		func(relativeToDirNotResolvedPath string, data []byte, err error) error {
 			if err != nil {
 				return err
@@ -31,7 +31,7 @@ func (r FileReader) ConfigGoTemplateFilesGlob(ctx context.Context, glob string) 
 }
 
 func (r FileReader) ConfigGoTemplateFilesGet(ctx context.Context, relPath string) ([]byte, error) {
-	data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedConfigGoTemplateRenderingFileAccepted)
+	data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.UncommittedConfigGoTemplateRenderingFilePathMatcher().MatchPath)
 	if err != nil {
 		return nil, fmt.Errorf("{{ .Files.Get %q }}: %s", relPath, err)
 	}

--- a/pkg/giterminism_manager/file_reader/config_go_template.go
+++ b/pkg/giterminism_manager/file_reader/config_go_template.go
@@ -13,7 +13,7 @@ func (r FileReader) ConfigGoTemplateFilesGlob(ctx context.Context, glob string) 
 		ctx,
 		"",
 		glob,
-		r.giterminismConfig.UncommittedConfigGoTemplateRenderingFilePathMatcher().MatchPath,
+		r.giterminismConfig.UncommittedConfigGoTemplateRenderingFilePathMatcher(),
 		func(relativeToDirNotResolvedPath string, data []byte, err error) error {
 			if err != nil {
 				return err

--- a/pkg/giterminism_manager/file_reader/config_templates.go
+++ b/pkg/giterminism_manager/file_reader/config_templates.go
@@ -44,7 +44,7 @@ func (r FileReader) readConfigTemplateFiles(ctx context.Context, customDirRelPat
 		ctx,
 		templatesDirRelPath,
 		"**/*.tmpl",
-		r.giterminismConfig.UncommittedConfigTemplateFilePathMatcher().MatchPath,
+		r.giterminismConfig.UncommittedConfigTemplateFilePathMatcher(),
 		func(relativeToDirNotResolvedPath string, data []byte, err error) error {
 			return tmplFunc(filepath.ToSlash(relativeToDirNotResolvedPath), data, err)
 		},

--- a/pkg/giterminism_manager/file_reader/config_templates.go
+++ b/pkg/giterminism_manager/file_reader/config_templates.go
@@ -44,7 +44,7 @@ func (r FileReader) readConfigTemplateFiles(ctx context.Context, customDirRelPat
 		ctx,
 		templatesDirRelPath,
 		"**/*.tmpl",
-		r.giterminismConfig.IsUncommittedConfigTemplateFileAccepted,
+		r.giterminismConfig.UncommittedConfigTemplateFilePathMatcher().MatchPath,
 		func(relativeToDirNotResolvedPath string, data []byte, err error) error {
 			return tmplFunc(filepath.ToSlash(relativeToDirNotResolvedPath), data, err)
 		},

--- a/pkg/giterminism_manager/file_reader/configuration.go
+++ b/pkg/giterminism_manager/file_reader/configuration.go
@@ -12,7 +12,7 @@ import (
 
 // WalkConfigurationFilesWithGlob reads the configuration files taking into account the giterminism config.
 // The result paths are relative to the passed directory, the method does reverse resolving for symlinks.
-func (r FileReader) WalkConfigurationFilesWithGlob(ctx context.Context, dir, glob string, isFileAcceptedCheckFunc func(relPath string) (bool, error), handleFileFunc func(relativeToDirNotResolvedPath string, data []byte, err error) error) (err error) {
+func (r FileReader) WalkConfigurationFilesWithGlob(ctx context.Context, dir, glob string, isFileAcceptedCheckFunc func(relPath string) bool, handleFileFunc func(relativeToDirNotResolvedPath string, data []byte, err error) error) (err error) {
 	logboek.Context(ctx).Debug().
 		LogBlock("WalkConfigurationFilesWithGlob %q %q", dir, glob).
 		Options(func(options types.LogBlockOptionsInterface) {
@@ -31,7 +31,7 @@ func (r FileReader) WalkConfigurationFilesWithGlob(ctx context.Context, dir, glo
 	return
 }
 
-func (r FileReader) walkConfigurationFilesWithGlob(ctx context.Context, dir, glob string, isFileAcceptedCheckFunc func(relPath string) (bool, error), handleFileFunc func(relativeToDirNotResolvedPath string, data []byte, err error) error) (err error) {
+func (r FileReader) walkConfigurationFilesWithGlob(ctx context.Context, dir, glob string, isFileAcceptedCheckFunc func(relPath string) bool, handleFileFunc func(relativeToDirNotResolvedPath string, data []byte, err error) error) (err error) {
 	relToDirFilePathListFromFS, err := r.ListFilesWithGlob(ctx, dir, glob)
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func (r FileReader) walkConfigurationFilesWithGlob(ctx context.Context, dir, glo
 }
 
 // ReadAndCheckConfigurationFile does CheckConfigurationFileExistenceAndAcceptance and ReadConfigurationFile.
-func (r FileReader) ReadAndCheckConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (data []byte, err error) {
+func (r FileReader) ReadAndCheckConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) bool) (data []byte, err error) {
 	logboek.Context(ctx).Debug().
 		LogBlock("ReadAndCheckConfigurationFile %q", relPath).
 		Options(func(options types.LogBlockOptionsInterface) {
@@ -99,7 +99,7 @@ func (r FileReader) ReadAndCheckConfigurationFile(ctx context.Context, relPath s
 	return
 }
 
-func (r FileReader) readAndCheckConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) ([]byte, error) {
+func (r FileReader) readAndCheckConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) bool) ([]byte, error) {
 	if err := r.CheckConfigurationFileExistenceAndAcceptance(ctx, relPath, isFileAcceptedCheckFunc); err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (r FileReader) readAndCheckConfigurationFile(ctx context.Context, relPath s
 }
 
 // ReadConfigurationFile does ReadFile or ReadCommitFile depending on the giterminism config.
-func (r FileReader) ReadConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (data []byte, err error) {
+func (r FileReader) ReadConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) bool) (data []byte, err error) {
 	logboek.Context(ctx).Debug().
 		LogBlock("ReadConfigurationFile %q", relPath).
 		Options(func(options types.LogBlockOptionsInterface) {
@@ -127,7 +127,7 @@ func (r FileReader) ReadConfigurationFile(ctx context.Context, relPath string, i
 	return
 }
 
-func (r FileReader) readConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) ([]byte, error) {
+func (r FileReader) readConfigurationFile(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) bool) ([]byte, error) {
 	shouldFileBeReadFromFS, err := r.ShouldFileBeRead(ctx, relPath, isFileAcceptedCheckFunc)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func (r FileReader) readConfigurationFile(ctx context.Context, relPath string, i
 }
 
 // CheckConfigurationFileExistenceAndAcceptance does CheckFileExistenceAndAcceptance or CheckCommitFileExistenceAndLocalChanges depending on the giterminism config.
-func (r FileReader) CheckConfigurationFileExistenceAndAcceptance(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (err error) {
+func (r FileReader) CheckConfigurationFileExistenceAndAcceptance(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) bool) (err error) {
 	logboek.Context(ctx).Debug().
 		LogBlock("CheckConfigurationFileExistenceAndAcceptance %q", relPath).
 		Options(func(options types.LogBlockOptionsInterface) {
@@ -160,7 +160,7 @@ func (r FileReader) CheckConfigurationFileExistenceAndAcceptance(ctx context.Con
 	return
 }
 
-func (r FileReader) checkConfigurationFileExistenceAndAcceptance(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) error {
+func (r FileReader) checkConfigurationFileExistenceAndAcceptance(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) bool) error {
 	shouldFileBeReadFromFS, err := r.ShouldFileBeRead(ctx, relPath, isFileAcceptedCheckFunc)
 	if err != nil {
 		return err
@@ -212,7 +212,7 @@ func (r FileReader) isConfigurationFileExistAnywhere(ctx context.Context, relPat
 
 // IsConfigurationFileExist checks the configuration file existence taking into account the giterminism config.
 // The method does not check acceptance for each symlink target if the configuration file is symlink.
-func (r FileReader) IsConfigurationFileExist(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (exist bool, err error) {
+func (r FileReader) IsConfigurationFileExist(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) bool) (exist bool, err error) {
 	logboek.Context(ctx).Debug().
 		LogBlock("IsConfigurationFileExist %q", relPath).
 		Options(func(options types.LogBlockOptionsInterface) {
@@ -231,7 +231,7 @@ func (r FileReader) IsConfigurationFileExist(ctx context.Context, relPath string
 	return
 }
 
-func (r FileReader) isConfigurationFileExist(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) (bool, error)) (bool, error) {
+func (r FileReader) isConfigurationFileExist(ctx context.Context, relPath string, isFileAcceptedCheckFunc func(relPath string) bool) (bool, error) {
 	shouldFileBeReadFromFS, err := r.ShouldFileBeRead(ctx, relPath, isFileAcceptedCheckFunc)
 	if err != nil {
 		return false, err

--- a/pkg/giterminism_manager/file_reader/errors.go
+++ b/pkg/giterminism_manager/file_reader/errors.go
@@ -40,7 +40,7 @@ func (r FileReader) NewFileNotFoundInProjectRepositoryError(relPath string) erro
 
 func (r FileReader) NewUncommittedSubmoduleChangesError(submodulePath string, filePathList []string) error {
 	errorMsg := fmt.Sprintf("the submodule %q has modified files and these changes must be committed (do not forget to push new changes to the submodule remote) or discarded:\n\n%s", filepath.ToSlash(submodulePath), prepareListOfFilesString(filePathList))
-	return errors.NewError(errorMsg)
+	return UncommittedFilesError{fmt.Errorf("%s", errorMsg)}
 }
 
 func (r FileReader) NewUncleanSubmoduleError(submodulePath, headCommit, currentCommit, expectedCommit string) error {

--- a/pkg/giterminism_manager/file_reader/file_reader.go
+++ b/pkg/giterminism_manager/file_reader/file_reader.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/werf/werf/pkg/git_repo"
+	"github.com/werf/werf/pkg/path_matcher"
 )
 
 type FileReader struct {
@@ -21,11 +22,11 @@ func NewFileReader(sharedOptions sharedOptions) FileReader {
 
 type giterminismConfig interface {
 	IsUncommittedConfigAccepted() bool
-	IsUncommittedConfigTemplateFileAccepted(relPath string) (bool, error)
-	IsUncommittedConfigGoTemplateRenderingFileAccepted(relPath string) (bool, error)
-	IsUncommittedDockerfileAccepted(relPath string) (bool, error)
-	IsUncommittedDockerignoreAccepted(relPath string) (bool, error)
-	IsUncommittedHelmFileAccepted(relPath string) (bool, error)
+	UncommittedConfigTemplateFilePathMatcher() path_matcher.PathMatcher
+	UncommittedConfigGoTemplateRenderingFilePathMatcher() path_matcher.PathMatcher
+	IsUncommittedDockerfileAccepted(relPath string) bool
+	IsUncommittedDockerignoreAccepted(relPath string) bool
+	UncommittedHelmFilePathMatcher() path_matcher.PathMatcher
 }
 
 type sharedOptions interface {

--- a/pkg/giterminism_manager/file_reader/giterminism_config.go
+++ b/pkg/giterminism_manager/file_reader/giterminism_config.go
@@ -53,7 +53,7 @@ func (r FileReader) ReadGiterminismConfig(ctx context.Context) (data []byte, err
 }
 
 func (r FileReader) readGiterminismConfig(ctx context.Context) ([]byte, error) {
-	return r.ReadAndCheckConfigurationFile(ctx, GiterminismConfigName, func(relPath string) (bool, error) {
-		return false, nil
+	return r.ReadAndCheckConfigurationFile(ctx, GiterminismConfigName, func(relPath string) bool {
+		return false
 	})
 }

--- a/pkg/giterminism_manager/file_reader/helm_chart_extender.go
+++ b/pkg/giterminism_manager/file_reader/helm_chart_extender.go
@@ -67,7 +67,7 @@ func (r FileReader) loadChartDir(ctx context.Context, relDir string) ([]*chart.C
 		ctx,
 		relDir,
 		"**/*",
-		r.giterminismConfig.UncommittedHelmFilePathMatcher().MatchPath,
+		r.giterminismConfig.UncommittedHelmFilePathMatcher(),
 		func(relativeToDirNotResolvedPath string, data []byte, err error) error {
 			if err != nil {
 				return err

--- a/pkg/giterminism_manager/file_reader/helm_chart_extender.go
+++ b/pkg/giterminism_manager/file_reader/helm_chart_extender.go
@@ -45,7 +45,7 @@ func (r FileReader) ReadChartFile(ctx context.Context, path string) ([]byte, err
 }
 
 func (r FileReader) readChartFile(ctx context.Context, relPath string) ([]byte, error) {
-	return r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.IsUncommittedHelmFileAccepted)
+	return r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.UncommittedHelmFilePathMatcher().MatchPath)
 }
 
 func (r FileReader) LoadChartDir(ctx context.Context, chartDir string) ([]*chart.ChartExtenderBufferedFile, error) {
@@ -67,7 +67,7 @@ func (r FileReader) loadChartDir(ctx context.Context, relDir string) ([]*chart.C
 		ctx,
 		relDir,
 		"**/*",
-		r.giterminismConfig.IsUncommittedHelmFileAccepted,
+		r.giterminismConfig.UncommittedHelmFilePathMatcher().MatchPath,
 		func(relativeToDirNotResolvedPath string, data []byte, err error) error {
 			if err != nil {
 				return err

--- a/pkg/giterminism_manager/inspector/dockerfile.go
+++ b/pkg/giterminism_manager/inspector/dockerfile.go
@@ -10,9 +10,7 @@ func (i Inspector) InspectConfigDockerfileContextAddFile(relPath string) error {
 		return nil
 	}
 
-	if isAccepted, err := i.giterminismConfig.IsConfigDockerfileContextAddFileAccepted(relPath); err != nil {
-		return err
-	} else if isAccepted {
+	if i.giterminismConfig.IsConfigDockerfileContextAddFileAccepted(relPath) {
 		return nil
 	}
 

--- a/pkg/giterminism_manager/inspector/inspector.go
+++ b/pkg/giterminism_manager/inspector/inspector.go
@@ -22,8 +22,8 @@ type giterminismConfig interface {
 	IsConfigStapelFromLatestAccepted() bool
 	IsConfigStapelGitBranchAccepted() bool
 	IsConfigStapelMountBuildDirAccepted() bool
-	IsConfigStapelMountFromPathAccepted(fromPath string) (bool, error)
-	IsConfigDockerfileContextAddFileAccepted(relPath string) (bool, error)
+	IsConfigStapelMountFromPathAccepted(fromPath string) bool
+	IsConfigDockerfileContextAddFileAccepted(relPath string) bool
 }
 
 type fileReader interface {

--- a/pkg/giterminism_manager/inspector/stapel.go
+++ b/pkg/giterminism_manager/inspector/stapel.go
@@ -40,9 +40,7 @@ func (i Inspector) InspectConfigStapelMountFromPath(fromPath string) error {
 		return nil
 	}
 
-	if isAccepted, err := i.giterminismConfig.IsConfigStapelMountFromPathAccepted(fromPath); err != nil {
-		return err
-	} else if isAccepted {
+	if i.giterminismConfig.IsConfigStapelMountFromPathAccepted(fromPath) {
 		return nil
 	}
 

--- a/pkg/path_matcher/stub_path_matcher.go
+++ b/pkg/path_matcher/stub_path_matcher.go
@@ -1,0 +1,22 @@
+package path_matcher
+
+func NewStubPathMatcher(basePath string) *StubPathMatcher {
+	return &StubPathMatcher{SimplePathMatcher: NewSimplePathMatcher(basePath, nil, true)}
+}
+
+// StubPathMatcher returns false when matching paths
+type StubPathMatcher struct {
+	*SimplePathMatcher
+}
+
+func (m *StubPathMatcher) MatchPath(_ string) bool {
+	return false
+}
+
+func (m *StubPathMatcher) ProcessDirOrSubmodulePath(_ string) (bool, bool) {
+	return false, false
+}
+
+func (m *StubPathMatcher) String() string {
+	return "none"
+}


### PR DESCRIPTION
Skip the file when reading a group of configurations from the FS if:
- not accepted by giterminism config
- not changed locally
- ignored by .gitignore
- not inside an unclean submodule repository