### PR TITLE
[docs] remove in cleanup  /var/log/werf-host-cleanup.log

### DIFF
--- a/docs/documentation/pages_ru/advanced/cleanup.md
+++ b/docs/documentation/pages_ru/advanced/cleanup.md
@@ -111,7 +111,7 @@ werf подключается **ко всем кластерам** Kubernetes, �
 ```shell
 # /etc/cron.d/werf-host-cleanup
 SHELL=/bin/bash
-*/30 * * * * gitlab-runner source ~/.profile ; source $(multiwerf use 1.2 ea --as-file) ; echo "# $(date)" >> /var/log/werf-host-cleanup.log ; werf host cleanup 2>&1 >> /var/log/werf-host-cleanup.log
+*/30 * * * * gitlab-runner source ~/.profile ; source $(multiwerf use 1.2 ea --as-file) ; echo "# $(date)" ; werf host cleanup
 ```
 
 По умолчанию без дополнительных параметров `werf host cleanup` будет чистить данные всех проектов на хосте. С параметром `--project-name PROJECT` команда может удалять только образы из локального docker-сервера. В данном режиме команда поддерживается частично.


### PR DESCRIPTION
1.because it is not created automatically and the task does not work out because of this
2.if you create such a file, it will not be rotated and will overwhelm the entire disk