### PR TITLE
fix(dev): commit hooks are executed when creating service commits

### DIFF
--- a/pkg/true_git/service_branch.go
+++ b/pkg/true_git/service_branch.go
@@ -189,7 +189,7 @@ func checkNewChangesInServiceWorktreeIndex(ctx context.Context, serviceWorktreeD
 }
 
 func commitNewChangesInServiceBranch(ctx context.Context, serviceWorktreeDir string, branchName string) (string, error) {
-	gitArgs := []string{"-c", "user.email=werf@werf.io", "-c", "user.name=werf", "commit", "-m", time.Now().String()}
+	gitArgs := []string{"-c", "user.email=werf@werf.io", "-c", "user.name=werf", "commit", "--no-verify", "-m", time.Now().String()}
 	if _, err := runGitCmd(ctx, gitArgs, serviceWorktreeDir, runGitCmdOptions{}); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Add --no-verify option creating service commit to skip the pre-commit and commit-msg hooks.