### PR TITLE
Fix .Release.IsInstall for a release which has not been installed successfully yet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,4 @@ replace k8s.io/helm => github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f
 
 replace github.com/deislabs/oras => github.com/werf/oras v0.8.2-0.20210128161614-26d583f169ea
 
-replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20210607121437-0a9ee16fc739
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 0925a8b88c6706b9ece8835635ccb18bbe7678af


### PR DESCRIPTION
`.Release.IsInstall` will be true until we successfully installed release..

https://github.com/werf/helm/pull/97