### PR TITLE
[ci] Fix tests and Documentation Validation workflow

### DIFF
--- a/.github/workflows/docs_tests.yml
+++ b/.github/workflows/docs_tests.yml
@@ -44,8 +44,7 @@ jobs:
 
       - name: Prepare
         run: |
-          cd docs
-          chmod 777 Gemfile.lock
+          cd docs/documentation
           mkdir -m 777 .jekyll-cache _site
           gem update bundler
           bundle install

--- a/scripts/tests/precompiled_tests_binaries.sh
+++ b/scripts/tests/precompiled_tests_binaries.sh
@@ -23,7 +23,7 @@ case "${unameOut}" in
 esac
 
 for package_path in $package_paths; do
-  if [[ $package_path == "./integration/suites/docs/docs/backend" ]] || [[ $package_path == "./integration/suites/docs/docs/_site/backend" ]] || [[ $package_path == "./integration/ci_suites/default/docs/_fixtures/cli/docs/backend" ]]; then
+  if [[ $package_path == "./integration/suites/docs/docs/backend" ]] || [[ $package_path == "./integration/suites/docs/docs/site/_site/backend" ]] || [[ $package_path == "./integration/ci_suites/default/docs/_fixtures/cli/docs/site/backend" ]]; then
     continue
   fi
 


### PR DESCRIPTION
- [ci] Fix tests
```
Run # unit tests binaries
?   	github.com/werf/werf/cmd/werf	[no test files]
go: directory integration/ci_suites/default/docs/_fixtures/cli/docs/site/backend is outside main module
Error: Process completed with exit code 1.
```
- [ci] Documentation Validation: fix `chmod: Gemfile.lock: No such file or directory`