### PR TITLE
Rework ls tree and path matcher interface

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -1105,7 +1105,7 @@ func prepareImageBasedOnImageFromDockerfile(ctx context.Context, imageFromDocker
 		return nil, err
 	}
 
-	dockerignorePathMatcher := path_matcher.NewDockerfileIgnorePathMatcher(imageFromDockerfileConfig.Context, dockerignorePatternMatcher, false)
+	dockerignorePathMatcher := path_matcher.NewDockerfileIgnorePathMatcher(imageFromDockerfileConfig.Context, dockerignorePatternMatcher)
 
 	p, err := parser.Parse(bytes.NewReader(dockerfileData))
 	if err != nil {

--- a/pkg/build/stage/dockerfile.go
+++ b/pkg/build/stage/dockerfile.go
@@ -693,7 +693,7 @@ func (s *DockerfileStage) calculateFilesChecksum(ctx context.Context, giterminis
 		logProcess = logboek.Context(ctx).Debug().LogProcess("Calculating contextAddFile checksum")
 		logProcess.Start()
 
-		wildcardsPathMatcher := path_matcher.NewSimplePathMatcher(s.dockerignorePathMatcher.BaseFilepath(), wildcards, false)
+		wildcardsPathMatcher := path_matcher.NewSimplePathMatcher(s.dockerignorePathMatcher.BaseFilepath(), wildcards)
 		if contextAddChecksum, err := context_manager.ContextAddFileChecksum(ctx, giterminismManager.ProjectDir(), s.context, s.contextAddFile, wildcardsPathMatcher); err != nil {
 			logProcess.Fail()
 			return "", fmt.Errorf("unable to calculate checksum for contextAddFile files list: %s", err)
@@ -740,7 +740,7 @@ func (s *DockerfileStage) calculateFilesChecksumWithGit(ctx context.Context, git
 	}
 
 entryNotFoundInGitRepository:
-	wildcardsPathMatcher := path_matcher.NewSimplePathMatcher(s.dockerignorePathMatcher.BaseFilepath(), wildcards, false)
+	wildcardsPathMatcher := path_matcher.NewSimplePathMatcher(s.dockerignorePathMatcher.BaseFilepath(), wildcards)
 
 	localGitRepository, err := giterminismManager.LocalGitRepo().PlainOpen()
 	if err != nil {
@@ -751,7 +751,7 @@ entryNotFoundInGitRepository:
 	if s.mainLsTreeResult != nil {
 		logProcess := logboek.Context(ctx).Debug().LogProcess("ls-tree (%s)", wildcardsPathMatcher.String())
 		logProcess.Start()
-		lsTreeResult, err := s.mainLsTreeResult.LsTree(ctx, localGitRepository, wildcardsPathMatcher)
+		lsTreeResult, err := s.mainLsTreeResult.LsTree(ctx, localGitRepository, wildcardsPathMatcher, false)
 		if err != nil {
 			logProcess.Fail()
 			return "", err
@@ -771,7 +771,7 @@ entryNotFoundInGitRepository:
 	if err := giterminismManager.Inspector().InspectBuildContextFiles(ctx, path_matcher.NewMultiPathMatcher(
 		s.dockerignorePathMatcher,
 		wildcardsPathMatcher,
-		path_matcher.NewGitMappingPathMatcher("", []string{}, s.contextAddFileRelativeToProject(), true),
+		path_matcher.NewGitMappingPathMatcher("", []string{}, s.contextAddFileRelativeToProject()),
 	)); err != nil {
 		return "", err
 	}

--- a/pkg/build/stage/git_archive.go
+++ b/pkg/build/stage/git_archive.go
@@ -51,7 +51,7 @@ func (s *GitArchiveStage) GetDependencies(ctx context.Context, c Conveyor, _, _ 
 	var args []string
 	for _, gitMapping := range s.gitMappings {
 		if gitMapping.LocalGitRepo != nil {
-			if err := c.GiterminismManager().Inspector().InspectBuildContextFiles(ctx, path_matcher.NewGitMappingPathMatcher(gitMapping.Add, gitMapping.IncludePaths, gitMapping.ExcludePaths, true)); err != nil {
+			if err := c.GiterminismManager().Inspector().InspectBuildContextFiles(ctx, path_matcher.NewGitMappingPathMatcher(gitMapping.Add, gitMapping.IncludePaths, gitMapping.ExcludePaths)); err != nil {
 				return "", err
 			}
 		}

--- a/pkg/context_manager/context_manager.go
+++ b/pkg/context_manager/context_manager.go
@@ -30,7 +30,7 @@ func ContextAddFileChecksum(ctx context.Context, projectDir string, contextDir s
 	var filePathListRelativeToProject []string
 	for _, addFileRelativeToContext := range contextAddFile {
 		addFileRelativeToProject := filepath.Join(contextDir, addFileRelativeToContext)
-		if !matcher.MatchPath(addFileRelativeToProject) {
+		if !matcher.IsPathMatched(addFileRelativeToProject) {
 			continue
 		}
 

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -518,7 +518,7 @@ func (repo *Base) checksumWithLsTree(ctx context.Context, repository *git.Reposi
 	var mainLsTreeResult *ls_tree.Result
 	if err := logboek.Context(ctx).Debug().LogProcess("ls-tree (%s)", mainPathMatcher.String()).DoError(func() error {
 		var err error
-		mainLsTreeResult, err = ls_tree.LsTree(ctx, repository, opts.Commit, mainPathMatcher, true)
+		mainLsTreeResult, err = ls_tree.LsTree(ctx, repository, opts.Commit, mainPathMatcher)
 		return err
 	}); err != nil {
 		return nil, err

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -201,7 +201,6 @@ func (repo *Base) createPatch(ctx context.Context, repoPath, gitDir, repoID, wor
 			opts.BasePath,
 			opts.IncludePaths,
 			opts.ExcludePaths,
-			false,
 		),
 		WithEntireFileContext: opts.WithEntireFileContext,
 		WithBinary:            opts.WithBinary,
@@ -353,7 +352,6 @@ func (repo *Base) createArchive(ctx context.Context, repoPath, gitDir, repoID, w
 			opts.BasePath,
 			opts.IncludePaths,
 			opts.ExcludePaths,
-			true,
 		),
 	}
 
@@ -512,7 +510,6 @@ func (repo *Base) checksumWithLsTree(ctx context.Context, repository *git.Reposi
 		opts.BasePath,
 		opts.IncludePaths,
 		opts.ExcludePaths,
-		false,
 	)
 
 	var mainLsTreeResult *ls_tree.Result
@@ -526,11 +523,7 @@ func (repo *Base) checksumWithLsTree(ctx context.Context, repository *git.Reposi
 
 	for _, p := range opts.Paths {
 		var pathLsTreeResult *ls_tree.Result
-		pathMatcher := path_matcher.NewSimplePathMatcher(
-			opts.BasePath,
-			[]string{p},
-			false,
-		)
+		pathMatcher := path_matcher.NewSimplePathMatcher(opts.BasePath, []string{p})
 
 		logProcess := logboek.Context(ctx).Debug().LogProcess("ls-tree (%s)", pathMatcher.String())
 		logProcess.Start()

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -515,7 +515,7 @@ func (repo *Base) checksumWithLsTree(ctx context.Context, repository *git.Reposi
 	var mainLsTreeResult *ls_tree.Result
 	if err := logboek.Context(ctx).Debug().LogProcess("ls-tree (%s)", mainPathMatcher.String()).DoError(func() error {
 		var err error
-		mainLsTreeResult, err = ls_tree.LsTree(ctx, repository, opts.Commit, mainPathMatcher)
+		mainLsTreeResult, err = ls_tree.LsTree(ctx, repository, opts.Commit, mainPathMatcher, false)
 		return err
 	}); err != nil {
 		return nil, err
@@ -528,7 +528,7 @@ func (repo *Base) checksumWithLsTree(ctx context.Context, repository *git.Reposi
 		logProcess := logboek.Context(ctx).Debug().LogProcess("ls-tree (%s)", pathMatcher.String())
 		logProcess.Start()
 		var err error
-		pathLsTreeResult, err = mainLsTreeResult.LsTree(ctx, repository, pathMatcher)
+		pathLsTreeResult, err = mainLsTreeResult.LsTree(ctx, repository, pathMatcher, false)
 		if err != nil {
 			logProcess.Fail()
 			return nil, err

--- a/pkg/git_repo/local.go
+++ b/pkg/git_repo/local.go
@@ -179,7 +179,6 @@ func (repo *Local) GetMergeCommitParents(_ context.Context, commit string) ([]st
 type LsTreeOptions struct {
 	Commit        string
 	UseHeadCommit bool
-	Strict        bool
 }
 
 func (repo *Local) LsTree(ctx context.Context, pathMatcher path_matcher.PathMatcher, opts LsTreeOptions) (*ls_tree.Result, error) {
@@ -219,7 +218,7 @@ func (repo *Local) getMainLsTreeResult(ctx context.Context, opts LsTreeOptions) 
 
 	var lsTreeResult *ls_tree.Result
 	if err := repo.yieldRepositoryBackedByWorkTree(ctx, commit, func(repository *git.Repository) error {
-		r, err := ls_tree.LsTree(ctx, repository, commit, path_matcher.NewSimplePathMatcher("", []string{}, false), opts.Strict)
+		r, err := ls_tree.LsTree(ctx, repository, commit, path_matcher.NewSimplePathMatcher("", []string{}, false))
 		if err != nil {
 			return err
 		}
@@ -454,7 +453,6 @@ func (repo *Local) WalkCommitFiles(ctx context.Context, commit string, dir strin
 
 	result, err := repo.LsTree(ctx, path_matcher.NewSimplePathMatcher(resolvedDir, []string{}, true), LsTreeOptions{
 		Commit: commit,
-		Strict: true,
 	})
 	if err != nil {
 		return err
@@ -762,7 +760,6 @@ func (repo *Local) resolveCommitFilePath(ctx context.Context, commit, path strin
 func (repo *Local) ReadCommitTreeEntryContent(ctx context.Context, commit, relPath string) ([]byte, error) {
 	lsTreeResult, err := repo.LsTree(ctx, path_matcher.NewSimplePathMatcher(relPath, []string{}, false), LsTreeOptions{
 		Commit: commit,
-		Strict: true,
 	})
 	if err != nil {
 		return nil, err
@@ -838,7 +835,6 @@ func (repo *Local) isTreeEntryExist(ctx context.Context, commit, relPath string)
 func (repo *Local) getCommitTreeEntry(ctx context.Context, commit, path string) (*ls_tree.LsTreeEntry, error) {
 	lsTreeResult, err := repo.LsTree(ctx, path_matcher.NewSimplePathMatcher(path, []string{}, false), LsTreeOptions{
 		Commit: commit,
-		Strict: true,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/git_repo/status/result.go
+++ b/pkg/git_repo/status/result.go
@@ -59,7 +59,7 @@ func (r *Result) Status(ctx context.Context, pathMatcher path_matcher.PathMatche
 		fileStatusFilepath := filepath.FromSlash(fileStatusPath)
 		fileStatusFullFilepath := filepath.Join(r.repositoryFullFilepath, fileStatusFilepath)
 
-		if pathMatcher.MatchPath(fileStatusFullFilepath) {
+		if pathMatcher.IsPathMatched(fileStatusFullFilepath) {
 			res.fileStatusList[fileStatusPath] = fileStatus
 
 			if debugProcess() {
@@ -74,8 +74,7 @@ func (r *Result) Status(ctx context.Context, pathMatcher path_matcher.PathMatche
 	}
 
 	for _, submoduleResult := range r.submoduleResults {
-		isMatched, shouldGoThrough := pathMatcher.ProcessDirOrSubmodulePath(submoduleResult.repositoryFullFilepath)
-		if isMatched || shouldGoThrough {
+		if pathMatcher.IsDirOrSubmodulePathMatched(submoduleResult.repositoryFullFilepath) {
 			if debugProcess() {
 				logboek.Context(ctx).Debug().LogF("Submodule was checking: %s\n", submoduleResult.repositoryFullFilepath)
 			}

--- a/pkg/git_repo/status/status.go
+++ b/pkg/git_repo/status/status.go
@@ -68,7 +68,7 @@ func status(ctx context.Context, repository *git.Repository, repositoryFullFilep
 		fileStatusFilepath := filepath.FromSlash(fileStatusPath)
 		fileStatusFullFilepath := filepath.Join(repositoryFullFilepath, fileStatusFilepath)
 
-		if pathMatcher.MatchPath(fileStatusFullFilepath) {
+		if pathMatcher.IsPathMatched(fileStatusFullFilepath) {
 			result.fileStatusList[fileStatusPath] = fileStatus
 
 			if debugProcess() {
@@ -86,8 +86,7 @@ func status(ctx context.Context, repository *git.Repository, repositoryFullFilep
 		submoduleFilepath := filepath.FromSlash(submodulePath)
 		submoduleFullFilepath := filepath.Join(repositoryFullFilepath, submoduleFilepath)
 
-		matched, shouldGoTrough := pathMatcher.ProcessDirOrSubmodulePath(submoduleFullFilepath)
-		if matched || shouldGoTrough {
+		if pathMatcher.IsDirOrSubmodulePathMatched(submoduleFullFilepath) {
 			if debugProcess() {
 				logboek.Context(ctx).Debug().LogF("Submodule was checking: %s\n", submoduleFullFilepath)
 			}

--- a/pkg/giterminism_manager/config/config.go
+++ b/pkg/giterminism_manager/config/config.go
@@ -190,12 +190,12 @@ func (h helm) UncommittedHelmFilePathMatcher() path_matcher.PathMatcher {
 }
 
 func isPathMatched(patterns []string, p string) bool {
-	return pathMatcher(patterns).MatchPath(p)
+	return pathMatcher(patterns).IsPathMatched(p)
 }
 
 func pathMatcher(patterns []string) path_matcher.PathMatcher {
 	if len(patterns) != 0 {
-		return path_matcher.NewSimplePathMatcher("", patterns, true)
+		return path_matcher.NewSimplePathMatcher("", patterns)
 	} else {
 		return path_matcher.NewStubPathMatcher("")
 	}

--- a/pkg/giterminism_manager/file_reader/config_go_template.go
+++ b/pkg/giterminism_manager/file_reader/config_go_template.go
@@ -31,7 +31,7 @@ func (r FileReader) ConfigGoTemplateFilesGlob(ctx context.Context, glob string) 
 }
 
 func (r FileReader) ConfigGoTemplateFilesGet(ctx context.Context, relPath string) ([]byte, error) {
-	data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.UncommittedConfigGoTemplateRenderingFilePathMatcher().MatchPath)
+	data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.UncommittedConfigGoTemplateRenderingFilePathMatcher().IsPathMatched)
 	if err != nil {
 		return nil, fmt.Errorf("{{ .Files.Get %q }}: %s", relPath, err)
 	}

--- a/pkg/giterminism_manager/file_reader/configuration.go
+++ b/pkg/giterminism_manager/file_reader/configuration.go
@@ -41,7 +41,7 @@ func (r FileReader) walkConfigurationFilesWithGlob(ctx context.Context, dir, glo
 	if r.sharedOptions.LooseGiterminism() {
 		for _, relToDirPath := range relToDirFilePathListFromFS {
 			relPath := filepath.Join(dir, relToDirPath)
-			data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, acceptedFilePathMatcher.MatchPath)
+			data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, acceptedFilePathMatcher.IsPathMatched)
 			if err := handleFileFunc(relToDirPath, data, err); err != nil {
 				return err
 			}
@@ -60,7 +60,7 @@ func (r FileReader) walkConfigurationFilesWithGlob(ctx context.Context, dir, glo
 	var relPathListWithUncommittedFiles []string
 	for _, relToDirPath := range relToDirPathList {
 		relPath := filepath.Join(dir, relToDirPath)
-		data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, acceptedFilePathMatcher.MatchPath)
+		data, err := r.ReadAndCheckConfigurationFile(ctx, relPath, acceptedFilePathMatcher.IsPathMatched)
 		err = handleFileFunc(relToDirPath, data, err)
 		if err != nil {
 			switch err.(type) {

--- a/pkg/giterminism_manager/file_reader/fs.go
+++ b/pkg/giterminism_manager/file_reader/fs.go
@@ -54,14 +54,14 @@ func (r FileReader) listFilesWithGlob(ctx context.Context, relDir, glob string, 
 	prefixWithoutPatterns, glob = util.GlobPrefixWithoutPatterns(glob)
 	relDirOrFileWithGlobPart := filepath.Join(relDir, prefixWithoutPatterns)
 
-	pathMatcher := path_matcher.NewSimplePathMatcher(relDirOrFileWithGlobPart, []string{glob}, true)
+	pathMatcher := path_matcher.NewSimplePathMatcher(relDirOrFileWithGlobPart, []string{glob})
 	if debug() {
 		logboek.Context(ctx).Debug().LogLn("pathMatcher:", pathMatcher.String())
 	}
 
 	var result []string
 	fileFunc := func(notResolvedPath string) error {
-		if pathMatcher.MatchPath(notResolvedPath) {
+		if pathMatcher.IsPathMatched(notResolvedPath) {
 			result = append(result, util.GetRelativeToBaseFilepath(relDir, notResolvedPath))
 		}
 
@@ -95,9 +95,7 @@ func (r FileReader) listFilesWithGlob(ctx context.Context, relDir, glob string, 
 }
 
 func (r FileReader) walkFilesWithPathMatcher(ctx context.Context, relDir string, pathMatcher path_matcher.PathMatcher, skipFileFunc func(ctx context.Context, r FileReader, existingRelPath string) (bool, error), fileFunc func(notResolvedPath string) error) error {
-	isDirMatched, shouldGoThroughDir := pathMatcher.ProcessDirOrSubmodulePath(relDir)
-	possiblyDirMatched := isDirMatched || shouldGoThroughDir
-	if !possiblyDirMatched {
+	if !pathMatcher.IsDirOrSubmodulePathMatched(relDir) {
 		return nil
 	}
 
@@ -135,10 +133,7 @@ func (r FileReader) walkFilesWithPathMatcher(ctx context.Context, relDir string,
 		for _, shouldSkipFileFunc := range []func(context.Context, FileReader, string, string) (bool, error){
 			// check requires not resolved parts in path to correctly process symlinks
 			func(_ context.Context, _ FileReader, resolvedRelPath, notResolvedRelPath string) (bool, error) {
-				isMatched, shouldGoThrough := pathMatcher.ProcessDirOrSubmodulePath(notResolvedRelPath)
-				possiblyMatched := isMatched || shouldGoThrough
-
-				return !possiblyMatched, nil
+				return !pathMatcher.IsDirOrSubmodulePathMatched(notResolvedRelPath), nil
 			},
 			// skip check expects file path
 			func(ctx context.Context, r FileReader, resolvedRelPath, notResolvedRelPath string) (bool, error) {
@@ -239,11 +234,8 @@ func (r FileReader) skipFileFunc(acceptedFilePathMatcher path_matcher.PathMatche
 		/* If not the file can be skipped */
 		var modified bool
 		for _, relPath := range pathsToCheck {
-			matched, shouldGoThrough := acceptedFilePathMatcher.ProcessDirOrSubmodulePath(existingRelPath)
-			probablyAccepted := matched || shouldGoThrough
-
 			/* The accepted file should be read from fs */
-			if probablyAccepted {
+			if acceptedFilePathMatcher.IsDirOrSubmodulePathMatched(existingRelPath) {
 				return false, nil
 			}
 

--- a/pkg/giterminism_manager/file_reader/git.go
+++ b/pkg/giterminism_manager/file_reader/git.go
@@ -44,7 +44,7 @@ func (r FileReader) ValidateRelatedSubmodules(ctx context.Context, relPath strin
 }
 
 func (r FileReader) validateRelatedSubmodules(ctx context.Context, relPath string) error {
-	return r.sharedOptions.LocalGitRepo().ValidateSubmodules(ctx, path_matcher.NewSimplePathMatcher(r.toWorkTreeRelativePath(relPath), nil, true))
+	return r.sharedOptions.LocalGitRepo().ValidateSubmodules(ctx, path_matcher.NewSimplePathMatcher(r.toWorkTreeRelativePath(relPath), nil))
 }
 
 func (r FileReader) IsCommitFileModifiedLocally(ctx context.Context, relPath string) (modified bool, err error) {

--- a/pkg/giterminism_manager/file_reader/helm_chart_extender.go
+++ b/pkg/giterminism_manager/file_reader/helm_chart_extender.go
@@ -45,7 +45,7 @@ func (r FileReader) ReadChartFile(ctx context.Context, path string) ([]byte, err
 }
 
 func (r FileReader) readChartFile(ctx context.Context, relPath string) ([]byte, error) {
-	return r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.UncommittedHelmFilePathMatcher().MatchPath)
+	return r.ReadAndCheckConfigurationFile(ctx, relPath, r.giterminismConfig.UncommittedHelmFilePathMatcher().IsPathMatched)
 }
 
 func (r FileReader) LoadChartDir(ctx context.Context, chartDir string) ([]*chart.ChartExtenderBufferedFile, error) {

--- a/pkg/path_matcher/git_mapping_test.go
+++ b/pkg/path_matcher/git_mapping_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type gitMappingMatchPathEntry struct {
+type gitMappingIsPathMatchedEntry struct {
 	baseBase        string
 	includePaths    []string
 	excludePaths    []string
@@ -16,63 +16,63 @@ type gitMappingMatchPathEntry struct {
 	notMatchedPaths []string
 }
 
-var _ = DescribeTable("git mapping path matcher (MatchPath)", func(e gitMappingMatchPathEntry) {
-	pathMatcher := NewGitMappingPathMatcher(e.baseBase, e.includePaths, e.excludePaths, false)
+var _ = DescribeTable("git mapping path matcher (IsPathMatched)", func(e gitMappingIsPathMatchedEntry) {
+	pathMatcher := NewGitMappingPathMatcher(e.baseBase, e.includePaths, e.excludePaths)
 
 	for _, matchedPath := range e.matchedPaths {
-		Ω(pathMatcher.MatchPath(matchedPath)).Should(BeTrue())
+		Ω(pathMatcher.IsPathMatched(matchedPath)).Should(BeTrue(), matchedPath)
 	}
 
 	for _, notMatchedPath := range e.notMatchedPaths {
-		Ω(pathMatcher.MatchPath(notMatchedPath)).Should(BeFalse())
+		Ω(pathMatcher.IsPathMatched(notMatchedPath)).Should(BeFalse(), notMatchedPath)
 	}
 },
-	Entry("basePath is equal to the path (includePaths)", gitMappingMatchPathEntry{
+	Entry("basePath is equal to the path (includePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		includePaths:    []string{"d"},
 		notMatchedPaths: []string{filepath.Join("a", "b", "c")},
 	}),
-	Entry("basePath is equal to the path (excludePaths)", gitMappingMatchPathEntry{
+	Entry("basePath is equal to the path (excludePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:     filepath.Join("a", "b", "c"),
 		excludePaths: []string{"d"},
 		matchedPaths: []string{filepath.Join("a", "b", "c")},
 	}),
-	Entry("basePath is equal to the path (includePaths and excludePaths)", gitMappingMatchPathEntry{
+	Entry("basePath is equal to the path (includePaths and excludePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		includePaths:    []string{"d"},
 		excludePaths:    []string{"e"},
 		notMatchedPaths: []string{filepath.Join("a", "b", "c")},
 	}),
-	Entry("basePath is equal to the path, includePath ''", gitMappingMatchPathEntry{
+	Entry("basePath is equal to the path, includePath ''", gitMappingIsPathMatchedEntry{
 		baseBase:     filepath.Join("a", "b", "c"),
 		includePaths: []string{""},
 		matchedPaths: []string{filepath.Join("a", "b", "c")},
 	}),
-	Entry("basePath is equal to the path, excludePath ''", gitMappingMatchPathEntry{
+	Entry("basePath is equal to the path, excludePath ''", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		excludePaths:    []string{""},
 		notMatchedPaths: []string{filepath.Join("a", "b", "c")},
 	}),
-	Entry("basePath is equal to the path, includePath '', excludePath ''", gitMappingMatchPathEntry{
+	Entry("basePath is equal to the path, includePath '', excludePath ''", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		includePaths:    []string{""},
 		excludePaths:    []string{""},
 		notMatchedPaths: []string{filepath.Join("a", "b", "c")},
 	}),
 
-	Entry("path is relative to the basePath (includePaths)", gitMappingMatchPathEntry{
+	Entry("path is relative to the basePath (includePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		includePaths:    []string{"d"},
 		matchedPaths:    []string{filepath.Join("a", "b", "c", "d")},
 		notMatchedPaths: []string{filepath.Join("a", "b", "c", "e"), filepath.Join("a", "b", "c", "de")},
 	}),
-	Entry("path is relative to the basePath (excludePaths)", gitMappingMatchPathEntry{
+	Entry("path is relative to the basePath (excludePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		excludePaths:    []string{"d"},
 		matchedPaths:    []string{filepath.Join("a", "b", "c", "e"), filepath.Join("a", "b", "c", "de")},
 		notMatchedPaths: []string{filepath.Join("a", "b", "c", "d")},
 	}),
-	Entry("path is relative to the basePath (includePaths and excludePaths)", gitMappingMatchPathEntry{
+	Entry("path is relative to the basePath (includePaths and excludePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		includePaths:    []string{"d"},
 		excludePaths:    []string{"e"},
@@ -80,41 +80,41 @@ var _ = DescribeTable("git mapping path matcher (MatchPath)", func(e gitMappingM
 		notMatchedPaths: []string{filepath.Join("a", "b", "c", "e")},
 	}),
 
-	Entry("path is not relative to the basePath(includePaths)", gitMappingMatchPathEntry{
+	Entry("path is not relative to the basePath(includePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		includePaths:    []string{"d"},
 		notMatchedPaths: []string{filepath.Join("a", "b", "d"), "b"},
 	}),
-	Entry("path is not relative to the basePath (excludePaths)", gitMappingMatchPathEntry{
+	Entry("path is not relative to the basePath (excludePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		excludePaths:    []string{"d"},
 		notMatchedPaths: []string{filepath.Join("a", "b", "d"), "b"},
 	}),
-	Entry("path is not relative to the basePath (includePaths and excludePaths)", gitMappingMatchPathEntry{
+	Entry("path is not relative to the basePath (includePaths and excludePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		includePaths:    []string{"d"},
 		excludePaths:    []string{"e"},
 		notMatchedPaths: []string{filepath.Join("a", "b", "d"), "b"},
 	}),
 
-	Entry("basePath is relative to the path (includePaths)", gitMappingMatchPathEntry{
+	Entry("basePath is relative to the path (includePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		includePaths:    []string{"d"},
 		notMatchedPaths: []string{filepath.Join("a")},
 	}),
-	Entry("basePath is relative to the path (excludePaths)", gitMappingMatchPathEntry{
+	Entry("basePath is relative to the path (excludePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		excludePaths:    []string{"d"},
 		notMatchedPaths: []string{filepath.Join("a")},
 	}),
-	Entry("basePath is relative to the path (includePaths and excludePaths)", gitMappingMatchPathEntry{
+	Entry("basePath is relative to the path (includePaths and excludePaths)", gitMappingIsPathMatchedEntry{
 		baseBase:        filepath.Join("a", "b", "c"),
 		includePaths:    []string{"d"},
 		excludePaths:    []string{"e"},
 		notMatchedPaths: []string{filepath.Join("a")},
 	}),
 
-	Entry("glob completion by default (includePaths)", gitMappingMatchPathEntry{
+	Entry("glob completion by default (includePaths)", gitMappingIsPathMatchedEntry{
 		includePaths: []string{
 			"a",
 			filepath.Join("b", "*"),
@@ -128,7 +128,7 @@ var _ = DescribeTable("git mapping path matcher (MatchPath)", func(e gitMappingM
 			filepath.Join("d", "b", "c", "d"),
 		},
 	}),
-	Entry("glob completion by default (excludePaths)", gitMappingMatchPathEntry{
+	Entry("glob completion by default (excludePaths)", gitMappingIsPathMatchedEntry{
 		excludePaths: []string{
 			"a",
 			filepath.Join("b", "*"),
@@ -142,7 +142,7 @@ var _ = DescribeTable("git mapping path matcher (MatchPath)", func(e gitMappingM
 			filepath.Join("d", "b", "c", "d"),
 		},
 	}),
-	Entry("glob completion by default (includePaths and excludePaths)", gitMappingMatchPathEntry{
+	Entry("glob completion by default (includePaths and excludePaths)", gitMappingIsPathMatchedEntry{
 		includePaths: []string{
 			"a",
 			filepath.Join("b", "*"),
@@ -164,168 +164,129 @@ var _ = DescribeTable("git mapping path matcher (MatchPath)", func(e gitMappingM
 	}),
 )
 
-type gitMappingProcessDirOrSubmodulePath struct {
-	baseBase               string
-	includePaths           []string
-	excludePaths           []string
-	matchedPaths           []string
-	shouldWalkThroughPaths []string
-	notMatchedPaths        []string
+type gitMappingShouldGoThrough struct {
+	baseBase                string
+	includePaths            []string
+	excludePaths            []string
+	shouldGoThroughPaths    []string
+	shouldNotGoThroughPaths []string
 }
 
-var _ = DescribeTable("git mapping path matcher (ProcessDirOrSubmodulePath)", func(e gitMappingProcessDirOrSubmodulePath) {
-	pathMatcher := NewGitMappingPathMatcher(e.baseBase, e.includePaths, e.excludePaths, false)
+var _ = DescribeTable("git mapping path matcher (ShouldGoThrough)", func(e gitMappingShouldGoThrough) {
+	pathMatcher := NewGitMappingPathMatcher(e.baseBase, e.includePaths, e.excludePaths)
 
-	for _, matchedPath := range e.matchedPaths {
-		isMatched, shouldWalkThrough := pathMatcher.ProcessDirOrSubmodulePath(matchedPath)
-		Ω(isMatched).Should(BeTrue(), fmt.Sprintln(pathMatcher, "==", matchedPath))
-		Ω(shouldWalkThrough).Should(BeFalse(), fmt.Sprintln(pathMatcher, "!=", matchedPath))
+	for _, shouldGoThroughPath := range e.shouldGoThroughPaths {
+		shouldGoThrough := pathMatcher.ShouldGoThrough(shouldGoThroughPath)
+		Ω(shouldGoThrough).Should(BeTrue(), fmt.Sprintln(pathMatcher, "==", shouldGoThroughPath))
 	}
 
-	for _, shouldWalkThroughPath := range e.shouldWalkThroughPaths {
-		isMatched, shouldWalkThrough := pathMatcher.ProcessDirOrSubmodulePath(shouldWalkThroughPath)
-		Ω(isMatched).Should(BeFalse(), fmt.Sprintln(pathMatcher, "!=", shouldWalkThroughPath))
-		Ω(shouldWalkThrough).Should(BeTrue(), fmt.Sprintln(pathMatcher, "==", shouldWalkThroughPath))
-	}
-
-	for _, notMatchedPath := range e.notMatchedPaths {
-		isMatched, shouldWalkThrough := pathMatcher.ProcessDirOrSubmodulePath(notMatchedPath)
-		Ω(isMatched).Should(BeFalse(), fmt.Sprintln(pathMatcher, "!=", notMatchedPath))
-		Ω(shouldWalkThrough).Should(BeFalse(), fmt.Sprintln(pathMatcher, "!=", notMatchedPath))
+	for _, shouldNotGoThroughPath := range e.shouldNotGoThroughPaths {
+		shouldGoThrough := pathMatcher.ShouldGoThrough(shouldNotGoThroughPath)
+		Ω(shouldGoThrough).Should(BeFalse(), fmt.Sprintln(pathMatcher, "!=", shouldNotGoThroughPath))
 	}
 },
-	Entry("basePath is equal to the path (base)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:     filepath.Join("a", "b", "c"),
-		matchedPaths: []string{filepath.Join("a", "b", "c")},
+	Entry("basePath is equal to the path (includePaths)", gitMappingShouldGoThrough{
+		baseBase:             filepath.Join("a", "b", "c"),
+		includePaths:         []string{"d"},
+		shouldGoThroughPaths: []string{filepath.Join("a", "b", "c")},
 	}),
-	Entry("basePath is equal to the path (includePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:               filepath.Join("a", "b", "c"),
-		includePaths:           []string{"d"},
-		shouldWalkThroughPaths: []string{filepath.Join("a", "b", "c")},
+	Entry("basePath is equal to the path (excludePaths)", gitMappingShouldGoThrough{
+		baseBase:             filepath.Join("a", "b", "c"),
+		excludePaths:         []string{"d"},
+		shouldGoThroughPaths: []string{filepath.Join("a", "b", "c")},
 	}),
-	Entry("basePath is equal to the path (excludePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:               filepath.Join("a", "b", "c"),
-		excludePaths:           []string{"d"},
-		shouldWalkThroughPaths: []string{filepath.Join("a", "b", "c")},
+	Entry("basePath is equal to the path (includePaths and excludePaths)", gitMappingShouldGoThrough{
+		baseBase:             filepath.Join("a", "b", "c"),
+		includePaths:         []string{"d"},
+		excludePaths:         []string{"e"},
+		shouldGoThroughPaths: []string{filepath.Join("a", "b", "c")},
 	}),
-	Entry("basePath is equal to the path (includePaths and excludePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:               filepath.Join("a", "b", "c"),
-		includePaths:           []string{"d"},
-		excludePaths:           []string{"e"},
-		shouldWalkThroughPaths: []string{filepath.Join("a", "b", "c")},
+	Entry("basePath is equal to the path, excludePath ''", gitMappingShouldGoThrough{
+		baseBase:                filepath.Join("a", "b", "c"),
+		excludePaths:            []string{""},
+		shouldNotGoThroughPaths: []string{filepath.Join("a", "b", "c")},
 	}),
-	Entry("basePath is equal to the path, includePath ''", gitMappingProcessDirOrSubmodulePath{
-		baseBase:     filepath.Join("a", "b", "c"),
-		includePaths: []string{""},
-		matchedPaths: []string{filepath.Join("a", "b", "c")},
-	}),
-	Entry("basePath is equal to the path, excludePath ''", gitMappingProcessDirOrSubmodulePath{
-		baseBase:        filepath.Join("a", "b", "c"),
-		excludePaths:    []string{""},
-		notMatchedPaths: []string{filepath.Join("a", "b", "c")},
-	}),
-	Entry("basePath is equal to the path, includePath '', excludePath ''", gitMappingProcessDirOrSubmodulePath{
-		baseBase:        filepath.Join("a", "b", "c"),
-		includePaths:    []string{""},
-		excludePaths:    []string{""},
-		notMatchedPaths: []string{filepath.Join("a", "b", "c")},
+	Entry("basePath is equal to the path, includePath '', excludePath ''", gitMappingShouldGoThrough{
+		baseBase:                filepath.Join("a", "b", "c"),
+		includePaths:            []string{""},
+		excludePaths:            []string{""},
+		shouldNotGoThroughPaths: []string{filepath.Join("a", "b", "c")},
 	}),
 
-	Entry("path is relative to the basePath (base)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:     filepath.Join("a", "b", "c"),
-		matchedPaths: []string{filepath.Join("a", "b", "c", "d")},
+	Entry("path is relative to the basePath (includePaths)", gitMappingShouldGoThrough{
+		baseBase:                filepath.Join("a", "b", "c"),
+		includePaths:            []string{"d"},
+		shouldNotGoThroughPaths: []string{filepath.Join("a", "b", "c", "e"), filepath.Join("a", "b", "c", "de")},
 	}),
-	Entry("path is relative to the basePath (includePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:        filepath.Join("a", "b", "c"),
-		includePaths:    []string{"d"},
-		matchedPaths:    []string{filepath.Join("a", "b", "c", "d")},
-		notMatchedPaths: []string{filepath.Join("a", "b", "c", "e"), filepath.Join("a", "b", "c", "de")},
+	Entry("path is relative to the basePath (excludePaths)", gitMappingShouldGoThrough{
+		baseBase:                filepath.Join("a", "b", "c"),
+		excludePaths:            []string{"d"},
+		shouldNotGoThroughPaths: []string{filepath.Join("a", "b", "c", "d")},
 	}),
-	Entry("path is relative to the basePath (excludePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:        filepath.Join("a", "b", "c"),
-		excludePaths:    []string{"d"},
-		matchedPaths:    []string{filepath.Join("a", "b", "c", "e"), filepath.Join("a", "b", "c", "de")},
-		notMatchedPaths: []string{filepath.Join("a", "b", "c", "d")},
-	}),
-	Entry("path is relative to the basePath (includePaths and excludePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:        filepath.Join("a", "b", "c"),
-		includePaths:    []string{"d"},
-		excludePaths:    []string{"e"},
-		matchedPaths:    []string{filepath.Join("a", "b", "c", "d")},
-		notMatchedPaths: []string{filepath.Join("a", "b", "c", "e")},
+	Entry("path is relative to the basePath (includePaths and excludePaths)", gitMappingShouldGoThrough{
+		baseBase:                filepath.Join("a", "b", "c"),
+		includePaths:            []string{"d"},
+		excludePaths:            []string{"e"},
+		shouldNotGoThroughPaths: []string{filepath.Join("a", "b", "c", "e")},
 	}),
 
-	Entry("path is not relative to the basePath (base)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:        filepath.Join("a", "b", "c"),
-		notMatchedPaths: []string{filepath.Join("a", "b", "d"), "b"},
+	Entry("path is not relative to the basePath (base)", gitMappingShouldGoThrough{
+		baseBase:                filepath.Join("a", "b", "c"),
+		shouldNotGoThroughPaths: []string{filepath.Join("a", "b", "d"), "b"},
 	}),
-	Entry("path is not relative to the basePath(includePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:        filepath.Join("a", "b", "c"),
-		includePaths:    []string{"d"},
-		notMatchedPaths: []string{filepath.Join("a", "b", "d"), "b"},
+	Entry("path is not relative to the basePath(includePaths)", gitMappingShouldGoThrough{
+		baseBase:                filepath.Join("a", "b", "c"),
+		includePaths:            []string{"d"},
+		shouldNotGoThroughPaths: []string{filepath.Join("a", "b", "d"), "b"},
 	}),
-	Entry("path is not relative to the basePath (excludePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:        filepath.Join("a", "b", "c"),
-		excludePaths:    []string{"d"},
-		notMatchedPaths: []string{filepath.Join("a", "b", "d"), "b"},
+	Entry("path is not relative to the basePath (excludePaths)", gitMappingShouldGoThrough{
+		baseBase:                filepath.Join("a", "b", "c"),
+		excludePaths:            []string{"d"},
+		shouldNotGoThroughPaths: []string{filepath.Join("a", "b", "d"), "b"},
 	}),
-	Entry("path is not relative to the basePath (includePaths and excludePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:        filepath.Join("a", "b", "c"),
-		includePaths:    []string{"d"},
-		excludePaths:    []string{"e"},
-		notMatchedPaths: []string{filepath.Join("a", "b", "d"), "b"},
-	}),
-
-	Entry("basePath is relative to the path (base)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:               filepath.Join("a", "b", "c"),
-		shouldWalkThroughPaths: []string{filepath.Join("a")},
-	}),
-	Entry("basePath is relative to the path (includePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:               filepath.Join("a", "b", "c"),
-		includePaths:           []string{"d"},
-		shouldWalkThroughPaths: []string{filepath.Join("a")},
-	}),
-	Entry("basePath is relative to the path (excludePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:               filepath.Join("a", "b", "c"),
-		excludePaths:           []string{"d"},
-		shouldWalkThroughPaths: []string{filepath.Join("a")},
-	}),
-	Entry("basePath is relative to the path (includePaths and excludePaths)", gitMappingProcessDirOrSubmodulePath{
-		baseBase:               filepath.Join("a", "b", "c"),
-		includePaths:           []string{"d"},
-		excludePaths:           []string{"e"},
-		shouldWalkThroughPaths: []string{filepath.Join("a")},
+	Entry("path is not relative to the basePath (includePaths and excludePaths)", gitMappingShouldGoThrough{
+		baseBase:                filepath.Join("a", "b", "c"),
+		includePaths:            []string{"d"},
+		excludePaths:            []string{"e"},
+		shouldNotGoThroughPaths: []string{filepath.Join("a", "b", "d"), "b"},
 	}),
 
-	Entry("glob completion by default (includePaths)", gitMappingProcessDirOrSubmodulePath{
-		includePaths: []string{
-			"a",
-			filepath.Join("b", "*"),
-			filepath.Join("c", "**"),
-			filepath.Join("d", "**", "*"),
-		},
-		matchedPaths: []string{
-			filepath.Join("a", "b", "c", "d"),
-			filepath.Join("b", "b", "c", "d"),
-			filepath.Join("c", "b", "c", "d"),
-			filepath.Join("d", "b", "c", "d"),
-		},
+	Entry("basePath is relative to the path (base)", gitMappingShouldGoThrough{
+		baseBase:             filepath.Join("a", "b", "c"),
+		shouldGoThroughPaths: []string{filepath.Join("a")},
 	}),
-	Entry("glob completion by default (excludePaths)", gitMappingProcessDirOrSubmodulePath{
+	Entry("basePath is relative to the path (includePaths)", gitMappingShouldGoThrough{
+		baseBase:             filepath.Join("a", "b", "c"),
+		includePaths:         []string{"d"},
+		shouldGoThroughPaths: []string{filepath.Join("a")},
+	}),
+	Entry("basePath is relative to the path (excludePaths)", gitMappingShouldGoThrough{
+		baseBase:             filepath.Join("a", "b", "c"),
+		excludePaths:         []string{"d"},
+		shouldGoThroughPaths: []string{filepath.Join("a")},
+	}),
+	Entry("basePath is relative to the path (includePaths and excludePaths)", gitMappingShouldGoThrough{
+		baseBase:             filepath.Join("a", "b", "c"),
+		includePaths:         []string{"d"},
+		excludePaths:         []string{"e"},
+		shouldGoThroughPaths: []string{filepath.Join("a")},
+	}),
+
+	Entry("glob completion by default (excludePaths)", gitMappingShouldGoThrough{
 		excludePaths: []string{
 			"a",
 			filepath.Join("b", "*"),
 			filepath.Join("c", "**"),
 			filepath.Join("d", "**", "*"),
 		},
-		notMatchedPaths: []string{
+		shouldNotGoThroughPaths: []string{
 			filepath.Join("a", "b", "c", "d"),
 			filepath.Join("b", "b", "c", "d"),
 			filepath.Join("c", "b", "c", "d"),
 			filepath.Join("d", "b", "c", "d"),
 		},
 	}),
-	Entry("glob completion by default (includePaths and excludePaths)", gitMappingProcessDirOrSubmodulePath{
+	Entry("glob completion by default (includePaths and excludePaths)", gitMappingShouldGoThrough{
 		includePaths: []string{
 			"a",
 			filepath.Join("b", "*"),
@@ -338,7 +299,7 @@ var _ = DescribeTable("git mapping path matcher (ProcessDirOrSubmodulePath)", fu
 			filepath.Join("c", "**"),
 			filepath.Join("d", "**", "*"),
 		},
-		notMatchedPaths: []string{
+		shouldNotGoThroughPaths: []string{
 			filepath.Join("a", "b", "c", "d"),
 			filepath.Join("b", "b", "c", "d"),
 			filepath.Join("c", "b", "c", "d"),

--- a/pkg/path_matcher/multi_path_matcher.go
+++ b/pkg/path_matcher/multi_path_matcher.go
@@ -16,9 +16,13 @@ type MultiPathMatcher struct {
 	PathMatchers []PathMatcher
 }
 
-func (m *MultiPathMatcher) MatchPath(path string) bool {
+func (f *MultiPathMatcher) IsDirOrSubmodulePathMatched(path string) bool {
+	return f.IsPathMatched(path) || f.ShouldGoThrough(path)
+}
+
+func (m *MultiPathMatcher) IsPathMatched(path string) bool {
 	for _, matcher := range m.PathMatchers {
-		if !matcher.MatchPath(path) {
+		if !matcher.IsPathMatched(path) {
 			return false
 		}
 	}
@@ -26,35 +30,14 @@ func (m *MultiPathMatcher) MatchPath(path string) bool {
 	return true
 }
 
-func (m *MultiPathMatcher) ProcessDirOrSubmodulePath(path string) (bool, bool) {
-	var isMatchedResults, shouldGoThroughResults []bool
+func (m *MultiPathMatcher) ShouldGoThrough(path string) bool {
 	for _, matcher := range m.PathMatchers {
-		isMatched, shouldGoThrough := matcher.ProcessDirOrSubmodulePath(path)
-		isMatchedResults = append(isMatchedResults, isMatched)
-		shouldGoThroughResults = append(shouldGoThroughResults, shouldGoThrough)
-	}
-
-	var isMatched bool
-	var shouldGoThrough bool
-	for _, isMatchedResult := range isMatchedResults {
-		if !isMatchedResult {
-			isMatched = false
-			break
+		if !matcher.ShouldGoThrough(path) {
+			return false
 		}
-
-		isMatched = true
 	}
 
-	for _, isMatchedResult := range shouldGoThroughResults {
-		if !isMatchedResult {
-			shouldGoThrough = false
-			break
-		}
-
-		shouldGoThrough = true
-	}
-
-	return isMatched, shouldGoThrough
+	return true
 }
 
 func (m *MultiPathMatcher) TrimFileBaseFilepath(path string) string {

--- a/pkg/path_matcher/path_matcher.go
+++ b/pkg/path_matcher/path_matcher.go
@@ -1,8 +1,17 @@
 package path_matcher
 
 type PathMatcher interface {
-	MatchPath(string) bool
-	ProcessDirOrSubmodulePath(string) (bool, bool)
+	// IsPathMatched checks for a complete matching of the path
+	IsPathMatched(string) bool
+
+	// ShouldGoThrough indicates that the directory or submodule path is not completely matched but may include matching files among the child files.
+	// The method returns false if the path is completely matched.
+	ShouldGoThrough(string) bool
+
+	// IsDirOrSubmodulePathMatched returns true if IsPathMatched or ShouldGoThrough.
+	// The method returns true if there is a possibility of containing the matching files among the child files.
+	IsDirOrSubmodulePathMatched(string) bool
+
 	TrimFileBaseFilepath(string) string
 	BaseFilepath() string
 	String() string

--- a/pkg/path_matcher/path_matcher_test.go
+++ b/pkg/path_matcher/path_matcher_test.go
@@ -20,19 +20,19 @@ var _ = Describe("path matcher (basePath)", func() {
 			pathMatcherName: "dockerfile ignore",
 			newOnlyWithBasePathFunc: func(basePath string) PathMatcher {
 				pm, _ := fileutils.NewPatternMatcher([]string{})
-				return NewDockerfileIgnorePathMatcher(basePath, pm, false)
+				return NewDockerfileIgnorePathMatcher(basePath, pm)
 			},
 		},
 		{
 			pathMatcherName: "git mapping",
 			newOnlyWithBasePathFunc: func(basePath string) PathMatcher {
-				return NewGitMappingPathMatcher(basePath, []string{}, []string{}, false)
+				return NewGitMappingPathMatcher(basePath, []string{}, []string{})
 			},
 		},
 		{
 			pathMatcherName: "simple",
 			newOnlyWithBasePathFunc: func(basePath string) PathMatcher {
-				return NewSimplePathMatcher(basePath, []string{}, false)
+				return NewSimplePathMatcher(basePath, []string{})
 			},
 		},
 	} {
@@ -40,30 +40,27 @@ var _ = Describe("path matcher (basePath)", func() {
 			var pathMatcher = entry.newOnlyWithBasePathFunc(filepath.Join("a", "b", "c"))
 
 			It("base path is equal to the path", func() {
-				isMatched := pathMatcher.MatchPath(filepath.Join("a", "b", "c"))
+				isMatched := pathMatcher.IsPathMatched(filepath.Join("a", "b", "c"))
 				Ω(isMatched).Should(BeTrue())
 
-				isMatched, shouldGoThrough := pathMatcher.ProcessDirOrSubmodulePath(filepath.Join("a", "b", "c"))
-				Ω(isMatched).Should(BeTrue())
+				shouldGoThrough := pathMatcher.ShouldGoThrough(filepath.Join("a", "b", "c"))
 				Ω(shouldGoThrough).Should(BeFalse())
 			})
 
 			It("path is relative to the basePath", func() {
-				isMatched := pathMatcher.MatchPath(filepath.Join("a", "b", "c", "d"))
+				isMatched := pathMatcher.IsPathMatched(filepath.Join("a", "b", "c", "d"))
 				Ω(isMatched).Should(BeTrue())
 
-				isMatched, shouldGoThrough := pathMatcher.ProcessDirOrSubmodulePath(filepath.Join("a", "b", "c", "d"))
-				Ω(isMatched).Should(BeTrue())
+				shouldGoThrough := pathMatcher.ShouldGoThrough(filepath.Join("a", "b", "c", "d"))
 				Ω(shouldGoThrough).Should(BeFalse())
 			})
 
 			It("path is not relative to the basePath", func() {
 				for _, path := range []string{filepath.Join("a", "b", "d"), "b"} {
-					isMatched := pathMatcher.MatchPath(path)
+					isMatched := pathMatcher.IsPathMatched(path)
 					Ω(isMatched).Should(BeFalse())
 
-					isMatched, shouldGoThrough := pathMatcher.ProcessDirOrSubmodulePath(path)
-					Ω(isMatched).Should(BeFalse())
+					shouldGoThrough := pathMatcher.ShouldGoThrough(path)
 					Ω(shouldGoThrough).Should(BeFalse())
 				}
 			})
@@ -71,11 +68,10 @@ var _ = Describe("path matcher (basePath)", func() {
 			It("basePath is relative to the path", func() {
 				pathMatcher := entry.newOnlyWithBasePathFunc(filepath.Join("a"))
 
-				isMatched := pathMatcher.MatchPath(filepath.Join("a", "b", "c"))
+				isMatched := pathMatcher.IsPathMatched(filepath.Join("a", "b", "c"))
 				Ω(isMatched).Should(BeTrue())
 
-				isMatched, shouldGoThrough := pathMatcher.ProcessDirOrSubmodulePath(filepath.Join("a", "b", "c"))
-				Ω(isMatched).Should(BeTrue())
+				shouldGoThrough := pathMatcher.ShouldGoThrough(filepath.Join("a", "b", "c"))
 				Ω(shouldGoThrough).Should(BeFalse())
 			})
 		})

--- a/pkg/path_matcher/stub_path_matcher.go
+++ b/pkg/path_matcher/stub_path_matcher.go
@@ -1,7 +1,7 @@
 package path_matcher
 
 func NewStubPathMatcher(basePath string) *StubPathMatcher {
-	return &StubPathMatcher{SimplePathMatcher: NewSimplePathMatcher(basePath, nil, true)}
+	return &StubPathMatcher{SimplePathMatcher: NewSimplePathMatcher(basePath, nil)}
 }
 
 // StubPathMatcher returns false when matching paths
@@ -9,12 +9,16 @@ type StubPathMatcher struct {
 	*SimplePathMatcher
 }
 
-func (m *StubPathMatcher) MatchPath(_ string) bool {
+func (f *StubPathMatcher) IsDirOrSubmodulePathMatched(_ string) bool {
 	return false
 }
 
-func (m *StubPathMatcher) ProcessDirOrSubmodulePath(_ string) (bool, bool) {
-	return false, false
+func (m *StubPathMatcher) IsPathMatched(_ string) bool {
+	return false
+}
+
+func (m *StubPathMatcher) ShouldGoThrough(_ string) bool {
+	return false
 }
 
 func (m *StubPathMatcher) String() string {

--- a/pkg/true_git/archive.go
+++ b/pkg/true_git/archive.go
@@ -131,7 +131,7 @@ func writeArchive(ctx context.Context, out io.Writer, gitDir, workTreeCacheDir s
 
 	logProcess := logboek.Context(ctx).Debug().LogProcess("ls-tree (%s)", opts.PathMatcher.String())
 	logProcess.Start()
-	result, err := ls_tree.LsTree(ctx, repository, opts.Commit, opts.PathMatcher)
+	result, err := ls_tree.LsTree(ctx, repository, opts.Commit, opts.PathMatcher, true)
 	if err != nil {
 		logProcess.Fail()
 		return nil, err

--- a/pkg/true_git/archive.go
+++ b/pkg/true_git/archive.go
@@ -131,7 +131,7 @@ func writeArchive(ctx context.Context, out io.Writer, gitDir, workTreeCacheDir s
 
 	logProcess := logboek.Context(ctx).Debug().LogProcess("ls-tree (%s)", opts.PathMatcher.String())
 	logProcess.Start()
-	result, err := ls_tree.LsTree(ctx, repository, opts.Commit, opts.PathMatcher, true)
+	result, err := ls_tree.LsTree(ctx, repository, opts.Commit, opts.PathMatcher)
 	if err != nil {
 		logProcess.Fail()
 		return nil, err

--- a/pkg/true_git/diff_parser.go
+++ b/pkg/true_git/diff_parser.go
@@ -258,7 +258,7 @@ func (p *diffParser) handleDiffBegin(line string) error {
 			}
 
 			path := strings.TrimPrefix(pathWithPrefix, data.Prefix)
-			if !p.PathMatcher.MatchPath(path) {
+			if !p.PathMatcher.IsPathMatched(path) {
 				p.state = ignoreDiff
 				return nil
 			}
@@ -271,7 +271,7 @@ func (p *diffParser) handleDiffBegin(line string) error {
 			trimmedPaths[data.PathWithPrefix] = strconv.Quote(newPathWithPrefix)
 		} else {
 			path := strings.TrimPrefix(data.PathWithPrefix, data.Prefix)
-			if !p.PathMatcher.MatchPath(path) {
+			if !p.PathMatcher.IsPathMatched(path) {
 				p.state = ignoreDiff
 				return nil
 			}

--- a/pkg/true_git/ls_tree/ls_tree.go
+++ b/pkg/true_git/ls_tree/ls_tree.go
@@ -32,8 +32,11 @@ func newHash(s string) (plumbing.Hash, error) {
 	return h, nil
 }
 
-func LsTree(ctx context.Context, repository *git.Repository, commit string, pathMatcher path_matcher.PathMatcher) (*Result, error) {
-	r, err := lsTree(ctx, repository, commit, pathMatcher)
+// LsTree returns the Result with tree entries that satisfy the passed pathMatcher.
+// The function works lazily and does not go through a tree directory unnecessarily.
+// If the result should contain only regular files (without directories and submodules), you should use the allFiles parameter.
+func LsTree(ctx context.Context, repository *git.Repository, commit string, pathMatcher path_matcher.PathMatcher, allFiles bool) (*Result, error) {
+	r, err := lsTree(ctx, repository, commit, pathMatcher, allFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +45,7 @@ func LsTree(ctx context.Context, repository *git.Repository, commit string, path
 	return r, nil
 }
 
-func lsTree(ctx context.Context, repository *git.Repository, commit string, pathMatcher path_matcher.PathMatcher) (*Result, error) {
+func lsTree(ctx context.Context, repository *git.Repository, commit string, pathMatcher path_matcher.PathMatcher, allFiles bool) (*Result, error) {
 	res := NewResult(commit, "", []*LsTreeEntry{}, []*SubmoduleResult{})
 
 	tree, err := getCommitTree(repository, commit)
@@ -52,7 +55,7 @@ func lsTree(ctx context.Context, repository *git.Repository, commit string, path
 
 	baseFilepath := pathMatcher.BaseFilepath()
 	if baseFilepath != "" {
-		lsTreeEntries, submodulesResults, err := processSpecificEntryFilepath(ctx, repository, tree, "", "", pathMatcher.BaseFilepath(), pathMatcher)
+		lsTreeEntries, submodulesResults, err := processSpecificEntryFilepath(ctx, repository, tree, "", "", pathMatcher.BaseFilepath(), pathMatcher, allFiles)
 		if err != nil {
 			return nil, err
 		}
@@ -63,38 +66,56 @@ func lsTree(ctx context.Context, repository *git.Repository, commit string, path
 		return res, nil
 	}
 
-	isTreeMatched, shouldWalkThrough := pathMatcher.ProcessDirOrSubmodulePath("")
-	if isTreeMatched {
-		if debugProcess() {
-			logboek.Context(ctx).Debug().LogLn("Root tree was added")
-		}
+	rootEntry := ""
+	if err := lsTreeDirOrSubmoduleEntryMatchBase(
+		rootEntry,
+		pathMatcher,
+		allFiles,
+		// add tree func
+		func() error {
+			if debugProcess() {
+				logboek.Context(ctx).Debug().LogLn("Root tree was added")
+			}
 
-		rootTreeEntry := &LsTreeEntry{
-			FullFilepath: "",
-			TreeEntry: object.TreeEntry{
-				Name: "",
-				Mode: filemode.Dir,
-				Hash: tree.Hash,
-			},
-		}
+			rootTreeEntry := &LsTreeEntry{
+				FullFilepath: "",
+				TreeEntry: object.TreeEntry{
+					Name: "",
+					Mode: filemode.Dir,
+					Hash: tree.Hash,
+				},
+			}
 
-		res.lsTreeEntries = append(res.lsTreeEntries, rootTreeEntry)
-	} else if shouldWalkThrough {
-		if debugProcess() {
-			logboek.Context(ctx).Debug().LogLn("Root tree was checking")
-		}
+			res.lsTreeEntries = append(res.lsTreeEntries, rootTreeEntry)
 
-		lsTreeEntries, submodulesLsTreeEntries, err := lsTreeWalk(ctx, repository, tree, "", "", pathMatcher)
-		if err != nil {
-			return nil, err
-		}
+			return nil
+		},
+		// check tree func
+		func() error {
+			if debugProcess() {
+				logboek.Context(ctx).Debug().LogLn("Root tree was checking")
+			}
 
-		res.lsTreeEntries = lsTreeEntries
-		res.submodulesResults = submodulesLsTreeEntries
-	} else {
-		if debugProcess() {
-			logboek.Context(ctx).Debug().LogLn("Root tree was skipped")
-		}
+			lsTreeEntries, submodulesLsTreeEntries, err := lsTreeWalk(ctx, repository, tree, "", "", pathMatcher, allFiles)
+			if err != nil {
+				return err
+			}
+
+			res.lsTreeEntries = lsTreeEntries
+			res.submodulesResults = submodulesLsTreeEntries
+
+			return nil
+		},
+		// skip tree func
+		func() error {
+			if debugProcess() {
+				logboek.Context(ctx).Debug().LogLn("Root tree was skipped")
+			}
+
+			return nil
+		},
+	); err != nil {
+		return nil, err
 	}
 
 	return res, nil
@@ -119,7 +140,7 @@ func getCommitTree(repository *git.Repository, commit string) (*object.Tree, err
 	return tree, nil
 }
 
-func processSpecificEntryFilepath(ctx context.Context, repository *git.Repository, tree *object.Tree, repositoryFullFilepath, treeFullFilepath, treeEntryFilepath string, pathMatcher path_matcher.PathMatcher) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
+func processSpecificEntryFilepath(ctx context.Context, repository *git.Repository, tree *object.Tree, repositoryFullFilepath, treeFullFilepath, treeEntryFilepath string, pathMatcher path_matcher.PathMatcher, allFiles bool) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
 	worktree, err := repository.Worktree()
 	if err != nil {
 		return nil, nil, err
@@ -143,7 +164,7 @@ func processSpecificEntryFilepath(ctx context.Context, repository *git.Repositor
 			return nil, nil, fmt.Errorf("getting submodule %q repository and tree failed: %s", submoduleFullFilepath, err)
 		}
 
-		sLsTreeEntries, sSubmodulesResults, err := processSpecificEntryFilepath(ctx, submoduleRepository, submoduleTree, submoduleFullFilepath, submoduleFullFilepath, relTreeEntryFilepath, pathMatcher)
+		sLsTreeEntries, sSubmodulesResults, err := processSpecificEntryFilepath(ctx, submoduleRepository, submoduleTree, submoduleFullFilepath, submoduleFullFilepath, relTreeEntryFilepath, pathMatcher, allFiles)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -167,7 +188,7 @@ func processSpecificEntryFilepath(ctx context.Context, repository *git.Repositor
 		return nil, nil, err
 	}
 
-	lsTreeEntries, submodulesLsTreeEntries, err := lsTreeEntryMatch(ctx, repository, tree, repositoryFullFilepath, treeFullFilepath, lsTreeEntry, pathMatcher)
+	lsTreeEntries, submodulesLsTreeEntries, err := lsTreeEntryMatch(ctx, repository, tree, repositoryFullFilepath, treeFullFilepath, lsTreeEntry, pathMatcher, allFiles)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -175,14 +196,14 @@ func processSpecificEntryFilepath(ctx context.Context, repository *git.Repositor
 	return lsTreeEntries, submodulesLsTreeEntries, nil
 }
 
-func lsTreeWalk(ctx context.Context, repository *git.Repository, tree *object.Tree, repositoryFullFilepath, treeFullFilepath string, pathMatcher path_matcher.PathMatcher) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
+func lsTreeWalk(ctx context.Context, repository *git.Repository, tree *object.Tree, repositoryFullFilepath, treeFullFilepath string, pathMatcher path_matcher.PathMatcher, allFiles bool) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
 	for _, treeEntry := range tree.Entries {
 		lsTreeEntry := &LsTreeEntry{
 			FullFilepath: filepath.Join(treeFullFilepath, treeEntry.Name),
 			TreeEntry:    treeEntry,
 		}
 
-		entryTreeEntries, entrySubmodulesTreeEntries, err := lsTreeEntryMatch(ctx, repository, tree, repositoryFullFilepath, treeFullFilepath, lsTreeEntry, pathMatcher)
+		entryTreeEntries, entrySubmodulesTreeEntries, err := lsTreeEntryMatch(ctx, repository, tree, repositoryFullFilepath, treeFullFilepath, lsTreeEntry, pathMatcher, allFiles)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -194,103 +215,160 @@ func lsTreeWalk(ctx context.Context, repository *git.Repository, tree *object.Tr
 	return
 }
 
-func lsTreeEntryMatch(ctx context.Context, repository *git.Repository, tree *object.Tree, repositoryFullFilepath, treeFullFilepath string, lsTreeEntry *LsTreeEntry, pathMatcher path_matcher.PathMatcher) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
+func lsTreeEntryMatch(ctx context.Context, repository *git.Repository, tree *object.Tree, repositoryFullFilepath, treeFullFilepath string, lsTreeEntry *LsTreeEntry, pathMatcher path_matcher.PathMatcher, allFiles bool) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
 	switch lsTreeEntry.Mode {
 	case filemode.Dir:
-		return lsTreeDirEntryMatch(ctx, repository, tree, repositoryFullFilepath, treeFullFilepath, lsTreeEntry, pathMatcher)
+		return lsTreeDirEntryMatch(ctx, repository, tree, repositoryFullFilepath, treeFullFilepath, lsTreeEntry, pathMatcher, allFiles)
 	case filemode.Submodule:
-		return lsTreeSubmoduleEntryMatch(ctx, repository, repositoryFullFilepath, lsTreeEntry, pathMatcher)
+		return lsTreeSubmoduleEntryMatch(ctx, repository, repositoryFullFilepath, lsTreeEntry, pathMatcher, allFiles)
 	default:
 		return lsTreeFileEntryMatch(ctx, lsTreeEntry, pathMatcher)
 	}
 }
 
-func lsTreeDirEntryMatch(ctx context.Context, repository *git.Repository, tree *object.Tree, repositoryFullFilepath, treeFullFilepath string, lsTreeEntry *LsTreeEntry, pathMatcher path_matcher.PathMatcher) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
-	isTreeMatched, shouldWalkThrough := pathMatcher.ProcessDirOrSubmodulePath(lsTreeEntry.FullFilepath)
-	if isTreeMatched {
-		if debugProcess() {
-			logboek.Context(ctx).Debug().LogLn("Dir entry was added:         ", lsTreeEntry.FullFilepath)
-		}
-		lsTreeEntries = append(lsTreeEntries, lsTreeEntry)
-	} else if shouldWalkThrough {
-		if debugProcess() {
-			logboek.Context(ctx).Debug().LogLn("Dir entry was checking:      ", lsTreeEntry.FullFilepath)
-		}
-		entryTree, err := treeTree(tree, treeFullFilepath, lsTreeEntry.FullFilepath)
-		if err != nil {
-			return nil, nil, err
-		}
+func lsTreeDirEntryMatch(ctx context.Context, repository *git.Repository, tree *object.Tree, repositoryFullFilepath, treeFullFilepath string, lsTreeEntry *LsTreeEntry, pathMatcher path_matcher.PathMatcher, allFiles bool) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
+	if err := lsTreeDirOrSubmoduleEntryMatchBase(
+		lsTreeEntry.FullFilepath,
+		pathMatcher,
+		allFiles,
+		// add tree func
+		func() error {
+			if debugProcess() {
+				logboek.Context(ctx).Debug().LogLn("Dir entry was added:         ", lsTreeEntry.FullFilepath)
+			}
 
-		return lsTreeWalk(ctx, repository, entryTree, repositoryFullFilepath, lsTreeEntry.FullFilepath, pathMatcher)
+			lsTreeEntries = append(lsTreeEntries, lsTreeEntry)
+
+			return nil
+		},
+		// check tree func
+		func() error {
+			if debugProcess() {
+				logboek.Context(ctx).Debug().LogLn("Dir entry was checking:      ", lsTreeEntry.FullFilepath)
+			}
+
+			entryTree, err := treeTree(tree, treeFullFilepath, lsTreeEntry.FullFilepath)
+			if err != nil {
+				return err
+			}
+
+			lsTreeEntries, submodulesResults, err = lsTreeWalk(ctx, repository, entryTree, repositoryFullFilepath, lsTreeEntry.FullFilepath, pathMatcher, allFiles)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		func() error {
+			if debugProcess() {
+				logboek.Context(ctx).Debug().LogLn("Dir entry was skipped:       ", lsTreeEntry.FullFilepath)
+			}
+
+			return nil
+		},
+	); err != nil {
+		return nil, nil, err
 	}
 
 	return
 }
 
-func lsTreeSubmoduleEntryMatch(ctx context.Context, repository *git.Repository, repositoryFullFilepath string, lsTreeEntry *LsTreeEntry, pathMatcher path_matcher.PathMatcher) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
-	isTreeMatched, shouldWalkThrough := pathMatcher.ProcessDirOrSubmodulePath(lsTreeEntry.FullFilepath)
-	if isTreeMatched {
-		if debugProcess() {
-			logboek.Context(ctx).Debug().LogLn("Submodule entry was added:   ", lsTreeEntry.FullFilepath)
-		}
-		lsTreeEntries = append(lsTreeEntries, lsTreeEntry)
-	} else if shouldWalkThrough {
-		if debugProcess() {
-			logboek.Context(ctx).Debug().LogLn("Submodule entry was checking:", lsTreeEntry.FullFilepath)
-		}
+func lsTreeSubmoduleEntryMatch(ctx context.Context, repository *git.Repository, repositoryFullFilepath string, lsTreeEntry *LsTreeEntry, pathMatcher path_matcher.PathMatcher, allFiles bool) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
+	if err := lsTreeDirOrSubmoduleEntryMatchBase(
+		lsTreeEntry.FullFilepath,
+		pathMatcher,
+		allFiles,
+		// add tree func
+		func() error {
+			if debugProcess() {
+				logboek.Context(ctx).Debug().LogLn("Submodule entry was added:   ", lsTreeEntry.FullFilepath)
+			}
+			lsTreeEntries = append(lsTreeEntries, lsTreeEntry)
 
-		submoduleFilepath, err := filepath.Rel(repositoryFullFilepath, lsTreeEntry.FullFilepath)
-		if err != nil || submoduleFilepath == "." || submoduleFilepath == ".." || strings.HasPrefix(submoduleFilepath, ".."+string(os.PathSeparator)) {
-			panic(fmt.Sprintf("unexpected paths: %s, %s", repositoryFullFilepath, lsTreeEntry.FullFilepath))
-		}
-
-		submodulePath := filepath.ToSlash(submoduleFilepath)
-		submoduleRepository, submoduleCommit, submoduleTree, err := submoduleRepositoryAndTree(ctx, repository, submodulePath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("getting submodule %q repository and tree failed: %s", lsTreeEntry.FullFilepath, err)
-		}
-
-		submoduleLsTreeEntrees, submoduleSubmoduleResults, err := lsTreeWalk(ctx, submoduleRepository, submoduleTree, lsTreeEntry.FullFilepath, lsTreeEntry.FullFilepath, pathMatcher)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if len(submoduleLsTreeEntrees) != 0 {
-			w, err := repository.Worktree()
-			if err != nil {
-				return nil, nil, err
+			return nil
+		},
+		// check tree func
+		func() error {
+			if debugProcess() {
+				logboek.Context(ctx).Debug().LogLn("Submodule entry was checking:", lsTreeEntry.FullFilepath)
 			}
 
-			ss, err := w.Submodules()
-			if err != nil {
-				return nil, nil, err
+			submoduleFilepath, err := filepath.Rel(repositoryFullFilepath, lsTreeEntry.FullFilepath)
+			if err != nil || submoduleFilepath == "." || submoduleFilepath == ".." || strings.HasPrefix(submoduleFilepath, ".."+string(os.PathSeparator)) {
+				panic(fmt.Sprintf("unexpected paths: %s, %s", repositoryFullFilepath, lsTreeEntry.FullFilepath))
 			}
 
-			var submoduleName string
-			for _, s := range ss {
-				if s.Config().Path == submodulePath {
-					submoduleName = s.Config().Name
+			submodulePath := filepath.ToSlash(submoduleFilepath)
+			submoduleRepository, submoduleCommit, submoduleTree, err := submoduleRepositoryAndTree(ctx, repository, submodulePath)
+			if err != nil {
+				return fmt.Errorf("getting submodule %q repository and tree failed: %s", lsTreeEntry.FullFilepath, err)
+			}
+
+			submoduleLsTreeEntrees, submoduleSubmoduleResults, err := lsTreeWalk(ctx, submoduleRepository, submoduleTree, lsTreeEntry.FullFilepath, lsTreeEntry.FullFilepath, pathMatcher, allFiles)
+			if err != nil {
+				return err
+			}
+
+			if len(submoduleLsTreeEntrees) != 0 {
+				w, err := repository.Worktree()
+				if err != nil {
+					return err
+				}
+
+				ss, err := w.Submodules()
+				if err != nil {
+					return err
+				}
+
+				var submoduleName string
+				for _, s := range ss {
+					if s.Config().Path == submodulePath {
+						submoduleName = s.Config().Name
+					}
+				}
+
+				if submoduleName == "" {
+					panic("unexpected condition " + submodulePath)
+				}
+
+				result := NewResult(submoduleCommit, lsTreeEntry.FullFilepath, submoduleLsTreeEntrees, submoduleSubmoduleResults)
+				submoduleResult := NewSubmoduleResult(submoduleName, submodulePath, result)
+
+				if !submoduleResult.IsEmpty() {
+					submodulesResults = append(submodulesResults, submoduleResult)
 				}
 			}
 
-			if submoduleName == "" {
-				panic("unexpected condition " + submodulePath)
-			}
-
-			result := NewResult(submoduleCommit, lsTreeEntry.FullFilepath, submoduleLsTreeEntrees, submoduleSubmoduleResults)
-			submoduleResult := NewSubmoduleResult(submoduleName, submodulePath, result)
-
-			if !submoduleResult.IsEmpty() {
-				submodulesResults = append(submodulesResults, submoduleResult)
-			}
-		}
+			return nil
+		},
+		// skip tree func
+		func() error {
+			logboek.Context(ctx).Debug().LogLn("Submodule entry was skipped: ", lsTreeEntry.FullFilepath)
+			return nil
+		},
+	); err != nil {
+		return nil, nil, err
 	}
 
 	return
 }
 
+func lsTreeDirOrSubmoduleEntryMatchBase(path string, pathMatched path_matcher.PathMatcher, allFiles bool, addTreeFunc, checkTreeFunc, skipTreeFunc func() error) error {
+	if pathMatched.ShouldGoThrough(path) {
+		return checkTreeFunc()
+	} else if pathMatched.IsPathMatched(path) {
+		if allFiles {
+			return checkTreeFunc()
+		} else {
+			return addTreeFunc()
+		}
+	} else {
+		return skipTreeFunc()
+	}
+}
+
 func lsTreeFileEntryMatch(ctx context.Context, lsTreeEntry *LsTreeEntry, pathMatcher path_matcher.PathMatcher) (lsTreeEntries []*LsTreeEntry, submodulesResults []*SubmoduleResult, err error) {
-	if pathMatcher.MatchPath(lsTreeEntry.FullFilepath) {
+	if pathMatcher.IsPathMatched(lsTreeEntry.FullFilepath) {
 		if debugProcess() {
 			logboek.Context(ctx).Debug().LogLn("File entry was added:        ", lsTreeEntry.FullFilepath)
 		}


### PR DESCRIPTION
**[ls_tree] Remove the strict option in LsTree function**

The option allowed to run ls tree for work tree with uninitialized submodules. We always work with the service work tree in current versions, where the submodules must be initialized.

**[path_matcher] Remove the greedySearch parameter and change interface**

There are the following changes in the PathMatcher interface:

- Rename the MatchPath method to IsPathMatched.
- Split the ProcessDirOrSubmodulePath method into ShouldGoThrough and IsDirOrSubmodulePathMatched methods.

```
// IsPathMatched checks for a complete matching of the path
IsPathMatched(string) bool

// ShouldGoThrough indicates that the directory or submodule path is not completely matched but may include matching files among the child files.
// The method returns false if the path is completely matched.
ShouldGoThrough(string) bool

// IsDirOrSubmodulePathMatched returns true if IsPathMatched or ShouldGoThrough.
// The method returns true if there is a possibility of containing the matching files among the child files.
IsDirOrSubmodulePathMatched(string) bool
```

**[ls_tree] Change the LsTree function interface**

```
// LsTree returns the Result with tree entries that satisfy the passed pathMatcher.
// The function works lazily and does not go through a tree directory unnecessarily.
// If the result should contain only regular files (without directories and submodules), you should use the allFiles parameter.
LsTree(ctx context.Context, repository *git.Repository, commit string, pathMatcher path_matcher.PathMatcher) (*Result, error) -> LsTree(ctx context.Context, repository *git.Repository, commit string, pathMatcher path_matcher.PathMatcher, allFiles bool) (*Result, error)
```