### PR TITLE
fix(buildah): fix native-rootless buildah mode init procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 /.github/trdl/src/**/*.js
 /.github/trdl/lib
 main
+buildah-test

--- a/cmd/buildah-test/main.go
+++ b/cmd/buildah-test/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/werf/werf/pkg/docker"
+
 	"github.com/werf/werf/pkg/util"
 
 	"github.com/werf/werf/pkg/buildah"
@@ -33,6 +34,8 @@ func do(ctx context.Context) error {
 	if err := werf.Init("", ""); err != nil {
 		return fmt.Errorf("unable to init werf subsystem: %s", err)
 	}
+
+	fmt.Printf("Using buildah mode: %s\n", mode)
 
 	if mode == buildah.ModeDockerWithFuse {
 		if err := docker.Init(ctx, "", false, false, ""); err != nil {

--- a/pkg/buildah/buildah_test/Dockerfile.simple.1
+++ b/pkg/buildah/buildah_test/Dockerfile.simple.1
@@ -1,0 +1,3 @@
+FROM alpine
+RUN wget ya.ru
+COPY . /app

--- a/pkg/buildah/native_rootless_buildah_linux.go
+++ b/pkg/buildah/native_rootless_buildah_linux.go
@@ -19,8 +19,8 @@ import (
 	is "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/pkg/unshare"
-	"github.com/docker/docker/pkg/reexec"
 	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 	"github.com/werf/logboek"
@@ -38,8 +38,9 @@ func InitNativeRootlessProcess() (bool, error) {
 		return true, nil
 	}
 
-	logrus.SetLevel(logrus.TraceLevel)
-
+	if debug() {
+		logrus.SetLevel(logrus.TraceLevel)
+	}
 	unshare.MaybeReexecUsingUserNamespace(false)
 
 	return false, nil


### PR DESCRIPTION
Use containers/storage/pkg/reexec instead of docker/docker/pkg/reexec (typo).