### PR TITLE
[v1.1, config] Add fromYaml function

### DIFF
--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -294,6 +294,15 @@ func funcMap(tmpl *template.Template) template.FuncMap {
 		}
 	}
 
+	funcMap["fromYaml"] = func(str string) (map[string]interface{}, error) {
+		m := map[string]interface{}{}
+
+		if err := yaml.Unmarshal([]byte(str), &m); err != nil {
+			return nil, err
+		}
+
+		return m, nil
+	}
 	funcMap["include"] = func(name string, data interface{}) (string, error) {
 		return executeTemplate(tmpl, name, data)
 	}


### PR DESCRIPTION
- fromYAML(str string) (map[string]interface{}, error)
- return error if unmarshalling failed

werf.yaml
```
...
{{- $values := .Files.Get "werf_values.yaml" | fromYaml -}} // or fromYaml (.Files.Get "werf_values.yaml")
from: {{- $values.image.from }}
```

werf_values.yaml
```
image:
  from: alpine
```