### PR TITLE
[GC] Host cleanup garbage collection refinements

### DIFF
--- a/cmd/werf/build/main.go
+++ b/cmd/werf/build/main.go
@@ -112,6 +112,7 @@ If one or more IMAGE_NAME parameters specified, werf will build only these image
 	common.SetupFollow(&commonCmdData, cmd)
 
 	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -119,6 +119,7 @@ func NewCmd() *cobra.Command {
 	common.SetupSkipBuild(&commonCmdData, cmd)
 
 	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	cmd.Flags().StringVarP(&cmdData.Destination, "destination", "d", os.Getenv("WERF_DESTINATION"), "Export bundle into the provided directory ($WERF_DESTINATION or chart-name by default)")

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -126,6 +126,7 @@ Published into container registry bundle can be rolled out by the "werf bundle" 
 	common.SetupParallelOptions(&commonCmdData, cmd, common.DefaultBuildParallelTasksLimit)
 
 	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	common.SetupSkipBuild(&commonCmdData, cmd)

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -82,6 +82,7 @@ It is safe to run this command periodically (daily is enough) by automated clean
 	common.SetupKeepStagesBuiltWithinLastNHours(&commonCmdData, cmd)
 
 	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -110,8 +110,9 @@ type CmdData struct {
 	Tag *string
 
 	// Host storage GC options
-	AllowedVolumeUsage      *int64
-	DockerServerStoragePath *string
+	AllowedVolumeUsage       *uint
+	AllowedVolumeUsageMargin *uint
+	DockerServerStoragePath  *string
 }
 
 const (
@@ -813,6 +814,14 @@ func GetIntEnvVar(varName string) (*int64, error) {
 	}
 
 	return nil, nil
+}
+
+func GetUint64EnvVarStrict(varName string) *uint64 {
+	valP, err := GetUint64EnvVar(varName)
+	if err != nil {
+		TerminateWithError(fmt.Sprintf("bad %s value: %s", varName, err), 1)
+	}
+	return valP
 }
 
 func GetUint64EnvVar(varName string) (*uint64, error) {

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -150,6 +150,7 @@ werf converge --repo registry.mydomain.com/web --env production`,
 	common.SetupFollow(&commonCmdData, cmd)
 
 	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -100,6 +100,7 @@ Read more info about Helm Release name, Kubernetes Namespace and how to change i
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.WithNamespace, "with-namespace", "", common.GetBoolEnvironmentDefaultFalse("WERF_WITH_NAMESPACE"), "Delete Kubernetes Namespace after purging Helm Release (default $WERF_WITH_NAMESPACE)")

--- a/cmd/werf/host/cleanup/cleanup.go
+++ b/cmd/werf/host/cleanup/cleanup.go
@@ -63,6 +63,7 @@ It is safe to run this command periodically by automated cleanup job in parallel
 	common.SetupDryRun(&commonCmdData, cmd)
 
 	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.Force, "force", "", common.GetBoolEnvironmentDefaultFalse("WERF_FORCE"), "Force deletion of images which are being used by some containers (default $WERF_FORCE)")
@@ -106,10 +107,11 @@ func runGC() error {
 	logboek.LogOptionalLn()
 
 	hostCleanupOptions := host_cleaning.HostCleanupOptions{
-		AllowedVolumeUsagePercentageThreshold: *commonCmdData.AllowedVolumeUsage,
-		DryRun:                                *commonCmdData.DryRun,
-		Force:                                 cmdData.Force,
-		DockerServerStoragePath:               *commonCmdData.DockerServerStoragePath,
+		AllowedVolumeUsagePercentage:       commonCmdData.AllowedVolumeUsage,
+		AllowedVolumeUsageMarginPercentage: commonCmdData.AllowedVolumeUsageMargin,
+		DryRun:                             *commonCmdData.DryRun,
+		Force:                              cmdData.Force,
+		DockerServerStoragePath:            *commonCmdData.DockerServerStoragePath,
 	}
 
 	return host_cleaning.HostCleanup(ctx, hostCleanupOptions)

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -77,6 +77,7 @@ WARNING: Do not run this command during any other werf command is working on the
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	common.SetupDryRun(&commonCmdData, cmd)

--- a/docs/_includes/documentation/reference/cli/werf_build.md
+++ b/docs/_includes/documentation/reference/cli/werf_build.md
@@ -41,6 +41,13 @@ werf build [IMAGE_NAME...] [options]
 {{ header }} Options
 
 ```shell
+      --allowed-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause garbage          
+            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
+      --allowed-volume-usage-margin=10
+            During garbage collection werf would delete images until volume usage becomes below     
+            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
+            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -63,6 +70,10 @@ werf build [IMAGE_NAME...] [options]
             ~/.docker (in the order of priority)
             Command needs granted permissions to read, pull and push images into the specified      
             repo, to pull base images
+      --docker-server-storage-path=''
+            Use specified path to the local docker server storage to check docker storage volume    
+            usage while performing garbage collection of local docker images (detect local docker   
+            server storage path by default or use $WERF_DOCKER_SERVER_STORAGE_PATH)
       --env=''
             Use specified environment (default $WERF_ENV)
       --follow=false

--- a/docs/_includes/documentation/reference/cli/werf_bundle_export.md
+++ b/docs/_includes/documentation/reference/cli/werf_bundle_export.md
@@ -40,6 +40,13 @@ werf bundle export [options]
             Format: labelName=labelValue.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
+      --allowed-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause garbage          
+            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
+      --allowed-volume-usage-margin=10
+            During garbage collection werf would delete images until volume usage becomes below     
+            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
+            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -64,6 +71,10 @@ werf bundle export [options]
             ~/.docker (in the order of priority)
             Command needs granted permissions to read, pull and push images into the specified repo 
             and to pull base images
+      --docker-server-storage-path=''
+            Use specified path to the local docker server storage to check docker storage volume    
+            usage while performing garbage collection of local docker images (detect local docker   
+            server storage path by default or use $WERF_DOCKER_SERVER_STORAGE_PATH)
       --env=''
             Use specified environment (default $WERF_ENV)
       --git-work-tree=''

--- a/docs/_includes/documentation/reference/cli/werf_bundle_publish.md
+++ b/docs/_includes/documentation/reference/cli/werf_bundle_publish.md
@@ -42,6 +42,13 @@ werf bundle publish [options]
             Format: labelName=labelValue.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
+      --allowed-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause garbage          
+            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
+      --allowed-volume-usage-margin=10
+            During garbage collection werf would delete images until volume usage becomes below     
+            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
+            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -64,6 +71,10 @@ werf bundle publish [options]
             ~/.docker (in the order of priority)
             Command needs granted permissions to read, pull and push images into the specified repo 
             and to pull base images
+      --docker-server-storage-path=''
+            Use specified path to the local docker server storage to check docker storage volume    
+            usage while performing garbage collection of local docker images (detect local docker   
+            server storage path by default or use $WERF_DOCKER_SERVER_STORAGE_PATH)
       --env=''
             Use specified environment (default $WERF_ENV)
       --git-work-tree=''

--- a/docs/_includes/documentation/reference/cli/werf_cleanup.md
+++ b/docs/_includes/documentation/reference/cli/werf_cleanup.md
@@ -26,6 +26,13 @@ werf cleanup [options]
 {{ header }} Options
 
 ```shell
+      --allowed-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause garbage          
+            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
+      --allowed-volume-usage-margin=10
+            During garbage collection werf would delete images until volume usage becomes below     
+            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
+            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -48,6 +55,10 @@ werf cleanup [options]
             ~/.docker (in the order of priority)
             Command needs granted permissions to read, pull and delete images from the specified    
             repo
+      --docker-server-storage-path=''
+            Use specified path to the local docker server storage to check docker storage volume    
+            usage while performing garbage collection of local docker images (detect local docker   
+            server storage path by default or use $WERF_DOCKER_SERVER_STORAGE_PATH)
       --dry-run=false
             Indicate what the command would do without actually doing that (default $WERF_DRY_RUN)
       --env=''

--- a/docs/_includes/documentation/reference/cli/werf_converge.md
+++ b/docs/_includes/documentation/reference/cli/werf_converge.md
@@ -53,6 +53,13 @@ werf converge --repo registry.mydomain.com/web --env production
             Format: labelName=labelValue.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
+      --allowed-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause garbage          
+            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
+      --allowed-volume-usage-margin=10
+            During garbage collection werf would delete images until volume usage becomes below     
+            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
+            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
       --atomic=false
             Enable auto rollback of the failed release to the previous deployed release version     
             when current deploy process have failed ($WERF_ATOMIC by default)
@@ -81,6 +88,10 @@ werf converge --repo registry.mydomain.com/web --env production
             ~/.docker (in the order of priority)
             Command needs granted permissions to read, pull and push images into the specified      
             repo, to pull base images
+      --docker-server-storage-path=''
+            Use specified path to the local docker server storage to check docker storage volume    
+            usage while performing garbage collection of local docker images (detect local docker   
+            server storage path by default or use $WERF_DOCKER_SERVER_STORAGE_PATH)
       --env=''
             Use specified environment (default $WERF_ENV)
       --follow=false

--- a/docs/_includes/documentation/reference/cli/werf_dismiss.md
+++ b/docs/_includes/documentation/reference/cli/werf_dismiss.md
@@ -35,6 +35,13 @@ werf dismiss [options]
 {{ header }} Options
 
 ```shell
+      --allowed-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause garbage          
+            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
+      --allowed-volume-usage-margin=10
+            During garbage collection werf would delete images until volume usage becomes below     
+            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
+            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -55,6 +62,10 @@ werf dismiss [options]
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)
+      --docker-server-storage-path=''
+            Use specified path to the local docker server storage to check docker storage volume    
+            usage while performing garbage collection of local docker images (detect local docker   
+            server storage path by default or use $WERF_DOCKER_SERVER_STORAGE_PATH)
       --env=''
             Use specified environment (default $WERF_ENV)
       --git-work-tree=''

--- a/docs/_includes/documentation/reference/cli/werf_host_cleanup.md
+++ b/docs/_includes/documentation/reference/cli/werf_host_cleanup.md
@@ -24,6 +24,13 @@ werf host cleanup [options]
 {{ header }} Options
 
 ```shell
+      --allowed-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause garbage          
+            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
+      --allowed-volume-usage-margin=10
+            During garbage collection werf would delete images until volume usage becomes below     
+            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
+            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
       --dev=false
             Enable development mode (default $WERF_DEV).
             The mode allows working with project files without doing redundant commits during       
@@ -36,8 +43,14 @@ werf host cleanup [options]
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)
+      --docker-server-storage-path=''
+            Use specified path to the local docker server storage to check docker storage volume    
+            usage while performing garbage collection of local docker images (detect local docker   
+            server storage path by default or use $WERF_DOCKER_SERVER_STORAGE_PATH)
       --dry-run=false
             Indicate what the command would do without actually doing that (default $WERF_DRY_RUN)
+      --force=false
+            Force deletion of images which are being used by some containers (default $WERF_FORCE)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
       --log-color-mode='auto'

--- a/docs/_includes/documentation/reference/cli/werf_purge.md
+++ b/docs/_includes/documentation/reference/cli/werf_purge.md
@@ -18,6 +18,13 @@ werf purge [options]
 {{ header }} Options
 
 ```shell
+      --allowed-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause garbage          
+            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
+      --allowed-volume-usage-margin=10
+            During garbage collection werf would delete images until volume usage becomes below     
+            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
+            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -39,6 +46,10 @@ werf purge [options]
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)
             Command needs granted permissions to delete images from the specified repo
