### PR TITLE
fix: ambiguous error when trying to export not in a registry

### DIFF
--- a/docs/documentation/_includes/reference/cli/werf_export.md
+++ b/docs/documentation/_includes/reference/cli/werf_export.md
@@ -18,7 +18,7 @@ werf export [IMAGE_NAME...] [options]
 
 ```shell
   # Export images to Docker Hub and GitHub Container Registry
-  $ werf export --tag=company/project:%image%-latest --tag=ghcr.io/company/project/%image%:latest
+  $ werf export --tag=index.docker.io/company/project:%image%-latest --tag=ghcr.io/company/project/%image%:latest
 ```
 
 {{ header }} Options


### PR DESCRIPTION
Error:
```
$ werf export --tag "test:%image%"
Error: phase export after image test stages handler failed: denied: requested access to the resource is denied

$ werf export --repo=REPO --tag=test
Error: phase export after image test stages handler failed: HEAD https://index.docker.io/v2/library/test/blobs/sha256:e25d89020eacd5ff45c65dd9f69da5f1c1ed9381c157707dde395d529e9f47cb: unexpected status code 401 Unauthorized (HEAD responses have no body, use GET for details)
```

Changes:
- Made mandatory use of Docker Hub address when exporting.
- Add detailed error:
  ```
  Error: invalid tag template "test:%image%":
  - the command exports images to the registry (cannot export them locally)
  - the user must explicitly provide the address "index.docker.io" when using Docker Hub as a registry
  ```