### PR TITLE
[CI] Documentation local development

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,6 +4,6 @@ _site/
 .jekyll-cache/
 _pdf/
 .idea/
-backend/multiwerf/
-backend/vendor/
-backend/root/
+site/backend/multiwerf/
+site/backend/vendor/
+site/backend/root/

--- a/docs/site/.werf/nginx-dev.conf
+++ b/docs/site/.werf/nginx-dev.conf
@@ -1,0 +1,106 @@
+user  nginx;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 500;
+    multi_accept on;
+    use epoll;
+}
+
+http {
+    log_format json_combined escape=json '{ "time_local": "$time_local", '
+     '"host": "$host", '
+     '"remote_addr": "$remote_addr", '
+     '"remote_user": "$remote_user", '
+     '"request": "$request", '
+     '"status": "$status", '
+     '"body_bytes_sent": "$body_bytes_sent", '
+     '"request_time": "$request_time", '
+     '"http_referrer": "$http_referer", '
+     '"http_user_agent": "$http_user_agent" }';
+
+    ssi on;
+    gzip off;
+
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    error_log /dev/stderr info;
+    server {
+        charset utf-8;
+        listen 80;
+        server_name _;
+
+        index       index.html;
+
+        set_real_ip_from  0.0.0.0/0;
+        access_log       /dev/stdout json_combined;
+        error_log        /dev/stderr info;
+
+        location / {
+            proxy_redirect    off;
+            proxy_set_header  Host              werf.io;
+            proxy_set_header  X-Real-IP         $remote_addr;
+            proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+            proxy_pass http://site:8080;
+          }
+        location /guides/ {
+            proxy_redirect    off;
+            proxy_set_header  Host              werf.io;
+            proxy_set_header  X-Real-IP         $remote_addr;
+            proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+            proxy_pass https://werf.io;
+          }
+        location /documentation/ {
+            rewrite ^/documentation/v[\d]+\.[\d]+[^\/]*(/.*)?$ /$1 break;
+            proxy_redirect    off;
+            proxy_set_header  Host              werf.io;
+            proxy_set_header  X-Real-IP         $remote_addr;
+            proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+            proxy_pass http://documentation-en:4040;
+          }
+    }
+
+    # ru.werf.io
+    server {
+        charset utf-8;
+        listen 80;
+        server_name ~^ru\..+$;
+
+        index       index.html;
+
+        set_real_ip_from  0.0.0.0/0;
+        access_log       /dev/stdout json_combined;
+        error_log        /dev/stderr info;
+
+        location / {
+            proxy_redirect    off;
+            proxy_set_header  Host              ru.werf.io;
+            proxy_set_header  X-Real-IP         $remote_addr;
+            proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+            proxy_pass http://site:8080;
+        }
+        location /guides/ {
+            proxy_redirect    off;
+            proxy_set_header  Host              ru.werf.io;
+            proxy_set_header  X-Real-IP         $remote_addr;
+            proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+            proxy_pass https://werf.io;
+        }
+        location /documentation/ {
+            rewrite ^/documentation/v[\d]+\.[\d]+[^\/]*(/.*)?$ /$1 break;
+            proxy_redirect    off;
+            proxy_set_header  Host              ru.werf.io;
+            proxy_set_header  X-Real-IP         $remote_addr;
+            proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+            proxy_pass http://documentation-ru:4041;
+        }
+    }
+}

--- a/docs/site/docker-compose.yml
+++ b/docs/site/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.9"
+
+services:
+  site:
+    image: $WERF_WEB_BACKEND_DOCKER_IMAGE_NAME
+    command: "/app/server"
+    environment:
+      WERF_LOG_VERBOSE: "on"
+      LOG_LEVEL: "debug"
+    volumes:
+      - ".helm/multiwerf-dev.json:/app/multiwerf/multiwerf.json:ro"
+  documentation-en:
+    image: jekyll/jekyll:3
+    working_dir: "/srv/jekyll-data/src/documentation"
+    command: bash -c "
+        mkdir -m 777 -p /srv/jekyll-data/_site/_en &&
+        jekyll serve --config _config.yml -d /srv/jekyll-data/_site/_en -P 4040 "
+    volumes:
+      - "../:/srv/jekyll-data/src/"
+  documentation-ru:
+    image: jekyll/jekyll:3
+    working_dir: "/srv/jekyll-data/src/documentation"
+    command: bash -c "
+      mkdir -m 777 -p /srv/jekyll-data/_site/_ru &&
+      jekyll serve --config _config.yml,_config_ru.yml -d /srv/jekyll-data/_site/_ru  -P 4041 "
+    volumes:
+      - "../:/srv/jekyll-data/src/"
+  front:
+    image: nginx:latest
+    volumes:
+      - ".werf/nginx-dev.conf:/etc/nginx/nginx.conf:ro"
+    ports:
+      - "80:80"

--- a/docs/site/werf.yaml
+++ b/docs/site/werf.yaml
@@ -71,7 +71,9 @@ git:
   group: jekyll
   excludePaths:
   - '**/*.sh'
-  - '**/werf.yaml'
+  - '**/werf*.yaml'
+  - '**/docker-compose.yml'
+  - site/.werf
   - site/.helm
   - site/backend
   - site/documentation


### PR DESCRIPTION
To run documentation locally, use:
```
cd docs/site &&
werf compose up --follow --docker-compose-command-options="-d"
```

Open http://localhost

To stop:
```
cd docs/site &&
werf compose down
```

You should commit main site files (site/*) into git to see changes.

Documentation files changes will be almost immediately available.