### PR TITLE
Fixing bundle publish synchronization

### DIFF
--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -244,6 +244,11 @@ func runPublish(ctx context.Context) error {
 		return err
 	}
 
+	common.SetupOndemandKubeInitializer(*commonCmdData.KubeContext, *commonCmdData.KubeConfig, *commonCmdData.KubeConfigBase64, *commonCmdData.KubeConfigPathMergeList)
+	if err := common.GetOndemandKubeInitializer().Init(ctx); err != nil {
+		return err
+	}
+
 	var imagesInfoGetters []*image.InfoGetter
 	var imagesRepository string
 


### PR DESCRIPTION
Hello. When I try execute `werf bundle publish`, I get exception:
```go
Using werf config render file: /tmp/werf-config-render-742633564
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x48035b4]

goroutine 1 [running]:
github.com/werf/werf/cmd/werf/common.GetSynchronization.func1({0xc00005e285, 0x14}, 0x0)
	/mnt/cmd/werf/common/synchronization.go:123 +0x354
github.com/werf/werf/cmd/werf/common.GetSynchronization({0x54b3720, 0xc0004d8ff0}, 0x6cd1e60, {0xc000d477b0, 0xe}, {0x5531750, 0xc0008d13e0})
	/mnt/cmd/werf/common/synchronization.go:167 +0x65e
github.com/werf/werf/cmd/werf/bundle/publish.runPublish({0x54b3720, 0xc0004d8ff0})
	/mnt/cmd/werf/bundle/publish/publish.go:259 +0x16ff
github.com/werf/werf/cmd/werf/bundle/publish.NewCmd.func1.1()
	/mnt/cmd/werf/bundle/publish/publish.go:73 +0x3b
github.com/werf/werf/cmd/werf/common.LogRunningTime(0xc0005e39e8)
	/mnt/cmd/werf/common/common.go:1464 +0x5e
github.com/werf/werf/cmd/werf/bundle/publish.NewCmd.func1(0xc000750f00, {0x6d134f8, 0x0, 0x0})
	/mnt/cmd/werf/bundle/publish/publish.go:73 +0x1ad
github.com/spf13/cobra.(*Command).execute(0xc000750f00, {0x6d134f8, 0x0, 0x0})
	/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0xaf0
github.com/spf13/cobra.(*Command).ExecuteC(0xc000750000)
	/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x8b3
github.com/spf13/cobra.(*Command).Execute(0xc000750000)
	/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902 +0x2f
main.main()
	/mnt/cmd/werf/main.go:73 +0x228
```
With this patch exception disappears.