### PR TITLE
[docs] Change api call to CI variable

### DIFF
--- a/docs/pages_ru/documentation/advanced/ci_cd/gitlab_ci_cd.md
+++ b/docs/pages_ru/documentation/advanced/ci_cd/gitlab_ci_cd.md
@@ -328,27 +328,8 @@ Review:
     - type werf && source $(werf ci-env gitlab --as-file)
     - >
       # do optional deploy/dismiss
-      
-      if [ -z "$PRIVATE_TOKEN" ]; then
-        echo "\$PRIVATE_TOKEN is not defined" >&2
-        exit 1
-      fi
 
-      api_url=${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}
-
-      if ! response_body=$(curl -sS --header "PRIVATE-TOKEN: ${PRIVATE_TOKEN}" ${api_url}); then
-        echo "GET ${api_url}"
-        echo ${response_body}
-        exit 1
-      fi
-
-      if ! echo ${response_body} | jq .labels[] >/dev/null 2>&1; then
-        echo "GET ${api_url}"
-        echo ${response_body}
-        exit 1
-      fi
-
-      if echo ${response_body} | jq .labels[] | grep -q '^"review"$'; then
+      if echo $CI_MERGE_REQUEST_LABELS | tr ',' '\n' | grep -q -P '^review$'; then
         werf converge --skip-build --set "global.env_url=$(echo ${CI_ENVIRONMENT_URL} | cut -d / -f 3)"
       else
         if werf helm get $(werf helm get-release) 2>/dev/null; then
@@ -387,8 +368,7 @@ Stop Review:
 ```
 {% endraw %}
 
-Для проверки наличия лейбла у MR используется GitLab API. 
-Так как токена `CI_JOB_TOKEN` недостаточно для работы с private репозиториями, необходимо сгенерировать специальный токен `PRIVATE_TOKEN`.
+Для проверки наличия лейбла у MR используется переменная среды `CI_MERGE_REQUEST_LABELS`. 
 
 ### Варианты организации staging и production окружений
 
@@ -599,27 +579,8 @@ Review:
     - type werf && source $(werf ci-env gitlab --as-file)
     - >
       # do optional deploy/dismiss
-      
-      if [ -z "$PRIVATE_TOKEN" ]; then
-        echo "\$PRIVATE_TOKEN is not defined" >&2
-        exit 1
-      fi
 
-      api_url=${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}
-
-      if ! response_body=$(curl -sS --header "PRIVATE-TOKEN: ${PRIVATE_TOKEN}" ${api_url}); then
-        echo "GET ${api_url}"
-        echo ${response_body}
-        exit 1
-      fi
-
-      if ! echo ${response_body} | jq .labels[] >/dev/null 2>&1; then
-        echo "GET ${api_url}"
-        echo ${response_body}
-        exit 1
-      fi
-
-      if echo ${response_body} | jq .labels[] | grep -q '^"review"$'; then
+      if echo $CI_MERGE_REQUEST_LABELS | tr ',' '\n' | grep -q -P '^review$'; then
         werf converge --skip-build --set "global.env_url=$(echo ${CI_ENVIRONMENT_URL} | cut -d / -f 3)"
       else
         if werf helm get $(werf helm get-release) 2>/dev/null; then


### PR DESCRIPTION
Since gitlab 11.9 `CI_MERGE_REQUEST_LABELS` is available.
So if we want to determine if label "review" is present for MR, we can use this variable. 
This solutions makes project configuration easier since we don't need to issue PRIVATE_TOKEN and declare it as CI variable, also this is faster because we don't make any API call