### PR TITLE
[stapel, git] Update warn message when a stage dependency not found in git

### DIFF
--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -693,9 +693,10 @@ func (gm *GitMapping) StageDependenciesChecksum(ctx context.Context, c Conveyor,
 		}
 
 		if checksum == "" {
+			absDepPath := path.Join(gm.Add, p)
 			logboek.Context(ctx).Warn().LogF(
-				"WARNING: stage %s dependency path %s has not been found in %s git\n",
-				stageName, p, gm.GitRepo().GetName(),
+				"WARNING: stage %s dependency path %q has not been found in %s git\n",
+				stageName, absDepPath, gm.GitRepo().GetName(),
 			)
 		} else {
 			hash.Write([]byte(checksum))


### PR DESCRIPTION
Replace the relative dependency path with the absolute one in git repo.
Previously, the message used a relative path (stageDependencies value) and the warning was less informative.

```
WARNING: stage install dependency path <STAGE_DEPENDENCY_PATH> has not been found in own git
```

=>

```
WARNING: stage install dependency path "<ADD_PATH/STAGE_DEPENDENCY_PATH>" has not been found in own git
```