### PR TITLE
[compose] Fetch last stages of built images before running compose

### DIFF
--- a/cmd/werf/compose/main.go
+++ b/cmd/werf/compose/main.go
@@ -362,6 +362,12 @@ func run(ctx context.Context, giterminismManager giterminism_manager.Interface, 
 			}
 		}
 
+		for _, imageName := range c.GetExportedImagesNames() {
+			if err := c.FetchLastImageStage(ctx, imageName); err != nil {
+				return err
+			}
+		}
+
 		envArray = c.GetImagesEnvArray()
 
 		return nil

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -324,6 +324,20 @@ func (c *Conveyor) GetImageInfoGetters() (images []*imagePkg.InfoGetter) {
 	return images
 }
 
+func (c *Conveyor) GetExportedImagesNames() []string {
+	var res []string
+
+	for _, img := range c.images {
+		if img.isArtifact {
+			continue
+		}
+
+		res = append(res, img.name)
+	}
+
+	return res
+}
+
 func (c *Conveyor) GetImagesEnvArray() []string {
 	var envArray []string
 	for _, img := range c.images {


### PR DESCRIPTION
 1. This will detect deleted stage image from the storage and cause werf to rebuild this image automatically (when stages-storage-cache is invalid).
 2. This allows setting LRU meta info for the stage image, which will be used by build-host GC of images.