### PR TITLE
[GC][v1.1] Save last/first werf run timestamps for v1.1

### DIFF
--- a/pkg/util/timestamps/timestamp_file.go
+++ b/pkg/util/timestamps/timestamp_file.go
@@ -1,0 +1,56 @@
+package timestamps
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func ReadTimestampFile(path string) (time.Time, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return time.Time{}, nil
+	} else if err != nil {
+		return time.Time{}, fmt.Errorf("error accessing %q: %s", path, err)
+	}
+
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("error reading %q: %s", path, err)
+	}
+
+	i, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		os.RemoveAll(path)
+		return time.Time{}, nil
+	}
+
+	return time.Unix(i, 0), nil
+}
+
+func WriteTimestampFile(path string, t time.Time) error {
+	timeStr := fmt.Sprintf("%d\n", t.Unix())
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return fmt.Errorf("error creating dir %q: %s", dir, err)
+	}
+
+	if err := ioutil.WriteFile(path, []byte(timeStr), 0644); err != nil {
+		return fmt.Errorf("error writing %q: %s", path, err)
+	}
+
+	return nil
+}
+
+func CheckTimestampFileExists(path string) (bool, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("error accessing %q: %s", path, err)
+	}
+	return true, nil
+}

--- a/pkg/werf/last_werf_run_at.go
+++ b/pkg/werf/last_werf_run_at.go
@@ -1,0 +1,68 @@
+package werf
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/werf/lockgate"
+	"github.com/werf/werf/pkg/util/timestamps"
+)
+
+func getWerfLastRunAtPath() string {
+	return filepath.Join(GetServiceDir(), "info", "v1.1", "last_werf_run_at")
+}
+
+func getWerfFirstRunAtPath() string {
+	return filepath.Join(GetServiceDir(), "info", "v1.1", "first_werf_run_at")
+}
+
+func SetWerfLastRunAt(ctx context.Context) error {
+	path := getWerfLastRunAtPath()
+	if _, lock, err := AcquireHostLock(ctx, path, lockgate.AcquireOptions{OnWaitFunc: func(lockName string, doWait func() error) error { return doWait() }}); err != nil {
+		return fmt.Errorf("error locking path %q: %s", path, err)
+	} else {
+		defer ReleaseHostLock(lock)
+	}
+
+	return timestamps.WriteTimestampFile(path, time.Now())
+}
+
+func GetWerfLastRunAt(ctx context.Context) (time.Time, error) {
+	path := getWerfLastRunAtPath()
+	if _, lock, err := AcquireHostLock(ctx, path, lockgate.AcquireOptions{OnWaitFunc: func(lockName string, doWait func() error) error { return doWait() }}); err != nil {
+		return time.Time{}, fmt.Errorf("error locking path %q: %s", path, err)
+	} else {
+		defer ReleaseHostLock(lock)
+	}
+
+	return timestamps.ReadTimestampFile(path)
+}
+
+func SetWerfFirstRunAt(ctx context.Context) error {
+	path := getWerfFirstRunAtPath()
+	if _, lock, err := AcquireHostLock(ctx, path, lockgate.AcquireOptions{OnWaitFunc: func(lockName string, doWait func() error) error { return doWait() }}); err != nil {
+		return fmt.Errorf("error locking path %q: %s", path, err)
+	} else {
+		defer ReleaseHostLock(lock)
+	}
+
+	if exists, err := timestamps.CheckTimestampFileExists(path); err != nil {
+		return fmt.Errorf("error checking existance of %q: %s", path, err)
+	} else if !exists {
+		return timestamps.WriteTimestampFile(path, time.Now())
+	}
+	return nil
+}
+
+func GetWerfFirstRunAt(ctx context.Context) (time.Time, error) {
+	path := getWerfFirstRunAtPath()
+	if _, lock, err := AcquireHostLock(ctx, path, lockgate.AcquireOptions{OnWaitFunc: func(lockName string, doWait func() error) error { return doWait() }}); err != nil {
+		return time.Time{}, fmt.Errorf("error locking path %q: %s", path, err)
+	} else {
+		defer ReleaseHostLock(lock)
+	}
+
+	return timestamps.ReadTimestampFile(path)
+}

--- a/pkg/werf/main.go
+++ b/pkg/werf/main.go
@@ -155,5 +155,13 @@ func Init(tmpDirOption, homeDirOption string) error {
 		hostLocker = locker
 	}
 
+	if err := SetWerfFirstRunAt(context.Background()); err != nil {
+		return fmt.Errorf("error setting werf first run at timestamp: %s", err)
+	}
+
+	if err := SetWerfLastRunAt(context.Background()); err != nil {
+		return fmt.Errorf("error setting werf last run at timestamp: %s", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
This info needed for v1.2's host cleanup procedure.