### PR TITLE
fix(bundles): fix werf-bundle-publish command error when --tag contains underscore chars

### DIFF
--- a/pkg/slug/slug.go
+++ b/pkg/slug/slug.go
@@ -71,7 +71,7 @@ func ValidateDockerTag(name string) error {
 		return nil
 	}
 
-	return fmt.Errorf(`%q is not a valid docker tag 
+	return fmt.Errorf(`%q is not a valid docker tag
 
  - a tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes;
  - a tag name may not start with a period or a dash and may contain a maximum of 128 characters.`, name)


### PR DESCRIPTION
Werf bundle publish command automatically generates chart.version metadata field, which equals 0.0.0-TIMESTAMP-SLUG(TAG), when TAG is not a valid semver by itself.