### PR TITLE
[dockerfile] The BuildKit support with explicit user activation

### DIFF
--- a/pkg/util/parallel/constant/constant.go
+++ b/pkg/util/parallel/constant/constant.go
@@ -1,0 +1,3 @@
+package constant
+
+const CtxBackgroundTaskIDKey = "background_task_id"

--- a/pkg/util/parallel/parallel.go
+++ b/pkg/util/parallel/parallel.go
@@ -10,6 +10,7 @@ import (
 	"github.com/werf/logboek/pkg/types"
 
 	"github.com/werf/werf/pkg/docker"
+	"github.com/werf/werf/pkg/util/parallel/constant"
 )
 
 type DoTasksOptions struct {
@@ -79,7 +80,8 @@ func DoTasks(ctx context.Context, numberOfTasks int, options DoTasksOptions, tas
 			workersBuffs = append(workersBuffs, workerBuf)
 			worker = &bufWorker{buf: workerBuf}
 
-			workerContext = logboek.NewContext(ctx, logboek.Context(ctx).NewSubLogger(workerBuf, workerBuf))
+			ctxWithBackgroundTaskID := context.WithValue(ctx, constant.CtxBackgroundTaskIDKey, i)
+			workerContext = logboek.NewContext(ctxWithBackgroundTaskID, logboek.Context(ctx).NewSubLogger(workerBuf, workerBuf))
 			logboek.Context(workerContext).Streams().SetPrefixStyle(style.Highlight())
 
 			if options.InitDockerCLIForEachWorker {


### PR DESCRIPTION
- By default werf disables BuildKit when building dockerfiles.
- If the user explicitly activates BuildKit (`DOCKER_BUILDKIT=1`), werf enables it but without output in the background builds due to https://github.com/docker/cli/issues/2889.