### PR TITLE
feat(buildah): refactor container-runtime interface and fix usage of runtime

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -697,7 +697,7 @@ func (phase *BuildPhase) atomicBuildStageImage(ctx context.Context, img *Image, 
 			phase.Conveyor.SetStageImage(stageImageObj)
 
 			if err := logboek.Context(ctx).Default().LogProcess("Store stage into %s", phase.Conveyor.StorageManager.GetStagesStorage().String()).DoError(func() error {
-				if err := phase.Conveyor.StorageManager.GetStagesStorage().StoreImage(ctx, &container_runtime.DockerImage{Image: stageImage}); err != nil {
+				if err := phase.Conveyor.StorageManager.GetStagesStorage().StoreImage(ctx, stageImage); err != nil {
 					return fmt.Errorf("unable to store stage %s digest %s image %s into repo %s: %s", stg.LogDetailedName(), stg.GetDigest(), stageImage.Name(), phase.Conveyor.StorageManager.GetStagesStorage().String(), err)
 				}
 				if desc, err := phase.Conveyor.StorageManager.GetStagesStorage().GetStageDescription(ctx, phase.Conveyor.projectName(), stg.GetDigest(), uniqueID); err != nil {

--- a/pkg/build/image.go
+++ b/pkg/build/image.go
@@ -169,7 +169,7 @@ func (i *Image) FetchBaseImage(ctx context.Context, c *Conveyor) error {
 				options.Style(style.Highlight())
 			}).
 			DoError(func() error {
-				return c.ContainerRuntime.PullImageFromRegistry(ctx, &container_runtime.DockerImage{Image: i.baseImage})
+				return c.ContainerRuntime.PullImageFromRegistry(ctx, i.baseImage)
 			}); err != nil {
 			return err
 		}
@@ -186,7 +186,7 @@ func (i *Image) FetchBaseImage(ctx context.Context, c *Conveyor) error {
 		}
 	case StageAsBaseImage:
 		// TODO: check no bug introduced
-		//if err := c.ContainerRuntime.RefreshImageObject(ctx, &container_runtime.DockerImage{Image: i.baseImage}); err != nil {
+		//if err := c.ContainerRuntime.RefreshImageObject(ctx, &container_runtime.Image{Image: i.baseImage}); err != nil {
 		//	return err
 		//}
 		if err := c.StorageManager.FetchStage(ctx, c.ContainerRuntime, i.stageAsBaseImage); err != nil {

--- a/pkg/container_runtime/buildah_runtime.go
+++ b/pkg/container_runtime/buildah_runtime.go
@@ -9,19 +9,19 @@ type BuildahImage struct {
 	Image LegacyImageInterface
 }
 
-func (runtime *BuildahRuntime) RefreshImageObject(ctx context.Context, img Image) error {
+func (runtime *BuildahRuntime) RefreshImageObject(ctx context.Context, img LegacyImageInterface) error {
 	panic("not implemented")
 }
 
-func (runtime *BuildahRuntime) PullImageFromRegistry(ctx context.Context, img Image) error {
+func (runtime *BuildahRuntime) PullImageFromRegistry(ctx context.Context, img LegacyImageInterface) error {
 	panic("not implemented")
 }
 
-func (runtime *BuildahRuntime) RenameImage(ctx context.Context, img Image, newImageName string, removeOldName bool) error {
+func (runtime *BuildahRuntime) RenameImage(ctx context.Context, img LegacyImageInterface, newImageName string, removeOldName bool) error {
 	panic("not implemented")
 }
 
-func (runtime *BuildahRuntime) RemoveImage(ctx context.Context, img Image) error {
+func (runtime *BuildahRuntime) RemoveImage(ctx context.Context, img LegacyImageInterface) error {
 	panic("not implemented")
 }
 

--- a/pkg/container_runtime/interface.go
+++ b/pkg/container_runtime/interface.go
@@ -3,6 +3,8 @@ package container_runtime
 import (
 	"context"
 	"io"
+
+	"github.com/werf/werf/pkg/image"
 )
 
 type BuildDockerfileOptions struct {
@@ -28,24 +30,23 @@ type BuildDockerfileOptions struct {
 type ContainerRuntime interface {
 	//GetImageInspect(ctx context.Context, ref string) (image.Info, error)
 	//Pull(ctx context.Context, ref string) error
-	//Tag(ctx, ref, newRef string)
 	//Rmi(ctx, ref string)
-	//Push(ctx, ref string)
 
+	Tag(ctx context.Context, ref, newRef string) error
+	Push(ctx context.Context, ref string) error
+
+	GetImageInfo(ctx context.Context, ref string) (*image.Info, error)
 	BuildDockerfile(ctx context.Context, dockerfile []byte, opts BuildDockerfileOptions) (string, error)
 	//StapelBuild(opts StapelBuildOptions) string
 
 	String() string
 
 	// Legacy
-	RefreshImageObject(ctx context.Context, img Image) error
-	PullImageFromRegistry(ctx context.Context, img Image) error
-	RenameImage(ctx context.Context, img Image, newImageName string, removeOldName bool) error
-	RemoveImage(ctx context.Context, img Image) error
+	RefreshImageObject(ctx context.Context, img LegacyImageInterface) error
+	PullImageFromRegistry(ctx context.Context, img LegacyImageInterface) error
+	RenameImage(ctx context.Context, img LegacyImageInterface, newImageName string, removeOldName bool) error
+	RemoveImage(ctx context.Context, img LegacyImageInterface) error
 }
-
-// Legacy image handle
-type Image interface{}
 
 /*
  * Stapel + docker server

--- a/pkg/container_runtime/legacy_base_image.go
+++ b/pkg/container_runtime/legacy_base_image.go
@@ -4,23 +4,21 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/api/types"
-
 	"github.com/werf/werf/pkg/image"
 )
 
 type legacyBaseImage struct {
 	name      string
-	inspect   *types.ImageInspect
+	info      *image.Info
 	stageDesc *image.StageDescription
 
-	DockerServerRuntime *DockerServerRuntime
+	ContainerRuntime ContainerRuntime
 }
 
-func newLegacyBaseImage(name string, dockerServerRuntime *DockerServerRuntime) *legacyBaseImage {
+func newLegacyBaseImage(name string, containerRuntime ContainerRuntime) *legacyBaseImage {
 	img := &legacyBaseImage{}
 	img.name = name
-	img.DockerServerRuntime = dockerServerRuntime
+	img.ContainerRuntime = containerRuntime
 	return img
 }
 
@@ -32,29 +30,29 @@ func (i *legacyBaseImage) SetName(name string) {
 	i.name = name
 }
 
-func (i *legacyBaseImage) MustResetInspect(ctx context.Context) error {
-	if inspect, err := i.DockerServerRuntime.GetImageInspect(ctx, i.Name()); err != nil {
-		return fmt.Errorf("unable to get inspect for image %s: %s", i.Name(), err)
+func (i *legacyBaseImage) MustResetInfo(ctx context.Context) error {
+	if info, err := i.ContainerRuntime.GetImageInfo(ctx, i.Name()); err != nil {
+		return fmt.Errorf("unable to get info for image %s: %s", i.Name(), err)
 	} else {
-		i.SetInspect(inspect)
+		i.SetInfo(info)
 	}
 
-	if i.inspect == nil {
-		panic(fmt.Sprintf("runtime error: inspect must be (%s)", i.name))
+	if i.info == nil {
+		panic(fmt.Sprintf("runtime error: info must be set for image %q", i.name))
 	}
 	return nil
 }
 
-func (i *legacyBaseImage) GetInspect() *types.ImageInspect {
-	return i.inspect
+func (i *legacyBaseImage) GetInfo() *image.Info {
+	return i.info
 }
 
-func (i *legacyBaseImage) SetInspect(inspect *types.ImageInspect) {
-	i.inspect = inspect
+func (i *legacyBaseImage) SetInfo(info *image.Info) {
+	i.info = info
 }
 
-func (i *legacyBaseImage) UnsetInspect() {
-	i.inspect = nil
+func (i *legacyBaseImage) UnsetInfo() {
+	i.info = nil
 }
 
 func (i *legacyBaseImage) SetStageDescription(stageDesc *image.StageDescription) {
@@ -66,5 +64,5 @@ func (i *legacyBaseImage) GetStageDescription() *image.StageDescription {
 }
 
 func (i *legacyBaseImage) IsExistsLocally() bool {
-	return i.inspect != nil
+	return i.info != nil
 }

--- a/pkg/container_runtime/legacy_interface.go
+++ b/pkg/container_runtime/legacy_interface.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"github.com/werf/werf/pkg/image"
-
-	"github.com/docker/docker/api/types"
 )
 
 type LegacyBuildOptions struct {
@@ -32,7 +30,8 @@ type LegacyImageInterface interface {
 
 	Introspect(ctx context.Context) error
 
-	SetInspect(inspect *types.ImageInspect)
+	SetInfo(info *image.Info)
+
 	IsExistsLocally() bool
 
 	SetStageDescription(stage *image.StageDescription)

--- a/pkg/storage/docker_server_stages_storage.go
+++ b/pkg/storage/docker_server_stages_storage.go
@@ -151,15 +151,15 @@ func (storage *DockerServerStagesStorage) GetStagesIDsByDigest(ctx context.Conte
 	return convertToStagesList(images)
 }
 
-func (storage *DockerServerStagesStorage) ShouldFetchImage(_ context.Context, _ container_runtime.Image) (bool, error) {
+func (storage *DockerServerStagesStorage) ShouldFetchImage(_ context.Context, _ container_runtime.LegacyImageInterface) (bool, error) {
 	return false, nil
 }
 
-func (storage *DockerServerStagesStorage) FetchImage(_ context.Context, _ container_runtime.Image) error {
+func (storage *DockerServerStagesStorage) FetchImage(_ context.Context, _ container_runtime.LegacyImageInterface) error {
 	return nil
 }
 
-func (storage *DockerServerStagesStorage) StoreImage(ctx context.Context, img container_runtime.Image) error {
+func (storage *DockerServerStagesStorage) StoreImage(ctx context.Context, img container_runtime.LegacyImageInterface) error {
 	return storage.DockerServerRuntime.TagImageByName(ctx, img)
 }
 

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -38,10 +38,10 @@ type StagesStorage interface {
 	ConstructStageImageName(projectName, digest string, uniqueID int64) string
 
 	// FetchImage will create a local image in the container-runtime
-	FetchImage(ctx context.Context, img container_runtime.Image) error
+	FetchImage(ctx context.Context, img container_runtime.LegacyImageInterface) error
 	// StoreImage will store a local image into the container-runtime, local built image should exist prior running store
-	StoreImage(ctx context.Context, img container_runtime.Image) error
-	ShouldFetchImage(ctx context.Context, img container_runtime.Image) (bool, error)
+	StoreImage(ctx context.Context, img container_runtime.LegacyImageInterface) error
+	ShouldFetchImage(ctx context.Context, img container_runtime.LegacyImageInterface) (bool, error)
 
 	CreateRepo(ctx context.Context) error
 	DeleteRepo(ctx context.Context) error


### PR DESCRIPTION
1. Removed excess container_runtime.DockerImage and container_runtime.Image. Use LegacyImageInterface instead for legacy container-runtime operations.
2. Make build conveyor indepdenent of DockerServerRuntime implementation, use generic ContainerRuntime interface instead everywhere.
3. Renamed legacy GetImageInspect to GetImageInfo and refactored LegacyImageInterface and all other code to use this new method.
4. Added necessary Tag and Push operations into the ContainerRuntime interface.