### PR TITLE
[dev] Fix incorrect behavior when project repository has a dirty submodule

### DIFF
--- a/pkg/true_git/dev_branch.go
+++ b/pkg/true_git/dev_branch.go
@@ -88,6 +88,7 @@ func syncWorktreeWithServiceWorktreeBranch(ctx context.Context, sourceWorkTreeDi
 		"diff",
 		"--full-index",
 		"--binary",
+		"--ignore-submodules=untracked",
 	}
 	if onlyStagedChanges {
 		gitDiffArgs = append(gitDiffArgs, "--cached")


### PR DESCRIPTION
```
Error: unable to sync staged changes: git command /usr/local/bin/git -C ~/.werf/local_cache/git_worktrees/9/local/9787063286a09974befa8dc3de81e63edb79c5304621035136d181f2ca792dd7/worktree -c core.autocrlf=false -c user.email=werf@werf.io -c user.name=werf commit -m 2021-06-03 20:00:52.409615 +0400 +04 m=+1.173176433 failed: exit status 1
On branch werf-dev-b90c24d97bcca2b4a69c4f78e85507fe925ab3f0
Nothing to commit, working tree clean
```