### PR TITLE
ci: fix 1.0 releaser workflows and scripts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5 // indirect
 	github.com/vishvananda/netlink v1.0.0 // indirect
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
-	github.com/werf/logboek v0.5.4 // indirect
+	github.com/werf/logboek v0.5.4
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190809123943-df4f5c81cb3b // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20170512152554-8a8cc2c7e54a

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -ti --rm --volume $GOPATH/mod:/go/mod --volume $GOPATH/pkg:/go/pkg --volume $(pwd):/werf --workdir /werf golang:1.14 scripts/do_build_release.sh "$@"

--- a/scripts/do_build_release.sh
+++ b/scripts/do_build_release.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+for f in $(find scripts/lib -type f -name "*.sh"); do
+    source $f
+done
+
+VERSION=$1
+if [ -z "$VERSION" ] ; then
+    echo "Required version argument!" 1>&2
+    echo 1>&2
+    echo "Usage: $0 VERSION" 1>&2
+    exit 1
+fi
+
+( go_build $VERSION ) || ( echo "Failed to build!" 1>&2 && exit 1 )

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -27,6 +27,6 @@ fi
 ( which git > /dev/null ) || ( echo "Cannot find git command!" 1>&2 && exit 1 )
 ( which curl > /dev/null ) || ( echo "Cannot find curl command!" 1>&2 && exit 1 )
 
-( go_build $VERSION ) || ( echo "Failed to build!" 1>&2 && exit 1 )
-( publish_binaries $VERSION ) || ( echo "Failed to publish release binaries!" 1>&2 && exit 1 )
+#( go_build $VERSION ) || ( echo "Failed to build!" 1>&2 && exit 1 )
+#( publish_binaries $VERSION ) || ( echo "Failed to publish release binaries!" 1>&2 && exit 1 )
 ( create_github_release $VERSION ) || ( echo "Failed to create github release!" 1>&2 && exit 1 )

--- a/trdl.yaml
+++ b/trdl.yaml
@@ -4,7 +4,8 @@ commands:
 - go install github.com/mitchellh/gox@8c3b2b9e647dc52457d6ee7b5adcf97e2bafe131
 - |
   gox -osarch="linux/amd64 darwin/amd64 windows/amd64" \
-    -output="release-build/$VERSION/{{.OS}}-{{.Arch}}/bin/werf" \
+    -output="release-build/{{ .Tag }}/{{ `{{.OS}}-{{.Arch}}` }}/bin/werf" \
     -tags="dfrunmount dfssh" \
-    -ldflags="-s -w -X github.com/flant/werf/pkg/werf.Version=$VERSION" \
+    -ldflags="-s -w -X github.com/flant/werf/pkg/werf.Version={{ .Tag }}" \
         github.com/flant/werf/cmd/werf
+- cp -a release-build/{{ .Tag }}/* /result


### PR DESCRIPTION
* added script to manually build release in the docker;
* fixed invalid trdl.yaml build script;
* fixed old outdated publish script (do not use bintray).