### PR TITLE
[cleanup][v1.1] Enable v1.2 werf-cleanup mode for v1.1 by default

### DIFF
--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -73,7 +73,7 @@ It is safe to run this command periodically (daily is enough) by automated clean
 	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.GitHistoryBasedCleanup, "git-history-based-cleanup", "", common.GetBoolEnvironmentDefaultTrue("WERF_GIT_HISTORY_BASED_CLEANUP"), "Use git history based cleanup (default $WERF_GIT_HISTORY_BASED_CLEANUP)")
-	cmd.Flags().BoolVarP(&cmdData.GitHistoryBasedCleanupV12, "git-history-based-cleanup-v1.2", "", common.GetBoolEnvironmentDefaultFalse("WERF_GIT_HISTORY_BASED_CLEANUP_v1_2"), "Use git history based cleanup and delete images tags without related image metadata (default $WERF_GIT_HISTORY_BASED_CLEANUP_v1_2)")
+	cmd.Flags().BoolVarP(&cmdData.GitHistoryBasedCleanupV12, "git-history-based-cleanup-v1.2", "", common.GetBoolEnvironmentDefaultTrue("WERF_GIT_HISTORY_BASED_CLEANUP_v1_2"), "Use git history based cleanup and delete images tags without related image metadata (default $WERF_GIT_HISTORY_BASED_CLEANUP_v1_2)")
 
 	common.SetupScanContextNamespaceOnly(&commonCmdData, cmd)
 	common.SetupDryRun(&commonCmdData, cmd)

--- a/cmd/werf/images/cleanup/cleanup.go
+++ b/cmd/werf/images/cleanup/cleanup.go
@@ -70,7 +70,7 @@ func NewCmd() *cobra.Command {
 	common.SetupAllowGitShallowClone(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.GitHistoryBasedCleanup, "git-history-based-cleanup", "", common.GetBoolEnvironmentDefaultTrue("WERF_GIT_HISTORY_BASED_CLEANUP"), "Use git history based cleanup (default $WERF_GIT_HISTORY_BASED_CLEANUP)")
-	cmd.Flags().BoolVarP(&cmdData.GitHistoryBasedCleanupV12, "git-history-based-cleanup-v1.2", "", common.GetBoolEnvironmentDefaultFalse("WERF_GIT_HISTORY_BASED_CLEANUP_v1_2"), "Use git history based cleanup and delete images tags without related image metadata (default $WERF_GIT_HISTORY_BASED_CLEANUP_v1_2)")
+	cmd.Flags().BoolVarP(&cmdData.GitHistoryBasedCleanupV12, "git-history-based-cleanup-v1.2", "", common.GetBoolEnvironmentDefaultTrue("WERF_GIT_HISTORY_BASED_CLEANUP_v1_2"), "Use git history based cleanup and delete images tags without related image metadata (default $WERF_GIT_HISTORY_BASED_CLEANUP_v1_2)")
 
 	common.SetupScanContextNamespaceOnly(&commonCmdData, cmd)
 	common.SetupDryRun(&commonCmdData, cmd)

--- a/docs/_includes/cli/werf_cleanup.md
+++ b/docs/_includes/cli/werf_cleanup.md
@@ -55,7 +55,7 @@ werf cleanup [options]
             $WERF_GIT_COMMIT_STRATEGY_LIMIT
       --git-history-based-cleanup=true
             Use git history based cleanup (default $WERF_GIT_HISTORY_BASED_CLEANUP)
-      --git-history-based-cleanup-v1.2=false
+      --git-history-based-cleanup-v1.2=true
             Use git history based cleanup and delete images tags without related image metadata     
             (default $WERF_GIT_HISTORY_BASED_CLEANUP_v1_2)
       --git-history-synchronization=false

--- a/docs/_includes/cli/werf_images_cleanup.md
+++ b/docs/_includes/cli/werf_images_cleanup.md
@@ -41,7 +41,7 @@ werf images cleanup [options]
             $WERF_GIT_COMMIT_STRATEGY_LIMIT
       --git-history-based-cleanup=true
             Use git history based cleanup (default $WERF_GIT_HISTORY_BASED_CLEANUP)
-      --git-history-based-cleanup-v1.2=false
+      --git-history-based-cleanup-v1.2=true
             Use git history based cleanup and delete images tags without related image metadata     
             (default $WERF_GIT_HISTORY_BASED_CLEANUP_v1_2)
       --git-history-synchronization=false


### PR DESCRIPTION
--git-history-based-cleanup-v1.2 option has been enabled by default: use git history based cleanup and delete images tags without related image metadata (default $WERF_GIT_HISTORY_BASED_CLEANUP_v1_2).