### PR TITLE
feat(buildah): debug werf-build with buildah container runtime

### DIFF
--- a/cmd/werf/common/container_runtime.go
+++ b/cmd/werf/common/container_runtime.go
@@ -22,6 +22,9 @@ func InitProcessContainerRuntime(ctx context.Context, cmdData *CmdData) (bool, c
 		shouldTerminate, mode, err := buildah.InitProcess(func() (buildah.Mode, error) {
 			return mode, nil
 		})
+		if shouldTerminate {
+			return true, nil, ctx, nil
+		}
 
 		if mode == buildah.ModeDockerWithFuse {
 			newCtx, err := InitProcessDocker(ctx, cmdData)
@@ -38,7 +41,7 @@ func InitProcessContainerRuntime(ctx context.Context, cmdData *CmdData) (bool, c
 			return false, nil, ctx, fmt.Errorf("unable to get buildah client: %s", err)
 		}
 
-		return shouldTerminate, container_runtime.NewBuildahRuntime(buildah), ctx, nil
+		return false, container_runtime.NewBuildahRuntime(buildah), ctx, nil
 	}
 
 	newCtx, err := InitProcessDocker(ctx, cmdData)

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -637,7 +637,7 @@ func (c *Conveyor) GetOrCreateStageImage(fromImage *container_runtime.LegacyStag
 		return img
 	}
 
-	img := container_runtime.NewLegacyStageImage(fromImage, name, c.ContainerRuntime.(*container_runtime.DockerServerRuntime))
+	img := container_runtime.NewLegacyStageImage(fromImage, name, c.ContainerRuntime)
 	c.SetStageImage(img)
 	return img
 }

