### PR TITLE
chore: fix cleanup deletion error format

### DIFF
--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -712,12 +712,14 @@ func handleDeletionError(err error) error {
 	switch {
 	case docker_registry.IsDockerHubUnauthorizedErr(err):
 		return fmt.Errorf(`%s
+
 You should specify Docker Hub token or username and password to remove tags with Docker Hub API.
 Check --repo-docker-hub-token, --repo-docker-hub-username and --repo-docker-hub-password options.
 Be aware that access to the resource is forbidden with personal access token.
 Read more details here https://werf.io/documentation/v1.2/advanced/supported_container_registries.html#docker-hub`, err)
 	case docker_registry.IsGitHubPackagesUnauthorizedErr(err), docker_registry.IsGitHubPackagesForbiddenErr(err):
 		return fmt.Errorf(`%s
+
 You should specify a token with delete:packages and read:packages scopes to remove package versions.
 Check --repo-github-token option.
 Be aware that the token provided to GitHub Actions workflow is not enough to remove package versions.

--- a/pkg/docker_registry/docker_hub.go
+++ b/pkg/docker_registry/docker_hub.go
@@ -2,6 +2,7 @@ package docker_registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -25,7 +26,7 @@ type (
 
 func NewDockerHubUnauthorizedErr(err error) DockerHubUnauthorizedErr {
 	return DockerHubUnauthorizedErr{
-		error: fmt.Errorf(dockerHubUnauthorizedErrPrefix + err.Error()),
+		error: errors.New(dockerHubUnauthorizedErrPrefix + err.Error()),
 	}
 }
 
@@ -35,7 +36,7 @@ func IsDockerHubUnauthorizedErr(err error) bool {
 
 func NewDockerHubRepositoryNotFoundErr(err error) DockerHubRepositoryNotFoundErr {
 	return DockerHubRepositoryNotFoundErr{
-		error: fmt.Errorf(dockerHubRepositoryNotFoundErrPrefix + err.Error()),
+		error: errors.New(dockerHubRepositoryNotFoundErrPrefix + err.Error()),
 	}
 }
 

--- a/pkg/docker_registry/github_packages.go
+++ b/pkg/docker_registry/github_packages.go
@@ -2,6 +2,7 @@ package docker_registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -29,7 +30,7 @@ type (
 
 func NewGitHubPackagesUnauthorizedErr(err error) GitHubPackagesUnauthorizedErr {
 	return GitHubPackagesUnauthorizedErr{
-		error: fmt.Errorf(gitHubPackagesUnauthorizedErrPrefix + err.Error()),
+		error: errors.New(gitHubPackagesUnauthorizedErrPrefix + err.Error()),
 	}
 }
 
@@ -39,7 +40,7 @@ func IsGitHubPackagesUnauthorizedErr(err error) bool {
 
 func NewGitHubPackagesForbiddenErr(err error) GitHubPackagesForbiddenErr {
 	return GitHubPackagesForbiddenErr{
-		error: fmt.Errorf(gitHubPackagesForbiddenErrPrefix + err.Error()),
+		error: errors.New(gitHubPackagesForbiddenErrPrefix + err.Error()),
 	}
 }
 

--- a/pkg/docker_registry/harbor.go
+++ b/pkg/docker_registry/harbor.go
@@ -2,7 +2,7 @@ package docker_registry
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -22,7 +22,7 @@ type HarborRepositoryNotFoundErr apiError
 
 func NewHarborRepositoryNotFoundErr(err error) HarborRepositoryNotFoundErr {
 	return HarborRepositoryNotFoundErr{
-		error: fmt.Errorf(harborRepositoryNotFoundErrPrefix + err.Error()),
+		error: errors.New(harborRepositoryNotFoundErrPrefix + err.Error()),
 	}
 }
 

--- a/pkg/docker_registry/quay.go
+++ b/pkg/docker_registry/quay.go
@@ -2,6 +2,7 @@ package docker_registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"path"
@@ -19,7 +20,7 @@ type QuayRepositoryNotFoundErr apiError
 
 func NewQuayRepositoryNotFoundErr(err error) QuayRepositoryNotFoundErr {
 	return QuayRepositoryNotFoundErr{
-		error: fmt.Errorf(quayRepositoryNotFoundErrPrefix + err.Error()),
+		error: errors.New(quayRepositoryNotFoundErrPrefix + err.Error()),
 	}
 }
 


### PR DESCRIPTION
```
Error: unable to remove repo image meta-798e6f97_3892ca702554b834870c7f00f3da90d6087ee823_29f5d2380bb079154881174870da00972fb1050e79179638533ffd41-1628241422196: gitHub packages forbidden: GET https://api.github.com/orgs/ORG/packages/container/actions-test%!F(MISSING)test/versions?page=REDACTED&per_page=REDACTED: unexpected status code 403 Forbidden (body: {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-an-organization"})
You should specify a token with delete:packages and read:packages scopes to remove package versions.
Check --repo-github-token option.
Be aware that the token provided to GitHub Actions workflow is not enough to remove package versions.
Read more details here https://werf.io/documentation/v1.2/advanced/supported_container_registries.html#github-packages
```

=>

```
Error: unable to remove repo image meta-798e6f97_3892ca702554b834870c7f00f3da90d6087ee823_29f5d2380bb079154881174870da00972fb1050e79179638533ffd41-1628241422196: gitHub packages forbidden: GET https://api.github.com/orgs/ORG/packages/container/actions-test%2Ftest/versions?page=REDACTED&per_page=REDACTED: unexpected status code 403 Forbidden (body: {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-an-organization"})

You should specify a token with delete:packages and read:packages scopes to remove package versions.
Check --repo-github-token option.
Be aware that the token provided to GitHub Actions workflow is not enough to remove package versions.
Read more details here https://werf.io/documentation/v1.2/advanced/supported_container_registries.html#github-packages
```