### PR TITLE
[path_matcher] Update Simple/GitMappingPathMatcher.IsMatched method logic

### DIFF
--- a/pkg/path_matcher/git_mapping.go
+++ b/pkg/path_matcher/git_mapping.go
@@ -167,7 +167,7 @@ func hasUniversalGlob(globs []string) bool {
 			return true
 		}
 
-		if strings.TrimRight(glob, "*"+string(os.PathSeparator)) == "" {
+		if trimRightAsterisks(glob) == "" {
 			return true
 		}
 	}
@@ -206,21 +206,23 @@ func isAnyPatternMatched(path string, patterns []string) bool {
 }
 
 func isPathMatched(filePath, pattern string) bool {
-	matched, err := doublestar.PathMatch(pattern, filePath)
-	if err != nil {
-		panic(err)
-	}
-	if matched {
-		return true
-	}
+	for _, p := range []string{
+		trimRightAsterisks(pattern),
+		filepath.Join(pattern, "**", "*"),
+	} {
+		matched, err := doublestar.PathMatch(p, filePath)
+		if err != nil {
+			panic(err)
+		}
 
-	matched, err = doublestar.PathMatch(filepath.Join(pattern, "**", "*"), filePath)
-	if err != nil {
-		panic(err)
-	}
-	if matched {
-		return true
+		if matched {
+			return true
+		}
 	}
 
 	return false
+}
+
+func trimRightAsterisks(pattern string) string {
+	return strings.TrimRight(pattern, "*\\/")
 }


### PR DESCRIPTION
Several sets of globes are used when comparing paths:

- The universal part `**/*` is added to all globes (as before).
- From all globes, all asterisks to the right are cut off.