### PR TITLE
Fixing kubernetes synchronization short notation bug

### DIFF
--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -105,6 +105,10 @@ Published into container registry bundle can be rolled out by the "werf bundle" 
 
 	common.SetupSynchronization(&commonCmdData, cmd)
 
+	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeConfigBase64(&commonCmdData, cmd)
+	common.SetupKubeContext(&commonCmdData, cmd)
+
 	common.SetupAddAnnotations(&commonCmdData, cmd)
 	common.SetupAddLabels(&commonCmdData, cmd)
 

--- a/pkg/storage/synchronization.go
+++ b/pkg/storage/synchronization.go
@@ -10,10 +10,11 @@ var (
 )
 
 type KubernetesSynchronizationParams struct {
-	ConfigDataBase64 string
-	ConfigPath       string
-	ConfigContext    string
-	Namespace        string
+	ConfigContext       string
+	ConfigPath          string
+	ConfigDataBase64    string
+	ConfigPathMergeList *[]string
+	Namespace           string
 }
 
 func ParseKubernetesSynchronization(address string) (*KubernetesSynchronizationParams, error) {


### PR DESCRIPTION
Hello.
On latest version, when `WERF_SYNCHRONIZATION` is specified in short fomat(like `kubernetes://default`) i get error, if i'm using custom kubeconfig path(defined over `KUBECONFIG` env var).