### PR TITLE
feat(buildah): fix git-archives tar creation procedure to include parent directories of added files

### DIFF
--- a/pkg/git_repo/gitdata/git_data_manager.go
+++ b/pkg/git_repo/gitdata/git_data_manager.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	GitArchivesCacheVersion = "6"
+	GitArchivesCacheVersion = "7"
 	GitPatchesCacheVersion  = "6"
 )
 


### PR DESCRIPTION
This change enables working images building in the werf-build command with docker-with-fuse buildah runtime.