### PR TITLE
fix(deploy): WERF_SET_DOCKER_CONFIG_VALUE not working

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -143,7 +143,7 @@ func GetLongCommandDescription(text string) string {
 
 func SetupSetDockerConfigJsonValue(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.SetDockerConfigJsonValue = new(bool)
-	cmd.Flags().BoolVarP(cmdData.SetDockerConfigJsonValue, "set-docker-config-json-value", "", GetBoolEnvironmentDefaultFalse(os.Getenv("WERF_SET_DOCKER_CONFIG_VALUE")), "Shortcut to set current docker config into the .Values.dockerconfigjson")
+	cmd.Flags().BoolVarP(cmdData.SetDockerConfigJsonValue, "set-docker-config-json-value", "", GetBoolEnvironmentDefaultFalse("WERF_SET_DOCKER_CONFIG_JSON_VALUE"), "Shortcut to set current docker config into the .Values.dockerconfigjson")
 }
 
 func SetupGitWorkTree(cmdData *CmdData, cmd *cobra.Command) {
@@ -1267,7 +1267,7 @@ func getAddCustomTag(cmdData *CmdData) []string {
 }
 
 func GetSet(cmdData *CmdData) []string {
-	return append(PredefinedValuesByEnvNamePrefix("WERF_SET_", "WERF_SET_STRING_", "WERF_SET_FILE_", "WERF_SET_DOCKER_CONFIG_VALUE"), *cmdData.Set...)
+	return append(PredefinedValuesByEnvNamePrefix("WERF_SET_", "WERF_SET_STRING_", "WERF_SET_FILE_", "WERF_SET_DOCKER_CONFIG_JSON_VALUE"), *cmdData.Set...)
 }
 
 func GetSetString(cmdData *CmdData) []string {


### PR DESCRIPTION
1. Rename WERF_SET_DOCKER_CONFIG_VALUE to WERF_SET_DOCKER_CONFIG_JSON_VALUE to match cli option `--set-docker-config-json-value`.
2. Fixed bug: WERF_SET_DOCKER_CONFIG_JSON_VALUE does not affect converge process.

Refs https://github.com/werf/actions/issues/40