### PR TITLE
fix(deploy): fix auto downloading of external chart deps, support local deps

### DIFF
--- a/pkg/deploy/helm/chart_extender/bundle.go
+++ b/pkg/deploy/helm/chart_extender/bundle.go
@@ -127,7 +127,13 @@ func (bundle *Bundle) LoadDir(dir string) (bool, []*chart.ChartExtenderBufferedF
 		return true, nil, err
 	}
 
-	res, err := LoadChartDependencies(bundle.ChartExtenderContext, convertBufferedFilesForChartExtender(files), bundle.HelmEnvSettings, bundle.RegistryClientHandle, bundle.BuildChartDependenciesOpts)
+	res, err := LoadChartDependencies(bundle.ChartExtenderContext, func(ctx context.Context, dir string) ([]*chart.ChartExtenderBufferedFile, error) {
+		files, err := loader.GetFilesFromLocalFilesystem(dir)
+		if err != nil {
+			return nil, err
+		}
+		return convertBufferedFilesForChartExtender(files), nil
+	}, dir, convertBufferedFilesForChartExtender(files), bundle.HelmEnvSettings, bundle.RegistryClientHandle, bundle.BuildChartDependenciesOpts)
 	return true, res, err
 }
 

--- a/pkg/deploy/helm/chart_extender/werf_chart.go
+++ b/pkg/deploy/helm/chart_extender/werf_chart.go
@@ -201,15 +201,16 @@ func (wc *WerfChart) SetupTemplateFuncs(t *template.Template, funcMap template.F
 
 // LoadDir method for the chart.Extender interface
 func (wc *WerfChart) LoadDir(dir string) (bool, []*chart.ChartExtenderBufferedFile, error) {
-	files, err := wc.GiterminismManager.FileReader().LoadChartDir(wc.ChartExtenderContext, dir)
+	chartFiles, err := wc.GiterminismManager.FileReader().LoadChartDir(wc.ChartExtenderContext, dir)
 	if err != nil {
 		return true, nil, fmt.Errorf("giterministic files loader failed: %s", err)
 	}
 
-	res, err := LoadChartDependencies(wc.ChartExtenderContext, files, wc.HelmEnvSettings, wc.RegistryClientHandle, wc.BuildChartDependenciesOpts)
+	res, err := LoadChartDependencies(wc.ChartExtenderContext, wc.GiterminismManager.FileReader().LoadChartDir, dir, chartFiles, wc.HelmEnvSettings, wc.RegistryClientHandle, wc.BuildChartDependenciesOpts)
 	if err != nil {
 		return true, res, fmt.Errorf("chart dependencies loader failed: %s", err)
 	}
+
 	return true, res, err
 }
 

--- a/pkg/deploy/helm/command_helpers/build_chart_dependencies.go
+++ b/pkg/deploy/helm/command_helpers/build_chart_dependencies.go
@@ -24,14 +24,14 @@ type BuildChartDependenciesOptions struct {
 	LoadOptions *loader.LoadOptions
 }
 
-func BuildChartDependenciesInDir(ctx context.Context, chartFile *chart.ChartExtenderBufferedFile, chartLockFile *chart.ChartExtenderBufferedFile, requirementsFile *chart.ChartExtenderBufferedFile, requirementsLockFile *chart.ChartExtenderBufferedFile, targetDir string, helmEnvSettings *cli.EnvSettings, registryClientHandle *helm_v3.RegistryClientHandle, opts BuildChartDependenciesOptions) error {
+func BuildChartDependenciesInDir(ctx context.Context, chartFile, chartLockFile *chart.ChartExtenderBufferedFile, targetDir string, helmEnvSettings *cli.EnvSettings, registryClientHandle *helm_v3.RegistryClientHandle, opts BuildChartDependenciesOptions) error {
 	logboek.Context(ctx).Debug().LogF("-- BuildChartDependenciesInDir\n")
 
 	if err := os.MkdirAll(targetDir, os.ModePerm); err != nil {
 		return fmt.Errorf("error creating dir %q: %s", targetDir, err)
 	}
 
-	files := []*chart.ChartExtenderBufferedFile{chartFile, chartLockFile, requirementsFile, requirementsLockFile}
+	files := []*chart.ChartExtenderBufferedFile{chartFile, chartLockFile}
 
 	for _, file := range files {
 		if file == nil {


### PR DESCRIPTION
 - Add support for local subcharts specified in the Chart.yaml dependencies.
 - Only external subcharts will be automatically downloaded into the ~/.werf/local_cache (using helm dependency build procedure).