### PR TITLE
[ci] Workflows: replace always with success || failure condition

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -97,7 +97,7 @@ jobs:
   unit_tests:
     name: Unit tests
     needs: precompiled_tests_binaries
-    if: always()
+    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:
@@ -148,7 +148,7 @@ jobs:
   integration_default_tests:
     name: Integration default tests
     needs: precompiled_tests_binaries
-    if: always()
+    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:
@@ -217,7 +217,7 @@ jobs:
   integration_container_registry_per_implementation_tests:
     name: Integration container_registry_per_implementation tests
     needs: precompiled_tests_binaries
-    if: always()
+    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:
@@ -341,7 +341,7 @@ jobs:
   integration_k8s_per_version_tests:
     name: Integration k8s_per_version tests
     needs: precompiled_tests_binaries
-    if: always()
+    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:
@@ -413,7 +413,7 @@ jobs:
   integration_k8s_per_version_and_container_registry_per_implementation_tests:
     name: Integration k8s_per_version_and_container_registry_per_implementation tests
     needs: precompiled_tests_binaries
-    if: always()
+    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:
@@ -547,7 +547,7 @@ jobs:
     name: Integration default tests
     needs: precompiled_tests_binaries
     if: "false"
-#    if: always()
+#    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:
@@ -632,7 +632,7 @@ jobs:
     name: Integration k8s_per_version tests
     needs: precompiled_tests_binaries
     if: "false"
-#    if: always()
+#    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
   unit_tests:
     name: Unit tests
     needs: precompiled_tests_binaries
-    if: always()
+    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:
@@ -135,7 +135,7 @@ jobs:
   integration_default_tests:
     name: Integration default tests
     needs: precompiled_tests_binaries
-    if: always()
+    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:
@@ -194,7 +194,7 @@ jobs:
   integration_k8s_per_version_tests:
     name: Integration k8s_per_version tests
     needs: precompiled_tests_binaries
-    if: always()
+    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:
@@ -257,7 +257,7 @@ jobs:
   integration_k8s_per_version_and_container_registry_per_implementation_tests:
     name: Integration k8s_per_version_and_container_registry_per_implementation tests
     needs: precompiled_tests_binaries
-    if: always()
+    if: ${{ success() || failure() }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The `always` function returns true even when canceled, or the previous tasks skipped.