### PR TITLE
fix(git_repo): unable to get a configuration file from a submodule

### DIFF
--- a/pkg/true_git/ls_tree/result.go
+++ b/pkg/true_git/ls_tree/result.go
@@ -40,7 +40,7 @@ func (r *Result) setParentRecursively() {
 	}
 }
 
-func NewSubmoduleResult(submodulePath, submoduleName string, result *Result) *SubmoduleResult {
+func NewSubmoduleResult(submoduleName, submodulePath string, result *Result) *SubmoduleResult {
 	return &SubmoduleResult{
 		submoduleName: submoduleName,
 		submodulePath: submodulePath,


### PR DESCRIPTION
Parameter order in the function was mixed up.

Possible error when using a submodule with a name that is not equal to the path:
```
Error: unable to read dockerfile "<submodule_name>/Dockerfile": unable to get tree entry <submodule_name>/Dockerfile
```