### PR TITLE
[builder] Proper rejection of blob-unknown stages

### DIFF
--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -64,6 +64,7 @@ func (api *api) TryGetRepoImage(ctx context.Context, reference string) (*image.I
 			// TODO: 1. auto reject images with manifest-unknown or blob-unknown errors
 			// TODO: 2. why TryGetRepoImage for rejected image records gives manifest-unknown errors?
 			// TODO: 3. make sure werf never ever creates rejected image records for name-unknown errors.
+			// TODO: 4. werf-cleanup should remove broken images
 
 			if os.Getenv("WERF_DOCKER_REGISTRY_DEBUG") == "1" {
 				logboek.Context(ctx).Error().LogF("WARNING: Got an error when inspecting repo image %q: %s\n", reference, err)


### PR DESCRIPTION
Do not reject stage when manifest-unknown or name-unknown errors detected. Only reject images with blob-unknown errors.