### PR TITLE
[v1.1,ci] Fix release publisher

### DIFF
--- a/.github/workflows/release_publisher.yml
+++ b/.github/workflows/release_publisher.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v1
     - name: Publish
       run: |
-        echo DISABLED ./scripts/publish_release.sh ${GITHUB_REF#refs/tags/}
+        echo./scripts/publish_release.sh ${GITHUB_REF#refs/tags/}
       shell: bash
       env:
         PUBLISH_BINTRAY_AUTH: ${{ secrets.PUBLISH_BINTRAY_AUTH }}

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -28,5 +28,4 @@ fi
 ( which curl > /dev/null ) || ( echo "Cannot find curl command!" 1>&2 && exit 1 )
 
 ( go_build $VERSION ) || ( echo "Failed to build!" 1>&2 && exit 1 )
-( publish_binaries $VERSION ) || ( echo "Failed to publish release binaries!" 1>&2 && exit 1 )
 ( create_github_release $VERSION ) || ( echo "Failed to create github release!" 1>&2 && exit 1 )


### PR DESCRIPTION
Perform automatic creation of github release, only not publish bintray packages automatically.