### PR TITLE
Fix werf-render command error shadowing and logging

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -570,7 +570,7 @@ Default $WERF_LOG_COLOR_MODE or auto mode.`)
 func setupLogQuiet(cmdData *CmdData, cmd *cobra.Command, isDefaultQuiet bool) {
 	cmdData.LogQuiet = new(bool)
 
-	var defaultValue = isDefaultQuiet
+	defaultValue := isDefaultQuiet
 
 	for _, envName := range []string{
 		"WERF_LOG_QUIET",
@@ -1218,14 +1218,14 @@ func ProcessLogOptions(cmdData *CmdData) error {
 		return err
 	}
 
-	if *cmdData.LogQuiet {
-		logboek.SetAcceptedLevel(level.Error)
-	} else if *cmdData.LogDebug {
+	if *cmdData.LogDebug {
 		logboek.SetAcceptedLevel(level.Debug)
 		logboek.Streams().EnablePrefixWithTime()
 		logboek.Streams().SetPrefixStyle(style.Details())
 	} else if *cmdData.LogVerbose {
 		logboek.SetAcceptedLevel(level.Info)
+	} else if *cmdData.LogQuiet {
+		logboek.SetAcceptedLevel(level.Error)
 	}
 
 	if !*cmdData.LogPretty {

--- a/pkg/deploy/helm/command_helpers/build_chart_dependencies.go
+++ b/pkg/deploy/helm/command_helpers/build_chart_dependencies.go
@@ -65,9 +65,10 @@ func BuildChartDependenciesInDir(ctx context.Context, chartFile *chart.ChartExte
 	}()
 
 	err := man.Build()
+
 	if e, ok := err.(downloader.ErrRepoNotFound); ok {
 		return fmt.Errorf("%s. Please add the missing repos via 'helm repo add'", e.Error())
 	}
 
-	return nil
+	return err
 }


### PR DESCRIPTION
 - Internal helm-dependency-build process error was shadowed and not affected anything.
 - `werf render (--verbose|--debug)` should enable verbose or debug mode, but it was not happened.