### PR TITLE
[migrate 2 to 3] Print warning when helm 2 and helm 3 releases exists at the same time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tonistiigi/fsutil v0.0.0-20200724193237-c3ed55f3b481 // indirect
 	github.com/tonistiigi/go-rosetta v0.0.0-20200727161949-f79598599c5d // indirect
-	github.com/werf/kubedog v0.4.1-0.20210217151630-ea6fa7dd04cf
+	github.com/werf/kubedog v0.4.1-0.20210219085634-2984d94c2a5f
 	github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea
 	github.com/werf/logboek v0.5.2
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -1298,6 +1298,8 @@ github.com/werf/kubedog v0.4.1-0.20210204234118-a6e65f252855 h1:SHKPEKqKXrf7qxu/
 github.com/werf/kubedog v0.4.1-0.20210204234118-a6e65f252855/go.mod h1:r+e1dof+vTeG43c56um6Qu0R1CAceGyww62Mv9t4/CM=
 github.com/werf/kubedog v0.4.1-0.20210217151630-ea6fa7dd04cf h1:z5pSSev1BuQhxeNezquDMhEuvPWXQmEKxQFtNMNuUS4=
 github.com/werf/kubedog v0.4.1-0.20210217151630-ea6fa7dd04cf/go.mod h1:W5uoloTanbe7uyTfxTl5yljLJvpH2b2NB+MWr8X2lOM=
+github.com/werf/kubedog v0.4.1-0.20210219085634-2984d94c2a5f h1:+ABULEwJWPwHmdvHzIdjeya/qnLjbgfoejzzya/G/Pg=
+github.com/werf/kubedog v0.4.1-0.20210219085634-2984d94c2a5f/go.mod h1:W5uoloTanbe7uyTfxTl5yljLJvpH2b2NB+MWr8X2lOM=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea h1:R5tJUhL5a3YfHTrHWyuAdJW3h//fmONrpHJjjAZ79e4=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea/go.mod h1:/CeY6KDiBSCU9PUmjt7zGhqpzp8FAPg/wNVfLZHQGWI=
 github.com/werf/logboek v0.4.3 h1:aXAVLlGT/ZiD8Srj+B71Tw20PtDyuYZSEJZjODNraeA=

--- a/pkg/deploy/helm/maintenance_helper/migrate2to3.go
+++ b/pkg/deploy/helm/maintenance_helper/migrate2to3.go
@@ -52,7 +52,7 @@ func Migrate2To3(ctx context.Context, helm2ReleaseName, helm3ReleaseName, helm3N
 	logboek.Context(ctx).LogOptionalLn()
 	if err := logboek.Context(ctx).Default().LogProcess("Creating helm 3 release %q", helm3ReleaseName).DoError(func() error {
 		if err := maintenanceHelper.CreateHelm3ReleaseMetadataFromHelm2Release(ctx, helm3ReleaseName, helm3Namespace, releaseData); err != nil {
-			return fmt.Errorf("unable to create helm 3 release %q: %s", helm3ReleaseName)
+			return fmt.Errorf("unable to create helm 3 release %q: %s", helm3ReleaseName, err)
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
If for some unknown and unexpected by werf migration workflow reason there is helm 2 and helm 3 releases at the moment,
then ignore helm 2 release and continue deploy process into helm 3 release, but print a WARNING about existing helm 2 release.

To disable this warning user should possible cleanup helm 2 metadata by kubectl -n kube-system delete cm RELEASE.VERSION.