### PR TITLE
[GC] Renamed allowed-volume-usage related options and enabled auto host cleanup by default

### DIFF
--- a/cmd/werf/build/main.go
+++ b/cmd/werf/build/main.go
@@ -113,8 +113,10 @@ If one or more IMAGE_NAME parameters specified, werf will build only these image
 	common.SetupFollow(&commonCmdData, cmd)
 
 	common.SetupDisableAutoHostCleanup(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -124,8 +124,10 @@ func NewCmd() *cobra.Command {
 	common.SetupSkipBuild(&commonCmdData, cmd)
 
 	common.SetupDisableAutoHostCleanup(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	cmd.Flags().StringVarP(&cmdData.Destination, "destination", "d", os.Getenv("WERF_DESTINATION"), "Export bundle into the provided directory ($WERF_DESTINATION or chart-name by default)")

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -129,8 +129,10 @@ Published into container registry bundle can be rolled out by the "werf bundle" 
 	common.SetupParallelOptions(&commonCmdData, cmd, common.DefaultBuildParallelTasksLimit)
 
 	common.SetupDisableAutoHostCleanup(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	common.SetupSkipBuild(&commonCmdData, cmd)

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -87,8 +87,10 @@ It is safe to run this command periodically (daily is enough) by automated clean
 	common.SetupKeepStagesBuiltWithinLastNHours(&commonCmdData, cmd)
 
 	common.SetupDisableAutoHostCleanup(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	return cmd

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -109,11 +109,13 @@ type CmdData struct {
 
 	Tag *string
 
-	// Host storage GC options
-	DisableAutoHostCleanup   *bool
-	AllowedVolumeUsage       *uint
-	AllowedVolumeUsageMargin *uint
-	DockerServerStoragePath  *string
+	// Host storage cleanup options
+	DisableAutoHostCleanup                *bool
+	DockerServerStoragePath               *string
+	AllowedDockerStorageVolumeUsage       *uint
+	AllowedDockerStorageVolumeUsageMargin *uint
+	AllowedLocalCacheVolumeUsage          *uint
+	AllowedLocalCacheVolumeUsageMargin    *uint
 }
 
 const (

--- a/cmd/werf/common/host_cleanup.go
+++ b/cmd/werf/common/host_cleanup.go
@@ -14,59 +14,99 @@ func RunAutoHostCleanup(ctx context.Context, cmdData *CmdData) error {
 		return nil
 	}
 
-	if *cmdData.AllowedVolumeUsageMargin >= *cmdData.AllowedVolumeUsage {
-		return fmt.Errorf("incompatible params --allowed-volume-usage=%d and --allowed-volume-usage-margin=%d: margin percentage should be less than allowed volume usage level percentage", *cmdData.AllowedVolumeUsage, *cmdData.AllowedVolumeUsageMargin)
+	if *cmdData.AllowedDockerStorageVolumeUsageMargin >= *cmdData.AllowedDockerStorageVolumeUsage {
+		return fmt.Errorf("incompatible params --allowed-docker-storage-volume-usage=%d and --allowed-docker-storage-volume-usage-margin=%d: margin percentage should be less than allowed volume usage level percentage", *cmdData.AllowedDockerStorageVolumeUsage, *cmdData.AllowedDockerStorageVolumeUsageMargin)
+	}
+
+	if *cmdData.AllowedLocalCacheVolumeUsageMargin >= *cmdData.AllowedLocalCacheVolumeUsage {
+		return fmt.Errorf("incompatible params --allowed-local-cache-volume-usage=%d and --allowed-local-cache-volume-usage-margin=%d: margin percentage should be less than allowed volume usage level percentage", *cmdData.AllowedLocalCacheVolumeUsage, *cmdData.AllowedLocalCacheVolumeUsageMargin)
 	}
 
 	return host_cleaning.RunAutoHostCleanup(ctx, host_cleaning.HostCleanupOptions{
-		DryRun:                             false,
-		Force:                              false,
-		AllowedVolumeUsagePercentage:       cmdData.AllowedVolumeUsage,
-		AllowedVolumeUsageMarginPercentage: cmdData.AllowedVolumeUsageMargin,
-		DockerServerStoragePath:            *cmdData.DockerServerStoragePath,
+		DryRun: false,
+		Force:  false,
+		AllowedDockerStorageVolumeUsagePercentage:       cmdData.AllowedDockerStorageVolumeUsage,
+		AllowedDockerStorageVolumeUsageMarginPercentage: cmdData.AllowedDockerStorageVolumeUsageMargin,
+		AllowedLocalCacheVolumeUsagePercentage:          cmdData.AllowedLocalCacheVolumeUsage,
+		AllowedLocalCacheVolumeUsageMarginPercentage:    cmdData.AllowedLocalCacheVolumeUsageMargin,
+		DockerServerStoragePath:                         *cmdData.DockerServerStoragePath,
 	})
 }
 
 func SetupDisableAutoHostCleanup(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.DisableAutoHostCleanup = new(bool)
-	cmd.Flags().BoolVarP(cmdData.DisableAutoHostCleanup, "disable-auto-host-cleanup", "", GetBoolEnvironmentDefaultTrue("WERF_DISABLE_AUTO_HOST_CLEANUP"), "Disable auto host cleanup procedure in main werf commands like werf-build, werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)") // FIXME: enable by default
+	cmd.Flags().BoolVarP(cmdData.DisableAutoHostCleanup, "disable-auto-host-cleanup", "", GetBoolEnvironmentDefaultFalse("WERF_DISABLE_AUTO_HOST_CLEANUP"), "Disable auto host cleanup procedure in main werf commands like werf-build, werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)")
 }
 
-func SetupAllowedVolumeUsage(cmdData *CmdData, cmd *cobra.Command) {
-	envVarName := "WERF_ALLOWED_VOLUME_USAGE"
+func SetupAllowedDockerStorageVolumeUsage(cmdData *CmdData, cmd *cobra.Command) {
+	envVarName := "WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE"
 
 	var defaultVal uint
 	if v := GetUint64EnvVarStrict(envVarName); v != nil {
 		defaultVal = uint(*v)
 	} else {
-		defaultVal = uint(host_cleaning.DefaultAllowedVolumeUsagePercentage)
+		defaultVal = uint(host_cleaning.DefaultAllowedDockerStorageVolumeUsagePercentage)
 	}
 	if defaultVal > 100 {
 		TerminateWithError(fmt.Sprintf("bad %s value: specify percentage between 0 and 100", envVarName), 1)
 	}
 
-	cmdData.AllowedVolumeUsage = new(uint)
-	cmd.Flags().UintVarP(cmdData.AllowedVolumeUsage, "allowed-volume-usage", "", defaultVal, fmt.Sprintf("Set allowed percentage of docker storage volume usage which will cause garbage collection of local docker images (default %d%% or $WERF_ALLOWED_VOLUME_USAGE)", uint(host_cleaning.DefaultAllowedVolumeUsagePercentage)))
+	cmdData.AllowedDockerStorageVolumeUsage = new(uint)
+	cmd.Flags().UintVarP(cmdData.AllowedDockerStorageVolumeUsage, "allowed-docker-storage-volume-usage", "", defaultVal, fmt.Sprintf("Set allowed percentage of docker storage volume usage which will cause cleanup of least recently used local docker images (default %d%% or $%s)", uint(host_cleaning.DefaultAllowedDockerStorageVolumeUsagePercentage), envVarName))
 }
 
-func SetupAllowedVolumeUsageMargin(cmdData *CmdData, cmd *cobra.Command) {
-	envVarName := "WERF_ALLOWED_VOLUME_USAGE_MARGIN"
+func SetupAllowedDockerStorageVolumeUsageMargin(cmdData *CmdData, cmd *cobra.Command) {
+	envVarName := "WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE_MARGIN"
 
 	var defaultVal uint
 	if v := GetUint64EnvVarStrict(envVarName); v != nil {
 		defaultVal = uint(*v)
 	} else {
-		defaultVal = uint(host_cleaning.DefaultAllowedVolumeUsageMarginPercentage)
+		defaultVal = uint(host_cleaning.DefaultAllowedDockerStorageVolumeUsageMarginPercentage)
 	}
 	if defaultVal > 100 {
 		TerminateWithError(fmt.Sprintf("bad %s value: specify percentage between 0 and 100", envVarName), 1)
 	}
 
-	cmdData.AllowedVolumeUsageMargin = new(uint)
-	cmd.Flags().UintVarP(cmdData.AllowedVolumeUsageMargin, "allowed-volume-usage-margin", "", defaultVal, fmt.Sprintf("During garbage collection werf would delete images until volume usage becomes below \"allowed-volume-usage - allowed-volume-usage-margin\" level (default %d%% or $WERF_ALLOWED_VOLUME_USAGE_MARGIN)", uint(host_cleaning.DefaultAllowedVolumeUsageMarginPercentage)))
+	cmdData.AllowedDockerStorageVolumeUsageMargin = new(uint)
+	cmd.Flags().UintVarP(cmdData.AllowedDockerStorageVolumeUsageMargin, "allowed-docker-storage-volume-usage-margin", "", defaultVal, fmt.Sprintf("During cleanup of least recently used local docker images werf would delete images until volume usage becomes below \"allowed-docker-storage-volume-usage - allowed-docker-storage-volume-usage-margin\" level (default %d%% or $%s)", uint(host_cleaning.DefaultAllowedDockerStorageVolumeUsageMarginPercentage), envVarName))
 }
 
 func SetupDockerServerStoragePath(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.DockerServerStoragePath = new(string)
 	cmd.Flags().StringVarP(cmdData.DockerServerStoragePath, "docker-server-storage-path", "", os.Getenv("WERF_DOCKER_SERVER_STORAGE_PATH"), "Use specified path to the local docker server storage to check docker storage volume usage while performing garbage collection of local docker images (detect local docker server storage path by default or use $WERF_DOCKER_SERVER_STORAGE_PATH)")
+}
+
+func SetupAllowedLocalCacheVolumeUsage(cmdData *CmdData, cmd *cobra.Command) {
+	envVarName := "WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE"
+
+	var defaultVal uint
+	if v := GetUint64EnvVarStrict(envVarName); v != nil {
+		defaultVal = uint(*v)
+	} else {
+		defaultVal = uint(host_cleaning.DefaultAllowedLocalCacheVolumeUsagePercentage)
+	}
+	if defaultVal > 100 {
+		TerminateWithError(fmt.Sprintf("bad %s value: specify percentage between 0 and 100", envVarName), 1)
+	}
+
+	cmdData.AllowedLocalCacheVolumeUsage = new(uint)
+	cmd.Flags().UintVarP(cmdData.AllowedLocalCacheVolumeUsage, "allowed-local-cache-volume-usage", "", defaultVal, fmt.Sprintf("Set allowed percentage of local cache (~/.werf/local_cache by default) volume usage which will cause cleanup of least recently used data from the local cache (default %d%% or $%s)", uint(host_cleaning.DefaultAllowedLocalCacheVolumeUsagePercentage), envVarName))
+}
+
+func SetupAllowedLocalCacheVolumeUsageMargin(cmdData *CmdData, cmd *cobra.Command) {
+	envVarName := "WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN"
+
+	var defaultVal uint
+	if v := GetUint64EnvVarStrict(envVarName); v != nil {
+		defaultVal = uint(*v)
+	} else {
+		defaultVal = uint(host_cleaning.DefaultAllowedLocalCacheVolumeUsageMarginPercentage)
+	}
+	if defaultVal > 100 {
+		TerminateWithError(fmt.Sprintf("bad %s value: specify percentage between 0 and 100", envVarName), 1)
+	}
+
+	cmdData.AllowedLocalCacheVolumeUsageMargin = new(uint)
+	cmd.Flags().UintVarP(cmdData.AllowedLocalCacheVolumeUsageMargin, "allowed-local-cache-volume-usage-margin", "", defaultVal, fmt.Sprintf("During cleanup of least recently used local docker images werf would delete images until volume usage becomes below \"allowed-docker-storage-volume-usage - allowed-docker-storage-volume-usage-margin\" level (default %d%% or $%s)", uint(host_cleaning.DefaultAllowedLocalCacheVolumeUsageMarginPercentage), envVarName))
 }

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -151,8 +151,10 @@ werf converge --repo registry.mydomain.com/web --env production`,
 	common.SetupFollow(&commonCmdData, cmd)
 
 	common.SetupDisableAutoHostCleanup(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -105,8 +105,10 @@ Read more info about Helm Release name, Kubernetes Namespace and how to change i
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
 	common.SetupDisableAutoHostCleanup(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.WithNamespace, "with-namespace", "", common.GetBoolEnvironmentDefaultFalse("WERF_WITH_NAMESPACE"), "Delete Kubernetes Namespace after purging Helm Release (default $WERF_WITH_NAMESPACE)")

--- a/cmd/werf/host/cleanup/cleanup.go
+++ b/cmd/werf/host/cleanup/cleanup.go
@@ -64,8 +64,10 @@ It is safe to run this command periodically by automated cleanup job in parallel
 	common.SetupDryRun(&commonCmdData, cmd)
 
 	common.SetupDisableAutoHostCleanup(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.Force, "force", "", common.GetBoolEnvironmentDefaultFalse("WERF_FORCE"), "Force deletion of images which are being used by some containers (default $WERF_FORCE)")
@@ -114,11 +116,13 @@ func runGC() error {
 	logboek.LogOptionalLn()
 
 	hostCleanupOptions := host_cleaning.HostCleanupOptions{
-		AllowedVolumeUsagePercentage:       commonCmdData.AllowedVolumeUsage,
-		AllowedVolumeUsageMarginPercentage: commonCmdData.AllowedVolumeUsageMargin,
-		DryRun:                             *commonCmdData.DryRun,
-		Force:                              cmdData.Force,
-		DockerServerStoragePath:            *commonCmdData.DockerServerStoragePath,
+		DryRun: *commonCmdData.DryRun,
+		Force:  cmdData.Force,
+		AllowedDockerStorageVolumeUsagePercentage:       commonCmdData.AllowedDockerStorageVolumeUsage,
+		AllowedDockerStorageVolumeUsageMarginPercentage: commonCmdData.AllowedDockerStorageVolumeUsageMargin,
+		AllowedLocalCacheVolumeUsagePercentage:          commonCmdData.AllowedLocalCacheVolumeUsage,
+		AllowedLocalCacheVolumeUsageMarginPercentage:    commonCmdData.AllowedLocalCacheVolumeUsageMargin,
+		DockerServerStoragePath:                         *commonCmdData.DockerServerStoragePath,
 	}
 
 	return host_cleaning.RunHostCleanup(ctx, hostCleanupOptions)

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -77,8 +77,10 @@ WARNING: Do not run this command during any other werf command is working on the
 	common.SetupKubeContext(&commonCmdData, cmd)
 
 	common.SetupDisableAutoHostCleanup(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsage(&commonCmdData, cmd)
-	common.SetupAllowedVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedDockerStorageVolumeUsageMargin(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsage(&commonCmdData, cmd)
+	common.SetupAllowedLocalCacheVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
 	common.SetupDryRun(&commonCmdData, cmd)

--- a/docs/documentation/_includes/reference/cli/werf_build.md
+++ b/docs/documentation/_includes/reference/cli/werf_build.md
@@ -41,13 +41,24 @@ werf build [IMAGE_NAME...] [options]
 {{ header }} Options
 
 ```shell
-      --allowed-volume-usage=80
-            Set allowed percentage of docker storage volume usage which will cause garbage          
-            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
-      --allowed-volume-usage-margin=10
-            During garbage collection werf would delete images until volume usage becomes below     
-            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
-            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
+      --allowed-docker-storage-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause cleanup of least 
+            recently used local docker images (default 80% or                                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE)
+      --allowed-docker-storage-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE_MARGIN)
+      --allowed-local-cache-volume-usage=80
+            Set allowed percentage of local cache (~/.werf/local_cache by default) volume usage     
+            which will cause cleanup of least recently used data from the local cache (default 80%  
+            or $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE)
+      --allowed-local-cache-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -65,7 +76,7 @@ werf build [IMAGE_NAME...] [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
-      --disable-auto-host-cleanup=true
+      --disable-auto-host-cleanup=false
             Disable auto host cleanup procedure in main werf commands like werf-build,              
             werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''

--- a/docs/documentation/_includes/reference/cli/werf_bundle_export.md
+++ b/docs/documentation/_includes/reference/cli/werf_bundle_export.md
@@ -40,13 +40,24 @@ werf bundle export [options]
             Format: labelName=labelValue.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --allowed-volume-usage=80
-            Set allowed percentage of docker storage volume usage which will cause garbage          
-            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
-      --allowed-volume-usage-margin=10
-            During garbage collection werf would delete images until volume usage becomes below     
-            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
-            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
+      --allowed-docker-storage-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause cleanup of least 
+            recently used local docker images (default 80% or                                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE)
+      --allowed-docker-storage-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE_MARGIN)
+      --allowed-local-cache-volume-usage=80
+            Set allowed percentage of local cache (~/.werf/local_cache by default) volume usage     
+            which will cause cleanup of least recently used data from the local cache (default 80%  
+            or $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE)
+      --allowed-local-cache-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -66,7 +77,7 @@ werf bundle export [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
-      --disable-auto-host-cleanup=true
+      --disable-auto-host-cleanup=false
             Disable auto host cleanup procedure in main werf commands like werf-build,              
             werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''

--- a/docs/documentation/_includes/reference/cli/werf_bundle_publish.md
+++ b/docs/documentation/_includes/reference/cli/werf_bundle_publish.md
@@ -42,13 +42,24 @@ werf bundle publish [options]
             Format: labelName=labelValue.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --allowed-volume-usage=80
-            Set allowed percentage of docker storage volume usage which will cause garbage          
-            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
-      --allowed-volume-usage-margin=10
-            During garbage collection werf would delete images until volume usage becomes below     
-            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
-            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
+      --allowed-docker-storage-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause cleanup of least 
+            recently used local docker images (default 80% or                                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE)
+      --allowed-docker-storage-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE_MARGIN)
+      --allowed-local-cache-volume-usage=80
+            Set allowed percentage of local cache (~/.werf/local_cache by default) volume usage     
+            which will cause cleanup of least recently used data from the local cache (default 80%  
+            or $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE)
+      --allowed-local-cache-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -66,7 +77,7 @@ werf bundle publish [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
-      --disable-auto-host-cleanup=true
+      --disable-auto-host-cleanup=false
             Disable auto host cleanup procedure in main werf commands like werf-build,              
             werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''

--- a/docs/documentation/_includes/reference/cli/werf_cleanup.md
+++ b/docs/documentation/_includes/reference/cli/werf_cleanup.md
@@ -26,13 +26,24 @@ werf cleanup [options]
 {{ header }} Options
 
 ```shell
-      --allowed-volume-usage=80
-            Set allowed percentage of docker storage volume usage which will cause garbage          
-            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
-      --allowed-volume-usage-margin=10
-            During garbage collection werf would delete images until volume usage becomes below     
-            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
-            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
+      --allowed-docker-storage-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause cleanup of least 
+            recently used local docker images (default 80% or                                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE)
+      --allowed-docker-storage-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE_MARGIN)
+      --allowed-local-cache-volume-usage=80
+            Set allowed percentage of local cache (~/.werf/local_cache by default) volume usage     
+            which will cause cleanup of least recently used data from the local cache (default 80%  
+            or $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE)
+      --allowed-local-cache-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -50,7 +61,7 @@ werf cleanup [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
-      --disable-auto-host-cleanup=true
+      --disable-auto-host-cleanup=false
             Disable auto host cleanup procedure in main werf commands like werf-build,              
             werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''

--- a/docs/documentation/_includes/reference/cli/werf_converge.md
+++ b/docs/documentation/_includes/reference/cli/werf_converge.md
@@ -53,13 +53,24 @@ werf converge --repo registry.mydomain.com/web --env production
             Format: labelName=labelValue.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --allowed-volume-usage=80
-            Set allowed percentage of docker storage volume usage which will cause garbage          
-            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
-      --allowed-volume-usage-margin=10
-            During garbage collection werf would delete images until volume usage becomes below     
-            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
-            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
+      --allowed-docker-storage-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause cleanup of least 
+            recently used local docker images (default 80% or                                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE)
+      --allowed-docker-storage-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE_MARGIN)
+      --allowed-local-cache-volume-usage=80
+            Set allowed percentage of local cache (~/.werf/local_cache by default) volume usage     
+            which will cause cleanup of least recently used data from the local cache (default 80%  
+            or $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE)
+      --allowed-local-cache-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
       --atomic=false
             Enable auto rollback of the failed release to the previous deployed release version     
             when current deploy process have failed ($WERF_ATOMIC by default)
@@ -83,7 +94,7 @@ werf converge --repo registry.mydomain.com/web --env production
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
-      --disable-auto-host-cleanup=true
+      --disable-auto-host-cleanup=false
             Disable auto host cleanup procedure in main werf commands like werf-build,              
             werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''

--- a/docs/documentation/_includes/reference/cli/werf_dismiss.md
+++ b/docs/documentation/_includes/reference/cli/werf_dismiss.md
@@ -35,13 +35,24 @@ werf dismiss [options]
 {{ header }} Options
 
 ```shell
-      --allowed-volume-usage=80
-            Set allowed percentage of docker storage volume usage which will cause garbage          
-            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
-      --allowed-volume-usage-margin=10
-            During garbage collection werf would delete images until volume usage becomes below     
-            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
-            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
+      --allowed-docker-storage-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause cleanup of least 
+            recently used local docker images (default 80% or                                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE)
+      --allowed-docker-storage-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE_MARGIN)
+      --allowed-local-cache-volume-usage=80
+            Set allowed percentage of local cache (~/.werf/local_cache by default) volume usage     
+            which will cause cleanup of least recently used data from the local cache (default 80%  
+            or $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE)
+      --allowed-local-cache-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -59,7 +70,7 @@ werf dismiss [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
-      --disable-auto-host-cleanup=true
+      --disable-auto-host-cleanup=false
             Disable auto host cleanup procedure in main werf commands like werf-build,              
             werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''

--- a/docs/documentation/_includes/reference/cli/werf_host_cleanup.md
+++ b/docs/documentation/_includes/reference/cli/werf_host_cleanup.md
@@ -24,13 +24,24 @@ werf host cleanup [options]
 {{ header }} Options
 
 ```shell
-      --allowed-volume-usage=80
-            Set allowed percentage of docker storage volume usage which will cause garbage          
-            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
-      --allowed-volume-usage-margin=10
-            During garbage collection werf would delete images until volume usage becomes below     
-            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
-            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
+      --allowed-docker-storage-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause cleanup of least 
+            recently used local docker images (default 80% or                                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE)
+      --allowed-docker-storage-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE_MARGIN)
+      --allowed-local-cache-volume-usage=80
+            Set allowed percentage of local cache (~/.werf/local_cache by default) volume usage     
+            which will cause cleanup of least recently used data from the local cache (default 80%  
+            or $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE)
+      --allowed-local-cache-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
       --dev=false
             Enable development mode (default $WERF_DEV).
             The mode allows working with project files without doing redundant commits during       
@@ -40,7 +51,7 @@ werf host cleanup [options]
             Two development modes are supported:
             - simple: for working with the worktree state of the git repository
             - strict: for working with the index state of the git repository
-      --disable-auto-host-cleanup=true
+      --disable-auto-host-cleanup=false
             Disable auto host cleanup procedure in main werf commands like werf-build,              
             werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''

--- a/docs/documentation/_includes/reference/cli/werf_purge.md
+++ b/docs/documentation/_includes/reference/cli/werf_purge.md
@@ -18,13 +18,24 @@ werf purge [options]
 {{ header }} Options
 
 ```shell
-      --allowed-volume-usage=80
-            Set allowed percentage of docker storage volume usage which will cause garbage          
-            collection of local docker images (default 80% or $WERF_ALLOWED_VOLUME_USAGE)
-      --allowed-volume-usage-margin=10
-            During garbage collection werf would delete images until volume usage becomes below     
-            "allowed-volume-usage - allowed-volume-usage-margin" level (default 10% or              
-            $WERF_ALLOWED_VOLUME_USAGE_MARGIN)
+      --allowed-docker-storage-volume-usage=80
+            Set allowed percentage of docker storage volume usage which will cause cleanup of least 
+            recently used local docker images (default 80% or                                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE)
+      --allowed-docker-storage-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_DOCKER_STORAGE_VOLUME_USAGE_MARGIN)
+      --allowed-local-cache-volume-usage=80
+            Set allowed percentage of local cache (~/.werf/local_cache by default) volume usage     
+            which will cause cleanup of least recently used data from the local cache (default 80%  
+            or $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE)
+      --allowed-local-cache-volume-usage-margin=10
+            During cleanup of least recently used local docker images werf would delete images      
+            until volume usage becomes below "allowed-docker-storage-volume-usage -                 
+            allowed-docker-storage-volume-usage-margin" level (default 10% or                       
+            $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
       --config=''
             Use custom configuration file (default $WERF_CONFIG or werf.yaml in working directory)
       --config-templates-dir=''
@@ -42,7 +53,7 @@ werf purge [options]
       --dir=''
             Use specified project directory where project’s werf.yaml and other configuration files 
             should reside (default $WERF_DIR or current working directory)
-      --disable-auto-host-cleanup=true
+      --disable-auto-host-cleanup=false
             Disable auto host cleanup procedure in main werf commands like werf-build,              
             werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
       --docker-config=''

--- a/pkg/git_repo/gitdata/gc.go
+++ b/pkg/git_repo/gitdata/gc.go
@@ -121,6 +121,10 @@ func RunGC(ctx context.Context, allowedVolumeUsagePercentage, allowedVolumeUsage
 	}
 
 	targetVolumeUsagePercentage := allowedVolumeUsagePercentage - allowedVolumeUsageMarginPercentage
+	if targetVolumeUsagePercentage < 0 {
+		targetVolumeUsagePercentage = 0
+	}
+
 	bytesToFree := getBytesToFree(vu, targetVolumeUsagePercentage)
 
 	if vu.Percentage <= allowedVolumeUsagePercentage {

--- a/pkg/host_cleaning/local_docker_server.go
+++ b/pkg/host_cleaning/local_docker_server.go
@@ -189,6 +189,9 @@ func RunGCForLocalDockerServer(ctx context.Context, allowedVolumeUsagePercentage
 	}
 
 	targetVolumeUsage := allowedVolumeUsagePercentage - allowedVolumeUsageMarginPercentage
+	if targetVolumeUsage < 0 {
+		targetVolumeUsage = 0
+	}
 
 	checkResult, err := GetLocalDockerServerStorageCheck(ctx, dockerServerStoragePath)
 	if err != nil {


### PR DESCRIPTION
 - --allowed-docker-storage-volume-usage and --allowed-docker-storage-volume-usage-margin to configure docker-storage host cleanup;
 - --allowed-local-cache-volume-usage and --allowed-local-cache-volume-usage-margin to configure local-storage host cleanup (including git-data).
