### PR TITLE
fix: panic in dismiss command, helm regsitry client initialization failure

### DIFF
--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -113,6 +113,10 @@ Read more info about Helm Release name, Kubernetes Namespace and how to change i
 	common.SetupAllowedLocalCacheVolumeUsageMargin(&commonCmdData, cmd)
 	common.SetupDockerServerStoragePath(&commonCmdData, cmd)
 
+	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupInsecureHelmDependencies(&commonCmdData, cmd)
+	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
+
 	common.SetupPlatform(&commonCmdData, cmd)
 
 	cmd.Flags().BoolVarP(&cmdData.WithNamespace, "with-namespace", "", common.GetBoolEnvironmentDefaultFalse("WERF_WITH_NAMESPACE"), "Delete Kubernetes Namespace after purging Helm Release (default $WERF_WITH_NAMESPACE)")

--- a/cmd/werf/helm/migrate2to3.go
+++ b/cmd/werf/helm/migrate2to3.go
@@ -87,6 +87,8 @@ func NewMigrate2To3Cmd() *cobra.Command {
 	common.SetupKubeConfigBase64(&migrate2To3CommonCmdData, cmd)
 	common.SetupKubeContext(&migrate2To3CommonCmdData, cmd)
 
+	common.SetupInsecureHelmDependencies(&migrate2To3CommonCmdData, cmd)
+
 	common.SetupLogOptions(&migrate2To3CommonCmdData, cmd)
 
 	cmd.Flags().StringVarP(&migrate2ToCmdData.Release, "release", "", os.Getenv("WERF_RELEASE"), "Existing helm 2 release name which should be migrated to helm 3 (default $WERF_RELEASE). Option also sets target name for a new helm 3 release, use --target-release option (or $WERF_TARGET_RELEASE) to specify a different helm 3 release name.")

--- a/docs/documentation/_includes/reference/cli/werf_dismiss.md
+++ b/docs/documentation/_includes/reference/cli/werf_dismiss.md
@@ -122,6 +122,9 @@ werf dismiss [options]
       --hooks-status-progress-period=5
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''

--- a/docs/documentation/_includes/reference/cli/werf_helm_migrate2to3.md
+++ b/docs/documentation/_includes/reference/cli/werf_helm_migrate2to3.md
@@ -23,6 +23,9 @@ werf helm migrate2to3 [options]
             $WERF_HELM2_RELEASE_STORAGE_TYPE, or $WERF_HELM_RELEASE_STORAGE_TYPE, or "configmap")
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-helm-dependencies=false
+            Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
+            configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)
       --release=''
             Existing helm 2 release name which should be migrated to helm 3 (default                
             $WERF_RELEASE). Option also sets target name for a new helm 3 release, use              

--- a/docs/documentation/_includes/reference/cli/werf_helm_show_all.md
+++ b/docs/documentation/_includes/reference/cli/werf_helm_show_all.md
@@ -5,7 +5,7 @@
 {% endif %}
 
 This command inspects a chart (directory, file, or URL) and displays all its content
-(values.yaml, Chart.yaml, README)
+(values.yaml, Charts.yaml, README)
 
 
 {{ header }} Syntax

--- a/docs/documentation/_includes/reference/cli/werf_helm_show_chart.md
+++ b/docs/documentation/_includes/reference/cli/werf_helm_show_chart.md
@@ -5,7 +5,7 @@
 {% endif %}
 
 This command inspects a chart (directory, file, or URL) and displays the contents
-of the Chart.yaml file
+of the Charts.yaml file
 
 
 {{ header }} Syntax


### PR DESCRIPTION
Added missing --insecure-helm-dependencies flag into werf-dismiss command.