### PR TITLE
[stapel] Fix: fetch artifact/image stage before running imports rsync server

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -209,6 +209,18 @@ func (c *Conveyor) GetImportServer(ctx context.Context, imageName, stageName str
 
 	var srv *import_server.RsyncServer
 
+	var stg stage.Interface
+
+	if stageName != "" {
+		stg = c.getImageStage(imageName, stageName)
+	} else {
+		stg = c.GetImage(imageName).GetLastNonEmptyStage()
+	}
+
+	if err := c.StorageManager.FetchStage(ctx, stg); err != nil {
+		return nil, fmt.Errorf("unable to fetch stage %s: %s", stg.GetImage().Name(), err)
+	}
+
 	if err := logboek.Context(ctx).Info().LogProcess(fmt.Sprintf("Firing up import rsync server for image %s", imageName)).
 		DoError(func() error {
 			var tmpDir string


### PR DESCRIPTION
Fetch operation will check that image exists correctly and will reset stages building conveyor to rebuild this stage if needed.