### PR TITLE
[stapel, git] Fix submodule not initialized

### DIFF
--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -14,8 +14,10 @@ import (
 
 	"github.com/werf/logboek"
 
+	"github.com/werf/werf/pkg/git_repo/repo_handle"
 	"github.com/werf/werf/pkg/true_git"
 	"github.com/werf/werf/pkg/true_git/ls_tree"
+	"github.com/werf/werf/pkg/util"
 	"github.com/werf/werf/pkg/werf"
 )
 
@@ -23,6 +25,9 @@ type Base struct {
 	Name string
 
 	Cache Cache
+
+	commitRepoHandle      sync.Map
+	commitRepoHandleMutex sync.Map
 }
 
 func NewBase(name string) Base {
@@ -459,7 +464,7 @@ func (repo *Base) remoteBranchesList(repoPath string) ([]string, error) {
 	return res, nil
 }
 
-func (repo *Base) getOrCreateChecksum(ctx context.Context, repository *git.Repository, opts ChecksumOptions) (string, error) {
+func (repo *Base) getOrCreateChecksum(ctx context.Context, repoHandle repo_handle.Handle, opts ChecksumOptions) (string, error) {
 	checksumID := opts.ID()
 	checksumMutex, ok := repo.Cache.checksumsMutex[checksumID]
 	if !ok {
@@ -470,7 +475,7 @@ func (repo *Base) getOrCreateChecksum(ctx context.Context, repository *git.Repos
 	defer checksumMutex.Unlock()
 
 	if _, hasKey := repo.Cache.Checksums[checksumID]; !hasKey {
-		checksum, err := repo.CreateChecksum(ctx, repository, opts)
+		checksum, err := repo.CreateChecksum(ctx, repoHandle, opts)
 		if err != nil {
 			return "", err
 		}
@@ -480,18 +485,18 @@ func (repo *Base) getOrCreateChecksum(ctx context.Context, repository *git.Repos
 	return repo.Cache.Checksums[checksumID], nil
 }
 
-func (repo *Base) CreateChecksum(ctx context.Context, repository *git.Repository, opts ChecksumOptions) (checksum string, err error) {
+func (repo *Base) CreateChecksum(ctx context.Context, repoHandle repo_handle.Handle, opts ChecksumOptions) (checksum string, err error) {
 	logboek.Context(ctx).Debug().LogProcess("Creating checksum").Do(func() {
 		logboek.Context(ctx).Debug().LogFDetails("repository: %s\noptions: %+v\n", repo.Name, opts)
 		logboek.Context(ctx).Debug().LogOptionalLn()
-		checksum, err = repo.createChecksum(ctx, repository, opts)
+		checksum, err = repo.createChecksum(ctx, repoHandle, opts)
 	})
 
 	return
 }
 
-func (repo *Base) createChecksum(ctx context.Context, repository *git.Repository, opts ChecksumOptions) (checksum string, err error) {
-	lsTreeResult, err := repo.lsTreeResult(ctx, repository, opts.Commit, opts.LsTreeOptions)
+func (repo *Base) createChecksum(ctx context.Context, repoHandle repo_handle.Handle, opts ChecksumOptions) (checksum string, err error) {
+	lsTreeResult, err := repo.lsTreeResult(ctx, repoHandle, opts.Commit, opts.LsTreeOptions)
 	if err != nil {
 		return "", err
 	}
@@ -499,6 +504,24 @@ func (repo *Base) createChecksum(ctx context.Context, repository *git.Repository
 	return lsTreeResult.Checksum(ctx), nil
 }
 
-func (repo *Base) lsTreeResult(ctx context.Context, repository *git.Repository, commit string, opts LsTreeOptions) (result *ls_tree.Result, err error) {
-	return ls_tree.LsTree(ctx, repository, commit, ls_tree.LsTreeOptions(opts))
+func (repo *Base) lsTreeResult(ctx context.Context, repoHandle repo_handle.Handle, commit string, opts LsTreeOptions) (result *ls_tree.Result, err error) {
+	return ls_tree.LsTree(ctx, repoHandle, commit, ls_tree.LsTreeOptions(opts))
+}
+
+func (repo *Base) withRepoHandle(ctx context.Context, commit string, initRepoHandleBackedByWorkTreeFunc func(ctx context.Context, commit string) (repo_handle.Handle, error), f func(handle repo_handle.Handle) error) error {
+	mutex := util.MapLoadOrCreateMutex(&repo.commitRepoHandleMutex, commit)
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if _, hasKey := repo.commitRepoHandle.Load(commit); !hasKey {
+		repoHandler, err := initRepoHandleBackedByWorkTreeFunc(ctx, commit)
+		if err != nil {
+			return err
+		}
+
+		repo.commitRepoHandle.Store(commit, repoHandler)
+	}
+
+	repoHandler := util.MapMustLoad(&repo.commitRepoHandle, commit).(repo_handle.Handle)
+	return f(repoHandler)
 }

--- a/pkg/git_repo/repo_handle/handle.go
+++ b/pkg/git_repo/repo_handle/handle.go
@@ -1,0 +1,59 @@
+package repo_handle
+
+import (
+	"fmt"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+)
+
+type handle struct {
+	repository          *git.Repository
+	submoduleHandleList []SubmoduleHandle
+}
+
+func newHandle(repository *git.Repository) *handle {
+	return &handle{
+		repository: repository,
+	}
+}
+
+func (h *handle) Repository() Repository {
+	return h.repository
+}
+
+func (h *handle) Submodule(submodulePath string) (SubmoduleHandle, error) {
+	for _, s := range h.submoduleHandleList {
+		if s.Config().Path == submodulePath {
+			return s, nil
+		}
+	}
+
+	return nil, fmt.Errorf("submodule %q not found", submodulePath)
+}
+
+func (h *handle) Submodules() []SubmoduleHandle {
+	return h.submoduleHandleList
+}
+
+type submoduleHandle struct {
+	Handle
+	config *config.Submodule
+	status *git.SubmoduleStatus
+}
+
+func newRepositorySubmoduleHandle(handle Handle, config *config.Submodule, status *git.SubmoduleStatus) *submoduleHandle {
+	return &submoduleHandle{
+		Handle: handle,
+		config: config,
+		status: status,
+	}
+}
+
+func (h *submoduleHandle) Config() *config.Submodule {
+	return h.config
+}
+
+func (h *submoduleHandle) Status() *git.SubmoduleStatus {
+	return h.status
+}

--- a/pkg/git_repo/repo_handle/interface.go
+++ b/pkg/git_repo/repo_handle/interface.go
@@ -1,0 +1,77 @@
+package repo_handle
+
+import (
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// Handle is a solution to get away from the worktree when working with the git repository,
+// caching the necessary data from the worktree during initialization,
+// and then working exclusively with git objects.
+type Handle interface {
+	Repository() Repository
+	Submodule(submodulePath string) (SubmoduleHandle, error)
+	Submodules() []SubmoduleHandle
+}
+
+type SubmoduleHandle interface {
+	Handle
+	Config() *config.Submodule
+	Status() *git.SubmoduleStatus
+}
+
+type Repository interface {
+	CommitObject(h plumbing.Hash) (*object.Commit, error)
+	BlobObject(h plumbing.Hash) (*object.Blob, error)
+}
+
+func NewHandle(repository *git.Repository) (Handle, error) {
+	h := newHandle(repository)
+
+	submoduleHandleList, err := getSubmoduleHandleList(repository)
+	if err != nil {
+		return nil, err
+	}
+
+	h.submoduleHandleList = submoduleHandleList
+
+	return h, nil
+}
+
+func getSubmoduleHandleList(parentRepository *git.Repository) ([]SubmoduleHandle, error) {
+	var list []SubmoduleHandle
+
+	w, err := parentRepository.Worktree()
+	if err != nil {
+		return nil, err
+	}
+
+	ss, err := w.Submodules()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range ss {
+		submoduleRepository, err := s.Repository()
+		if err != nil {
+			return nil, err
+		}
+
+		submoduleStatus, err := s.Status()
+		if err != nil {
+			return nil, err
+		}
+
+		handle, err := NewHandle(submoduleRepository)
+		if err != nil {
+			return nil, err
+		}
+
+		submoduleHandle := newRepositorySubmoduleHandle(handle, s.Config(), submoduleStatus)
+		list = append(list, submoduleHandle)
+	}
+
+	return list, nil
+}

--- a/pkg/true_git/archive.go
+++ b/pkg/true_git/archive.go
@@ -10,10 +10,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/werf/logboek"
-
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 
+	"github.com/werf/logboek"
+
+	"github.com/werf/werf/pkg/git_repo/repo_handle"
 	"github.com/werf/werf/pkg/path_matcher"
 	"github.com/werf/werf/pkg/true_git/ls_tree"
 	"github.com/werf/werf/pkg/util"
@@ -132,11 +133,15 @@ func writeArchive(ctx context.Context, out io.Writer, gitDir, workTreeCacheDir s
 		}
 	}
 
-	tw := tar.NewWriter(out)
+	repoHandle, err := repo_handle.NewHandle(repository)
+	if err != nil {
+		return nil, err
+	}
 
+	tw := tar.NewWriter(out)
 	logProcess := logboek.Context(ctx).Debug().LogProcess("ls-tree (%s)", opts.PathMatcher.String())
 	logProcess.Start()
-	result, err := ls_tree.LsTree(ctx, repository, opts.Commit, ls_tree.LsTreeOptions{
+	result, err := ls_tree.LsTree(ctx, repoHandle, opts.Commit, ls_tree.LsTreeOptions{
 		PathScope:   opts.PathScope,
 		PathMatcher: opts.PathMatcher,
 		AllFiles:    true,

--- a/pkg/util/sync.go
+++ b/pkg/util/sync.go
@@ -1,0 +1,20 @@
+package util
+
+import "sync"
+
+func MapLoadOrCreateMutex(m *sync.Map, key string) *sync.Mutex {
+	if _, hasKey := m.Load(key); !hasKey {
+		m.Store(key, &sync.Mutex{})
+	}
+
+	return MapMustLoad(m, key).(*sync.Mutex)
+}
+
+func MapMustLoad(m *sync.Map, key string) interface{} {
+	val, hasKey := m.Load(key)
+	if !hasKey {
+		panic("key must be set in map")
+	}
+
+	return val
+}


### PR DESCRIPTION
**Implement git repository handle**

A solution to get away from the worktree when working with the git repository, caching the necessary data from the worktree during initialization, and then working exclusively with git objects.