### PR TITLE
[container registry] Fix processing of reference with digest

### DIFF
--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -122,9 +122,22 @@ func (api *api) GetRepoImage(_ context.Context, reference string) (*image.Info, 
 		}
 	}
 
-	parsedReference, err := name.NewTag(reference, api.parseReferenceOptions()...)
-	if err != nil {
-		return nil, err
+	digestDelimiter := "@"
+	var parsedReference name.Tag
+	if strings.Contains(reference, digestDelimiter) {
+		// skip any validation due to the valid reference at this point
+		parts := strings.Split(reference, digestDelimiter)
+		base, _ := parts[0], parts[1]
+
+		parsedReference, err = name.NewTag(base, api.parseReferenceOptions()...)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		parsedReference, err = name.NewTag(reference, api.parseReferenceOptions()...)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	repoImage := &image.Info{


### PR DESCRIPTION
The user may have encountered related issues when using the base image (`from`) with digest (`REPO@DIGEST`, `REPO:TAG@DIGEST`).

```
WARNING: cannot get base image id (alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f): can not get base image id from registry (alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f): repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: alpine@sha256
WARNING: using existing image alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f without pull
```