### PR TITLE
[dev] Change the cache logic in simple development mode

### DIFF
--- a/pkg/true_git/dev_branch.go
+++ b/pkg/true_git/dev_branch.go
@@ -41,21 +41,9 @@ func SyncSourceWorktreeWithServiceWorktreeBranch(ctx context.Context, gitDir, so
 		}
 
 		devBranchName := fmt.Sprintf("werf-dev-%s", commit)
-		devCommitWithStagedChanges, err := syncWorktreeWithServiceWorktreeBranch(ctx, sourceWorkTreeDir, destinationWorkTreeDir, commit, devBranchName, true)
+		resultCommit, err = syncWorktreeWithServiceWorktreeBranch(ctx, sourceWorkTreeDir, destinationWorkTreeDir, commit, devBranchName, opts.OnlyStagedChanges)
 		if err != nil {
 			return fmt.Errorf("unable to sync staged changes: %s", err)
-		}
-
-		if opts.OnlyStagedChanges {
-			resultCommit = devCommitWithStagedChanges
-		} else {
-			devBranchName = fmt.Sprintf("werf-dev-%s-%s", commit, devCommitWithStagedChanges)
-			devCommitWithTrackedChanges, err := syncWorktreeWithServiceWorktreeBranch(ctx, sourceWorkTreeDir, destinationWorkTreeDir, devCommitWithStagedChanges, devBranchName, false)
-			if err != nil {
-				return fmt.Errorf("unable to sync tracked changes: %s", err)
-			}
-
-			resultCommit = devCommitWithTrackedChanges
 		}
 
 		return nil


### PR DESCRIPTION
Create a single commit for changes in the worktree instead of two separate commits for index and worktree changes.