### PR TITLE
Fix werf resources tracker exits before resources are ready

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1
 	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig/v3 v3.2.2
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053
 	github.com/aws/aws-sdk-go v1.35.20
@@ -64,7 +65,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tonistiigi/go-rosetta v0.0.0-20200727161949-f79598599c5d // indirect
-	github.com/werf/kubedog v0.5.1-0.20210512165540-cb7b6159dc43
+	github.com/werf/kubedog v0.5.1-0.20210609160536-255fd6e7fe3e
 	github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea
 	github.com/werf/logboek v0.5.4
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -1536,6 +1536,8 @@ github.com/werf/helm/v3 v3.0.0-20210607121437-0a9ee16fc739 h1:FnieKRzlwwxKd+lGRt
 github.com/werf/helm/v3 v3.0.0-20210607121437-0a9ee16fc739/go.mod h1:mIIus8EOqj+obtycw3sidsR4ORr2aFDmXMSI3k+oeVY=
 github.com/werf/kubedog v0.5.1-0.20210512165540-cb7b6159dc43 h1:YM/4dEowpI9yYJBg2R6l1/sYRWi2oJdvuUISn/CfsGg=
 github.com/werf/kubedog v0.5.1-0.20210512165540-cb7b6159dc43/go.mod h1:W5uoloTanbe7uyTfxTl5yljLJvpH2b2NB+MWr8X2lOM=
+github.com/werf/kubedog v0.5.1-0.20210609160536-255fd6e7fe3e h1:1nsdVCV3Gl0KuW4aOEQiGUZ0PoDc5ZfUYoqpWMwaETA=
+github.com/werf/kubedog v0.5.1-0.20210609160536-255fd6e7fe3e/go.mod h1:W5uoloTanbe7uyTfxTl5yljLJvpH2b2NB+MWr8X2lOM=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea h1:R5tJUhL5a3YfHTrHWyuAdJW3h//fmONrpHJjjAZ79e4=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea/go.mod h1:/CeY6KDiBSCU9PUmjt7zGhqpzp8FAPg/wNVfLZHQGWI=
 github.com/werf/logboek v0.5.1/go.mod h1:1RKvhO4ulmpD5sUN/9a2XsRjt+Xh8CxJjMbmya85YVA=

--- a/integration/suites/deploy/kubedog_multitrack_test.go
+++ b/integration/suites/deploy/kubedog_multitrack_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/werf/werf/integration/pkg/utils"
 	"github.com/werf/werf/integration/pkg/utils/liveexec"
 
+	"github.com/acarl005/stripansi"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -84,6 +86,7 @@ var _ = Describe("Kubedog multitrack — werf's kubernetes resources tracker", f
 
 			Expect(werfConverge(SuiteData.GetProjectWorktree(SuiteData.ProjectName), liveexec.ExecCommandOptions{
 				OutputLineHandler: func(line string) {
+					line = stripansi.Strip(line)
 					if statusProgressLine := releaseResourcesStatusProgressLine(line); statusProgressLine != "" {
 						if mydeploy1 := mydeploy1State(statusProgressLine); mydeploy1 != nil {
 							unknownDeploymentStateForbidden(mydeploy1)
@@ -120,7 +123,7 @@ var _ = Describe("Kubedog multitrack — werf's kubernetes resources tracker", f
 					if strings.Contains(line, `Allowed failures count for deploy/mydeploy1 exceeded 1 errors: stop tracking immediately!`) {
 						gotAllowedErrorsExceeded = true
 					}
-					if strings.Contains(line, "deploy/mydeploy1 ERROR:") && strings.HasSuffix(line, `ImagePullBackOff: Back-off pulling image "ubuntu:18.03"`) {
+					if strings.Contains(line, "deploy/mydeploy1 ERROR:") && strings.Contains(line, `ImagePullBackOff: Back-off pulling image "ubuntu:18.03"`) {
 						gotImagePullBackoffLine = true
 					}
 


### PR DESCRIPTION
Updated kubedog: https://github.com/werf/kubedog/pull/208.