### PR TITLE
[helm] Remove usage of ghodss yaml, use sigs.k8s.io/yaml instead

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	k8s.io/kubectl v0.21.0
 	mvdan.cc/xurls v1.1.0
 	rsc.io/letsencrypt v0.0.3 // indirect
-	sigs.k8s.io/yaml v1.2.0
+	sigs.k8s.io/yaml v1.2.1-0.20210128145534-11e43d4a8b92
 	vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2297,6 +2297,8 @@ sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
+sigs.k8s.io/yaml v1.2.1-0.20210128145534-11e43d4a8b92 h1:+1N7jh6zMJeFMCYKdF265qwz9fPFEPii8YXqcLZ77sU=
+sigs.k8s.io/yaml v1.2.1-0.20210128145534-11e43d4a8b92/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 sourcegraph.com/sqs/pbtypes v1.0.0/go.mod h1:3AciMUv4qUuRHRHhOG4TZOB+72GdPVz5k+c648qsFS4=

--- a/pkg/deploy/helm/chart_extender/helpers/service_values.go
+++ b/pkg/deploy/helm/chart_extender/helpers/service_values.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/werf/logboek"
 	"github.com/werf/werf/pkg/image"

--- a/pkg/deploy/helm/extra_annotations_and_labels_post_renderer.go
+++ b/pkg/deploy/helm/extra_annotations_and_labels_post_renderer.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/werf/logboek"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -86,6 +86,10 @@ func (pr *ExtraAnnotationsAndLabelsPostRenderer) Run(renderedManifests *bytes.Bu
 		if obj.GetKind() == "" {
 			logboek.Debug().LogF("Skipping empty object\n")
 			continue
+		}
+
+		if os.Getenv("WERF_HELM_V3_EXTRA_ANNOTATIONS_AND_LABELS_DEBUG") == "1" {
+			fmt.Printf("Unpacket obj annotations: %#v\n", obj.GetAnnotations())
 		}
 
 		if len(extraAnnotations) > 0 {

--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -3,7 +3,7 @@ package util
 import (
 	"fmt"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 func DumpYaml(v interface{}) string {


### PR DESCRIPTION
Only for helm-related part, do not change legacy ansible pkg which uses ghodss.