### PR TITLE
Fix werf automatical namespace creation RBAC issue

### DIFF
--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -437,7 +437,10 @@ func run(ctx context.Context, giterminismManager giterminism_manager.Interface) 
 	})
 
 	return command_helpers.LockReleaseWrapper(ctx, releaseName, lockManager, func() error {
-		return helmUpgradeCmd.RunE(helmUpgradeCmd, []string{releaseName, filepath.Join(giterminismManager.ProjectDir(), chartDir)})
+		if err := helmUpgradeCmd.RunE(helmUpgradeCmd, []string{releaseName, filepath.Join(giterminismManager.ProjectDir(), chartDir)}); err != nil {
+			return fmt.Errorf("helm upgrade have failed: %s", err)
+		}
+		return nil
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -100,4 +100,4 @@ replace k8s.io/helm => github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f
 
 replace github.com/deislabs/oras => github.com/werf/oras v0.8.2-0.20210128161614-26d583f169ea
 
-replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20210601124235-a8f8c178d9b8
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20210607121437-0a9ee16fc739

--- a/go.sum
+++ b/go.sum
@@ -1532,6 +1532,8 @@ github.com/werf/helm/v3 v3.0.0-20210601122918-0620d01a7321 h1:QxE+QxmDn64I8NXQRY
 github.com/werf/helm/v3 v3.0.0-20210601122918-0620d01a7321/go.mod h1:mIIus8EOqj+obtycw3sidsR4ORr2aFDmXMSI3k+oeVY=
 github.com/werf/helm/v3 v3.0.0-20210601124235-a8f8c178d9b8 h1:SeNG4hZ1Ec3vvnZr/qUGkwGIubpTJoHcCNe6dzu6oEs=
 github.com/werf/helm/v3 v3.0.0-20210601124235-a8f8c178d9b8/go.mod h1:mIIus8EOqj+obtycw3sidsR4ORr2aFDmXMSI3k+oeVY=
+github.com/werf/helm/v3 v3.0.0-20210607121437-0a9ee16fc739 h1:FnieKRzlwwxKd+lGRtuewlfGCxpTLNSjlXvc2cFE61U=
+github.com/werf/helm/v3 v3.0.0-20210607121437-0a9ee16fc739/go.mod h1:mIIus8EOqj+obtycw3sidsR4ORr2aFDmXMSI3k+oeVY=
 github.com/werf/kubedog v0.5.1-0.20210512165540-cb7b6159dc43 h1:YM/4dEowpI9yYJBg2R6l1/sYRWi2oJdvuUISn/CfsGg=
 github.com/werf/kubedog v0.5.1-0.20210512165540-cb7b6159dc43/go.mod h1:W5uoloTanbe7uyTfxTl5yljLJvpH2b2NB+MWr8X2lOM=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea h1:R5tJUhL5a3YfHTrHWyuAdJW3h//fmONrpHJjjAZ79e4=

--- a/pkg/kubeutils/configmap.go
+++ b/pkg/kubeutils/configmap.go
@@ -14,7 +14,16 @@ import (
 func CreateNamespaceIfNotExists(client kubernetes.Interface, namespace string) error {
 	if _, err := client.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{}); errors.IsNotFound(err) {
 		ns := &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Namespace",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+				Labels: map[string]string{
+					"name": namespace,
+				},
+			},
 		}
 
 		if _, err := client.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{}); errors.IsAlreadyExists(err) {


### PR DESCRIPTION
Werf internally uses `--create-namespace` flag of helm, which is broken.

Fixed in the werf/helm fork for now: https://github.com/werf/helm/pull/96.