### PR TITLE
fix(build): commit object or packfile not found after git GC

### DIFF
--- a/pkg/true_git/common.go
+++ b/pkg/true_git/common.go
@@ -24,5 +24,5 @@ func SetCommandRecordingLiveOutput(ctx context.Context, cmd *exec.Cmd) *bytes.Bu
 }
 
 func getCommonGitOptions() []string {
-	return []string{"-c", "core.autocrlf=false"}
+	return []string{"-c", "core.autocrlf=false", "-c", "gc.auto=0"}
 }


### PR DESCRIPTION
```
Error: phase build on image <IMAGE_NAME> stage dockerfile handler failed: unable to get commit "<COMMIT_SHA>" object: object not found
```

```
Error: phase build on image tests stage gitLatestPatch handler failed: error getting patch between previous built image <DOCKER_IMAGE_NAME> and current commit for git mapping own: unable to make git patch options: unable to determine whether ls tree entry for path "<PATH>" on commit "<COMMIT_SHA>" is directory or not: packfile not found
```

closes #3848 