### PR TITLE
feat(buildah-for-stapel): added buildah-test subcommand to experiment with buildah abilities for stapel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: all werf buildah-test clean
+
+all: werf
+
+werf:
+	CGO_ENABLED=1 go install -compiler gc -ldflags="-linkmode external -extldflags=-static" -tags="dfrunmount dfssh containers_image_openpgp osusergo exclude_graphdriver_devicemapper netgo no_devmapper static_build" github.com/werf/werf/cmd/werf
+
+buildah-test:
+	CGO_ENABLED=1 go install -compiler gc -ldflags="-linkmode external -extldflags=-static" -tags="dfrunmount dfssh containers_image_openpgp osusergo exclude_graphdriver_devicemapper netgo no_devmapper static_build" github.com/werf/werf/cmd/buildah-test
+
+
+fmt:
+	gci -w -local github.com/werf/ pkg/ cmd/
+	gofumpt -w cmd/ pkg/
+
+lint:
+	golangci-lint -E bidichk -E errname run ./... --build-tags="dfrunmount dfssh containers_image_openpgp osusergo exclude_graphdriver_devicemapper netgo no_devmapper static_build"
+
+
+clean:
+	rm /home/distorhead/go/bin/werf
+	rm /home/distorhead/go/bin/buildah-test

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/onsi/gomega v1.16.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31
+	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v1.0.0 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2

--- a/pkg/buildah/buildah.go
+++ b/pkg/buildah/buildah.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/werf/werf/pkg/buildah/types"
 	"github.com/werf/werf/pkg/werf"
 )
@@ -28,25 +30,17 @@ type BuildFromDockerfileOpts struct {
 	BuildArgs  map[string]string
 }
 
+type RunMount struct {
+	Type        string
+	TmpfsSize   string
+	Source      string
+	Destination string
+}
+
 type RunCommandOpts struct {
 	CommonOpts
-	Args []string
-}
-
-type FromCommandOpts struct {
-	CommonOpts
-}
-
-type PullOpts struct {
-	CommonOpts
-}
-
-type PushOpts struct {
-	CommonOpts
-}
-
-type TagOpts struct {
-	CommonOpts
+	Args   []string
+	Mounts []specs.Mount
 }
 
 type RmiOpts struct {
@@ -54,15 +48,26 @@ type RmiOpts struct {
 	Force bool
 }
 
+type (
+	FromCommandOpts CommonOpts
+	PushOpts        CommonOpts
+	PullOpts        CommonOpts
+	TagOpts         CommonOpts
+	MountOpts       CommonOpts
+	UmountOpts      CommonOpts
+)
+
 type Buildah interface {
 	Tag(ctx context.Context, ref, newRef string, opts TagOpts) error
 	Push(ctx context.Context, ref string, opts PushOpts) error
 	BuildFromDockerfile(ctx context.Context, dockerfile []byte, opts BuildFromDockerfileOpts) (string, error)
 	RunCommand(ctx context.Context, container string, command []string, opts RunCommandOpts) error
-	FromCommand(ctx context.Context, container string, image string, opts FromCommandOpts) error
+	FromCommand(ctx context.Context, container string, image string, opts FromCommandOpts) (string, error)
 	Pull(ctx context.Context, ref string, opts PullOpts) error
 	Inspect(ctx context.Context, ref string) (*types.BuilderInfo, error)
 	Rmi(ctx context.Context, ref string, opts RmiOpts) error
+	Mount(ctx context.Context, container string, opts MountOpts) (string, error)
+	Umount(ctx context.Context, container string, opts UmountOpts) error
 }
 
 type Mode string

--- a/pkg/buildah/docker_with_fuse_buildah.go
+++ b/pkg/buildah/docker_with_fuse_buildah.go
@@ -47,6 +47,14 @@ func (b *DockerWithFuseBuildah) Push(ctx context.Context, ref string, opts PushO
 	return err
 }
 
+func (b *DockerWithFuseBuildah) Mount(ctx context.Context, container string, opts MountOpts) (string, error) {
+	panic("not implemented")
+}
+
+func (b *DockerWithFuseBuildah) Umount(ctx context.Context, container string, opts UmountOpts) error {
+	panic("not implemented")
+}
+
 func (b *DockerWithFuseBuildah) BuildFromDockerfile(ctx context.Context, dockerfile []byte, opts BuildFromDockerfileOpts) (string, error) {
 	sessionTmpDir, _, _, err := b.prepareBuildFromDockerfile(dockerfile, opts.ContextTar)
 	if err != nil {
@@ -94,11 +102,12 @@ func (b *DockerWithFuseBuildah) RunCommand(ctx context.Context, container string
 	return err
 }
 
-func (b *DockerWithFuseBuildah) FromCommand(ctx context.Context, container string, image string, opts FromCommandOpts) error {
+func (b *DockerWithFuseBuildah) FromCommand(ctx context.Context, container string, image string, opts FromCommandOpts) (string, error) {
 	_, _, err := b.runBuildah(ctx, []string{}, []string{
 		"from", fmt.Sprintf("--tls-verify=%s", strconv.FormatBool(!b.Insecure)), "--name", container, image,
 	}, opts.LogWriter)
-	return err
+	// FIXME: return container name
+	return "", err
 }
 
 // TODO(ilya-lesikov): make it more generic to handle not only images

--- a/pkg/config/werf.go
+++ b/pkg/config/werf.go
@@ -320,7 +320,7 @@ func (c *WerfConfig) imageDependenciesInOrder(images []ImageInterface) (imageDep
 
 	outerLoop:
 		for _, dep := range imageDeps[current] {
-			for key, _ := range imageDeps {
+			for key := range imageDeps {
 				if key == dep {
 					continue outerLoop
 				}

--- a/pkg/container_runtime/buildah_runtime.go
+++ b/pkg/container_runtime/buildah_runtime.go
@@ -59,25 +59,19 @@ func (runtime *BuildahRuntime) Rmi(ctx context.Context, ref string, opts RmiOpts
 
 func (runtime *BuildahRuntime) Pull(ctx context.Context, ref string, opts PullOpts) error {
 	return runtime.buildah.Pull(ctx, ref, buildah.PullOpts{
-		CommonOpts: buildah.CommonOpts{
-			LogWriter: logboek.Context(ctx).OutStream(),
-		},
+		LogWriter: logboek.Context(ctx).OutStream(),
 	})
 }
 
 func (runtime *BuildahRuntime) Tag(ctx context.Context, ref, newRef string, opts TagOpts) error {
 	return runtime.buildah.Tag(ctx, ref, newRef, buildah.TagOpts{
-		CommonOpts: buildah.CommonOpts{
-			LogWriter: logboek.Context(ctx).OutStream(),
-		},
+		LogWriter: logboek.Context(ctx).OutStream(),
 	})
 }
 
 func (runtime *BuildahRuntime) Push(ctx context.Context, ref string, opts PushOpts) error {
 	return runtime.buildah.Push(ctx, ref, buildah.PushOpts{
-		CommonOpts: buildah.CommonOpts{
-			LogWriter: logboek.Context(ctx).OutStream(),
-		},
+		LogWriter: logboek.Context(ctx).OutStream(),
 	})
 }
 


### PR DESCRIPTION
* Mounts of host files into the build containers is supported [check].
* Mount container root into the host and perform golang code file operations over this root [check].
* Small refactor of buildah pkg.
* Added project makefile with basic tasks: werf and buildah-test cmds build, lint, fmt, clean.