### PR TITLE
feat: add exports-values for dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,4 +99,4 @@ replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+inc
 
 replace k8s.io/helm => github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f
 
-replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20210722125525-31cea4c4a97d
+replace helm.sh/helm/v3 => github.com/werf/helm/v3 v3.0.0-20210826102128-2e1fa7ca762d

--- a/go.sum
+++ b/go.sum
@@ -1626,6 +1626,8 @@ github.com/werf/helm/v3 v3.0.0-20210625074159-a5d77a6118d1 h1:2oy4bBgcXKdS4TJynq
 github.com/werf/helm/v3 v3.0.0-20210625074159-a5d77a6118d1/go.mod h1:mIIus8EOqj+obtycw3sidsR4ORr2aFDmXMSI3k+oeVY=
 github.com/werf/helm/v3 v3.0.0-20210722125525-31cea4c4a97d h1:s/Cu6bYv2mhlf5Ty+4PAh/zRG7SXk2fAFpkllAxiFiU=
 github.com/werf/helm/v3 v3.0.0-20210722125525-31cea4c4a97d/go.mod h1:mIIus8EOqj+obtycw3sidsR4ORr2aFDmXMSI3k+oeVY=
+github.com/werf/helm/v3 v3.0.0-20210826102128-2e1fa7ca762d h1:cXAyM2JN9gZJw8eAA8XM42AWKskltr37BuYjXA7VWC4=
+github.com/werf/helm/v3 v3.0.0-20210826102128-2e1fa7ca762d/go.mod h1:mIIus8EOqj+obtycw3sidsR4ORr2aFDmXMSI3k+oeVY=
 github.com/werf/kubedog v0.5.1-0.20210512165540-cb7b6159dc43 h1:YM/4dEowpI9yYJBg2R6l1/sYRWi2oJdvuUISn/CfsGg=
 github.com/werf/kubedog v0.5.1-0.20210512165540-cb7b6159dc43/go.mod h1:W5uoloTanbe7uyTfxTl5yljLJvpH2b2NB+MWr8X2lOM=
 github.com/werf/kubedog v0.5.1-0.20210609160536-255fd6e7fe3e h1:1nsdVCV3Gl0KuW4aOEQiGUZ0PoDc5ZfUYoqpWMwaETA=


### PR DESCRIPTION
Adds export-values directive for Chart.yaml dependencies to pass values from parent chart to its
  child. Usage almost as in [import-values](https://helm.sh/docs/topics/charts/#importing-child-values-via-dependencies) directive:
```yaml
.helm/requirements.yaml
------------------------------------------------------
dependencies:
- name: subchart
  version: 1.0.0
  export-values:
  - parent: werf
    child: werf
```
This will pass werf service values `$.Values.werf` from the main chart to the subchart. Service values will become available in the subchart on the same path: `$.Values.werf`.

closes #3411, #3661, #3667