### PR TITLE
[helm] Werf-helm fixes

### DIFF
--- a/pkg/deploy/helm/chart_extender/helpers/service_values.go
+++ b/pkg/deploy/helm/chart_extender/helpers/service_values.go
@@ -58,6 +58,9 @@ func GetServiceValues(ctx context.Context, projectName string, repo string, imag
 	if opts.Env != "" {
 		globalInfo["env"] = opts.Env
 		werfInfo["env"] = opts.Env
+	} else if opts.IsStub {
+		globalInfo["env"] = ""
+		werfInfo["env"] = ""
 	}
 
 	if opts.Namespace != "" {

--- a/pkg/deploy/helm/chart_extender/werf_chart_stub.go
+++ b/pkg/deploy/helm/chart_extender/werf_chart_stub.go
@@ -70,8 +70,10 @@ func (wc *WerfChartStub) ChartLoaded(files []*chart.ChartExtenderBufferedFile) e
 		return fmt.Errorf("error getting current process working directory: %s", err)
 	}
 
-	if err := wc.SecretsRuntimeData.DecodeAndLoadSecrets(wc.ChartExtenderContext, files, wc.SecretValueFiles, wc.ChartDir, cwd, wc.SecretsManager); err != nil {
-		return fmt.Errorf("error decoding secrets: %s", err)
+	if wc.SecretsManager != nil {
+		if err := wc.SecretsRuntimeData.DecodeAndLoadSecrets(wc.ChartExtenderContext, files, wc.SecretValueFiles, wc.ChartDir, cwd, wc.SecretsManager); err != nil {
+			return fmt.Errorf("error decoding secrets: %s", err)
+		}
 	}
 
 	var opts helpers.GetHelmChartMetadataOptions


### PR DESCRIPTION
 - Fix panic on werf-helm-dep-update when secret-values are used (fixes https://github.com/werf/werf/issues/3443).
 - Set .Values.werf.env="" stub werf service value in werf-helm-* commands.
