### PR TITLE
tests: fix invalid memory address or nil pointer dereference

### DIFF
--- a/integration/pkg/suite_init/container_registry_per_implementation_data.go
+++ b/integration/pkg/suite_init/container_registry_per_implementation_data.go
@@ -60,6 +60,7 @@ func (data *ContainerRegistryPerImplementationData) TeardownRepo(ctx context.Con
 		err := registry.DeleteRepo(ctx, repo)
 
 		switch {
+		case err == nil:
 		case docker_registry.IsAzureCrRepositoryNotFoundErr(err),
 			docker_registry.IsDockerHubRepositoryNotFoundErr(err),
 			docker_registry.IsHarborRepositoryNotFoundErr(err),


### PR DESCRIPTION
```
/home/ubuntu/actions-runner/_work/_tool/go/1.14.15/x64/src/runtime/panic.go:212

Full Stack Trace
github.com/werf/werf/pkg/docker_registry.IsAzureCrRepositoryNotFoundErr(0x0, 0x0, 0xc000128010)
	/home/ubuntu/actions-runner/_work/werf/werf/pkg/docker_registry/azure_cr.go:30 +0x2c
```