### PR TITLE
fix(host-cleanup): "permission denied" errors, do not wipe git-patches on every run

### DIFF
--- a/pkg/git_repo/gitdata/gc.go
+++ b/pkg/git_repo/gitdata/gc.go
@@ -110,7 +110,7 @@ func RunGC(ctx context.Context, allowedVolumeUsagePercentage, allowedVolumeUsage
 
 	{
 		cacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_patches")
-		if err := wipeCacheDirs(ctx, cacheRoot, []string{GitArchivesCacheVersion}); err != nil {
+		if err := wipeCacheDirs(ctx, cacheRoot, []string{GitPatchesCacheVersion}); err != nil {
 			return fmt.Errorf("unable to wipe old git patches cache dirs in %q: %s", cacheRoot, err)
 		}
 	}
@@ -200,6 +200,8 @@ func RunGC(ctx context.Context, allowedVolumeUsagePercentage, allowedVolumeUsage
 	}
 
 	sort.Sort(GitDataLruSort(gitDataEntries))
+
+	gitDataEntries = PreserveGitDataByLru(gitDataEntries)
 
 	var freedBytes uint64
 	for _, entry := range gitDataEntries {

--- a/pkg/git_repo/gitdata/git_data_entry.go
+++ b/pkg/git_repo/gitdata/git_data_entry.go
@@ -15,3 +15,19 @@ func (a GitDataLruSort) Less(i, j int) bool {
 	return a[i].GetLastAccessAt().Before(a[j].GetLastAccessAt())
 }
 func (a GitDataLruSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+func PreserveGitDataByLru(entries []GitDataEntry) []GitDataEntry {
+	var res []GitDataEntry
+
+	for _, entry := range entries {
+		if !ShouldPreserveGitDataEntryByLru(entry) {
+			res = append(res, entry)
+		}
+	}
+
+	return res
+}
+
+func ShouldPreserveGitDataEntryByLru(entry GitDataEntry) bool {
+	return time.Since(entry.GetLastAccessAt()) < 3*time.Hour
+}


### PR DESCRIPTION
* Fix bug related to wiping of old git-patches by cache-version: fixed typo.
* Do not remove git data entries which has been used recently (wait for 3 hours).