### PR TITLE
[git_repo] Fix LsTree/Patch/Archive cache ID

### DIFF
--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/werf/werf/pkg/true_git"
 	"github.com/werf/werf/pkg/true_git/ls_tree"
-	"github.com/werf/werf/pkg/util"
 )
 
 type Base struct {
@@ -125,14 +124,15 @@ func (repo *Base) getOrCreatePatch(ctx context.Context, repoPath, gitDir, repoID
 	repo.Cache.patchesMutex.Lock()
 	defer repo.Cache.patchesMutex.Unlock()
 
-	if _, hasKey := repo.Cache.Patches[util.ObjectToHashKey(opts)]; !hasKey {
+	patchID := true_git.PatchOptions(opts).ID()
+	if _, hasKey := repo.Cache.Patches[patchID]; !hasKey {
 		patch, err := repo.CreatePatch(ctx, repoPath, gitDir, repoID, workTreeCacheDir, opts)
 		if err != nil {
 			return nil, err
 		}
-		repo.Cache.Patches[util.ObjectToHashKey(opts)] = patch
+		repo.Cache.Patches[patchID] = patch
 	}
-	return repo.Cache.Patches[util.ObjectToHashKey(opts)], nil
+	return repo.Cache.Patches[patchID], nil
 }
 
 func (repo *Base) CreatePatch(ctx context.Context, repoPath, gitDir, repoID, workTreeCacheDir string, opts PatchOptions) (patch Patch, err error) {
@@ -274,14 +274,15 @@ func (repo *Base) getOrCreateArchive(ctx context.Context, repoPath, gitDir, repo
 	repo.Cache.archivesMutex.Lock()
 	defer repo.Cache.archivesMutex.Unlock()
 
-	if _, hasKey := repo.Cache.Archives[util.ObjectToHashKey(opts)]; !hasKey {
+	archiveID := true_git.ArchiveOptions(opts).ID()
+	if _, hasKey := repo.Cache.Archives[archiveID]; !hasKey {
 		archive, err := repo.CreateArchive(ctx, repoPath, gitDir, repoID, workTreeCacheDir, opts)
 		if err != nil {
 			return nil, err
 		}
-		repo.Cache.Archives[util.ObjectToHashKey(opts)] = archive
+		repo.Cache.Archives[archiveID] = archive
 	}
-	return repo.Cache.Archives[util.ObjectToHashKey(opts)], nil
+	return repo.Cache.Archives[archiveID], nil
 }
 
 func (repo *Base) CreateArchive(ctx context.Context, repoPath, gitDir, repoID, workTreeCacheDir string, opts ArchiveOptions) (archive Archive, err error) {

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -21,7 +21,7 @@ type ChecksumOptions struct {
 }
 
 func (opts ChecksumOptions) ID() string {
-	return util.Sha256Hash(opts.Commit, opts.PathMatcher.ID())
+	return util.Sha256Hash(opts.Commit, ls_tree.LsTreeOptions(opts.LsTreeOptions).ID())
 }
 
 type ArchiveType string

--- a/pkg/true_git/archive.go
+++ b/pkg/true_git/archive.go
@@ -28,6 +28,14 @@ type ArchiveOptions struct {
 	PathMatcher path_matcher.PathMatcher
 }
 
+func (opts ArchiveOptions) ID() string {
+	return util.Sha256Hash(
+		opts.Commit,
+		opts.PathScope,
+		opts.PathMatcher.ID(),
+	)
+}
+
 type ArchiveDescriptor struct {
 	Type    ArchiveType
 	IsEmpty bool

--- a/pkg/true_git/ls_tree/ls_tree.go
+++ b/pkg/true_git/ls_tree/ls_tree.go
@@ -18,6 +18,7 @@ import (
 	"github.com/werf/logboek"
 
 	"github.com/werf/werf/pkg/path_matcher"
+	"github.com/werf/werf/pkg/util"
 )
 
 func newHash(s string) (plumbing.Hash, error) {
@@ -37,6 +38,14 @@ type LsTreeOptions struct {
 	PathScope   string
 	PathMatcher path_matcher.PathMatcher
 	AllFiles    bool
+}
+
+func (opts LsTreeOptions) ID() string {
+	return util.Sha256Hash(
+		opts.PathScope,
+		opts.PathMatcher.ID(),
+		fmt.Sprint(opts.AllFiles),
+	)
 }
 
 func (opts LsTreeOptions) formattedPathScope() string {

--- a/pkg/true_git/patch.go
+++ b/pkg/true_git/patch.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/werf/werf/pkg/path_matcher"
+	"github.com/werf/werf/pkg/util"
 )
 
 type PatchOptions struct {
@@ -21,6 +22,17 @@ type PatchOptions struct {
 
 	WithEntireFileContext bool
 	WithBinary            bool
+}
+
+func (opts PatchOptions) ID() string {
+	return util.Sha256Hash(
+		opts.FromCommit,
+		opts.ToCommit,
+		opts.PathScope,
+		opts.PathMatcher.ID(),
+		fmt.Sprint(opts.WithBinary),
+		fmt.Sprint(opts.WithEntireFileContext),
+	)
 }
 
 type PatchDescriptor struct {


### PR DESCRIPTION
The cache IDs broke in v1.2.10.