### PR TITLE
infra: use gox parallel release build tool, update base builder image

### DIFF
--- a/scripts/build_release_v3.sh
+++ b/scripts/build_release_v3.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+VERSION=$1
+if [ -z "$VERSION" ] ; then
+    echo "Required version argument!" 1>&2
+    echo 1>&2
+    echo "Usage: $0 VERSION" 1>&2
+    exit 1
+fi
+
+gox -osarch="linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64" \
+    -output="release-build/$VERSION/{{.OS}}-{{.Arch}}/werf" \
+    -tags "dfrunmount dfssh" \
+    -ldflags="-s -w -X github.com/werf/werf/pkg/werf.Version=$VERSION" \
+        github.com/werf/werf/cmd/werf

--- a/scripts/werf-builder/Dockerfile
+++ b/scripts/werf-builder/Dockerfile
@@ -1,13 +1,12 @@
 FROM golang:1.17-alpine
 
 RUN apk add gcc bash libc-dev git
+RUN go install github.com/mitchellh/gox@8c3b2b9e647dc52457d6ee7b5adcf97e2bafe131
 
-ADD cmd /werf/cmd
-ADD pkg /werf/pkg
-ADD go.mod /werf/go.mod
-ADD go.sum /werf/go.sum
-ADD scripts/lib /werf/scripts/lib
+ADD cmd /.werf-deps/cmd
+ADD pkg /.werf-deps/pkg
+ADD go.mod /.werf-deps/go.mod
+ADD go.sum /.werf-deps/go.sum
+ADD scripts /.werf-deps/scripts
 
-WORKDIR /werf
-
-RUN bash -ec "source scripts/lib/release/global_data.sh && source scripts/lib/release/build.sh && go_mod_download && go_build_v2"
+RUN bash -ec "cd /.werf-deps && ./scripts/build_release_v3.sh base && rm -rf /.werf-deps"

--- a/scripts/werf-builder/build.sh
+++ b/scripts/werf-builder/build.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-IMAGE_NAME=ghcr.io/werf/builder:latest
+IMAGE_NAME=ghcr.io/werf/builder:"$(git rev-parse HEAD)"
 docker build -f scripts/werf-builder/Dockerfile -t $IMAGE_NAME .

--- a/scripts/werf-builder/publish.sh
+++ b/scripts/werf-builder/publish.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-IMAGE_NAME=ghcr.io/werf/builder:latest
+IMAGE_NAME=ghcr.io/werf/builder:"$(git rev-parse HEAD)"
 docker push $IMAGE_NAME

--- a/trdl.yaml
+++ b/trdl.yaml
@@ -1,4 +1,4 @@
-docker_image: ghcr.io/werf/builder:latest@sha256:caefd9cd0b23a0a3ff8bdc45c1ef3c2492223c712c6ed86fd42f3096eeae1945
+docker_image: ghcr.io/werf/builder:d07b2b81c4899e552a51dbce89e5e253bca8e967@sha256:5a19a2ddd416c4310099f3f9818abcc54cd552aa88e0823a5d1bda8b3583060e
 commands: 
- - scripts/build_release_v2.sh {{ .Tag }}
+ - scripts/build_release_v3.sh {{ .Tag }}
  - cp -a release-build/{{ .Tag }}/* /result


### PR DESCRIPTION
 - New script scripts/build_release_v3.sh uses gox build tool to create release binaries.
 - Tag werf-builder images by the commit in the scripts/werf-builder/{build|publish}.sh scripts.
 - Update trdl.yaml to use new build tool and new base image.