### PR TITLE
[site][landing] Reword GitOps section

### DIFF
--- a/docs/documentation/pages_en/quickstart.md
+++ b/docs/documentation/pages_en/quickstart.md
@@ -38,7 +38,7 @@ Or use one of the following instructions to set up the local Kubernetes cluster 
 
    {% raw %}
    ```shell
-   minikube start --insecure-registry registry.example.com:80
+   minikube start --driver=hyperv --insecure-registry registry.example.com:80
    ```
    {% endraw %}
     
@@ -259,7 +259,7 @@ Or use one of the following instructions to set up the local Kubernetes cluster 
 
    {% raw %}
    ```shell
-   minikube start --insecure-registry registry.example.com:80
+   minikube start --driver=docker --insecure-registry registry.example.com:80
    ```
    {% endraw %}
     

--- a/docs/documentation/pages_ru/quickstart.md
+++ b/docs/documentation/pages_ru/quickstart.md
@@ -40,7 +40,7 @@ werf version
 
    {% raw %}
    ```shell
-   minikube start --insecure-registry registry.example.com:80
+   minikube start --driver=hyperv --insecure-registry registry.example.com:80
    ```
    {% endraw %}
 
@@ -263,7 +263,7 @@ werf version
 
    {% raw %}
    ```shell
-   minikube start --insecure-registry registry.example.com:80
+   minikube start --driver=docker --insecure-registry registry.example.com:80
    ```
    {% endraw %}
 

--- a/docs/site/css/index.css
+++ b/docs/site/css/index.css
@@ -574,6 +574,17 @@ body,
   max-width: 500px;
 }
 
+.welcome__subtitle_mini {
+  font-size: 20px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 30px;
+  letter-spacing: normal;
+  color: rgba(0, 18, 44, 0.75);
+  max-width: 500px;
+}
+
 .stats {
   position: relative;
 }

--- a/docs/site/pages_en/index.md
+++ b/docs/site/pages_en/index.md
@@ -1,5 +1,5 @@
 ---
-title: GitOps CLI tool
+title: Giterministic CLI tool
 permalink: /
 layout: default
 sidebar: none
@@ -35,7 +35,7 @@ sidebar: none
                 <h1 class="intro__title">Consistent<br/>delivery tool</h1>
                 <ul class="intro__features">
                     <li>The CLI tool glueing Git, Docker, Helm & Kubernetes<br/>
-                    with any CI system to implement CI/CD and GitOps.</li>
+                    with any CI system to implement CI/CD and Giterminism.</li>
                 </ul>
                 <div class="intro__btns page__btn-group">
                     <a href="{{ "introduction.html" | true_relative_url }}" target="_blank" class="page__btn page__btn_b page__btn_small">
@@ -142,12 +142,45 @@ sidebar: none
     <div class="page__container">
         <div class="welcome__content">
             <h1 class="welcome__title">
-                It’s GitOps,<br/>
-                but done <a href="https://www.youtube.com/watch?v=FPMuVdW2hYs"><b>another way</b></a>!
+                It’s like GitOps,<br/>
+                but <a href="https://www.youtube.com/watch?v=FPMuVdW2hYs"><b>even better!</b></a>
             </h1>
-            <div class="welcome__subtitle">
-                Git as a single source of&nbsp;truth allows you to&nbsp;make the&nbsp;entire delivery pipeline deterministic and&nbsp;idempotent.
-                You can use it manually, from within your CI/CD system or&nbsp;as&nbsp;an&nbsp;operator (coming&nbsp;soon).
+            <div class="welcome__subtitle_mini">
+                Werf introduces <b>Giterminism</b>:
+                <ul>
+                    <li>
+                        use git as a single source of truth;
+                    </li>
+                    <li>
+                        make the entire delivery pipeline deterministic and idempotent.
+                    </li>
+                </ul>
+
+                Werf supports <b>2 ways to deploy</b> an application:
+                <ol>
+                    <li>
+                        deploy application from git commit into the Kubernetes;
+                    </li>
+                    <li>
+                        publish application from git commit into the Container Registry as a <b>bundle</b>, then deploy bundle into the Kubernetes.
+                    </li>
+                </ol>
+
+                Werf tool allows usage in a different ways:
+                <ul>
+                    <li>
+                        manually;
+                    </li>
+                    <li>
+                        by CI/CD system;
+                    </li>
+                    <li>
+                        by Kubernetes operator (feature available partially);
+                    </li>
+                    <li>
+                        by heroku-like git push approach (feature unavailable yet).
+                    </li>
+                </ul>
             </div>
         </div>
     </div>

--- a/docs/site/pages_ru/index.md
+++ b/docs/site/pages_ru/index.md
@@ -1,5 +1,5 @@
 ---
-title: GitOps CLI-утилита
+title: Гитерминированная CLI утилита
 permalink: /
 layout: default
 sidebar: none
@@ -35,7 +35,7 @@ sidebar: none
                 <h1 class="intro__title">Инструмент<br/>консистентной<br/>доставки</h1>
                 <ul class="intro__features">
                     <li>CLI-утилита, «склеивающая» Git, Docker, Helm и Kubernetes<br>
-                    с любой CI-системой для реализации CI/CD и подхода GitOps.</li>
+                    с любой CI-системой для реализации CI/CD и подхода гитерминизм.</li>
                 </ul>
                 <div class="intro__btns page__btn-group">
                     <a href="{{ "introduction.html" | true_relative_url }}" target="_blank" class="page__btn page__btn_b page__btn_small">
@@ -143,11 +143,44 @@ sidebar: none
     <div class="page__container">
         <div class="welcome__content">
             <h1 class="welcome__title">
-                Это GitOps,<br/>но реализованный<br/><a href="https://www.youtube.com/watch?v=FPMuVdW2hYs"><b>по-другому</b></a>!
+                Это как GitOps,<br/><a href="https://www.youtube.com/watch?v=FPMuVdW2hYs"><b>но лучше!</b></a>
             </h1>
-            <div class="welcome__subtitle">
-                werf использует Git как единый источник истины и позволяет добиться детерминированного и идемпотентного процесса доставки по всему пайплайну.
-                Возможно использование вручную, из CI/CD-системы или в качестве оператора (фича в разработке и скоро будет доступна).
+            <div class="welcome__subtitle_mini">
+                Werf вводит понятие <b>гитерминизм</b>:
+                <ul>
+                    <li>
+                        использование Git как единого источника истины;
+                    </li>
+                    <li>
+                        позволяет добиться детерминированного и идемпотентного процесса доставки по всему пайплайну.
+                    </li>
+                </ul>
+
+                <b>2 способа деплоя</b> приложений через werf:
+                <ol>
+                    <li>
+                        деплой приложения из git-коммита в кластер Kubernetes
+                    </li>
+                    <li>
+                        публикация приложения из git-коммита в Container Registry в виде <b>бандла</b>, затем деплой этого бандла в Kubernetes.
+                    </li>
+                </ol>
+
+                Разные способы взаимодействия c werf:
+                <ul>
+                    <li>
+                        вручную;
+                    </li>
+                    <li>
+                        из CI/CD системы;
+                    </li>
+                    <li>
+                        в качестве оператора Kubernetes (фича доступна частично);
+                    </li>
+                    <li>
+                        через git push как в heroku (фича пока недоступна).
+                    </li>
+                </ul>
             </div>
         </div>
     </div>


### PR DESCRIPTION
 - Use Giterminism instead of GitOps in title.
 - Add usage workflows supported by the werf (converge and bundles).
 - Add note about the way werf used (manually, CI/CD, etc.).
