### PR TITLE
fix: broken release building script, fix site installation instructions

### DIFF
--- a/docs/site/.werf/artifacts/channels_versions.json
+++ b/docs/site/.werf/artifacts/channels_versions.json
@@ -1,12 +1,12 @@
 {
   "versions": {
-    "alpha-1.1": "v1.1.23+fix21",
-    "beta-1.1": "v1.1.23+fix21",
-    "ea-1.1": "v1.1.23+fix21",
-    "stable-1.1": "v1.1.23+fix6",
-    "rock-solid-1.1": "v1.1.22+fix37",
-    "alpha-1.2": "v1.2.9+fix9",
-    "beta-1.2": "v1.2.9+fix9",
-    "ea-1.2": "v1.2.8+fix13"
+    "alpha-1.1": "v1.1.23+fix50",
+    "beta-1.1": "v1.1.23+fix50",
+    "ea-1.1": "v1.1.23+fix50",
+    "stable-1.1": "v1.1.23+fix50",
+    "rock-solid-1.1": "v1.1.23+fix50",
+    "alpha-1.2": "v1.2.18",
+    "beta-1.2": "v1.2.17+fix1",
+    "ea-1.2": "v1.2.17+fix1"
   }
 }

--- a/docs/site/_includes/installation/binary_linux.md
+++ b/docs/site/_includes/installation/binary_linux.md
@@ -1,4 +1,4 @@
 ```shell
-curl -LO https://tuf.werf.dev/targets/releases/{{ include.version }}/linux-{{ include.arch }}/bin/werf
+curl -LO https://tuf.werf.io/targets/releases/{{ include.version }}/linux-{{ include.arch }}/bin/werf
 sudo install ./werf /usr/local/bin/werf
 ```

--- a/docs/site/_includes/installation/binary_macos.md
+++ b/docs/site/_includes/installation/binary_macos.md
@@ -1,4 +1,4 @@
 ```shell
-curl -LO https://tuf.werf.dev/targets/releases/{{ include.version }}/darwin-{{ include.arch }}/bin/werf
+curl -LO https://tuf.werf.io/targets/releases/{{ include.version }}/darwin-{{ include.arch }}/bin/werf
 sudo install ./werf /usr/local/bin/werf
 ```

--- a/docs/site/_includes/installation/binary_windows.md
+++ b/docs/site/_includes/installation/binary_windows.md
@@ -2,7 +2,7 @@
 $WERF_BIN_PATH = "C:\ProgramData\werf\bin"
 mkdir $WERF_BIN_PATH
 
-Invoke-WebRequest -Uri https://tuf.werf.dev/targets/releases/{{ include.version }}/windows-{{ include.arch }}/bin/werf.exe -OutFile $WERF_BIN_PATH\werf.exe
+Invoke-WebRequest -Uri https://tuf.werf.io/targets/releases/{{ include.version }}/windows-{{ include.arch }}/bin/werf.exe -OutFile $WERF_BIN_PATH\werf.exe
 
 [Environment]::SetEnvironmentVariable(
     "Path",

--- a/docs/site/pages_en/installation.md
+++ b/docs/site/pages_en/installation.md
@@ -179,7 +179,7 @@ The latest release can be found [at this page](https://github.com/werf/werf/rele
           {% for arch in page.arch %}
             <div class="installation-instruction__tab-content" data-install-content-group="arch" data-install-content="{{ arch }}">
   {% capture version_key %}{{ channel }}-{{ version }}{% endcapture %}
-  {% assign download_version = site.data.channels_versions.versions[version_key] %}
+  {% assign download_version = site.data.channels_versions.versions[version_key] | replace_first: "v", "" %}
 <div markdown="1">
 {% include installation/binary_linux.md version=download_version arch=arch %}
 </div>
@@ -199,7 +199,7 @@ The latest release can be found [at this page](https://github.com/werf/werf/rele
           {% for arch in page.arch %}
             <div class="installation-instruction__tab-content" data-install-content-group="arch" data-install-content="{{ arch }}">
   {% capture version_key %}{{ channel }}-{{ version }}{% endcapture %}
-  {% assign download_version = site.data.channels_versions.versions[version_key] %}
+  {% assign download_version = site.data.channels_versions.versions[version_key] | replace_first: "v", "" %}
 <div markdown="1">
 {% include installation/binary_macos.md version=download_version arch=arch %}
 </div>
@@ -219,7 +219,7 @@ The latest release can be found [at this page](https://github.com/werf/werf/rele
           {% for arch in page.arch %}
             <div class="installation-instruction__tab-content" data-install-content-group="arch" data-install-content="{{ arch }}">
   {% capture version_key %}{{ channel }}-{{ version }}{% endcapture %}
-  {% assign download_version = site.data.channels_versions.versions[version_key] %}
+  {% assign download_version = site.data.channels_versions.versions[version_key] | replace_first: "v", "" %}
 <div markdown="1">
 {% include installation/binary_windows.md version=download_version arch=arch %}
 </div>

--- a/docs/site/pages_ru/installation.md
+++ b/docs/site/pages_ru/installation.md
@@ -179,7 +179,7 @@ arch:
           {% for arch in page.arch %}
             <div class="installation-instruction__tab-content" data-install-content-group="arch" data-install-content="{{ arch }}">
   {% capture version_key %}{{ channel }}-{{ version }}{% endcapture %}
-  {% assign download_version = site.data.channels_versions.versions[version_key] %}
+  {% assign download_version = site.data.channels_versions.versions[version_key] | replace_first: "v", "" %}
 <div markdown="1">
 {% include installation/binary_linux.md version=download_version arch=arch %}
 </div>
@@ -199,7 +199,7 @@ arch:
           {% for arch in page.arch %}
             <div class="installation-instruction__tab-content" data-install-content-group="arch" data-install-content="{{ arch }}">
   {% capture version_key %}{{ channel }}-{{ version }}{% endcapture %}
-  {% assign download_version = site.data.channels_versions.versions[version_key] %}
+  {% assign download_version = site.data.channels_versions.versions[version_key] | replace_first: "v", "" %}
 <div markdown="1">
 {% include installation/binary_macos.md version=download_version arch=arch %}
 </div>
@@ -219,7 +219,7 @@ arch:
           {% for arch in page.arch %}
             <div class="installation-instruction__tab-content" data-install-content-group="arch" data-install-content="{{ arch }}">
   {% capture version_key %}{{ channel }}-{{ version }}{% endcapture %}
-  {% assign download_version = site.data.channels_versions.versions[version_key] %}
+  {% assign download_version = site.data.channels_versions.versions[version_key] | replace_first: "v", "" %}
 <div markdown="1">
 {% include installation/binary_windows.md version=download_version arch=arch %}
 </div>

--- a/scripts/build_release_v3.sh
+++ b/scripts/build_release_v3.sh
@@ -11,7 +11,7 @@ if [ -z "$VERSION" ] ; then
 fi
 
 gox -osarch="linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64" \
-    -output="release-build/$VERSION/{{.OS}}-{{.Arch}}/werf" \
+    -output="release-build/$VERSION/{{.OS}}-{{.Arch}}/bin/werf" \
     -tags "dfrunmount dfssh" \
     -ldflags="-s -w -X github.com/werf/werf/pkg/werf.Version=$VERSION" \
         github.com/werf/werf/cmd/werf


### PR DESCRIPTION
- fix binary download urls: tuf.werf.dev -> tuf.werf.io and remove 'v' letter;
- store release binaries in the bin dir for trdl.
