### PR TITLE
[path_matcher] Fix Simple/GitMappingPathMatcher.IsMatched method logic

### DIFF
--- a/pkg/path_matcher/git_mapping.go
+++ b/pkg/path_matcher/git_mapping.go
@@ -205,12 +205,16 @@ func isAnyPatternMatched(path string, patterns []string) bool {
 	return false
 }
 
-func isPathMatched(filePath, pattern string) bool {
-	for _, p := range []string{
-		trimRightAsterisks(pattern),
-		filepath.Join(pattern, "**", "*"),
+func isPathMatched(filePath, glob string) bool {
+	// The glob as-is.
+	// The glob without asterisks on the right (path/*/dir/**/*, path/*/dir/**, path/*/dir/*/*/** -> path/*/dir).
+	// The previous glob with the universal part `**/*` (path/*/dir/**/*).
+	for _, g := range []string{
+		glob,
+		trimRightAsterisks(glob),
+		filepath.Join(trimRightAsterisks(glob), "**", "*"),
 	} {
-		matched, err := doublestar.PathMatch(p, filePath)
+		matched, err := doublestar.PathMatch(g, filePath)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Several sets of globes are used when comparing paths:

- The globes as they are.
- The globes without asterisks on the right (`path/*/dir/**/*`, `path/*/dir/**`, `path/*/dir/*/*/**` -> `path/*/dir`).
- The globes from the previous set with the universal part `**/*` (`path/*/dir/**/*`).