### PR TITLE
[GC] Rework host cleaning GC more

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -618,7 +618,7 @@ jobs:
     - name: Test (windows)
       run: |
         test_binaries=$(find integration -type f \( -name '*.test' -or -name '*.test.exe' \) ${{ matrix.extra-find-args }})
-        WERF_DISABLE_AUTO_GC=1 WERF_TEST_BINARY_PATH=$GITHUB_WORKSPACE/werf_with_coverage ./ginkgo -p -keepGoing $test_binaries
+        WERF_DISABLE_AUTO_HOST_CLEANUP=1 WERF_TEST_BINARY_PATH=$GITHUB_WORKSPACE/werf_with_coverage ./ginkgo -p -keepGoing $test_binaries
       shell: bash
       if: matrix.os == 'windows'
 
@@ -706,7 +706,7 @@ jobs:
       run: |
         source ./scripts/ci/integration_k8s_tests_before_hook.sh
         test_binaries=$(find integration -type f \( -name '*.test' -or -name '*.test.exe' \))
-        WERF_DISABLE_AUTO_GC=1 WERF_TEST_BINARY_PATH=$GITHUB_WORKSPACE/werf_with_coverage ./ginkgo -p -keepGoing $test_binaries
+        WERF_DISABLE_AUTO_HOST_CLEANUP=1 WERF_TEST_BINARY_PATH=$GITHUB_WORKSPACE/werf_with_coverage ./ginkgo -p -keepGoing $test_binaries
       shell: bash
       env:
         WERF_TEST_K8S_DOCKER_REGISTRY: ${{ secrets.WERF_TEST_K8S_DOCKER_REGISTRY }}

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -110,6 +110,7 @@ type CmdData struct {
 	Tag *string
 
 	// Host storage GC options
+	DisableAutoHostCleanup   *bool
 	AllowedVolumeUsage       *uint
 	AllowedVolumeUsageMargin *uint
 	DockerServerStoragePath  *string

--- a/cmd/werf/host/cleanup/cleanup.go
+++ b/cmd/werf/host/cleanup/cleanup.go
@@ -62,6 +62,7 @@ It is safe to run this command periodically by automated cleanup job in parallel
 
 	common.SetupDryRun(&commonCmdData, cmd)
 
+	common.SetupDisableAutoHostCleanup(&commonCmdData, cmd)
 	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
 	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
@@ -114,5 +115,5 @@ func runGC() error {
 		DockerServerStoragePath:            *commonCmdData.DockerServerStoragePath,
 	}
 
-	return host_cleaning.HostCleanup(ctx, hostCleanupOptions)
+	return host_cleaning.RunHostCleanup(ctx, hostCleanupOptions)
 }

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -26,7 +26,6 @@ import (
 	"github.com/werf/werf/pkg/deploy/secrets_manager"
 	"github.com/werf/werf/pkg/docker"
 	"github.com/werf/werf/pkg/git_repo"
-	"github.com/werf/werf/pkg/host_cleaning"
 	"github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/ssh_agent"
 	"github.com/werf/werf/pkg/storage"
@@ -193,12 +192,6 @@ func runRender() error {
 		return fmt.Errorf("getting project tmp dir failed: %s", err)
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
-
-	if lock, err := host_cleaning.AcquireSharedHostStorageLock(ctx); err != nil {
-		return fmt.Errorf("failed to acquire shared storage lock: %s", err)
-	} else {
-		defer werf.ReleaseHostLock(lock)
-	}
 
 	if err := ssh_agent.Init(ctx, common.GetSSHKey(&commonCmdData)); err != nil {
 		return fmt.Errorf("cannot initialize ssh agent: %s", err)

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/werf/werf/pkg/giterminism_manager"
-	"github.com/werf/werf/pkg/host_cleaning"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -324,12 +323,6 @@ func run(ctx context.Context, giterminismManager giterminism_manager.Interface) 
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
-	hostStorageLock, err := host_cleaning.AcquireSharedHostStorageLock(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to acquire shared storage lock: %s", err)
-	}
-	defer werf.ReleaseHostLock(hostStorageLock)
-
 	imageName := cmdData.ImageName
 	if imageName == "" && len(werfConfig.GetAllImages()) == 1 {
 		imageName = werfConfig.GetAllImages()[0].GetName()
@@ -400,8 +393,6 @@ func run(ctx context.Context, giterminismManager giterminism_manager.Interface) 
 		fmt.Printf("docker run %s\n", strings.Join(dockerRunArgs, " "))
 		return nil
 	} else {
-		werf.ReleaseHostLock(hostStorageLock)
-
 		return logboek.Streams().DoErrorWithoutProxyStreamDataFormatting(func() error {
 			return common.WithoutTerminationSignalsTrap(func() error {
 				return docker.CliRun_LiveOutput(ctx, dockerRunArgs...)

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/werf/werf/pkg/container_runtime"
 	"github.com/werf/werf/pkg/docker"
 	"github.com/werf/werf/pkg/git_repo"
-	"github.com/werf/werf/pkg/host_cleaning"
 	"github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/logging"
 	"github.com/werf/werf/pkg/ssh_agent"
@@ -142,12 +141,6 @@ func run(imageName string) error {
 		return fmt.Errorf("getting project tmp dir failed: %s", err)
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
-
-	if lock, err := host_cleaning.AcquireSharedHostStorageLock(ctx); err != nil {
-		return fmt.Errorf("failed to acquire shared storage lock: %s", err)
-	} else {
-		defer werf.ReleaseHostLock(lock)
-	}
 
 	if err := ssh_agent.Init(ctx, common.GetSSHKey(&commonCmdData)); err != nil {
 		return fmt.Errorf("cannot initialize ssh agent: %s", err)

--- a/docs/documentation/_includes/reference/cli/werf_build.md
+++ b/docs/documentation/_includes/reference/cli/werf_build.md
@@ -65,6 +65,9 @@ werf build [IMAGE_NAME...] [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
+      --disable-auto-host-cleanup=true
+            Disable auto host cleanup procedure in main werf commands like werf-build,              
+            werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)

--- a/docs/documentation/_includes/reference/cli/werf_bundle_export.md
+++ b/docs/documentation/_includes/reference/cli/werf_bundle_export.md
@@ -66,6 +66,9 @@ werf bundle export [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
+      --disable-auto-host-cleanup=true
+            Disable auto host cleanup procedure in main werf commands like werf-build,              
+            werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)

--- a/docs/documentation/_includes/reference/cli/werf_bundle_publish.md
+++ b/docs/documentation/_includes/reference/cli/werf_bundle_publish.md
@@ -66,6 +66,9 @@ werf bundle publish [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
+      --disable-auto-host-cleanup=true
+            Disable auto host cleanup procedure in main werf commands like werf-build,              
+            werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)

--- a/docs/documentation/_includes/reference/cli/werf_cleanup.md
+++ b/docs/documentation/_includes/reference/cli/werf_cleanup.md
@@ -50,6 +50,9 @@ werf cleanup [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
+      --disable-auto-host-cleanup=true
+            Disable auto host cleanup procedure in main werf commands like werf-build,              
+            werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)

--- a/docs/documentation/_includes/reference/cli/werf_converge.md
+++ b/docs/documentation/_includes/reference/cli/werf_converge.md
@@ -83,6 +83,9 @@ werf converge --repo registry.mydomain.com/web --env production
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
+      --disable-auto-host-cleanup=true
+            Disable auto host cleanup procedure in main werf commands like werf-build,              
+            werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)

--- a/docs/documentation/_includes/reference/cli/werf_dismiss.md
+++ b/docs/documentation/_includes/reference/cli/werf_dismiss.md
@@ -59,6 +59,9 @@ werf dismiss [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
+      --disable-auto-host-cleanup=true
+            Disable auto host cleanup procedure in main werf commands like werf-build,              
+            werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)

--- a/docs/documentation/_includes/reference/cli/werf_host_cleanup.md
+++ b/docs/documentation/_includes/reference/cli/werf_host_cleanup.md
@@ -40,6 +40,9 @@ werf host cleanup [options]
             Two development modes are supported:
             - simple: for working with the worktree state of the git repository
             - strict: for working with the index state of the git repository
+      --disable-auto-host-cleanup=true
+            Disable auto host cleanup procedure in main werf commands like werf-build,              
+            werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)

--- a/docs/documentation/_includes/reference/cli/werf_purge.md
+++ b/docs/documentation/_includes/reference/cli/werf_purge.md
@@ -42,6 +42,9 @@ werf purge [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
+      --disable-auto-host-cleanup=true
+            Disable auto host cleanup procedure in main werf commands like werf-build,              
+            werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)

--- a/integration/suites/build/stapel_image/imports/suite_test.go
+++ b/integration/suites/build/stapel_image/imports/suite_test.go
@@ -25,5 +25,5 @@ var _ = SuiteData.SetupWerfBinary(suite_init.NewWerfBinaryData(SuiteData.Synchro
 var _ = SuiteData.SetupProjectName(suite_init.NewProjectNameData(SuiteData.StubsData))
 
 var _ = ginkgo.BeforeEach(func() {
-	SuiteData.Stubs.SetEnv("WERF_DISABLE_AUTO_GC", "1")
+	SuiteData.Stubs.SetEnv("WERF_DISABLE_AUTO_HOST_CLEANUP", "1")
 })

--- a/pkg/host_cleaning/host_cleanup.go
+++ b/pkg/host_cleaning/host_cleanup.go
@@ -3,13 +3,12 @@ package host_cleaning
 import (
 	"context"
 	"fmt"
-
-	"github.com/werf/lockgate"
-	"github.com/werf/werf/pkg/werf"
+	"time"
 
 	"github.com/werf/logboek"
 
 	"github.com/werf/werf/pkg/tmp_manager"
+	"github.com/werf/werf/pkg/werf"
 )
 
 type HostCleanupOptions struct {
@@ -21,14 +20,62 @@ type HostCleanupOptions struct {
 	DockerServerStoragePath string
 }
 
-func HostCleanup(ctx context.Context, options HostCleanupOptions) error {
-	return werf.WithHostLock(ctx, "gc", lockgate.AcquireOptions{}, func() error {
-		if err := tmp_manager.GC(ctx, options.DryRun); err != nil {
-			return fmt.Errorf("tmp files GC failed: %s", err)
-		}
+func RunAutoHostCleanup(ctx context.Context, options HostCleanupOptions) error {
+	shouldRun, err := ShouldRunAutoHostCleanup(ctx, options)
+	if err != nil {
+		return err
+	}
+	if !shouldRun {
+		return nil
+	}
 
-		return logboek.Context(ctx).Default().LogProcess("Running GC for local docker server").DoError((func() error {
-			return RunGCForLocalDockerServer(ctx, options)
-		}))
+	return logboek.Context(ctx).Default().LogProcess("Running auto host cleanup").DoError(func() error {
+		logboek.Context(ctx).Default().LogFDetails("### Auto host cleanup note ###\n")
+		logboek.Context(ctx).Default().LogLn()
+		logboek.Context(ctx).Default().LogFDetails("Werf tries to maintain host clean by deleting:\n")
+		logboek.Context(ctx).Default().LogFDetails(" - old unused files from werf caches (which are stored in the ~/.werf/local_cache);\n")
+		logboek.Context(ctx).Default().LogFDetails(" - old temporary service files /tmp/werf-project-data-* and /tmp/werf-config-render-*;\n")
+		logboek.Context(ctx).Default().LogFDetails(" - least recently used werf images (only >= v1.2 werf images could be removed, note that werf <= v1.1 images will not be deleted by this auto cleanup);\n")
+		logboek.Context(ctx).Default().LogLn()
+		logboek.Context(ctx).Default().LogFDetails("To disable this auto host cleanup please specify --disable-auto-host-cleanup option (or WERF_DISABLE_AUTO_HOST_CLEANUP=true environment variable).\n")
+		logboek.Context(ctx).Default().LogFDetails("Host cleanup could be performed manually with the `werf host cleanup` command, please set this command into crontab for your host in the case when auto host cleanup disabled.\n")
+		logboek.Context(ctx).Default().LogLn()
+
+		return RunHostCleanup(ctx, options)
 	})
+}
+
+func RunHostCleanup(ctx context.Context, options HostCleanupOptions) error {
+	if err := tmp_manager.GC(ctx, options.DryRun); err != nil {
+		return fmt.Errorf("tmp files GC failed: %s", err)
+	}
+
+	return logboek.Context(ctx).Default().LogProcess("Running GC for local docker server").DoError((func() error {
+		return RunGCForLocalDockerServer(ctx, options)
+	}))
+}
+
+func ShouldRunAutoHostCleanup(ctx context.Context, options HostCleanupOptions) (bool, error) {
+	t, err := werf.GetWerfFirstRunAt(ctx)
+	if err != nil {
+		return false, fmt.Errorf("error getting last werf run timestamp: %s", err)
+	}
+	// Only run auto host cleanup on persistent hosts
+	if t.IsZero() || time.Since(t) <= 2*time.Hour {
+		return false, nil
+	}
+
+	shouldRun, err := tmp_manager.ShouldRunAutoGC()
+	if err != nil {
+		return false, fmt.Errorf("failed to check tmp manager GC: %s", err)
+	}
+	if shouldRun {
+		return true, nil
+	}
+
+	shouldRun, err = ShouldRunAutoGCForLocalDockerServer(ctx, options)
+	if err != nil {
+		return false, fmt.Errorf("failed to check local docker server host cleaner GC: %s", err)
+	}
+	return shouldRun, nil
 }

--- a/pkg/tmp_manager/docker_config_dir.go
+++ b/pkg/tmp_manager/docker_config_dir.go
@@ -45,17 +45,5 @@ func CreateDockerConfigDir(ctx context.Context, fromDockerConfig string) (string
 		return "", err
 	}
 
-	shouldRunGC, err := checkShouldRunGC()
-	if err != nil {
-		return "", err
-	}
-
-	if shouldRunGC {
-		err := runGC(ctx)
-		if err != nil {
-			return "", fmt.Errorf("tmp manager GC failed: %s", err)
-		}
-	}
-
 	return newDir, nil
 }

--- a/pkg/tmp_manager/gc.go
+++ b/pkg/tmp_manager/gc.go
@@ -10,29 +10,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/werf/lockgate"
-
 	"github.com/werf/logboek"
 
 	"github.com/werf/werf/pkg/util"
 	"github.com/werf/werf/pkg/werf"
 )
 
-var (
-	AutoGCEnabled bool
-)
-
-func runGC(ctx context.Context) error {
-	return werf.WithHostLock(ctx, "gc", lockgate.AcquireOptions{}, func() error {
-		return GC(ctx, false)
-	})
-}
-
-func checkShouldRunGC() (bool, error) {
-	if !isAutoGCEnabled() {
-		return false, nil
-	}
-
+func ShouldRunAutoGC() (bool, error) {
 	releasedProjectsDir := filepath.Join(GetReleasedTmpDirs(), projectsServiceDir)
 	if _, err := os.Stat(releasedProjectsDir); !os.IsNotExist(err) {
 		var err error
@@ -79,10 +63,6 @@ func checkShouldRunGC() (bool, error) {
 	}
 
 	return false, nil
-}
-
-func isAutoGCEnabled() bool {
-	return AutoGCEnabled && os.Getenv("WERF_DISABLE_AUTO_GC") != "1"
 }
 
 func GC(ctx context.Context, dryRun bool) error {

--- a/pkg/tmp_manager/project_dir.go
+++ b/pkg/tmp_manager/project_dir.go
@@ -2,7 +2,6 @@ package tmp_manager
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -16,18 +15,6 @@ func CreateProjectDir(ctx context.Context) (string, error) {
 	if err := registerCreatedPath(newDir, filepath.Join(GetCreatedTmpDirs(), projectsServiceDir)); err != nil {
 		os.RemoveAll(newDir)
 		return "", err
-	}
-
-	shouldRunGC, err := checkShouldRunGC()
-	if err != nil {
-		return "", err
-	}
-
-	if shouldRunGC {
-		err := runGC(ctx)
-		if err != nil {
-			return "", fmt.Errorf("tmp manager GC failed: %s", err)
-		}
 	}
 
 	return newDir, nil

--- a/pkg/tmp_manager/werf_config_render.go
+++ b/pkg/tmp_manager/werf_config_render.go
@@ -2,7 +2,6 @@ package tmp_manager
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -16,18 +15,6 @@ func CreateWerfConfigRender(ctx context.Context) (string, error) {
 	if err := registerCreatedPath(newFile, filepath.Join(GetCreatedTmpDirs(), werfConfigRendersServiceDir)); err != nil {
 		os.RemoveAll(newFile)
 		return "", err
-	}
-
-	shouldRunGC, err := checkShouldRunGC()
-	if err != nil {
-		return "", err
-	}
-
-	if shouldRunGC {
-		err := runGC(ctx)
-		if err != nil {
-			return "", fmt.Errorf("tmp manager GC failed: %s", err)
-		}
 	}
 
 	return newFile, nil

--- a/pkg/werf/last_werf_run_at.go
+++ b/pkg/werf/last_werf_run_at.go
@@ -1,0 +1,117 @@
+package werf
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/werf/lockgate"
+)
+
+func getWerfLastRunAtPath() string {
+	return filepath.Join(GetServiceDir(), "var", "last_werf_run_at")
+}
+
+func getWerfFirstRunAtPath() string {
+	return filepath.Join(GetServiceDir(), "var", "first_werf_run_at")
+}
+
+func SetWerfLastRunAt(ctx context.Context) error {
+	path := getWerfLastRunAtPath()
+	if _, lock, err := AcquireHostLock(ctx, path, lockgate.AcquireOptions{OnWaitFunc: func(lockName string, doWait func() error) error { return doWait() }}); err != nil {
+		return fmt.Errorf("error locking path %q: %s", path, err)
+	} else {
+		defer ReleaseHostLock(lock)
+	}
+
+	return writeTimestampFile(path, time.Now())
+}
+
+func GetWerfLastRunAt(ctx context.Context) (time.Time, error) {
+	path := getWerfLastRunAtPath()
+	if _, lock, err := AcquireHostLock(ctx, path, lockgate.AcquireOptions{OnWaitFunc: func(lockName string, doWait func() error) error { return doWait() }}); err != nil {
+		return time.Time{}, fmt.Errorf("error locking path %q: %s", path, err)
+	} else {
+		defer ReleaseHostLock(lock)
+	}
+
+	return readTimestampFile(path)
+}
+
+func SetWerfFirstRunAt(ctx context.Context) error {
+	path := getWerfFirstRunAtPath()
+	if _, lock, err := AcquireHostLock(ctx, path, lockgate.AcquireOptions{OnWaitFunc: func(lockName string, doWait func() error) error { return doWait() }}); err != nil {
+		return fmt.Errorf("error locking path %q: %s", path, err)
+	} else {
+		defer ReleaseHostLock(lock)
+	}
+
+	if exists, err := checkTimestampFileExists(path); err != nil {
+		return fmt.Errorf("error checking existance of %q: %s", path, err)
+	} else if !exists {
+		return writeTimestampFile(path, time.Now())
+	}
+	return nil
+}
+
+func GetWerfFirstRunAt(ctx context.Context) (time.Time, error) {
+	path := getWerfFirstRunAtPath()
+	if _, lock, err := AcquireHostLock(ctx, path, lockgate.AcquireOptions{OnWaitFunc: func(lockName string, doWait func() error) error { return doWait() }}); err != nil {
+		return time.Time{}, fmt.Errorf("error locking path %q: %s", path, err)
+	} else {
+		defer ReleaseHostLock(lock)
+	}
+
+	return readTimestampFile(path)
+}
+
+func readTimestampFile(path string) (time.Time, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return time.Time{}, nil
+	} else if err != nil {
+		return time.Time{}, fmt.Errorf("error accessing %q: %s", path, err)
+	}
+
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("error reading %q: %s", path, err)
+	}
+
+	i, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		// os.RemoveAll(path)
+		// return time.Time{}, nil
+		return time.Time{}, fmt.Errorf("error parsing %q timestamp data %q: %s", path, data, err)
+	}
+
+	return time.Unix(i, 0), nil
+}
+
+func writeTimestampFile(path string, t time.Time) error {
+	timeStr := fmt.Sprintf("%d\n", t.Unix())
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return fmt.Errorf("error creating dir %q: %s", dir, err)
+	}
+
+	if err := ioutil.WriteFile(path, []byte(timeStr), 0644); err != nil {
+		return fmt.Errorf("error writing %q: %s", path, err)
+	}
+
+	return nil
+}
+
+func checkTimestampFileExists(path string) (bool, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("error accessing %q: %s", path, err)
+	}
+	return true, nil
+}

--- a/pkg/werf/main.go
+++ b/pkg/werf/main.go
@@ -155,5 +155,13 @@ func Init(tmpDirOption, homeDirOption string) error {
 		hostLocker = locker
 	}
 
+	if err := SetWerfFirstRunAt(context.Background()); err != nil {
+		return fmt.Errorf("error setting werf first run at timestamp: %s", err)
+	}
+
+	if err := SetWerfLastRunAt(context.Background()); err != nil {
+		return fmt.Errorf("error setting werf last run at timestamp: %s", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
 - Run auto host cleanup only when --disable-host-cleanup=false (WERF_DISABLE_HOST_CLEANUP=false), cleanup will be enabled by default later.
 - Run auto host cleanup could run in werf-build/werf-converge and other commands as previously, BUT it will run in the end of the command.
     - Big note message is printed before running auto host cleanup.
         - This message contains info how to disable auto-host-cleanup.
 - Run /tmp/werf-config-render-* and /tmp/werf-project-data-* cleanup in the werf-host-cleanup procedure as well.
 - Removed global lock for host cleanup, added individual locks for stage-images and build-containers
 - Run auto host cleanup only when 2 hour has passed since first werf run on this host (try to determine that current host is persistent).
