### PR TITLE
feat(buildah): communication with insecure registries

### DIFF
--- a/cmd/werf/common/container_runtime.go
+++ b/cmd/werf/common/container_runtime.go
@@ -43,7 +43,12 @@ func InitProcessContainerRuntime(ctx context.Context, cmdData *CmdData) (contain
 			ctx = newCtx
 		}
 
-		b, err := buildah.NewBuildah(resolvedMode, buildah.BuildahOpts{})
+		insecure := *cmdData.InsecureRegistry || *cmdData.SkipTlsVerifyRegistry
+		b, err := buildah.NewBuildah(resolvedMode, buildah.BuildahOpts{
+			CommonBuildahOpts: buildah.CommonBuildahOpts{
+				Insecure: insecure,
+			},
+		})
 		if err != nil {
 			return nil, ctx, fmt.Errorf("unable to get buildah client: %s", err)
 		}

--- a/pkg/buildah/base.go
+++ b/pkg/buildah/base.go
@@ -11,12 +11,18 @@ import (
 )
 
 type BaseBuildah struct {
-	TmpDir string
+	TmpDir   string
+	Insecure bool
 }
 
-func NewBaseBuildah(tmpDir string) (*BaseBuildah, error) {
+type BaseBuildahOpts struct {
+	Insecure bool
+}
+
+func NewBaseBuildah(tmpDir string, opts BaseBuildahOpts) (*BaseBuildah, error) {
 	b := &BaseBuildah{
-		TmpDir: tmpDir,
+		TmpDir:   tmpDir,
+		Insecure: opts.Insecure,
 	}
 
 	if err := os.MkdirAll(b.TmpDir, os.ModePerm); err != nil {

--- a/pkg/buildah/buildah.go
+++ b/pkg/buildah/buildah.go
@@ -84,7 +84,8 @@ func ProcessStartupHook(mode Mode) (bool, error) {
 }
 
 type CommonBuildahOpts struct {
-	TmpDir string
+	TmpDir   string
+	Insecure bool
 }
 
 type NativeRootlessModeOpts struct{}

--- a/pkg/buildah/native_rootless_buildah_linux.go
+++ b/pkg/buildah/native_rootless_buildah_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 	is "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/transports/alltransports"
+	imgtypes "github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/pkg/unshare"
@@ -57,7 +58,7 @@ type NativeRootlessBuildah struct {
 func NewNativeRootlessBuildah(commonOpts CommonBuildahOpts, opts NativeRootlessModeOpts) (*NativeRootlessBuildah, error) {
 	b := &NativeRootlessBuildah{}
 
-	baseBuildah, err := NewBaseBuildah(commonOpts.TmpDir)
+	baseBuildah, err := NewBaseBuildah(commonOpts.TmpDir, BaseBuildahOpts{Insecure: commonOpts.Insecure})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create BaseBuildah: %s", err)
 	}
@@ -117,6 +118,11 @@ func (b *NativeRootlessBuildah) Push(ctx context.Context, ref string, opts PushO
 		ManifestType: manifest.DockerV2Schema2MediaType,
 		MaxRetries:   MaxPullPushRetries,
 		RetryDelay:   PullPushRetryDelay,
+		SystemContext: &imgtypes.SystemContext{
+			OCIInsecureSkipTLSVerify:          b.Insecure,
+			DockerInsecureSkipTLSVerify:       imgtypes.NewOptionalBool(b.Insecure),
+			DockerDaemonInsecureSkipTLSVerify: b.Insecure,
+		},
 	}
 
 	if opts.LogWriter != nil {
@@ -141,6 +147,11 @@ func (b *NativeRootlessBuildah) BuildFromDockerfile(ctx context.Context, dockerf
 		OutputFormat: buildah.Dockerv2ImageManifest,
 		CommonBuildOpts: &define.CommonBuildOptions{
 			ShmSize: DefaultShmSize,
+		},
+		SystemContext: &imgtypes.SystemContext{
+			OCIInsecureSkipTLSVerify:          b.Insecure,
+			DockerInsecureSkipTLSVerify:       imgtypes.NewOptionalBool(b.Insecure),
+			DockerDaemonInsecureSkipTLSVerify: b.Insecure,
 		},
 	}
 
@@ -214,6 +225,11 @@ func (b *NativeRootlessBuildah) Pull(ctx context.Context, ref string, opts PullO
 		MaxRetries: MaxPullPushRetries,
 		RetryDelay: PullPushRetryDelay,
 		PullPolicy: define.PullIfNewer,
+		SystemContext: &imgtypes.SystemContext{
+			OCIInsecureSkipTLSVerify:          b.Insecure,
+			DockerInsecureSkipTLSVerify:       imgtypes.NewOptionalBool(b.Insecure),
+			DockerDaemonInsecureSkipTLSVerify: b.Insecure,
+		},
 	}
 
 	if opts.LogWriter != nil {


### PR DESCRIPTION
When $WERF_SKIP_TLS_VERIFY_REGISTRY or $WERF_INSECURE_REGISTRY
enabled, then buildah container runtime allows HTTP and unverified HTTPS
communication with registry.