### PR TITLE
feat(buildah): working native-rootless buildah mode inside docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,7 @@
 ### Features
 
 * Completed first step of buildah adoption: allow building of dockerfiles with buildah on any supported by the werf platform (linux, windows and macos).
-   * Enable buildah mode with `WERF_BUILDAH_CONTAINER_RUNTIME=auto|native-rootless|docker-with-fuse` environment variable:
+   * Enable buildah mode with `WERF_CONTAINER_RUNTIME_BUILDAH=auto|native-rootless|docker-with-fuse` environment variable:
         * `native-rootless` mode uses local storage and runs only under Linux.
         * `docker-with-fuse` mode runs buildah inside docker enabling crossplatform buildah support. This mode could be changed later to use podman instead of docker server.
 
@@ -158,7 +158,7 @@
 ### Features
 
 * Completed first step of buildah adoption: allow building of dockerfiles with buildah on any supported by the werf platform (linux, windows and macos).
-   * Enable buildah mode with `WERF_BUILDAH_CONTAINER_RUNTIME=auto|native-rootless|docker-with-fuse` environment variable:
+   * Enable buildah mode with `WERF_CONTAINER_RUNTIME_BUILDAH=auto|native-rootless|docker-with-fuse` environment variable:
         * `native-rootless` mode uses local storage and runs only under Linux.
         * `docker-with-fuse` mode runs buildah inside docker enabling crossplatform buildah support. This mode could be changed later to use podman instead of docker server.
 

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -411,7 +411,7 @@ Also, can be specified with $WERF_SECONDARY_REPO_* (e.g. $WERF_SECONDARY_REPO_1=
 func SetupAddCustomTag(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.AddCustomTag = new([]string)
 	cmd.Flags().StringArrayVarP(cmdData.AddCustomTag, "add-custom-tag", "", []string{}, `Set tag aliases for the content-based tag of each image.
-It is necessary to use the image name shortcut %image% or %image_slug% in the tag format if there is more than one image in the werf config. 
+It is necessary to use the image name shortcut %image% or %image_slug% in the tag format if there is more than one image in the werf config.
 Also, can be defined with $WERF_ADD_CUSTOM_TAG_* (e.g. $WERF_ADD_CUSTOM_TAG_1="%image%-tag1", $WERF_ADD_CUSTOM_TAG_2="%image%-tag2").
 For cleaning custom tags and associated content-based tag are treated as one`)
 }
@@ -419,7 +419,7 @@ For cleaning custom tags and associated content-based tag are treated as one`)
 func SetupUseCustomTag(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.UseCustomTag = new(string)
 	cmd.Flags().StringVarP(cmdData.UseCustomTag, "use-custom-tag", "", os.Getenv("WERF_USE_CUSTOM_TAG"), `Use a tag alias in helm templates instead of an image content-based tag (NOT RECOMMENDED).
-It is necessary to use the image name shortcut %image% or %image_slug% in the tag format if there is more than one image in the werf config. 
+It is necessary to use the image name shortcut %image% or %image_slug% in the tag format if there is more than one image in the werf config.
 Also, can be defined with $WERF_USE_CUSTOM_TAG (e.g. $WERF_USE_CUSTOM_TAG="%image%-tag").
 For cleaning custom tags and associated content-based tag are treated as one`)
 }

--- a/cmd/werf/common/container_runtime.go
+++ b/cmd/werf/common/container_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/werf/werf/pkg/buildah"
 	"github.com/werf/werf/pkg/container_runtime"
@@ -12,9 +13,14 @@ import (
 
 func ContainerRuntimeProcessStartupHook() (bool, error) {
 	buildahMode := GetContainerRuntimeBuildahMode()
-	if buildahMode != "" {
+
+	switch {
+	case buildahMode != "":
 		return buildah.ProcessStartupHook(buildahMode)
+	case strings.HasPrefix(os.Args[0], "buildah-") || strings.HasPrefix(os.Args[0], "chrootuser-") || strings.HasPrefix(os.Args[0], "storage-"):
+		return buildah.ProcessStartupHook("native-rootless")
 	}
+
 	return false, nil
 }
 

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -399,7 +399,7 @@ func (c *Conveyor) checkContainerRuntimeSupported(ctx context.Context) error {
 
 Please select only dockerfile images or delete all non-dockerfile images from your werf.yaml.
 
-Or disable buildah runtime by unsetting WERF_BUILDAH_CONTAINER_RUNTIME environment variable.`, strings.Join(nonDockerfileImages, ", "))
+Or disable buildah runtime by unsetting WERF_CONTAINER_RUNTIME_BUILDAH environment variable.`, strings.Join(nonDockerfileImages, ", "))
 	}
 
 	return nil

--- a/pkg/buildah/native_rootless_buildah_linux.go
+++ b/pkg/buildah/native_rootless_buildah_linux.go
@@ -144,7 +144,7 @@ func (b *NativeRootlessBuildah) Push(ctx context.Context, ref string, opts PushO
 
 func (b *NativeRootlessBuildah) BuildFromDockerfile(ctx context.Context, dockerfile []byte, opts BuildFromDockerfileOpts) (string, error) {
 	buildOpts := define.BuildOptions{
-		Isolation:    define.IsolationOCIRootless,
+		Isolation:    define.IsolationChroot,
 		OutputFormat: buildah.Dockerv2ImageManifest,
 		CommonBuildOpts: &define.CommonBuildOptions{
 			ShmSize: DefaultShmSize,

--- a/pkg/docker/main.go
+++ b/pkg/docker/main.go
@@ -32,6 +32,10 @@ const (
 	ctxDockerCliKey = "docker_cli"
 )
 
+func IsEnabled() bool {
+	return defaultCLi != nil
+}
+
 func Init(ctx context.Context, dockerConfigDir string, verbose, debug bool, platform string) error {
 	if (platform == "" && runtime.GOARCH != "amd64") || (platform != "" && platform != "linux/amd64") {
 		logboek.Context(ctx).Error().LogF("werf currently does not support building of images for any other platform besides linux/amd64.\n")

--- a/pkg/docker_registry/generic_api.go
+++ b/pkg/docker_registry/generic_api.go
@@ -22,7 +22,7 @@ func newGenericApi(ctx context.Context, options apiOptions) (*genericApi, error)
 	d.commonApi = newAPI(options)
 
 	// init registry mirrors if docker cli initialized in context
-	if docker.IsContext(ctx) {
+	if docker.IsEnabled() && docker.IsContext(ctx) {
 		info, err := docker.Info(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get docker system info: %s", err)


### PR DESCRIPTION
 * Use "chroot" isolation instead of "rootless" in werf's native-rootless buildah mode.
 * Fix initialization of werf process with reexec.