+      --docker-server-storage-path=''
+            Use specified path to the local docker server storage to check docker storage volume    
+            usage while performing garbage collection of local docker images (detect local docker   
+            server storage path by default or use $WERF_DOCKER_SERVER_STORAGE_PATH)
       --dry-run=false
             Indicate what the command would do without actually doing that (default $WERF_DRY_RUN)
       --env=''

--- a/pkg/host_cleaning/host_cleanup.go
+++ b/pkg/host_cleaning/host_cleanup.go
@@ -13,10 +13,12 @@ import (
 )
 
 type HostCleanupOptions struct {
-	DryRun                                bool
-	AllowedVolumeUsagePercentageThreshold int64
-	Force                                 bool
-	DockerServerStoragePath               string
+	AllowedVolumeUsagePercentage       *uint
+	AllowedVolumeUsageMarginPercentage *uint
+
+	DryRun                  bool
+	Force                   bool
+	DockerServerStoragePath string
 }
 
 func HostCleanup(ctx context.Context, options HostCleanupOptions) error {
@@ -26,12 +28,7 @@ func HostCleanup(ctx context.Context, options HostCleanupOptions) error {
 		}
 
 		return logboek.Context(ctx).Default().LogProcess("Running GC for local docker server").DoError((func() error {
-			return RunGCForLocalDockerServer(ctx, LocalDockerServerGCOptions{
-				AllowedVolumeUsagePercentageThreshold: options.AllowedVolumeUsagePercentageThreshold,
-				DryRun:                                options.DryRun,
-				Force:                                 options.Force,
-				DockerServerStoragePath:               options.DockerServerStoragePath,
-			})
+			return RunGCForLocalDockerServer(ctx, options)
 		}))
 	})
 }


### PR DESCRIPTION
 - Added --allowed-volume-usage-margin param which sets target volume usage after cleanup: allowed-volume-usage - allowed-volume-usage-margin.
 - Delete 10 images minimal in each GC iteration to speed up cleanup.