### PR TITLE
[v1.1] Fix werf resources tracker exits before resources are ready

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tonistiigi/fsutil v0.0.0-20200724193237-c3ed55f3b481 // indirect
 	github.com/tonistiigi/go-rosetta v0.0.0-20200727161949-f79598599c5d // indirect
-	github.com/werf/kubedog v0.4.1-0.20210604070304-fde5b6c69f6a
+	github.com/werf/kubedog v0.4.1-0.20210609160549-c5ed5d787e86
 	github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea
 	github.com/werf/logboek v0.4.7
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -1531,6 +1531,8 @@ github.com/werf/kubedog v0.4.1-0.20210524142239-7a7653d33d7a h1:J/Y4XfsM8ZAv8S34
 github.com/werf/kubedog v0.4.1-0.20210524142239-7a7653d33d7a/go.mod h1:7SuLhuQddKnJri0LiMPoch94b6zAor7X3GvcufmgLqY=
 github.com/werf/kubedog v0.4.1-0.20210604070304-fde5b6c69f6a h1:S9uj3JDE0i/Ux+DSTX2pZOusJkbRDD3YVQhVuwpxRpk=
 github.com/werf/kubedog v0.4.1-0.20210604070304-fde5b6c69f6a/go.mod h1:7SuLhuQddKnJri0LiMPoch94b6zAor7X3GvcufmgLqY=
+github.com/werf/kubedog v0.4.1-0.20210609160549-c5ed5d787e86 h1:o+Xy3n9Kvme9wfalydgcRYv3Tjk/fIoLb5/BQOyhpd8=
+github.com/werf/kubedog v0.4.1-0.20210609160549-c5ed5d787e86/go.mod h1:7SuLhuQddKnJri0LiMPoch94b6zAor7X3GvcufmgLqY=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea h1:R5tJUhL5a3YfHTrHWyuAdJW3h//fmONrpHJjjAZ79e4=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea/go.mod h1:/CeY6KDiBSCU9PUmjt7zGhqpzp8FAPg/wNVfLZHQGWI=
 github.com/werf/logboek v0.4.3 h1:aXAVLlGT/ZiD8Srj+B71Tw20PtDyuYZSEJZjODNraeA=


### PR DESCRIPTION
Updated kubedog: https://github.com/werf/kubedog/pull/209.