### PR TITLE
[helm] Enable secret-values in 'werf helm *' commands, fix lint command, fix secret-values params priority

### DIFF
--- a/cmd/werf/bundle/apply/apply.go
+++ b/cmd/werf/bundle/apply/apply.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers"
 	"github.com/werf/werf/pkg/deploy/helm/command_helpers"
 
 	"github.com/werf/werf/pkg/deploy/lock_manager"
@@ -208,7 +209,7 @@ func runApply() error {
 	bundle := chart_extender.NewBundle(ctx, bundleTmpDir, cmd_helm.Settings, chart_extender.BundleOptions{})
 
 	if *commonCmdData.SetDockerConfigJsonValue {
-		if err := chart_extender.WriteDockerConfigJsonValue(ctx, bundle.GetExtraValues(), *commonCmdData.DockerConfig); err != nil {
+		if err := helpers.WriteDockerConfigJsonValue(ctx, bundle.GetExtraValues(), *commonCmdData.DockerConfig); err != nil {
 			return fmt.Errorf("error writing docker config value into bundle extra values: %s", err)
 		}
 	}

--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -13,6 +13,7 @@ import (
 	"github.com/werf/werf/pkg/deploy/secrets_manager"
 
 	"github.com/werf/werf/pkg/deploy/helm/chart_extender"
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers"
 	cmd_helm "helm.sh/helm/v3/cmd/helm"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -269,7 +270,7 @@ func runExport() error {
 		logboek.LogOptionalLn()
 	}
 
-	secretsManager := secrets_manager.NewSecretsManager(giterminismManager.ProjectDir(), secrets_manager.SecretsManagerOptions{DisableSecretsDecryption: *commonCmdData.IgnoreSecretKey})
+	secretsManager := secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{DisableSecretsDecryption: *commonCmdData.IgnoreSecretKey})
 
 	wc := chart_extender.NewWerfChart(ctx, giterminismManager, secretsManager, chartDir, cmd_helm.Settings, chart_extender.WerfChartOptions{
 		SecretValueFiles: common.GetSecretValues(&commonCmdData),
@@ -283,7 +284,7 @@ func runExport() error {
 	if err := wc.SetWerfConfig(werfConfig); err != nil {
 		return err
 	}
-	if vals, err := chart_extender.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, chart_extender.ServiceValuesOptions{Env: *commonCmdData.Environment}); err != nil {
+	if vals, err := helpers.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{Env: *commonCmdData.Environment}); err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	} else if err := wc.SetServiceValues(vals); err != nil {
 		return err

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -18,6 +18,7 @@ import (
 	"github.com/werf/werf/pkg/deploy/secrets_manager"
 
 	"github.com/werf/werf/pkg/deploy/helm/chart_extender"
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers"
 	cmd_helm "helm.sh/helm/v3/cmd/helm"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -282,7 +283,7 @@ func runPublish() error {
 		logboek.LogOptionalLn()
 	}
 
-	secretsManager := secrets_manager.NewSecretsManager(giterminismManager.ProjectDir(), secrets_manager.SecretsManagerOptions{DisableSecretsDecryption: *commonCmdData.IgnoreSecretKey})
+	secretsManager := secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{DisableSecretsDecryption: *commonCmdData.IgnoreSecretKey})
 
 	wc := chart_extender.NewWerfChart(ctx, giterminismManager, secretsManager, chartDir, cmd_helm.Settings, chart_extender.WerfChartOptions{
 		SecretValueFiles: *commonCmdData.SecretValues,
@@ -296,7 +297,7 @@ func runPublish() error {
 	if err := wc.SetWerfConfig(werfConfig); err != nil {
 		return err
 	}
-	if vals, err := chart_extender.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, chart_extender.ServiceValuesOptions{Env: *commonCmdData.Environment}); err != nil {
+	if vals, err := helpers.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{Env: *commonCmdData.Environment}); err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	} else if err := wc.SetServiceValues(vals); err != nil {
 		return err

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/werf/werf/pkg/giterminism_manager"
 
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers"
 	"github.com/werf/werf/pkg/deploy/helm/command_helpers"
 	"github.com/werf/werf/pkg/deploy/helm/maintenance_helper"
 
@@ -305,7 +306,7 @@ func run(ctx context.Context, giterminismManager giterminism_manager.Interface) 
 		logboek.LogOptionalLn()
 	}
 
-	secretsManager := secrets_manager.NewSecretsManager(giterminismManager.ProjectDir(), secrets_manager.SecretsManagerOptions{DisableSecretsDecryption: *commonCmdData.IgnoreSecretKey})
+	secretsManager := secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{DisableSecretsDecryption: *commonCmdData.IgnoreSecretKey})
 
 	releaseName, err := common.GetHelmRelease(*commonCmdData.Release, *commonCmdData.Environment, werfConfig)
 	if err != nil {
@@ -352,14 +353,14 @@ func run(ctx context.Context, giterminismManager giterminism_manager.Interface) 
 	if err := wc.SetWerfConfig(werfConfig); err != nil {
 		return err
 	}
-	if vals, err := chart_extender.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, chart_extender.ServiceValuesOptions{Namespace: namespace, Env: *commonCmdData.Environment}); err != nil {
+	if vals, err := helpers.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{Namespace: namespace, Env: *commonCmdData.Environment}); err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	} else if err := wc.SetServiceValues(vals); err != nil {
 		return err
 	}
 
 	if *commonCmdData.SetDockerConfigJsonValue {
-		if err := chart_extender.WriteDockerConfigJsonValue(ctx, wc.GetExtraValues(), *commonCmdData.DockerConfig); err != nil {
+		if err := helpers.WriteDockerConfigJsonValue(ctx, wc.GetExtraValues(), *commonCmdData.DockerConfig); err != nil {
 			return fmt.Errorf("error writing docker config value into werf chart extra values: %s", err)
 		}
 	}

--- a/cmd/werf/helm/get_autogenerated_values.go
+++ b/cmd/werf/helm/get_autogenerated_values.go
@@ -11,7 +11,7 @@ import (
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/build"
 	"github.com/werf/werf/pkg/container_runtime"
-	"github.com/werf/werf/pkg/deploy/helm/chart_extender"
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers"
 	"github.com/werf/werf/pkg/docker"
 	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/image"
@@ -202,7 +202,7 @@ func runGetServiceValues() error {
 		}
 	}
 
-	serviceValues, err := chart_extender.GetServiceValues(ctx, projectName, imagesRepository, imagesInfoGetters, chart_extender.ServiceValuesOptions{Namespace: namespace, Env: environment})
+	serviceValues, err := helpers.GetServiceValues(ctx, projectName, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{Namespace: namespace, Env: environment})
 	if err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	}

--- a/cmd/werf/helm/helm.go
+++ b/cmd/werf/helm/helm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/werf/werf/pkg/werf"
 
 	"github.com/werf/werf/pkg/deploy/helm/chart_extender"
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers"
 
 	helm_secret_decrypt "github.com/werf/werf/cmd/werf/helm/secret/decrypt"
 	helm_secret_encrypt "github.com/werf/werf/cmd/werf/helm/secret/encrypt"
@@ -74,7 +75,7 @@ func NewCmd() *cobra.Command {
 		cmd_helm.NewDependencyCmd(actionConfig, os.Stdout),
 		cmd_helm.NewGetCmd(actionConfig, os.Stdout),
 		cmd_helm.NewHistoryCmd(actionConfig, os.Stdout),
-		cmd_helm.NewLintCmd(os.Stdout),
+		NewLintCmd(actionConfig, wc),
 		cmd_helm.NewListCmd(actionConfig, os.Stdout),
 		NewTemplateCmd(actionConfig, wc),
 		cmd_helm.NewRepoCmd(os.Stdout),
@@ -129,7 +130,7 @@ func NewCmd() *cobra.Command {
 
 				ctx := common.BackgroundContext()
 
-				if vals, err := chart_extender.GetServiceValues(ctx, "PROJECT", "REPO", nil, chart_extender.ServiceValuesOptions{Namespace: namespace, IsStub: true}); err != nil {
+				if vals, err := helpers.GetServiceValues(ctx, "PROJECT", "REPO", nil, helpers.ServiceValuesOptions{Namespace: namespace, IsStub: true}); err != nil {
 					return fmt.Errorf("error creating service values: %s", err)
 				} else {
 					wc.SetStubServiceValues(vals)

--- a/cmd/werf/helm/install.go
+++ b/cmd/werf/helm/install.go
@@ -40,10 +40,10 @@ func NewInstallCmd(actionConfig *action.Configuration, wc *chart_extender.WerfCh
 			return err
 		}
 
-		if releaseName, chartDir, err := helmAction.NameAndChart(args); err != nil {
+		if releaseName, _, err := helmAction.NameAndChart(args); err != nil {
 			return err
 		} else {
-			if err := InitRenderRelatedWerfChartParams(ctx, &installCmdData, wc, chartDir); err != nil {
+			if err := InitRenderRelatedWerfChartParams(ctx, &installCmdData, wc); err != nil {
 				return fmt.Errorf("unable to init werf chart: %s", err)
 			}
 

--- a/cmd/werf/helm/lint.go
+++ b/cmd/werf/helm/lint.go
@@ -15,24 +15,17 @@ import (
 	cmd_helm "helm.sh/helm/v3/cmd/helm"
 )
 
-var templateCmdData cmd_werf_common.CmdData
+var lintCmdData cmd_werf_common.CmdData
 
-func NewTemplateCmd(actionConfig *action.Configuration, wc *chart_extender.WerfChartStub) *cobra.Command {
-	postRenderer, err := wc.GetPostRenderer()
-	if err != nil {
-		panic(err.Error())
-	}
-
-	cmd, _ := cmd_helm.NewTemplateCmd(actionConfig, os.Stdout, cmd_helm.TemplateCmdOptions{
-		PostRenderer: postRenderer,
-	})
-	SetupRenderRelatedWerfChartParams(cmd, &templateCmdData)
+func NewLintCmd(actionConfig *action.Configuration, wc *chart_extender.WerfChartStub) *cobra.Command {
+	cmd := cmd_helm.NewLintCmd(os.Stdout)
+	SetupRenderRelatedWerfChartParams(cmd, &lintCmdData)
 
 	oldRunE := cmd.RunE
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := common.BackgroundContext()
 
-		if err := InitRenderRelatedWerfChartParams(ctx, &templateCmdData, wc); err != nil {
+		if err := InitRenderRelatedWerfChartParams(ctx, &lintCmdData, wc); err != nil {
 			return fmt.Errorf("unable to init werf chart: %s", err)
 		}
 

--- a/cmd/werf/helm/secret/common/decrypt.go
+++ b/cmd/werf/helm/secret/common/decrypt.go
@@ -14,33 +14,33 @@ import (
 	"github.com/werf/werf/pkg/deploy/secrets_manager"
 )
 
-func SecretFileDecrypt(ctx context.Context, m *secrets_manager.SecretsManager, filePath, outputFilePath string) error {
+func SecretFileDecrypt(ctx context.Context, m *secrets_manager.SecretsManager, workingDir, filePath, outputFilePath string) error {
 	options := &GenerateOptions{
 		FilePath:       filePath,
 		OutputFilePath: outputFilePath,
 		Values:         false,
 	}
 
-	return secretDecrypt(ctx, m, options)
+	return secretDecrypt(ctx, m, workingDir, options)
 }
 
-func SecretValuesDecrypt(ctx context.Context, m *secrets_manager.SecretsManager, filePath, outputFilePath string) error {
+func SecretValuesDecrypt(ctx context.Context, m *secrets_manager.SecretsManager, workingDir, filePath, outputFilePath string) error {
 	options := &GenerateOptions{
 		FilePath:       filePath,
 		OutputFilePath: outputFilePath,
 		Values:         true,
 	}
 
-	return secretDecrypt(ctx, m, options)
+	return secretDecrypt(ctx, m, workingDir, options)
 }
 
-func secretDecrypt(ctx context.Context, m *secrets_manager.SecretsManager, options *GenerateOptions) error {
+func secretDecrypt(ctx context.Context, m *secrets_manager.SecretsManager, workingDir string, options *GenerateOptions) error {
 	var encodedData []byte
 	var data []byte
 	var err error
 
 	var encoder *secret.YamlEncoder
-	if enc, err := m.GetYamlEncoder(ctx); err != nil {
+	if enc, err := m.GetYamlEncoder(ctx, workingDir); err != nil {
 		return err
 	} else {
 		encoder = enc

--- a/cmd/werf/helm/secret/common/edit.go
+++ b/cmd/werf/helm/secret/common/edit.go
@@ -26,9 +26,9 @@ import (
 	"github.com/werf/werf/pkg/werf"
 )
 
-func SecretEdit(ctx context.Context, m *secrets_manager.SecretsManager, filePath string, values bool) error {
+func SecretEdit(ctx context.Context, m *secrets_manager.SecretsManager, workingDir, filePath string, values bool) error {
 	var encoder *secret.YamlEncoder
-	if enc, err := m.GetYamlEncoder(ctx); err != nil {
+	if enc, err := m.GetYamlEncoder(ctx, workingDir); err != nil {
 		return err
 	} else {
 		encoder = enc

--- a/cmd/werf/helm/secret/common/encrypt.go
+++ b/cmd/werf/helm/secret/common/encrypt.go
@@ -13,33 +13,33 @@ import (
 	"github.com/werf/werf/pkg/deploy/secrets_manager"
 )
 
-func SecretFileEncrypt(ctx context.Context, m *secrets_manager.SecretsManager, filePath, outputFilePath string) error {
+func SecretFileEncrypt(ctx context.Context, m *secrets_manager.SecretsManager, workingDir, filePath, outputFilePath string) error {
 	options := &GenerateOptions{
 		FilePath:       filePath,
 		OutputFilePath: outputFilePath,
 		Values:         false,
 	}
 
-	return secretEncrypt(ctx, m, options)
+	return secretEncrypt(ctx, m, workingDir, options)
 }
 
-func SecretValuesEncrypt(ctx context.Context, m *secrets_manager.SecretsManager, filePath, outputFilePath string) error {
+func SecretValuesEncrypt(ctx context.Context, m *secrets_manager.SecretsManager, workingDir, filePath, outputFilePath string) error {
 	options := &GenerateOptions{
 		FilePath:       filePath,
 		OutputFilePath: outputFilePath,
 		Values:         true,
 	}
 
-	return secretEncrypt(ctx, m, options)
+	return secretEncrypt(ctx, m, workingDir, options)
 }
 
-func secretEncrypt(ctx context.Context, m *secrets_manager.SecretsManager, options *GenerateOptions) error {
+func secretEncrypt(ctx context.Context, m *secrets_manager.SecretsManager, workingDir string, options *GenerateOptions) error {
 	var data []byte
 	var encodedData []byte
 	var err error
 
 	var encoder *secret.YamlEncoder
-	if enc, err := m.GetYamlEncoder(ctx); err != nil {
+	if enc, err := m.GetYamlEncoder(ctx, workingDir); err != nil {
 		return err
 	} else {
 		encoder = enc

--- a/cmd/werf/helm/secret/decrypt/decrypt.go
+++ b/cmd/werf/helm/secret/decrypt/decrypt.go
@@ -76,16 +76,16 @@ func runSecretDecrypt(ctx context.Context) error {
 
 	workingDir := common.GetWorkingDir(&commonCmdData)
 
-	return secretDecrypt(ctx, secrets_manager.NewSecretsManager(workingDir, secrets_manager.SecretsManagerOptions{}))
+	return secretDecrypt(ctx, secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{}), workingDir)
 }
 
-func secretDecrypt(ctx context.Context, m *secrets_manager.SecretsManager) error {
+func secretDecrypt(ctx context.Context, m *secrets_manager.SecretsManager, workingDir string) error {
 	var encodedData []byte
 	var data []byte
 	var err error
 
 	var encoder *secret.YamlEncoder
-	if enc, err := m.GetYamlEncoder(ctx); err != nil {
+	if enc, err := m.GetYamlEncoder(ctx, workingDir); err != nil {
 		return err
 	} else {
 		encoder = enc

--- a/cmd/werf/helm/secret/encrypt/encrypt.go
+++ b/cmd/werf/helm/secret/encrypt/encrypt.go
@@ -75,16 +75,16 @@ func runSecretEncrypt(ctx context.Context) error {
 
 	workingDir := common.GetWorkingDir(&commonCmdData)
 
-	return secretEncrypt(ctx, secrets_manager.NewSecretsManager(workingDir, secrets_manager.SecretsManagerOptions{}))
+	return secretEncrypt(ctx, secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{}), workingDir)
 }
 
-func secretEncrypt(ctx context.Context, m *secrets_manager.SecretsManager) error {
+func secretEncrypt(ctx context.Context, m *secrets_manager.SecretsManager, workingDir string) error {
 	var data []byte
 	var encodedData []byte
 	var err error
 
 	var encoder *secret.YamlEncoder
-	if enc, err := m.GetYamlEncoder(ctx); err != nil {
+	if enc, err := m.GetYamlEncoder(ctx, workingDir); err != nil {
 		return err
 	} else {
 		encoder = enc

--- a/cmd/werf/helm/secret/file/decrypt/decrypt.go
+++ b/cmd/werf/helm/secret/file/decrypt/decrypt.go
@@ -85,5 +85,5 @@ func runSecretDecrypt(ctx context.Context, filePath string) error {
 
 	workingDir := common.GetWorkingDir(&commonCmdData)
 
-	return secret_common.SecretFileDecrypt(ctx, secrets_manager.NewSecretsManager(workingDir, secrets_manager.SecretsManagerOptions{}), filePath, CmdData.OutputFilePath)
+	return secret_common.SecretFileDecrypt(ctx, secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{}), workingDir, filePath, CmdData.OutputFilePath)
 }

--- a/cmd/werf/helm/secret/file/edit/edit.go
+++ b/cmd/werf/helm/secret/file/edit/edit.go
@@ -64,5 +64,5 @@ func runSecretEdit(ctx context.Context, filePath string) error {
 
 	workingDir := common.GetWorkingDir(&commonCmdData)
 
-	return secret_common.SecretEdit(ctx, secrets_manager.NewSecretsManager(workingDir, secrets_manager.SecretsManagerOptions{}), filePath, false)
+	return secret_common.SecretEdit(ctx, secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{}), workingDir, filePath, false)
 }

--- a/cmd/werf/helm/secret/file/encrypt/encrypt.go
+++ b/cmd/werf/helm/secret/file/encrypt/encrypt.go
@@ -80,5 +80,5 @@ func runSecretEncrypt(ctx context.Context, filePath string) error {
 
 	workingDir := common.GetWorkingDir(&commonCmdData)
 
-	return secret_common.SecretFileEncrypt(ctx, secrets_manager.NewSecretsManager(workingDir, secrets_manager.SecretsManagerOptions{}), filePath, cmdData.OutputFilePath)
+	return secret_common.SecretFileEncrypt(ctx, secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{}), workingDir, filePath, cmdData.OutputFilePath)
 }

--- a/cmd/werf/helm/secret/rotate_secret_key/rotate_secret_key.go
+++ b/cmd/werf/helm/secret/rotate_secret_key/rotate_secret_key.go
@@ -95,9 +95,9 @@ func runRotateSecretKey(ctx context.Context, cmd *cobra.Command, secretValuesPat
 		return fmt.Errorf("getting helm chart dir failed: %s", err)
 	}
 
-	secretsManager := secrets_manager.NewSecretsManager(giterminismManager.ProjectDir(), secrets_manager.SecretsManagerOptions{})
+	secretsManager := secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{})
 
-	newEncoder, err := secretsManager.GetYamlEncoder(ctx)
+	newEncoder, err := secretsManager.GetYamlEncoder(ctx, giterminismManager.ProjectDir())
 	if err != nil {
 		common.PrintHelp(cmd)
 		return err

--- a/cmd/werf/helm/secret/values/decrypt/decrypt.go
+++ b/cmd/werf/helm/secret/values/decrypt/decrypt.go
@@ -90,5 +90,5 @@ func runSecretDecrypt(ctx context.Context, filePath string) error {
 
 	workingDir := common.GetWorkingDir(&commonCmdData)
 
-	return secret_common.SecretValuesDecrypt(ctx, secrets_manager.NewSecretsManager(workingDir, secrets_manager.SecretsManagerOptions{}), filePath, cmdData.OutputFilePath)
+	return secret_common.SecretValuesDecrypt(ctx, secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{}), workingDir, filePath, cmdData.OutputFilePath)
 }

--- a/cmd/werf/helm/secret/values/edit/edit.go
+++ b/cmd/werf/helm/secret/values/edit/edit.go
@@ -64,5 +64,5 @@ func runSecretEdit(ctx context.Context, filepPath string) error {
 
 	workingDir := common.GetWorkingDir(&commonCmdData)
 
-	return secret_common.SecretEdit(ctx, secrets_manager.NewSecretsManager(workingDir, secrets_manager.SecretsManagerOptions{}), filepPath, true)
+	return secret_common.SecretEdit(ctx, secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{}), workingDir, filepPath, true)
 }

--- a/cmd/werf/helm/secret/values/encrypt/encrypt.go
+++ b/cmd/werf/helm/secret/values/encrypt/encrypt.go
@@ -81,5 +81,5 @@ func runSecretEncrypt(ctx context.Context, filePath string) error {
 
 	workingDir := common.GetWorkingDir(&commonCmdData)
 
-	return secret_common.SecretValuesEncrypt(ctx, secrets_manager.NewSecretsManager(workingDir, secrets_manager.SecretsManagerOptions{}), filePath, cmdData.OutputFilePath)
+	return secret_common.SecretValuesEncrypt(ctx, secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{}), workingDir, filePath, cmdData.OutputFilePath)
 }

--- a/cmd/werf/helm/werf_chart.go
+++ b/cmd/werf/helm/werf_chart.go
@@ -19,7 +19,7 @@ func SetupRenderRelatedWerfChartParams(cmd *cobra.Command, commonCmdData *cmd_we
 	cmd_werf_common.SetupIgnoreSecretKey(commonCmdData, cmd)
 }
 
-func InitRenderRelatedWerfChartParams(ctx context.Context, commonCmdData *cmd_werf_common.CmdData, wc *chart_extender.WerfChartStub, chartDir string) error {
+func InitRenderRelatedWerfChartParams(ctx context.Context, commonCmdData *cmd_werf_common.CmdData, wc *chart_extender.WerfChartStub) error {
 	if extraAnnotations, err := cmd_werf_common.GetUserExtraAnnotations(commonCmdData); err != nil {
 		return err
 	} else {
@@ -36,7 +36,7 @@ func InitRenderRelatedWerfChartParams(ctx context.Context, commonCmdData *cmd_we
 	// NOTE: project-dir is the same as chart-dir for werf helm install/upgrade commands
 	// NOTE: project-dir is werf-project dir only for werf converge/dismiss commands
 
-	wc.SetupSecretsManager(secrets_manager.NewSecretsManager(chartDir, secrets_manager.SecretsManagerOptions{
+	wc.SetupSecretsManager(secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{
 		DisableSecretsDecryption: *commonCmdData.IgnoreSecretKey,
 	}))
 

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -22,6 +22,7 @@ import (
 	"github.com/werf/werf/pkg/container_runtime"
 	"github.com/werf/werf/pkg/deploy/helm"
 	"github.com/werf/werf/pkg/deploy/helm/chart_extender"
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers"
 	"github.com/werf/werf/pkg/deploy/secrets_manager"
 	"github.com/werf/werf/pkg/docker"
 	"github.com/werf/werf/pkg/git_repo"
@@ -291,7 +292,7 @@ func runRender() error {
 		}
 	}
 
-	secretsManager := secrets_manager.NewSecretsManager(giterminismManager.ProjectDir(), secrets_manager.SecretsManagerOptions{DisableSecretsDecryption: *commonCmdData.IgnoreSecretKey})
+	secretsManager := secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{DisableSecretsDecryption: *commonCmdData.IgnoreSecretKey})
 
 	wc := chart_extender.NewWerfChart(ctx, giterminismManager, secretsManager, chartDir, cmd_helm.Settings, chart_extender.WerfChartOptions{
 		SecretValueFiles: common.GetSecretValues(&commonCmdData),
@@ -305,14 +306,14 @@ func runRender() error {
 	if err := wc.SetWerfConfig(werfConfig); err != nil {
 		return err
 	}
-	if vals, err := chart_extender.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, chart_extender.ServiceValuesOptions{Namespace: namespace, Env: *commonCmdData.Environment, IsStub: isStub}); err != nil {
+	if vals, err := helpers.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{Namespace: namespace, Env: *commonCmdData.Environment, IsStub: isStub}); err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	} else if err := wc.SetServiceValues(vals); err != nil {
 		return err
 	}
 
 	if *commonCmdData.SetDockerConfigJsonValue {
-		if err := chart_extender.WriteDockerConfigJsonValue(ctx, wc.GetExtraValues(), *commonCmdData.DockerConfig); err != nil {
+		if err := helpers.WriteDockerConfigJsonValue(ctx, wc.GetExtraValues(), *commonCmdData.DockerConfig); err != nil {
 			return fmt.Errorf("error writing docker config value into werf chart extra values: %s", err)
 		}
 	}

--- a/docs/_includes/documentation/reference/cli/werf_helm_lint.md
+++ b/docs/_includes/documentation/reference/cli/werf_helm_lint.md
@@ -21,6 +21,24 @@ werf helm lint PATH [flags] [options]
 {{ header }} Options
 
 ```shell
+      --add-annotation=[]
+            Add annotation to deploying resources (can specify multiple).
+            Format: annoName=annoValue.
+            Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
+            $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
+            $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
+      --add-label=[]
+            Add label to deploying resources (can specify multiple).
+            Format: labelName=labelValue.
+            Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
+            $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
+      --ignore-secret-key=false
+            Disable secrets decryption (default $WERF_IGNORE_SECRET_KEY)
+      --secret-values=[]
+            Specify helm secret values in a YAML file (can specify multiple).
+            Also, can be defined with $WERF_SECRET_VALUES_* (e.g.                                   
+            $WERF_SECRET_VALUES_ENV=.helm/secret_values_test.yaml,                                  
+            $WERF_SECRET_VALUES_DB=.helm/secret_values_db.yaml)
       --set=[]
             set values on the command line (can specify multiple or separate values with commas:    
             key1=val1,key2=val2)

--- a/go.mod
+++ b/go.mod
@@ -104,4 +104,4 @@ replace k8s.io/helm => github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f
 
 replace github.com/deislabs/oras => github.com/werf/oras v0.8.2-0.20210128161614-26d583f169ea
 
-replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20210309132425-cd96d0eff22f
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20210309164546-5025d62f56c2

--- a/go.sum
+++ b/go.sum
@@ -1291,6 +1291,8 @@ github.com/werf/helm/v3 v3.0.0-20210309122251-afbbf154ae85 h1:4u9Trt4AE+e6FOZWRA
 github.com/werf/helm/v3 v3.0.0-20210309122251-afbbf154ae85/go.mod h1:bjwXfmGAF+SEuJZ2AtN1xmTuz4FqaNYOJrXP+vtj6Tw=
 github.com/werf/helm/v3 v3.0.0-20210309132425-cd96d0eff22f h1:w/WAM27lW6uTKBd9FQEqkAAHAkmJ6ImEz551YZzsg1A=
 github.com/werf/helm/v3 v3.0.0-20210309132425-cd96d0eff22f/go.mod h1:7+CqT745B1Sy/4dzhzbbY9U08pGnJfrJXBkoEEFj18c=
+github.com/werf/helm/v3 v3.0.0-20210309164546-5025d62f56c2 h1:YIbBrOQpUniBU8UN77gZT7cIqWQk1YmhkUKC9kUZK30=
+github.com/werf/helm/v3 v3.0.0-20210309164546-5025d62f56c2/go.mod h1:7+CqT745B1Sy/4dzhzbbY9U08pGnJfrJXBkoEEFj18c=
 github.com/werf/kubedog v0.4.1-0.20200923112210-4079add7a93c h1:aM9Gs5CF9YuCFs25mCNfZKTx+3dNe97YGQGKLIumW5U=
 github.com/werf/kubedog v0.4.1-0.20200923112210-4079add7a93c/go.mod h1:b/5MyrNDmxXtr68uucMmZCZmWS3h7cfAcgqtQbHsw5o=
 github.com/werf/kubedog v0.4.1-0.20201125180623-08ad3ea6f58c h1:caA8J/bf3AQgcjo0RCSKdY3blSSswMH47pDcnmsNxPg=

--- a/pkg/deploy/helm/chart_extender/helpers/chart_extender_context_data.go
+++ b/pkg/deploy/helm/chart_extender/helpers/chart_extender_context_data.go
@@ -1,11 +1,11 @@
-package chart_extender
+package helpers
 
 import "context"
 
 type ChartExtenderContextData struct {
-	chartExtenderContext context.Context
+	ChartExtenderContext context.Context
 }
 
 func NewChartExtenderContextData(ctx context.Context) *ChartExtenderContextData {
-	return &ChartExtenderContextData{chartExtenderContext: ctx}
+	return &ChartExtenderContextData{ChartExtenderContext: ctx}
 }

--- a/pkg/deploy/helm/chart_extender/helpers/chart_metadata_autosetter.go
+++ b/pkg/deploy/helm/chart_extender/helpers/chart_metadata_autosetter.go
@@ -1,4 +1,4 @@
-package chart_extender
+package helpers
 
 import "helm.sh/helm/v3/pkg/chart"
 

--- a/pkg/deploy/helm/chart_extender/helpers/chart_template_helpers.go
+++ b/pkg/deploy/helm/chart_extender/helpers/chart_template_helpers.go
@@ -1,4 +1,4 @@
-package chart_extender
+package helpers
 
 var ChartTemplateHelpers = `{{- define "_werf_image" -}}
 {{-   $context := index . 0 -}}

--- a/pkg/deploy/helm/chart_extender/helpers/common_template_funcs.go
+++ b/pkg/deploy/helm/chart_extender/helpers/common_template_funcs.go
@@ -1,4 +1,4 @@
-package chart_extender
+package helpers
 
 import (
 	"context"

--- a/pkg/deploy/helm/chart_extender/helpers/extra_values.go
+++ b/pkg/deploy/helm/chart_extender/helpers/extra_values.go
@@ -1,4 +1,4 @@
-package chart_extender
+package helpers
 
 import (
 	"context"
@@ -11,16 +11,16 @@ import (
 	"github.com/werf/logboek"
 )
 
-func NewExtraValuesData() *ExtraValuesData {
-	return &ExtraValuesData{extraValues: make(map[string]interface{})}
+func NewChartExtenderExtraValuesData() *ChartExtenderExtraValuesData {
+	return &ChartExtenderExtraValuesData{ExtraValues: make(map[string]interface{})}
 }
 
-type ExtraValuesData struct {
-	extraValues map[string]interface{}
+type ChartExtenderExtraValuesData struct {
+	ExtraValues map[string]interface{}
 }
 
-func (d *ExtraValuesData) GetExtraValues() map[string]interface{} {
-	return d.extraValues
+func (d *ChartExtenderExtraValuesData) GetExtraValues() map[string]interface{} {
+	return d.ExtraValues
 }
 
 func WriteDockerConfigJsonValue(ctx context.Context, values map[string]interface{}, dockerConfigPath string) error {

--- a/pkg/deploy/helm/chart_extender/helpers/secrets/chart_secrets_loader.go
+++ b/pkg/deploy/helm/chart_extender/helpers/secrets/chart_secrets_loader.go
@@ -32,8 +32,8 @@ func GetSecretValuesFiles(chartDir string, loadedChartFiles []*chart.ChartExtend
 	}
 
 	var res []*chart.ChartExtenderBufferedFile
-	for _, file := range loadedChartFiles {
-		for _, valuesFilePath := range valuesFilePaths {
+	for _, valuesFilePath := range valuesFilePaths {
+		for _, file := range loadedChartFiles {
 			if file.Name == valuesFilePath {
 				res = append(res, file)
 			}

--- a/pkg/deploy/helm/chart_extender/helpers/secrets/chart_secrets_loader.go
+++ b/pkg/deploy/helm/chart_extender/helpers/secrets/chart_secrets_loader.go
@@ -1,4 +1,4 @@
-package chart_extender
+package secrets
 
 import (
 	"fmt"
@@ -13,6 +13,11 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 
 	"sigs.k8s.io/yaml"
+)
+
+const (
+	DefaultSecretValuesFileName = "secret-values.yaml"
+	SecretDirName               = "secret"
 )
 
 type SecretValuesFilesOptions struct {

--- a/pkg/deploy/helm/chart_extender/helpers/secrets/secrets_runtime_data.go
+++ b/pkg/deploy/helm/chart_extender/helpers/secrets/secrets_runtime_data.go
@@ -1,0 +1,59 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/werf/werf/pkg/deploy/secrets_manager"
+	"github.com/werf/werf/pkg/secret"
+	"github.com/werf/werf/pkg/util/secretvalues"
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+type SecretsRuntimeData struct {
+	DecodedSecretValues    map[string]interface{}
+	DecodedSecretFilesData map[string]string
+	SecretValuesToMask     []string
+}
+
+func NewSecretsRuntimeData() *SecretsRuntimeData {
+	return &SecretsRuntimeData{
+		DecodedSecretFilesData: make(map[string]string),
+	}
+}
+
+func (secretsRuntimeData *SecretsRuntimeData) DecodeAndLoadSecrets(ctx context.Context, files []*chart.ChartExtenderBufferedFile, secretValueFiles []string, chartDir, secretsWorkingDir string, secretsManager *secrets_manager.SecretsManager) error {
+	secretDirFiles := GetSecretDirFiles(files)
+	secretValuesFiles := GetSecretValuesFiles(chartDir, files, SecretValuesFilesOptions{CustomFiles: secretValueFiles})
+
+	var encoder *secret.YamlEncoder
+	if len(secretDirFiles)+len(secretValuesFiles) > 0 {
+		if enc, err := secretsManager.GetYamlEncoder(ctx, secretsWorkingDir); err != nil {
+			return err
+		} else {
+			encoder = enc
+		}
+	}
+
+	if len(secretDirFiles) > 0 {
+		if data, err := LoadChartSecretDirFilesData(chartDir, secretDirFiles, encoder); err != nil {
+			return fmt.Errorf("error loading secret files data: %s", err)
+		} else {
+			secretsRuntimeData.DecodedSecretFilesData = data
+			for _, fileData := range secretsRuntimeData.DecodedSecretFilesData {
+				secretsRuntimeData.SecretValuesToMask = append(secretsRuntimeData.SecretValuesToMask, fileData)
+			}
+		}
+	}
+
+	if len(secretValuesFiles) > 0 {
+		if values, err := LoadChartSecretValueFiles(chartDir, secretValuesFiles, encoder); err != nil {
+			return fmt.Errorf("error loading secret value files: %s", err)
+		} else {
+			secretsRuntimeData.DecodedSecretValues = values
+			secretsRuntimeData.SecretValuesToMask = append(secretsRuntimeData.SecretValuesToMask, secretvalues.ExtractSecretValuesFromMap(values)...)
+		}
+	}
+
+	return nil
+}

--- a/pkg/deploy/helm/chart_extender/helpers/service_values.go
+++ b/pkg/deploy/helm/chart_extender/helpers/service_values.go
@@ -1,4 +1,4 @@
-package chart_extender
+package helpers
 
 import (
 	"context"

--- a/pkg/deploy/secrets_manager/secret_manager.go
+++ b/pkg/deploy/secrets_manager/secret_manager.go
@@ -10,7 +10,6 @@ import (
 )
 
 type SecretsManager struct {
-	WorkingDir               string
 	DisableSecretsDecryption bool
 }
 
@@ -18,20 +17,19 @@ type SecretsManagerOptions struct {
 	DisableSecretsDecryption bool
 }
 
-func NewSecretsManager(workingDir string, opts SecretsManagerOptions) *SecretsManager {
+func NewSecretsManager(opts SecretsManagerOptions) *SecretsManager {
 	return &SecretsManager{
-		WorkingDir:               workingDir,
 		DisableSecretsDecryption: opts.DisableSecretsDecryption,
 	}
 }
 
-func (manager *SecretsManager) GetYamlEncoder(ctx context.Context) (*secret.YamlEncoder, error) {
+func (manager *SecretsManager) GetYamlEncoder(ctx context.Context, workingDir string) (*secret.YamlEncoder, error) {
 	if manager.DisableSecretsDecryption {
 		logboek.Context(ctx).Default().LogLnDetails("Secrets decryption disabled")
 		return secret.NewYamlEncoder(nil), nil
 	}
 
-	if key, err := GetRequiredSecretKey(manager.WorkingDir); err != nil {
+	if key, err := GetRequiredSecretKey(workingDir); err != nil {
 		return nil, fmt.Errorf("unable to load secret key: %s", err)
 	} else if enc, err := secret.NewAesEncoder(key); err != nil {
 		return nil, fmt.Errorf("check encryption key: %s", err)


### PR DESCRIPTION
 - Refactored pkg/deploy/helm/chart_extender.
     - Separation of chart-extenders itself and helpers.
     - Common code for secret loader.
 - Refactored secrets-manager: accept working dir param only when reading secret-key.
 - Fixed 'werf helm lint' command (disabled linting of an optional .helm/Chart.yaml file).
     - Refs https://github.com/werf/helm/pull/89