### PR TITLE
fix(stapel): disable python 2 deprecation warning in ansible builder

### DIFF
--- a/pkg/stapel/stapel.go
+++ b/pkg/stapel/stapel.go
@@ -12,7 +12,7 @@ import (
 	"github.com/werf/werf/pkg/docker"
 )
 
-const VERSION = "0.7.0"
+const VERSION = "0.7.1"
 const IMAGE = "ghcr.io/werf/stapel"
 
 func getVersion() string {

--- a/stapel/Dockerfile
+++ b/stapel/Dockerfile
@@ -596,6 +596,8 @@ mv /tmp/UNICODE.so $TOOLS/lib/gconv
 
 RUN find $TOOLS/embedded/lib/python2.7 -name *.py[oc] | xargs rm
 
+RUN sed -i -e 's|if sys.version_info\[0\] == 2:|if False:|g' $TOOLS/embedded/lib/python2.7/site-packages/cryptography/__init__.py
+
 RUN mkdir /tmp/bin && \
 cp $TOOLS/bin/gpg* /tmp/bin && \
 cp $TOOLS/bin/gnutls* /tmp/bin && \


### PR DESCRIPTION
```
│ │ x/install  /.werf/stapel/embedded/lib/python2.7/site-packages/ansible/parsing/vault/__init__.py:41: CryptographyDeprecationWarning: Python 2 is    ↵
│ │ x/install  no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
│ │ x/install    from cryptography.exceptions import InvalidSignature
```