### PR TITLE
[ci_env] Fix unable to create tmp docker config based on the user's one

### DIFF
--- a/pkg/tmp_manager/docker_config_dir.go
+++ b/pkg/tmp_manager/docker_config_dir.go
@@ -3,6 +3,7 @@ package tmp_manager
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -20,9 +21,22 @@ func CreateDockerConfigDir(ctx context.Context, fromDockerConfig string) (string
 	}
 
 	if _, err := os.Stat(fromDockerConfig); !os.IsNotExist(err) {
-		err := copy.Copy(fromDockerConfig, newDir)
+		files, err := ioutil.ReadDir(fromDockerConfig)
 		if err != nil {
-			return "", fmt.Errorf("unable to copy %s to %s: %s", fromDockerConfig, newDir, err)
+			return "", fmt.Errorf("unable to read %q", fromDockerConfig)
+		}
+
+		for _, file := range files {
+			if file.Name() == "run" {
+				continue
+			}
+
+			source := filepath.Join(fromDockerConfig, file.Name())
+			destination := filepath.Join(newDir, file.Name())
+			err := copy.Copy(source, destination)
+			if err != nil {
+				return "", fmt.Errorf("unable to copy %q to %q: %s", source, destination, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
```
Error: unable to create tmp docker config: unable to copy /home/user/.docker to /tmp/werf-docker-config-780142139: open /home/user/.docker/run/docker-cli-api.sock: no such device or address
```