### PR TITLE
Fix git.add single file rename not working

### DIFF
--- a/pkg/build/stage/git_archive.go
+++ b/pkg/build/stage/git_archive.go
@@ -46,6 +46,7 @@ func (s *GitArchiveStage) SelectSuitableStage(ctx context.Context, c Conveyor, s
 	return s.selectStageByOldestCreationTimestamp(ancestorsStages)
 }
 
+// TODO: 1.3 add git mapping type (dir, file, ...) to gitArchive stage digest
 func (s *GitArchiveStage) GetDependencies(ctx context.Context, c Conveyor, _, _ container_runtime.ImageInterface) (string, error) {
 	var args []string
 	for _, gitMapping := range s.gitMappings {

--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -100,12 +100,88 @@ func (gm *GitMapping) GitRepo() git_repo.GitRepo {
 	panic("GitRepo not initialized")
 }
 
+func (gm *GitMapping) makeArchiveOptions(ctx context.Context, commit string) (*git_repo.ArchiveOptions, error) {
+	fileRenames, err := gm.getFileRenames(ctx, commit)
+	if err != nil {
+		return nil, fmt.Errorf("unable to make git archive options: %s", err)
+	}
+
+	pathScope, err := gm.getPathScope(ctx, commit)
+	if err != nil {
+		return nil, fmt.Errorf("unable to make git archive options: %s", err)
+	}
+
+	return &git_repo.ArchiveOptions{
+		PathScope:   pathScope,
+		PathMatcher: gm.getPathMatcher(),
+		Commit:      commit,
+		FileRenames: fileRenames,
+	}, nil
+}
+
+func (gm *GitMapping) makePatchOptions(ctx context.Context, fromCommit, toCommit string, withEntireFileContext, withBinary bool) (*git_repo.PatchOptions, error) {
+	fileRenames, err := gm.getFileRenames(ctx, toCommit)
+	if err != nil {
+		return nil, fmt.Errorf("unable to make git patch options: %s", err)
+	}
+
+	pathScope, err := gm.getPathScope(ctx, toCommit)
+	if err != nil {
+		return nil, fmt.Errorf("unable to make git patch options: %s", err)
+	}
+
+	return &git_repo.PatchOptions{
+		PathScope:             pathScope,
+		PathMatcher:           gm.getPathMatcher(),
+		FromCommit:            fromCommit,
+		ToCommit:              toCommit,
+		FileRenames:           fileRenames,
+		WithEntireFileContext: withEntireFileContext,
+		WithBinary:            withBinary,
+	}, nil
+}
+
 func (gm *GitMapping) getPathMatcher() path_matcher.PathMatcher {
 	return path_matcher.NewPathMatcher(path_matcher.PathMatcherOptions{
 		BasePath:     gm.Add,
 		IncludeGlobs: gm.IncludePaths,
 		ExcludeGlobs: gm.ExcludePaths,
 	})
+}
+
+func (gm *GitMapping) getPathScope(ctx context.Context, commit string) (string, error) {
+	var pathScope string
+
+	gitAddIsDirOrSubmodule, err := gm.GitRepo().IsCommitTreeEntryDirectory(ctx, commit, gm.Add)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine whether ls tree entry for path %q on commit %q is directory or not: %s", gm.Add, commit, err)
+	}
+
+	if gitAddIsDirOrSubmodule {
+		pathScope = gm.Add
+	} else {
+		pathScope = filepath.ToSlash(filepath.Dir(gm.Add))
+	}
+
+	return pathScope, nil
+}
+
+func (gm *GitMapping) getFileRenames(ctx context.Context, commit string) (map[string]string, error) {
+	gitAddIsDirOrSubmodule, err := gm.GitRepo().IsCommitTreeEntryDirectory(ctx, commit, gm.Add)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine whether ls tree entry for path %q on commit %q is directory or not: %s", gm.Add, commit, err)
+	}
+
+	fileRenames := make(map[string]string)
+	if gitAddIsDirOrSubmodule {
+		return fileRenames, nil
+	}
+
+	if filepath.Base(gm.Add) != filepath.Base(gm.To) {
+		fileRenames[gm.Add] = filepath.Base(gm.To)
+	}
+
+	return fileRenames, nil
 }
 
 func (gm *GitMapping) IsLocal() bool {
@@ -344,14 +420,12 @@ func (gm *GitMapping) VirtualMergeIntoCommitLabel() string {
 func (gm *GitMapping) baseApplyPatchCommand(ctx context.Context, fromCommit, toCommit string, prevBuiltImage container_runtime.ImageInterface) ([]string, error) {
 	archiveType := git_repo.ArchiveType(prevBuiltImage.GetStageDescription().Info.Labels[gm.getArchiveTypeLabelName()])
 
-	patchOpts := git_repo.PatchOptions{
-		PathScope:   gm.Add,
-		PathMatcher: gm.getPathMatcher(),
-		FromCommit:  fromCommit,
-		ToCommit:    toCommit,
+	patchOpts, err := gm.makePatchOptions(ctx, fromCommit, toCommit, false, false)
+	if err != nil {
+		return nil, err
 	}
 
-	patch, err := gm.GitRepo().GetOrCreatePatch(ctx, patchOpts)
+	patch, err := gm.GitRepo().GetOrCreatePatch(ctx, *patchOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -422,13 +496,12 @@ func (gm *GitMapping) baseApplyPatchCommand(ctx context.Context, fromCommit, toC
 			}
 		}
 
-		archiveOpts := git_repo.ArchiveOptions{
-			PathScope:   gm.Add,
-			PathMatcher: gm.getPathMatcher(),
-			Commit:      toCommit,
+		archiveOpts, err := gm.makeArchiveOptions(ctx, toCommit)
+		if err != nil {
+			return nil, err
 		}
 
-		archive, err := gm.GitRepo().GetOrCreateArchive(ctx, archiveOpts)
+		archive, err := gm.GitRepo().GetOrCreateArchive(ctx, *archiveOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -443,7 +516,10 @@ func (gm *GitMapping) baseApplyPatchCommand(ctx context.Context, fromCommit, toC
 			return nil, fmt.Errorf("cannot prepare archive file: %s", err)
 		}
 
-		archiveType := archive.GetType()
+		archiveType, err := gm.getArchiveType(ctx, toCommit)
+		if err != nil {
+			return nil, err
+		}
 
 		applyArchiveCommands, err := gm.applyArchiveCommand(archiveFile, archiveType)
 		if err != nil {
@@ -544,13 +620,12 @@ func (gm *GitMapping) applyScript(image container_runtime.ImageInterface, comman
 }
 
 func (gm *GitMapping) baseApplyArchiveCommand(ctx context.Context, commit string, image container_runtime.ImageInterface) ([]string, error) {
-	archiveOpts := git_repo.ArchiveOptions{
-		PathScope:   gm.Add,
-		PathMatcher: gm.getPathMatcher(),
-		Commit:      commit,
+	archiveOpts, err := gm.makeArchiveOptions(ctx, commit)
+	if err != nil {
+		return nil, err
 	}
 
-	archive, err := gm.GitRepo().GetOrCreateArchive(ctx, archiveOpts)
+	archive, err := gm.GitRepo().GetOrCreateArchive(ctx, *archiveOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -564,7 +639,10 @@ func (gm *GitMapping) baseApplyArchiveCommand(ctx context.Context, commit string
 		return nil, fmt.Errorf("cannot prepare archive file: %s", err)
 	}
 
-	archiveType := archive.GetType()
+	archiveType, err := gm.getArchiveType(ctx, commit)
+	if err != nil {
+		return nil, err
+	}
 
 	commands, err := gm.applyArchiveCommand(archiveFile, archiveType)
 	if err != nil {
@@ -638,16 +716,12 @@ func (gm *GitMapping) PatchSize(ctx context.Context, c Conveyor, fromCommit stri
 		return 0, nil
 	}
 
-	patchOpts := git_repo.PatchOptions{
-		PathScope:             gm.Add,
-		PathMatcher:           gm.getPathMatcher(),
-		FromCommit:            fromCommit,
-		ToCommit:              toCommitInfo.Commit,
-		WithEntireFileContext: true,
-		WithBinary:            true,
+	patchOpts, err := gm.makePatchOptions(ctx, fromCommit, toCommitInfo.Commit, true, true)
+	if err != nil {
+		return 0, err
 	}
 
-	patch, err := gm.GitRepo().GetOrCreatePatch(ctx, patchOpts)
+	patch, err := gm.GitRepo().GetOrCreatePatch(ctx, *patchOpts)
 	if err != nil {
 		return 0, err
 	}
@@ -727,13 +801,12 @@ func (gm *GitMapping) GetPatchContent(ctx context.Context, c Conveyor, prevBuilt
 		return "", nil
 	}
 
-	patchOpts := git_repo.PatchOptions{
-		PathScope:   gm.Add,
-		PathMatcher: gm.getPathMatcher(),
-		FromCommit:  fromCommit,
-		ToCommit:    toCommitInfo.Commit,
+	patchOpts, err := gm.makePatchOptions(ctx, fromCommit, toCommitInfo.Commit, false, false)
+	if err != nil {
+		return "", err
 	}
-	patch, err := gm.GitRepo().GetOrCreatePatch(ctx, patchOpts)
+
+	patch, err := gm.GitRepo().GetOrCreatePatch(ctx, *patchOpts)
 	if err != nil {
 		return "", err
 	}
@@ -764,14 +837,12 @@ func (gm *GitMapping) baseIsPatchEmpty(ctx context.Context, fromCommit, toCommit
 		return true, nil
 	}
 
-	patchOpts := git_repo.PatchOptions{
-		PathScope:   gm.Add,
-		PathMatcher: gm.getPathMatcher(),
-		FromCommit:  fromCommit,
-		ToCommit:    toCommit,
+	patchOpts, err := gm.makePatchOptions(ctx, fromCommit, toCommit, false, false)
+	if err != nil {
+		return false, err
 	}
 
-	patch, err := gm.GitRepo().GetOrCreatePatch(ctx, patchOpts)
+	patch, err := gm.GitRepo().GetOrCreatePatch(ctx, *patchOpts)
 	if err != nil {
 		return false, err
 	}
@@ -785,17 +856,12 @@ func (gm *GitMapping) IsEmpty(ctx context.Context, c Conveyor) (bool, error) {
 		return false, fmt.Errorf("unable to get latest commit info: %s", err)
 	}
 
-	archiveOpts := git_repo.ArchiveOptions{
-		PathScope:   gm.Add,
-		PathMatcher: gm.getPathMatcher(),
-		Commit:      commitInfo.Commit,
-	}
-
-	archive, err := gm.GitRepo().GetOrCreateArchive(ctx, archiveOpts)
+	archiveOpts, err := gm.makeArchiveOptions(ctx, commitInfo.Commit)
 	if err != nil {
 		return false, err
 	}
 
+	archive, err := gm.GitRepo().GetOrCreateArchive(ctx, *archiveOpts)
 	return archive.IsEmpty(), nil
 }
 
@@ -874,4 +940,17 @@ func (gm *GitMapping) makeCredentialsOpts() string {
 
 func (gm *GitMapping) getArchiveTypeLabelName() string {
 	return fmt.Sprintf("werf-git-%s-type", gm.GetParamshash())
+}
+
+func (gm *GitMapping) getArchiveType(ctx context.Context, commit string) (git_repo.ArchiveType, error) {
+	archiveTypeIsDirectory, err := gm.GitRepo().IsCommitTreeEntryDirectory(ctx, commit, gm.Add)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine git mapping archive type for commit %q: %s", commit, err)
+	}
+
+	if archiveTypeIsDirectory {
+		return git_repo.DirectoryArchive, nil
+	}
+
+	return git_repo.FileArchive, nil
 }

--- a/pkg/git_repo/archive_file.go
+++ b/pkg/git_repo/archive_file.go
@@ -1,8 +1,6 @@
 package git_repo
 
-import (
-	"github.com/werf/werf/pkg/true_git"
-)
+import "github.com/werf/werf/pkg/true_git"
 
 type ArchiveFile struct {
 	FilePath   string
@@ -11,10 +9,6 @@ type ArchiveFile struct {
 
 func (a *ArchiveFile) GetFilePath() string {
 	return a.FilePath
-}
-
-func (a *ArchiveFile) GetType() ArchiveType {
-	return ArchiveType(a.Descriptor.Type)
 }
 
 func (a *ArchiveFile) IsEmpty() bool {

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -508,7 +508,7 @@ func (repo *Base) CreateChecksum(ctx context.Context, repoHandle repo_handle.Han
 }
 
 func (repo *Base) createChecksum(ctx context.Context, repoHandle repo_handle.Handle, opts ChecksumOptions) (checksum string, err error) {
-	lsTreeResult, err := repo.lsTreeResult(ctx, repoHandle, opts.Commit, opts.LsTreeOptions)
+	lsTreeResult, err := repo.lsTreeResultWithExistingHandle(ctx, repoHandle, opts.Commit, opts.LsTreeOptions)
 	if err != nil {
 		return "", err
 	}
@@ -516,16 +516,16 @@ func (repo *Base) createChecksum(ctx context.Context, repoHandle repo_handle.Han
 	return lsTreeResult.Checksum(ctx), nil
 }
 
-func (repo *Base) LsTreeResult(ctx context.Context, commit string, opts LsTreeOptions) (result *ls_tree.Result, err error) {
+func (repo *Base) lsTreeResult(ctx context.Context, commit string, opts LsTreeOptions) (result *ls_tree.Result, err error) {
 	err = repo.withRepoHandle(ctx, commit, func(repoHandle repo_handle.Handle) error {
-		result, err = repo.lsTreeResult(ctx, repoHandle, commit, opts)
+		result, err = repo.lsTreeResultWithExistingHandle(ctx, repoHandle, commit, opts)
 		return err
 	})
 
 	return
 }
 
-func (repo *Base) lsTreeResult(ctx context.Context, repoHandle repo_handle.Handle, commit string, opts LsTreeOptions) (result *ls_tree.Result, err error) {
+func (repo *Base) lsTreeResultWithExistingHandle(ctx context.Context, repoHandle repo_handle.Handle, commit string, opts LsTreeOptions) (result *ls_tree.Result, err error) {
 	return ls_tree.LsTree(ctx, repoHandle, commit, ls_tree.LsTreeOptions(opts))
 }
 
@@ -548,7 +548,7 @@ func (repo *Base) withRepoHandle(ctx context.Context, commit string, f func(hand
 }
 
 func (repo *Base) GetCommitTreeEntry(ctx context.Context, commit string, path string) (*ls_tree.LsTreeEntry, error) {
-	lsTreeResult, err := repo.LsTreeResult(ctx, commit, LsTreeOptions{
+	lsTreeResult, err := repo.lsTreeResult(ctx, commit, LsTreeOptions{
 		PathScope: path,
 		AllFiles:  false,
 	})
@@ -618,7 +618,7 @@ func (repo *Base) isCommitTreeEntryDirectory(ctx context.Context, commit string,
 }
 
 func (repo *Base) ReadCommitTreeEntryContent(ctx context.Context, commit string, relPath string) ([]byte, error) {
-	lsTreeResult, err := repo.LsTreeResult(ctx, commit, LsTreeOptions{
+	lsTreeResult, err := repo.lsTreeResult(ctx, commit, LsTreeOptions{
 		PathScope: relPath,
 		AllFiles:  false,
 	})
@@ -897,7 +897,7 @@ func (repo *Base) WalkCommitFiles(ctx context.Context, commit string, dir string
 		return fmt.Errorf("unable to resolve commit file %q: %s", dir, err)
 	}
 
-	result, err := repo.LsTreeResult(ctx, commit, LsTreeOptions{
+	result, err := repo.lsTreeResult(ctx, commit, LsTreeOptions{
 		PathScope: resolvedDir,
 		AllFiles:  true,
 	})

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -53,7 +53,6 @@ type GitRepo interface {
 	IsEmpty(ctx context.Context) (bool, error)
 	LatestBranchCommit(ctx context.Context, branch string) (string, error)
 	ListCommitFilesWithGlob(ctx context.Context, commit string, dir string, glob string) ([]string, error)
-	LsTreeResult(ctx context.Context, commit string, opts LsTreeOptions) (*ls_tree.Result, error)
 	ReadCommitFile(ctx context.Context, commit, path string) ([]byte, error)
 	ReadCommitTreeEntryContent(ctx context.Context, commit string, relPath string) ([]byte, error)
 	ResolveAndCheckCommitFilePath(ctx context.Context, commit, path string, checkSymlinkTargetFunc func(resolvedPath string) error) (string, error)

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -48,6 +48,7 @@ type GitRepo interface {
 	IsCommitDirectoryExist(ctx context.Context, commit, path string) (bool, error)
 	IsCommitExists(ctx context.Context, commit string) (bool, error)
 	IsCommitFileExist(ctx context.Context, commit, path string) (bool, error)
+	IsNoCommitTreeEntriesMatched(ctx context.Context, commit string, pathScope string, pathMatcher path_matcher.PathMatcher) (bool, error)
 	IsCommitTreeEntryDirectory(ctx context.Context, commit string, relPath string) (bool, error)
 	IsCommitTreeEntryExist(ctx context.Context, commit string, relPath string) (bool, error)
 	IsEmpty(ctx context.Context) (bool, error)
@@ -73,7 +74,6 @@ type Patch interface {
 
 type Archive interface {
 	GetFilePath() string
-	GetType() ArchiveType
 	IsEmpty() bool
 }
 

--- a/pkg/git_repo/gitdata/git_data_manager.go
+++ b/pkg/git_repo/gitdata/git_data_manager.go
@@ -180,7 +180,7 @@ func (manager *GitDataManager) CreateArchiveFile(ctx context.Context, repoID str
 		return nil, fmt.Errorf("unable to rename %s to %s: %s", tmpPath, path, err)
 	}
 
-	return &git_repo.ArchiveFile{FilePath: path, Descriptor: desc}, nil
+	return &git_repo.ArchiveFile{FilePath: path, Descriptor: metadata.Descriptor}, nil
 }
 
 func (manager *GitDataManager) GetPatchFile(ctx context.Context, repoID string, opts git_repo.PatchOptions) (*git_repo.PatchFile, error) {


### PR DESCRIPTION
Fix git.add single file rename not working

This previously resulted in `/dir/oldfilename` in an image, but now results in
`/dir/newfilename` as supposed to:
```
git:
- add: /dir/oldfilename
  to: /dir/newfilename
```

Fixes: #1741, #3180