### PR TITLE
[GC] Added basic support for cached git-data cleaning into host cleanup procedure

### DIFF
--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -19,6 +19,7 @@ import (
 	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/path_matcher"
 	"github.com/werf/werf/pkg/stapel"
+	"github.com/werf/werf/pkg/util"
 )
 
 type GitMapping struct {
@@ -801,19 +802,19 @@ func (gm *GitMapping) IsEmpty(ctx context.Context, c Conveyor) (bool, error) {
 func (gm *GitMapping) prepareArchiveFile(archive git_repo.Archive) (*ContainerFileDescriptor, error) {
 	return &ContainerFileDescriptor{
 		FilePath:          archive.GetFilePath(),
-		ContainerFilePath: path.Join(gm.ContainerArchivesDir, filepath.Base(archive.GetFilePath())),
+		ContainerFilePath: path.Join(gm.ContainerArchivesDir, filepath.ToSlash(util.GetRelativeToBaseFilepath(git_repo.CommonGitDataManager.ArchivesCacheDir, archive.GetFilePath()))),
 	}, nil
 }
 
 func (gm *GitMapping) preparePatchPathsListFile(patch git_repo.Patch) (*ContainerFileDescriptor, error) {
-	fileName := fmt.Sprintf("%s.paths_list", filepath.Base(patch.GetFilePath()))
-	filePath := filepath.Join(filepath.Dir(patch.GetFilePath()), fileName)
+	filePath := filepath.Join(filepath.Dir(patch.GetFilePath()), fmt.Sprintf("%s.paths_list", filepath.Base(patch.GetFilePath())))
+	containerFilePath := path.Join(gm.ContainerPatchesDir, filepath.ToSlash(util.GetRelativeToBaseFilepath(git_repo.CommonGitDataManager.PatchesCacheDir, patch.GetFilePath())))
 
 	//FIXME: create this file using GitDataManager
 
 	fileDesc := &ContainerFileDescriptor{
 		FilePath:          filePath,
-		ContainerFilePath: path.Join(gm.ContainerPatchesDir, fileName),
+		ContainerFilePath: path.Join(gm.ContainerPatchesDir, containerFilePath),
 	}
 
 	fileExists := true
@@ -854,7 +855,7 @@ func (gm *GitMapping) preparePatchPathsListFile(patch git_repo.Patch) (*Containe
 func (gm *GitMapping) preparePatchFile(patch git_repo.Patch) (*ContainerFileDescriptor, error) {
 	return &ContainerFileDescriptor{
 		FilePath:          patch.GetFilePath(),
-		ContainerFilePath: path.Join(gm.ContainerPatchesDir, filepath.Base(patch.GetFilePath())),
+		ContainerFilePath: path.Join(gm.ContainerPatchesDir, filepath.ToSlash(util.GetRelativeToBaseFilepath(git_repo.CommonGitDataManager.PatchesCacheDir, patch.GetFilePath()))),
 	}, nil
 }
 

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/werf/werf/pkg/true_git"
 	"github.com/werf/werf/pkg/true_git/ls_tree"
+	"github.com/werf/werf/pkg/werf"
 )
 
 type Base struct {
@@ -146,6 +147,12 @@ func (repo *Base) CreatePatch(ctx context.Context, repoPath, gitDir, repoID, wor
 }
 
 func (repo *Base) createPatch(ctx context.Context, repoPath, gitDir, repoID, workTreeCacheDir string, opts PatchOptions) (Patch, error) {
+	if lock, err := lockGC(ctx, true); err != nil {
+		return nil, err
+	} else {
+		defer werf.ReleaseHostLock(lock)
+	}
+
 	if patch, err := CommonGitDataManager.GetPatchFile(ctx, repoID, opts); err != nil {
 		return nil, err
 	} else if patch != nil {
@@ -227,6 +234,12 @@ func HasSubmodulesInCommit(commit *object.Commit) (bool, error) {
 }
 
 func (repo *Base) createDetachedMergeCommit(ctx context.Context, gitDir, path, workTreeCacheDir string, fromCommit, toCommit string) (string, error) {
+	if lock, err := lockGC(ctx, true); err != nil {
+		return "", err
+	} else {
+		defer werf.ReleaseHostLock(lock)
+	}
+
 	repository, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{EnableDotGitCommonDir: true})
 	if err != nil {
 		return "", fmt.Errorf("cannot open repo at %s: %s", path, err)
@@ -296,6 +309,12 @@ func (repo *Base) CreateArchive(ctx context.Context, repoPath, gitDir, repoID, w
 }
 
 func (repo *Base) createArchive(ctx context.Context, repoPath, gitDir, repoID, workTreeCacheDir string, opts ArchiveOptions) (Archive, error) {
+	if lock, err := lockGC(ctx, true); err != nil {
+		return nil, err
+	} else {
+		defer werf.ReleaseHostLock(lock)
+	}
+
 	if archive, err := CommonGitDataManager.GetArchiveFile(ctx, repoID, opts); err != nil {
 		return nil, err
 	} else if archive != nil {

--- a/pkg/git_repo/git_data_gc.go
+++ b/pkg/git_repo/git_data_gc.go
@@ -1,0 +1,151 @@
+package git_repo
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/dustin/go-humanize"
+	"github.com/werf/kubedog/pkg/utils"
+	"github.com/werf/lockgate"
+	"github.com/werf/logboek"
+	"github.com/werf/werf/pkg/volumeutils"
+	"github.com/werf/werf/pkg/werf"
+)
+
+const (
+	KeepGitWorkTreeCacheVersionV1_1 = "6"
+	KeepGitRepoCacheVersionV1_1     = "3"
+)
+
+func ShouldRunAutoGC(ctx context.Context, allowedVolumeUsagePercentage float64) (bool, error) {
+	vu, err := volumeutils.GetVolumeUsageByPath(ctx, werf.GetLocalCacheDir())
+	if err != nil {
+		return false, fmt.Errorf("error getting volume usage by path %q: %s", werf.GetLocalCacheDir(), err)
+	}
+
+	return vu.Percentage > allowedVolumeUsagePercentage, nil
+}
+
+func getBytesToFree(vu volumeutils.VolumeUsage, targetVolumeUsagePercentage float64) uint64 {
+	allowedVolumeUsageToFree := vu.Percentage - targetVolumeUsagePercentage
+	return uint64((float64(vu.TotalBytes) / 100.0) * allowedVolumeUsageToFree)
+}
+
+func RunGC(ctx context.Context, allowedVolumeUsagePercentage, allowedVolumeUsageMarginPercentage float64) error {
+	if lock, err := lockGC(ctx, false); err != nil {
+		return err
+	} else {
+		defer werf.ReleaseHostLock(lock)
+	}
+
+	// TODO: Completely remove v1.1 repos when 1.1 has not been used 2 weeks on the host
+	gitReposCacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_repos")
+	if err := wipeCacheDirs(ctx, gitReposCacheRoot, []string{KeepGitRepoCacheVersionV1_1, GitReposCacheVersion}); err != nil {
+		return fmt.Errorf("unable to wipe old git repos cache dirs in %q: %s", gitReposCacheRoot, err)
+	}
+
+	// TODO: Completely remove v1.1 worktrees when 1.1 has not been used 2 weeks on the host
+	gitWorktreesCacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_worktrees")
+	if err := wipeCacheDirs(ctx, gitWorktreesCacheRoot, []string{KeepGitWorkTreeCacheVersionV1_1, GitWorktreesCacheVersion}); err != nil {
+		return fmt.Errorf("unable to wipe old git worktrees cache dirs in %q: %s", gitWorktreesCacheRoot, err)
+	}
+
+	gitArchivesCacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_archives")
+	if err := wipeCacheDirs(ctx, gitArchivesCacheRoot, []string{GitArchivesCacheVersion}); err != nil {
+		return fmt.Errorf("unable to wipe old git archives cache dirs in %q: %s", gitArchivesCacheRoot, err)
+	}
+
+	gitPatchesCacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_patches")
+	if err := wipeCacheDirs(ctx, gitPatchesCacheRoot, []string{GitArchivesCacheVersion}); err != nil {
+		return fmt.Errorf("unable to wipe old git patches cache dirs in %q: %s", gitPatchesCacheRoot, err)
+	}
+
+	// Remove *.tmp from git_repos dir
+
+	vu, err := volumeutils.GetVolumeUsageByPath(ctx, werf.GetLocalCacheDir())
+	if err != nil {
+		return fmt.Errorf("error getting volume usage by path %q: %s", werf.GetLocalCacheDir(), err)
+	}
+
+	targetVolumeUsagePercentage := allowedVolumeUsagePercentage - allowedVolumeUsageMarginPercentage
+	bytesToFree := getBytesToFree(vu, targetVolumeUsagePercentage)
+
+	if vu.Percentage <= allowedVolumeUsagePercentage {
+		logboek.Context(ctx).Default().LogBlock("Git data storage check").Do(func() {
+			logboek.Context(ctx).Default().LogF("Werf local cache dir: %s\n", werf.GetLocalCacheDir())
+			logboek.Context(ctx).Default().LogF("Volume usage: %s / %s\n", humanize.Bytes(vu.UsedBytes), humanize.Bytes(vu.TotalBytes))
+			logboek.Context(ctx).Default().LogF("Allowed volume usage percentage: %s <= %s — %s\n", utils.GreenF("%0.2f%%", vu.Percentage), utils.BlueF("%0.2f%%", allowedVolumeUsagePercentage), utils.GreenF("OK"))
+		})
+
+		return nil
+	}
+
+	logboek.Context(ctx).Default().LogBlock("Git data storage check").Do(func() {
+		logboek.Context(ctx).Default().LogF("Werf local cache dir: %s\n", werf.GetLocalCacheDir())
+		logboek.Context(ctx).Default().LogF("Volume usage: %s / %s\n", humanize.Bytes(vu.UsedBytes), humanize.Bytes(vu.TotalBytes))
+		logboek.Context(ctx).Default().LogF("Allowed percentage level exceeded: %s > %s — %s\n", utils.RedF("%0.2f%%", vu.Percentage), utils.YellowF("%0.2f%%", allowedVolumeUsagePercentage), utils.RedF("HIGH VOLUME USAGE"))
+		logboek.Context(ctx).Default().LogF("Target percentage level after cleanup: %0.2f%% - %0.2f%% (margin) = %s\n", allowedVolumeUsagePercentage, allowedVolumeUsageMarginPercentage, utils.BlueF("%0.2f%%", targetVolumeUsagePercentage))
+		logboek.Context(ctx).Default().LogF("Needed to free: %s\n", utils.RedF("%s", humanize.Bytes(bytesToFree)))
+	})
+
+	// var freedBytes uint64
+	// TODO: remove following git data based on bytesToFree and LRU
+	// TODO: for now temporarily this is complete-wipe-out type of cleanup
+
+	for _, path := range []string{
+		filepath.Join(werf.GetLocalCacheDir(), "git_patches", GitPatchesCacheVersion),
+		filepath.Join(werf.GetLocalCacheDir(), "git_repos", GitReposCacheVersion),
+		filepath.Join(werf.GetLocalCacheDir(), "git_worktrees", GitWorktreesCacheVersion),
+		filepath.Join(werf.GetLocalCacheDir(), "git_repos", GitReposCacheVersion),
+	} {
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("unable to remove %q: %s", path, err)
+		}
+	}
+
+	return nil
+}
+
+// type GitWorktreeDesc struct {
+// }
+// TODO: get existing worktrees should gather all existing worktrees and meta info: size and last usage timestamp — this is needed to implement cleanup
+// func GetExistingGitWorktrees() ([]*GitWorktreeDesc, error) {
+// 	return nil, nil
+// }
+
+func wipeCacheDirs(ctx context.Context, cacheRootDir string, keepCacheVersions []string) error {
+	if _, err := os.Stat(cacheRootDir); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("error accessing %q: %s", cacheRootDir, err)
+	}
+
+	dirs, err := ioutil.ReadDir(cacheRootDir)
+	if err != nil {
+		return fmt.Errorf("error reading dir %q: %s", cacheRootDir, err)
+	}
+
+WipeCacheDirs:
+	for _, finfo := range dirs {
+		for _, keepCacheVersion := range keepCacheVersions {
+			if finfo.Name() == keepCacheVersion {
+				continue WipeCacheDirs
+			}
+		}
+
+		path := filepath.Join(cacheRootDir, finfo.Name())
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("unable to remove %q: %s", path, err)
+		}
+	}
+
+	return nil
+}
+
+func lockGC(ctx context.Context, shared bool) (lockgate.LockHandle, error) {
+	_, handle, err := werf.AcquireHostLock(ctx, "git_data_manager", lockgate.AcquireOptions{Shared: shared})
+	return handle, err
+}

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -10,7 +10,7 @@ import (
 	"github.com/werf/werf/pkg/werf"
 )
 
-const GitRepoCacheVersion = "4"
+const GitReposCacheVersion = "5"
 
 type PatchOptions true_git.PatchOptions
 type ArchiveOptions true_git.ArchiveOptions
@@ -65,5 +65,5 @@ type Archive interface {
 }
 
 func GetGitRepoCacheDir() string {
-	return filepath.Join(werf.GetLocalCacheDir(), "git_repos", GitRepoCacheVersion)
+	return filepath.Join(werf.GetLocalCacheDir(), "git_repos", GitReposCacheVersion)
 }

--- a/pkg/git_repo/work_tree.go
+++ b/pkg/git_repo/work_tree.go
@@ -6,8 +6,8 @@ import (
 	"github.com/werf/werf/pkg/werf"
 )
 
-const GitWorkTreeCacheVersion = "8"
+const GitWorktreesCacheVersion = "9"
 
 func GetWorkTreeCacheDir() string {
-	return filepath.Join(werf.GetLocalCacheDir(), "git_worktrees", GitWorkTreeCacheVersion)
+	return filepath.Join(werf.GetLocalCacheDir(), "git_worktrees", GitWorktreesCacheVersion)
 }

--- a/pkg/tmp_manager/gc.go
+++ b/pkg/tmp_manager/gc.go
@@ -65,11 +65,7 @@ func ShouldRunAutoGC() (bool, error) {
 	return false, nil
 }
 
-func GC(ctx context.Context, dryRun bool) error {
-	return logboek.Context(ctx).LogProcess("Running GC for tmp data").DoError(func() error { return gc(ctx, dryRun) })
-}
-
-func gc(ctx context.Context, dryRun bool) error {
+func RunGC(ctx context.Context, dryRun bool) error {
 	projectDirsToRemove := []string{}
 	pathsToRemove := []string{}
 

--- a/pkg/true_git/work_tree.go
+++ b/pkg/true_git/work_tree.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/werf/lockgate"
 
+	"github.com/werf/werf/pkg/util/timestamps"
 	"github.com/werf/werf/pkg/werf"
 
 	"github.com/werf/logboek"
@@ -53,6 +54,11 @@ func withWorkTreeCacheLock(ctx context.Context, workTreeCacheDir string, f func(
 func prepareWorkTree(ctx context.Context, repoDir, workTreeCacheDir string, commit string, withSubmodules bool) (string, error) {
 	if err := os.MkdirAll(workTreeCacheDir, os.ModePerm); err != nil {
 		return "", fmt.Errorf("unable to create dir %s: %s", workTreeCacheDir, err)
+	}
+
+	lastAccessAtPath := filepath.Join(workTreeCacheDir, "last_access_at")
+	if err := timestamps.WriteTimestampFile(lastAccessAtPath, time.Now()); err != nil {
+		return "", fmt.Errorf("error writing timestamp file %q: %s", lastAccessAtPath, err)
 	}
 
 	gitDirPath := filepath.Join(workTreeCacheDir, "git_dir")

--- a/pkg/util/timestamps/timestamp_file.go
+++ b/pkg/util/timestamps/timestamp_file.go
@@ -1,0 +1,56 @@
+package timestamps
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func ReadTimestampFile(path string) (time.Time, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return time.Time{}, nil
+	} else if err != nil {
+		return time.Time{}, fmt.Errorf("error accessing %q: %s", path, err)
+	}
+
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("error reading %q: %s", path, err)
+	}
+
+	i, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		os.RemoveAll(path)
+		return time.Time{}, nil
+	}
+
+	return time.Unix(i, 0), nil
+}
+
+func WriteTimestampFile(path string, t time.Time) error {
+	timeStr := fmt.Sprintf("%d\n", t.Unix())
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return fmt.Errorf("error creating dir %q: %s", dir, err)
+	}
+
+	if err := ioutil.WriteFile(path, []byte(timeStr), 0644); err != nil {
+		return fmt.Errorf("error writing %q: %s", path, err)
+	}
+
+	return nil
+}
+
+func CheckTimestampFileExists(path string) (bool, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("error accessing %q: %s", path, err)
+	}
+	return true, nil
+}

--- a/pkg/volumeutils/volume_usage.go
+++ b/pkg/volumeutils/volume_usage.go
@@ -1,0 +1,44 @@
+package volumeutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/minio/minio/pkg/disk"
+)
+
+type VolumeUsage struct {
+	UsedBytes  uint64
+	TotalBytes uint64
+	Percentage float64
+}
+
+func GetVolumeUsageByPath(ctx context.Context, path string) (VolumeUsage, error) {
+	di, err := disk.GetInfo(path)
+	if err != nil {
+		return VolumeUsage{}, fmt.Errorf("unable to get disk info: %s", err)
+	}
+
+	usedBytes := di.Total - di.Free
+	return VolumeUsage{
+		UsedBytes:  usedBytes,
+		TotalBytes: di.Total,
+		Percentage: (float64(usedBytes) / float64(di.Total)) * 100,
+	}, nil
+}
+
+func DirSizeBytes(path string) (uint64, error) {
+	var size uint64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("error accecssing %q: %s", path, err)
+		}
+		if !info.IsDir() {
+			size += uint64(info.Size())
+		}
+		return err
+	})
+	return size, err
+}

--- a/pkg/werf/last_werf_run_at.go
+++ b/pkg/werf/last_werf_run_at.go
@@ -3,14 +3,11 @@ package werf
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/werf/lockgate"
+	"github.com/werf/werf/pkg/util/timestamps"
 )
 
 func getWerfLastRunAtPath() string {
@@ -29,7 +26,7 @@ func SetWerfLastRunAt(ctx context.Context) error {
 		defer ReleaseHostLock(lock)
 	}
 
-	return writeTimestampFile(path, time.Now())
+	return timestamps.WriteTimestampFile(path, time.Now())
 }
 
 func GetWerfLastRunAt(ctx context.Context) (time.Time, error) {
@@ -40,7 +37,7 @@ func GetWerfLastRunAt(ctx context.Context) (time.Time, error) {
 		defer ReleaseHostLock(lock)
 	}
 
-	return readTimestampFile(path)
+	return timestamps.ReadTimestampFile(path)
 }
 
 func SetWerfFirstRunAt(ctx context.Context) error {
@@ -51,10 +48,10 @@ func SetWerfFirstRunAt(ctx context.Context) error {
 		defer ReleaseHostLock(lock)
 	}
 
-	if exists, err := checkTimestampFileExists(path); err != nil {
+	if exists, err := timestamps.CheckTimestampFileExists(path); err != nil {
 		return fmt.Errorf("error checking existance of %q: %s", path, err)
 	} else if !exists {
-		return writeTimestampFile(path, time.Now())
+		return timestamps.WriteTimestampFile(path, time.Now())
 	}
 	return nil
 }
@@ -67,51 +64,5 @@ func GetWerfFirstRunAt(ctx context.Context) (time.Time, error) {
 		defer ReleaseHostLock(lock)
 	}
 
-	return readTimestampFile(path)
-}
-
-func readTimestampFile(path string) (time.Time, error) {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return time.Time{}, nil
-	} else if err != nil {
-		return time.Time{}, fmt.Errorf("error accessing %q: %s", path, err)
-	}
-
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("error reading %q: %s", path, err)
-	}
-
-	i, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
-	if err != nil {
-		// os.RemoveAll(path)
-		// return time.Time{}, nil
-		return time.Time{}, fmt.Errorf("error parsing %q timestamp data %q: %s", path, data, err)
-	}
-
-	return time.Unix(i, 0), nil
-}
-
-func writeTimestampFile(path string, t time.Time) error {
-	timeStr := fmt.Sprintf("%d\n", t.Unix())
-
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return fmt.Errorf("error creating dir %q: %s", dir, err)
-	}
-
-	if err := ioutil.WriteFile(path, []byte(timeStr), 0644); err != nil {
-		return fmt.Errorf("error writing %q: %s", path, err)
-	}
-
-	return nil
-}
-
-func checkTimestampFileExists(path string) (bool, error) {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return false, nil
-	} else if err != nil {
-		return false, fmt.Errorf("error accessing %q: %s", path, err)
-	}
-	return true, nil
+	return timestamps.ReadTimestampFile(path)
 }


### PR DESCRIPTION
 - Remove ~/.werf/local_cache/{git_patches|git_archives|git_worktrees|git_repos} completely when volume usage exceeds allowed level, smart GC for git-data will be added in a separate PR.
 - Added last-used-timestamps into git_patches, git_archives, git_worktrees and git_repos caches.
 - Refactored git_patches and git_archives files structure in ~/.werf/local_cache to reduce number of files which stored in the cache dir at the same time (use first byte of sha256 hash as a directory).
