### PR TITLE
infra: update ghcr.io/werf/builder image building scripts and use latest builder in the trdl.yaml

### DIFF
--- a/scripts/lib/release/build.sh
+++ b/scripts/lib/release/build.sh
@@ -5,7 +5,11 @@ go_mod_download() {
     VERSION=$1
 
     for os in linux darwin windows ; do
-        for arch in amd64 ; do
+        for arch in amd64 arm64 ; do
+            if [ "$os" == "windows" ] && [ "$arch" == "arm64" ] ; then
+                continue
+            fi
+
             echo "# Downloading go modules for GOOS=$os GOARCH=$arch"
 
             n=0

--- a/scripts/werf-builder/Dockerfile
+++ b/scripts/werf-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine
+FROM golang:1.17-alpine
 
 RUN apk add gcc bash libc-dev git
 
@@ -10,4 +10,4 @@ ADD scripts/lib /werf/scripts/lib
 
 WORKDIR /werf
 
-RUN bash -ec "echo '142.93.108.123 gonum.org www.gonum.org' >> /etc/hosts && source scripts/lib/release/global_data.sh && source scripts/lib/release/build.sh && go_mod_download"
+RUN bash -ec "source scripts/lib/release/global_data.sh && source scripts/lib/release/build.sh && go_mod_download && go_build_v2"

--- a/scripts/werf-builder/build.sh
+++ b/scripts/werf-builder/build.sh
@@ -2,12 +2,5 @@
 
 set -e
 
-if [ -z "$1" ] ; then
-	echo "Provide new werf-builder version: $0 VERSION!" 1>&2
-	exit 1
-fi
-NEW_VERSION=$1
-
-IMAGE_NAME=flant/werf-builder:$NEW_VERSION
-
+IMAGE_NAME=ghcr.io/werf/builder:latest
 docker build -f scripts/werf-builder/Dockerfile -t $IMAGE_NAME .

--- a/scripts/werf-builder/publish.sh
+++ b/scripts/werf-builder/publish.sh
@@ -2,12 +2,5 @@
 
 set -e
 
-if [ -z "$1" ] ; then
-	echo "Provide new werf-builder version: $0 VERSION!" 1>&2
-	exit 1
-fi
-NEW_VERSION=$1
-
-IMAGE_NAME=flant/werf-builder:$NEW_VERSION
-
+IMAGE_NAME=ghcr.io/werf/builder:latest
 docker push $IMAGE_NAME

--- a/trdl.yaml
+++ b/trdl.yaml
@@ -1,4 +1,4 @@
-docker_image: ghcr.io/werf/builder:latest@sha256:4eecfcd8e04e256d43c4197efced22a0216412b8f435fbea8de6088a3cd233c0
+docker_image: ghcr.io/werf/builder:latest@sha256:caefd9cd0b23a0a3ff8bdc45c1ef3c2492223c712c6ed86fd42f3096eeae1945
 commands: 
  - scripts/build_release_v2.sh {{ .Tag }}
  - cp -a release-build/{{ .Tag }}/* /result


### PR DESCRIPTION
Use golang 1.17 and alpine based image.