--- a/pkg/container_runtime/buildah_runtime.go
+++ b/pkg/container_runtime/buildah_runtime.go
@@ -36,6 +36,7 @@ func (runtime *BuildahRuntime) GetImageInfo(ctx context.Context, ref string) (*i
 		Labels:            inspect.Docker.Config.Labels,
 		CreatedAtUnixNano: inspect.Docker.Created.UnixNano(),
 		// RepoDigest:        repoDigest, // FIXME
+		OnBuild:  inspect.Docker.Config.OnBuild,
 		ID:       inspect.Docker.ID,
 		ParentID: inspect.Docker.Config.Image,
 		Size:     inspect.Docker.Size,

--- a/pkg/container_runtime/docker_server_runtime.go
+++ b/pkg/container_runtime/docker_server_runtime.go
@@ -84,15 +84,6 @@ func (runtime *DockerServerRuntime) GetImageInspect(ctx context.Context, ref str
 	return inspect, err
 }
 
-// PullImage only available for DockerServerRuntime
-func (runtime *DockerServerRuntime) PullImage(ctx context.Context, ref string) error {
-	if err := docker.CliPull(ctx, ref); err != nil {
-		return fmt.Errorf("unable to pull image %s: %s", ref, err)
-	}
-
-	return nil
-}
-
 func (runtime *DockerServerRuntime) RefreshImageObject(ctx context.Context, img LegacyImageInterface) error {
 	if info, err := runtime.GetImageInfo(ctx, img.Name()); err != nil {
 		return err
@@ -143,16 +134,9 @@ func (runtime *DockerServerRuntime) RenameImage(ctx context.Context, img LegacyI
 }
 
 func (runtime *DockerServerRuntime) RemoveImage(ctx context.Context, img LegacyImageInterface) error {
-	if err := logboek.Context(ctx).Info().LogProcess(fmt.Sprintf("Removing image tag %s", img.Name())).DoError(func() error {
-		if err := docker.CliRmi(ctx, img.Name()); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	return logboek.Context(ctx).Info().LogProcess(fmt.Sprintf("Removing image tag %s", img.Name())).DoError(func() error {
+		return runtime.Rmi(ctx, img.Name())
+	})
 }
 
 func (runtime *DockerServerRuntime) PullImageFromRegistry(ctx context.Context, img LegacyImageInterface) error {
@@ -178,11 +162,14 @@ func (runtime *DockerServerRuntime) Push(ctx context.Context, ref string) error 
 }
 
 func (runtime *DockerServerRuntime) Pull(ctx context.Context, ref string) error {
-	panic("not implemented")
+	if err := docker.CliPull(ctx, ref); err != nil {
+		return fmt.Errorf("unable to pull image %s: %s", ref, err)
+	}
+	return nil
 }
 
 func (runtime *DockerServerRuntime) Rmi(ctx context.Context, ref string) error {
-	panic("not implemented")
+	return docker.CliRmi(ctx, ref)
 }
 
 func (runtime *DockerServerRuntime) PushImage(ctx context.Context, img LegacyImageInterface) error {

--- a/pkg/container_runtime/legacy_stage_image.go
+++ b/pkg/container_runtime/legacy_stage_image.go
@@ -23,9 +23,9 @@ type LegacyStageImage struct {
 	dockerfileImageBuilder *DockerfileImageBuilder
 }
 
-func NewLegacyStageImage(fromImage *LegacyStageImage, name string, localDockerServerRuntime *DockerServerRuntime) *LegacyStageImage {
+func NewLegacyStageImage(fromImage *LegacyStageImage, name string, containerRuntime ContainerRuntime) *LegacyStageImage {
 	stage := &LegacyStageImage{}
-	stage.legacyBaseImage = newLegacyBaseImage(name, localDockerServerRuntime)
+	stage.legacyBaseImage = newLegacyBaseImage(name, containerRuntime)
 	stage.fromImage = fromImage
 	stage.container = newLegacyStageImageContainer(stage)
 	return stage
@@ -189,14 +189,20 @@ func (i *LegacyStageImage) GetBuiltId() string {
 }
 
 func (i *LegacyStageImage) TagBuiltImage(ctx context.Context) error {
+	_ = i.ContainerRuntime.(*DockerServerRuntime)
+
 	return docker.CliTag(ctx, i.MustGetBuiltId(), i.name)
 }
 
 func (i *LegacyStageImage) Tag(ctx context.Context, name string) error {
+	_ = i.ContainerRuntime.(*DockerServerRuntime)
+
 	return docker.CliTag(ctx, i.GetID(), name)
 }
 
 func (i *LegacyStageImage) Pull(ctx context.Context) error {
+	_ = i.ContainerRuntime.(*DockerServerRuntime)
+
 	if err := docker.CliPullWithRetries(ctx, i.name); err != nil {
 		return err
 	}
@@ -207,6 +213,8 @@ func (i *LegacyStageImage) Pull(ctx context.Context) error {
 }
 
 func (i *LegacyStageImage) Push(ctx context.Context) error {
+	_ = i.ContainerRuntime.(*DockerServerRuntime)
+
 	return docker.CliPushWithRetries(ctx, i.name)
 }
 

--- a/pkg/container_runtime/legacy_stage_image_container.go
+++ b/pkg/container_runtime/legacy_stage_image_container.go
@@ -261,6 +261,8 @@ func (c *LegacyStageImageContainer) prepareInheritedCommitOptions(ctx context.Co
 }
 
 func (c *LegacyStageImageContainer) run(ctx context.Context) error {
+	_ = c.image.ContainerRuntime.(*DockerServerRuntime)
+
 	runArgs, err := c.prepareRunArgs(ctx)
 	if err != nil {
 		return err
@@ -274,6 +276,8 @@ func (c *LegacyStageImageContainer) run(ctx context.Context) error {
 }
 
 func (c *LegacyStageImageContainer) introspect(ctx context.Context) error {
+	_ = c.image.ContainerRuntime.(*DockerServerRuntime)
+
 	runArgs, err := c.prepareIntrospectArgs(ctx)
 	if err != nil {
 		return err
@@ -289,6 +293,8 @@ func (c *LegacyStageImageContainer) introspect(ctx context.Context) error {
 }
 
 func (c *LegacyStageImageContainer) introspectBefore(ctx context.Context) error {
+	_ = c.image.ContainerRuntime.(*DockerServerRuntime)
+
 	runArgs, err := c.prepareIntrospectBeforeArgs(ctx)
 	if err != nil {
 		return err
@@ -315,6 +321,8 @@ func IsStartContainerErr(err error) bool {
 }
 
 func (c *LegacyStageImageContainer) commit(ctx context.Context) (string, error) {
+	_ = c.image.ContainerRuntime.(*DockerServerRuntime)
+
 	commitChanges, err := c.prepareCommitChanges(ctx)
 	if err != nil {
 		return "", err
@@ -330,5 +338,7 @@ func (c *LegacyStageImageContainer) commit(ctx context.Context) (string, error) 
 }
 
 func (c *LegacyStageImageContainer) rm(ctx context.Context) error {
+	_ = c.image.ContainerRuntime.(*DockerServerRuntime)
+
 	return docker.ContainerRemove(ctx, c.name, types.ContainerRemoveOptions{})
 }

--- a/pkg/image/info.go
+++ b/pkg/image/info.go
@@ -16,6 +16,7 @@ type Info struct {
 	Tag        string `json:"tag"`
 	RepoDigest string `json:"repoDigest"`
 
+	OnBuild           []string          `json:"onBuild"`
 	ID                string            `json:"ID"`
 	ParentID          string            `json:"parentID"`
 	Labels            map[string]string `json:"labels"`
@@ -49,6 +50,7 @@ func NewInfoFromInspect(ref string, inspect *types.ImageInspect) *Info {
 		Repository:        repository,
 		Tag:               tag,
 		Labels:            inspect.Config.Labels,
+		OnBuild:           inspect.Config.OnBuild,
 		CreatedAtUnixNano: MustParseTimestampString(inspect.Created).UnixNano(),
 		RepoDigest:        repoDigest,
 		ID:                inspect.ID,


### PR DESCRIPTION
* Guard all legacy image methods to work only when DockerServer runtime is used.
* Remove excess container-runtime convertions to DockerServer.