### PR TITLE
feat(buildah): fix go-build, do not use gpgme, use opengpg golang impl. instead

### DIFF
--- a/go-build.sh
+++ b/go-build.sh
@@ -9,6 +9,6 @@ cd $SOURCE
 
 export GO111MODULE=on
 export CGO_ENABLED=0
-go install -tags "dfrunmount dfssh" github.com/werf/werf/cmd/werf
+go install -tags "dfrunmount dfssh containers_image_openpgp" github.com/werf/werf/cmd/werf
 
 cd $CWD

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/cloudflare/cfssl v1.4.1 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.8.0 // indirect
 	github.com/containers/buildah v1.23.0
+	github.com/containers/common v0.44.0 // indirect
 	github.com/containers/image/v5 v5.16.0
 	github.com/containers/storage v1.36.0
 	github.com/docker/cli v20.10.5+incompatible

--- a/pkg/buildah/docker_with_fuse_buildah.go
+++ b/pkg/buildah/docker_with_fuse_buildah.go
@@ -104,6 +104,10 @@ func (b *DockerWithFuseBuildah) Pull(ctx context.Context, ref string, opts PullO
 	return err
 }
 
+func (b *DockerWithFuseBuildah) Rmi(ctx context.Context, ref string) error {
+	panic("not implemented yet")
+}
+
 func (b *DockerWithFuseBuildah) runBuildah(ctx context.Context, dockerArgs []string, buildahArgs []string, logWriter io.Writer) (string, string, error) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}

--- a/pkg/buildah/native_rootless_buildah_linux.go
+++ b/pkg/buildah/native_rootless_buildah_linux.go
@@ -193,6 +193,10 @@ func (b *NativeRootlessBuildah) Pull(ctx context.Context, ref string, opts PullO
 	panic("not implemented yet")
 }
 
+func (b *NativeRootlessBuildah) Rmi(ctx context.Context, ref string) error {
+	panic("not implemented yet")
+}
+
 func (b *NativeRootlessBuildah) getImage(ref string) (*libimage.Image, error) {
 	image, _, err := b.Runtime.LookupImage(ref, &libimage.LookupImageOptions{
 		ManifestList: true,

--- a/pkg/container_runtime/buildah_runtime.go
+++ b/pkg/container_runtime/buildah_runtime.go
@@ -66,7 +66,7 @@ func (runtime *BuildahRuntime) Tag(ctx context.Context, ref, newRef string) erro
 }
 
 func (runtime *BuildahRuntime) Push(ctx context.Context, ref string) error {
-	return runtime.buildah.Push(ctx, ref)
+	return runtime.buildah.Push(ctx, ref, buildah.PushOpts{})
 }
 
 func (runtime *BuildahRuntime) BuildDockerfile(ctx context.Context, dockerfile []byte, opts BuildDockerfileOptions) (string, error) {

--- a/pkg/container_runtime/docker_server_runtime.go
+++ b/pkg/container_runtime/docker_server_runtime.go
@@ -171,6 +171,14 @@ func (runtime *DockerServerRuntime) Push(ctx context.Context, ref string) error 
 	panic("not implemented")
 }
 
+func (runtime *DockerServerRuntime) Pull(ctx context.Context, ref string) error {
+	panic("not implemented")
+}
+
+func (runtime *DockerServerRuntime) Rmi(ctx context.Context, ref string) error {
+	panic("not implemented")
+}
+
 func (runtime *DockerServerRuntime) PushImage(ctx context.Context, img LegacyImageInterface) error {
 	if err := logboek.Context(ctx).Info().LogProcess(fmt.Sprintf("Pushing %s", img.Name())).DoError(func() error {
 		return docker.CliPushWithRetries(ctx, img.Name())


### PR DESCRIPTION
```
containers_image_openpgp: Use a Golang-only OpenPGP implementation for signature verification instead of the default cgo/gpgme-based implementation; the primary downside is that creating new signatures with the Golang-only implementation is not supported.
```