### PR TITLE
fix(cleanup): host cleanup removes base images pulled by full name (REPO:TAG@DIGEST)

### DIFF
--- a/pkg/host_cleaning/local_docker_server.go
+++ b/pkg/host_cleaning/local_docker_server.go
@@ -425,13 +425,12 @@ func (a ImagesLruSort) Less(i, j int) bool {
 func (a ImagesLruSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 
 func safeDanglingImagesCleanup(ctx context.Context, options CommonOptions) error {
-	images, err := werfImagesByFilterSet(ctx, danglingFilterSet())
+	images, err := trueDanglingImages(ctx)
 	if err != nil {
 		return err
 	}
 
 	var imagesToRemove []types.ImageSummary
-
 	for _, img := range images {
 		imagesToRemove = append(imagesToRemove, img)
 	}


### PR DESCRIPTION
Remove images that do not have any tags and digests instead of dangling.

**Details**

Images pulled by full name `REPO:TAG@DIGEST` do not have tags and are considered dangling.