### PR TITLE
ci: trdl releaser workflow

### DIFF
--- a/.github/workflows/trdl_releaser.yml
+++ b/.github/workflows/trdl_releaser.yml
@@ -1,0 +1,24 @@
+name: Trdl releaser
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  release:
+    name: Perform werf release using trdl server
+    runs-on: ubuntu-latest
+    steps:
+    - name: Prepare git info
+      id: git_info
+      run: |
+        echo ::set-output name=GIT_TAG::${GITHUB_REF#refs/tags/}
+    - name: Release
+      uses: werf/trdl-vault-actions/release@main
+      with:
+        vault-addr: ${{ secrets.TRDL_VAULT_ADDR }}
+        project-name: werf
+        git-tag: ${{ steps.git_info.outputs.GIT_TAG }}
+        vault-auth-method: approle
+        vault-role-id: ${{ secrets.TRDL_VAULT_ROLE_ID }}
+        vault-secret-id: ${{ secrets.TRDL_VAULT_SECRET_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 
 /docs/\.jekyll-cache/
 /docs/backend/root/
+
+/.github/trdl/node_modules
+/.github/trdl/src/**/*.js
+/.github/trdl/lib

--- a/trdl.yaml
+++ b/trdl.yaml
@@ -1,4 +1,4 @@
-docker_image: golang:1.16.4@sha256:f7a5c5872d4bb68e152be72e4a4bf9a142a47ec2dcbb4074798d4feb6197abd7
+docker_image: ghcr.io/werf/builder:latest@sha256:4eecfcd8e04e256d43c4197efced22a0216412b8f435fbea8de6088a3cd233c0
 commands: 
  - scripts/build_release_v2.sh {{ .Tag }}
  - cp -a release-build/{{ .Tag }}/* /result


### PR DESCRIPTION
Use https://github.com/werf/trdl-actions library to release werf with trdl server.