### PR TITLE
[path_matcher] Fix incorrect path matcher IDs

### DIFF
--- a/pkg/path_matcher/base_path.go
+++ b/pkg/path_matcher/base_path.go
@@ -1,8 +1,8 @@
 package path_matcher
 
 import (
-	"crypto/sha256"
 	"fmt"
+	"strings"
 
 	"github.com/werf/werf/pkg/util"
 )
@@ -54,14 +54,14 @@ func (m basePathMatcher) ID() string {
 		return ""
 	}
 
-	h := sha256.New()
-	h.Write([]byte(m.basePath))
-
+	var args []string
+	args = append(args, "basePath")
+	args = append(args, m.basePath)
 	if m.matcher != nil {
-		h.Write([]byte(m.matcher.ID()))
+		args = append(args, m.matcher.ID())
 	}
 
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return util.Sha256Hash(strings.Join(args, ":::"))
 }
 
 func (m basePathMatcher) String() string {

--- a/pkg/path_matcher/common.go
+++ b/pkg/path_matcher/common.go
@@ -1,27 +1,13 @@
 package path_matcher
 
 import (
-	"crypto/sha256"
-	"fmt"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/bmatcuk/doublestar"
 
 	"github.com/werf/werf/pkg/util"
 )
-
-func includeExcludePathMatchersID(globs []string) string {
-	if len(globs) == 0 {
-		return ""
-	}
-
-	h := sha256.New()
-	sort.Strings(globs)
-	h.Write([]byte(fmt.Sprint(globs)))
-	return fmt.Sprintf("%x", h.Sum(nil))
-}
 
 func matchGlobs(pathPart string, globs []string) (inProgressGlobs []string, matchedGlobs []string) {
 	for _, glob := range globs {

--- a/pkg/path_matcher/dockerfile_ignore.go
+++ b/pkg/path_matcher/dockerfile_ignore.go
@@ -1,9 +1,9 @@
 package path_matcher
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/docker/docker/pkg/fileutils"
 
@@ -113,10 +113,12 @@ func (m dockerfileIgnorePathMatcher) ID() string {
 		return ""
 	}
 
-	h := sha256.New()
 	sort.Strings(cleanedPatterns)
-	h.Write([]byte(fmt.Sprint(cleanedPatterns)))
-	return fmt.Sprintf("%x", h.Sum(nil))
+
+	var args []string
+	args = append(args, "dockerfileIgnore")
+	args = append(args, cleanedPatterns...)
+	return util.Sha256Hash(strings.Join(args, ":::"))
 }
 
 func (m dockerfileIgnorePathMatcher) String() string {

--- a/pkg/path_matcher/exclude.go
+++ b/pkg/path_matcher/exclude.go
@@ -2,6 +2,8 @@ package path_matcher
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/werf/werf/pkg/util"
 )
@@ -66,7 +68,16 @@ func (m excludePathMatcher) shouldGoThrough(path string) bool {
 }
 
 func (m excludePathMatcher) ID() string {
-	return includeExcludePathMatchersID(m.excludeGlobs)
+	if len(m.excludeGlobs) == 0 {
+		return ""
+	}
+
+	sort.Strings(m.excludeGlobs)
+
+	var args []string
+	args = append(args, "exclude")
+	args = append(args, m.excludeGlobs...)
+	return util.Sha256Hash(strings.Join(args, ":::"))
 }
 
 func (m excludePathMatcher) String() string {

--- a/pkg/path_matcher/include.go
+++ b/pkg/path_matcher/include.go
@@ -2,6 +2,8 @@ package path_matcher
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/werf/werf/pkg/util"
 )
@@ -67,7 +69,16 @@ func (m includePathMatcher) shouldGoThrough(path string) bool {
 }
 
 func (m includePathMatcher) ID() string {
-	return includeExcludePathMatchersID(m.includeGlobs)
+	if len(m.includeGlobs) == 0 {
+		return ""
+	}
+
+	sort.Strings(m.includeGlobs)
+
+	var args []string
+	args = append(args, "include")
+	args = append(args, m.includeGlobs...)
+	return util.Sha256Hash(strings.Join(args, ":::"))
 }
 
 func (m includePathMatcher) String() string {

--- a/pkg/path_matcher/multi.go
+++ b/pkg/path_matcher/multi.go
@@ -1,10 +1,11 @@
 package path_matcher
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/werf/werf/pkg/util"
 )
 
 func NewMultiPathMatcher(matchers ...PathMatcher) PathMatcher {
@@ -48,17 +49,17 @@ func (m MultiPathMatcher) ShouldGoThrough(path string) bool {
 }
 
 func (m MultiPathMatcher) ID() string {
-	h := sha256.New()
-
 	var ids []string
 	for _, matcher := range m.matchers {
 		ids = append(ids, matcher.ID())
 	}
 
 	sort.Strings(ids)
-	h.Write([]byte(fmt.Sprint(ids)))
 
-	return fmt.Sprintf("%x", h.Sum(nil))
+	var args []string
+	args = append(args, "multi")
+	args = append(args, ids...)
+	return util.Sha256Hash(strings.Join(args, ":::"))
 }
 
 func (m MultiPathMatcher) String() string {


### PR DESCRIPTION
The identifiers included paths but did not include path matcher type. 
Since identifiers were used for caching, this could lead to invalid caching.

For example, the following path mappings were cached using the same key:
```
git:
  - add: /
    to: /app
    includePaths:
      - go.mod
      - go.sum
      
git:
  - add: /
    to: /app
    excludePaths:
      - go.mod
      - go.sum
```