### PR TITLE
fix: separate --insecure-helm-dependencies flag

### DIFF
--- a/cmd/werf/build/main.go
+++ b/cmd/werf/build/main.go
@@ -90,6 +90,7 @@ If one or more IMAGE_NAME parameters specified, werf will build only these image
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified repo, to pull base images")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupIntrospectAfterError(&commonCmdData, cmd)

--- a/cmd/werf/bundle/apply/apply.go
+++ b/cmd/werf/bundle/apply/apply.go
@@ -70,14 +70,12 @@ func NewCmd() *cobra.Command {
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
 
-	common.SetupInsecureRegistry(&commonCmdData, cmd)
-	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
-
 	common.SetupStagesStorageOptions(&commonCmdData, cmd) // FIXME
 	common.SetupFinalStagesStorageOptions(&commonCmdData, cmd)
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified repo, to pull base images")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/bundle/download/download.go
+++ b/cmd/werf/bundle/download/download.go
@@ -56,6 +56,7 @@ func NewCmd() *cobra.Command {
 	common.SetupHomeDir(&commonCmdData, cmd)
 
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupStagesStorageOptions(&commonCmdData, cmd) // FIXME

--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -87,6 +87,7 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified repo and to pull base images")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -98,6 +98,7 @@ Published into container registry bundle can be rolled out by the "werf bundle" 
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified repo and to pull base images")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -72,6 +72,7 @@ It is safe to run this command periodically (daily is enough) by automated clean
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and delete images from the specified repo")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupScanContextNamespaceOnly(&commonCmdData, cmd)

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -82,6 +82,7 @@ type CmdData struct {
 	DockerConfig                    *string
 	InsecureRegistry                *bool
 	SkipTlsVerifyRegistry           *bool
+	InsecureHelmDependencies        *bool
 	DryRun                          *bool
 	KeepStagesBuiltWithinLastNHours *uint64
 	WithoutKube                     *bool
@@ -513,6 +514,11 @@ func hooksStatusProgressPeriodDefaultValue() *int64 {
 	} else {
 		return v
 	}
+}
+
+func SetupInsecureHelmDependencies(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.InsecureHelmDependencies = new(bool)
+	cmd.Flags().BoolVarP(cmdData.InsecureHelmDependencies, "insecure-helm-dependencies", "", GetBoolEnvironmentDefaultFalse("WERF_INSECURE_HELM_DEPENDENCIES"), "Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)")
 }
 
 func SetupInsecureRegistry(cmdData *CmdData, cmd *cobra.Command) {

--- a/cmd/werf/common/helm.go
+++ b/cmd/werf/common/helm.go
@@ -14,7 +14,7 @@ import (
 )
 
 func NewHelmRegistryClientHandle(ctx context.Context, commonCmdData *CmdData) (*helm_v3.RegistryClientHandle, error) {
-	if registryClient, err := helm_v3.NewRegistryClient(logboek.Context(ctx).Debug().IsAccepted(), *commonCmdData.InsecureRegistry, logboek.Context(ctx).OutStream()); err != nil {
+	if registryClient, err := helm_v3.NewRegistryClient(logboek.Context(ctx).Debug().IsAccepted(), *commonCmdData.InsecureHelmDependencies, logboek.Context(ctx).OutStream()); err != nil {
 		return nil, err
 	} else {
 		return helm_v3.NewRegistryClientHandle(registryClient), nil

--- a/cmd/werf/compose/main.go
+++ b/cmd/werf/compose/main.go
@@ -224,6 +224,7 @@ services:
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read and pull images from the specified repo")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -112,6 +112,7 @@ werf converge --repo registry.mydomain.com/web --env production`,
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified repo, to pull base images")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/export/export.go
+++ b/cmd/werf/export/export.go
@@ -86,6 +86,7 @@ All meta-information related to werf is removed from the exported images, and th
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read and pull images from the specified repo")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/helm/helm.go
+++ b/cmd/werf/helm/helm.go
@@ -69,7 +69,7 @@ func NewCmd() *cobra.Command {
 	cmd_werf_common.SetupHooksStatusProgressPeriod(&_commonCmdData, cmd)
 	cmd_werf_common.SetupReleasesHistoryMax(&_commonCmdData, cmd)
 	cmd_werf_common.SetupLogOptions(&_commonCmdData, cmd)
-	cmd_werf_common.SetupInsecureRegistry(&_commonCmdData, cmd)
+	cmd_werf_common.SetupInsecureHelmDependencies(&_commonCmdData, cmd)
 
 	cmd.AddCommand(
 		cmd_helm.NewUninstallCmd(actionConfig, os.Stdout, cmd_helm.UninstallCmdOptions{}),

--- a/cmd/werf/managed_images/add/add.go
+++ b/cmd/werf/managed_images/add/add.go
@@ -59,6 +59,7 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read and write images to the specified repo")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/managed_images/ls/ls.go
+++ b/cmd/werf/managed_images/ls/ls.go
@@ -56,6 +56,7 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read images from the specified repo")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/managed_images/rm/rm.go
+++ b/cmd/werf/managed_images/rm/rm.go
@@ -60,6 +60,7 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read and write images to the specified repo")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -63,6 +63,7 @@ WARNING: Images that are being used in the Kubernetes cluster will also be delet
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to delete images from the specified repo")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -91,6 +91,7 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified repo and to pull base images")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptionsDefaultQuiet(&commonCmdData, cmd)

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -135,6 +135,7 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read and pull images from the specified repo")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -69,6 +69,7 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read and pull images from the specified stages storage")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogProjectDir(&commonCmdData, cmd)

--- a/docs/documentation/_includes/reference/cli/werf_build.md
+++ b/docs/documentation/_includes/reference/cli/werf_build.md
@@ -132,6 +132,9 @@ werf build [IMAGE_NAME...] [options]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --introspect-before-error=false

--- a/docs/documentation/_includes/reference/cli/werf_bundle_apply.md
+++ b/docs/documentation/_includes/reference/cli/werf_bundle_apply.md
@@ -61,6 +61,9 @@ werf bundle apply [options]
       --hooks-status-progress-period=5
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_bundle_download.md
+++ b/docs/documentation/_includes/reference/cli/werf_bundle_download.md
@@ -43,6 +43,9 @@ werf bundle download [options]
             quay.io token for  (default $WERF_FINAL_REPO_QUAY_TOKEN)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --log-color-mode='auto'

--- a/docs/documentation/_includes/reference/cli/werf_bundle_export.md
+++ b/docs/documentation/_includes/reference/cli/werf_bundle_export.md
@@ -116,6 +116,9 @@ werf bundle export [options]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --introspect-before-error=false

--- a/docs/documentation/_includes/reference/cli/werf_bundle_publish.md
+++ b/docs/documentation/_includes/reference/cli/werf_bundle_publish.md
@@ -116,6 +116,9 @@ werf bundle publish [options]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --introspect-before-error=false

--- a/docs/documentation/_includes/reference/cli/werf_cleanup.md
+++ b/docs/documentation/_includes/reference/cli/werf_cleanup.md
@@ -114,6 +114,9 @@ werf cleanup [options]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --keep-stages-built-within-last-n-hours=2

--- a/docs/documentation/_includes/reference/cli/werf_compose_config.md
+++ b/docs/documentation/_includes/reference/cli/werf_compose_config.md
@@ -157,6 +157,9 @@ werf compose config [IMAGE_NAME...] [options] [--docker-compose-options="OPTIONS
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_compose_down.md
+++ b/docs/documentation/_includes/reference/cli/werf_compose_down.md
@@ -150,6 +150,9 @@ werf compose down [IMAGE_NAME...] [options] [--docker-compose-options="OPTIONS"]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_compose_run.md
+++ b/docs/documentation/_includes/reference/cli/werf_compose_run.md
@@ -147,6 +147,9 @@ werf compose run [IMAGE_NAME...] [options] [--docker-compose-options="OPTIONS"] 
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_compose_up.md
+++ b/docs/documentation/_includes/reference/cli/werf_compose_up.md
@@ -158,6 +158,9 @@ werf compose up [IMAGE_NAME...] [options] [--docker-compose-options="OPTIONS"] [
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_converge.md
+++ b/docs/documentation/_includes/reference/cli/werf_converge.md
@@ -155,6 +155,9 @@ werf converge --repo registry.mydomain.com/web --env production
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --ignore-secret-key=false
             Disable secrets decryption (default $WERF_IGNORE_SECRET_KEY)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --introspect-before-error=false

--- a/docs/documentation/_includes/reference/cli/werf_export.md
+++ b/docs/documentation/_includes/reference/cli/werf_export.md
@@ -86,6 +86,9 @@ werf export [IMAGE_NAME...] [options]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_helm.md
+++ b/docs/documentation/_includes/reference/cli/werf_helm.md
@@ -13,8 +13,9 @@ Manage application deployment with helm
       --hooks-status-progress-period=5
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
-      --insecure-registry=false
-            Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --kube-config=''
             Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)

--- a/docs/documentation/_includes/reference/cli/werf_managed_images_add.md
+++ b/docs/documentation/_includes/reference/cli/werf_managed_images_add.md
@@ -74,6 +74,9 @@ werf managed-images add [options]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_managed_images_ls.md
+++ b/docs/documentation/_includes/reference/cli/werf_managed_images_ls.md
@@ -74,6 +74,9 @@ werf managed-images ls [options]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_managed_images_rm.md
+++ b/docs/documentation/_includes/reference/cli/werf_managed_images_rm.md
@@ -74,6 +74,9 @@ werf managed-images rm [options]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_purge.md
+++ b/docs/documentation/_includes/reference/cli/werf_purge.md
@@ -103,6 +103,9 @@ werf purge [options]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_render.md
+++ b/docs/documentation/_includes/reference/cli/werf_render.md
@@ -103,6 +103,9 @@ werf render [options]
             Disable secrets decryption (default $WERF_IGNORE_SECRET_KEY)
       --include-crds=true
             Include CRDs in the templated output (default $WERF_INCLUDE_CRDS)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --introspect-before-error=false

--- a/docs/documentation/_includes/reference/cli/werf_run.md
+++ b/docs/documentation/_includes/reference/cli/werf_run.md
@@ -102,6 +102,9 @@ werf run [options] [IMAGE_NAME] [-- COMMAND ARG...]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''


### PR DESCRIPTION
 - Do not allow insecure helm dependencies registries to be used when --insecure-registry has been specified.
 - Use dedicated --insecure-helm-dependencies flag for such purpose.