### PR TITLE
fix(cleanup, v1.1): ignore harbor "unsupported 404 status code" errors

### DIFF
--- a/pkg/build/publish_images_phase.go
+++ b/pkg/build/publish_images_phase.go
@@ -374,7 +374,7 @@ func (phase *PublishImagesPhase) checkImageAlreadyExists(ctx context.Context, ex
 
 	repoImage, err := phase.ImagesRepo.GetRepoImage(ctx, werfImageName, imageMetaTag)
 	if err != nil {
-		if docker_registry.IsNameUnknownError(err) || docker_registry.IsManifestUnknownError(err) || docker_registry.IsBlobUnknownError(err) {
+		if docker_registry.IsNameUnknownError(err) || docker_registry.IsManifestUnknownError(err) || docker_registry.IsBlobUnknownError(err) || docker_registry.IsHarbor404Error(err) {
 			return false, nil, nil
 		}
 

--- a/pkg/cleaning/images_purge.go
+++ b/pkg/cleaning/images_purge.go
@@ -64,7 +64,7 @@ func (m *imagesPurgeManager) run(ctx context.Context) error {
 
 func selectRepoImagesFromImagesRepo(ctx context.Context, storageManager *manager.StorageManager, imageNameList []string) (map[string][]*image.Info, error) {
 	return storageManager.SelectRepoImages(ctx, imageNameList, func(reference string, _ *image.Info, err error) (bool, error) {
-		if err != nil && (docker_registry.IsManifestUnknownError(err) || docker_registry.IsBlobUnknownError(err)) {
+		if err != nil && (docker_registry.IsManifestUnknownError(err) || docker_registry.IsBlobUnknownError(err) || docker_registry.IsHarbor404Error(err)) {
 			logboek.Context(ctx).Warn().LogF("Skip image %s: %s\n", reference, err)
 			return false, nil
 		}

--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -60,7 +60,7 @@ func (api *api) IsRepoImageExists(ctx context.Context, reference string) (bool, 
 
 func (api *api) TryGetRepoImage(ctx context.Context, reference string) (*image.Info, error) {
 	if imgInfo, err := api.GetRepoImage(ctx, reference); err != nil {
-		if IsBlobUnknownError(err) || IsManifestUnknownError(err) {
+		if IsBlobUnknownError(err) || IsManifestUnknownError(err) || IsHarbor404Error(err) {
 			// TODO: 1. auto reject images with manifest-unknown or blob-unknown errors
 			// TODO: 2. why TryGetRepoImage for rejected image records gives manifest-unknown errors?
 			// TODO: 3. make sure werf never ever creates rejected image records for name-unknown errors.

--- a/pkg/docker_registry/default.go
+++ b/pkg/docker_registry/default.go
@@ -63,3 +63,15 @@ func IsBlobUnknownError(err error) bool {
 func IsNameUnknownError(err error) bool {
 	return (err != nil) && strings.Contains(err.Error(), "NAME_UNKNOWN")
 }
+
+func IsHarbor404Error(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Example error:
+	// GET https://domain/harbor/s3/object/name/prefix/docker/registry/v2/blobs/sha256/2d/3d8c68cd9df32f1beb4392298a123eac58aba1433a15b3258b2f3728bad4b7d1/data?X-Amz-Algorithm=REDACTED&X-Amz-Credential=REDACTED&X-Amz-Date=REDACTED&X-Amz-Expires=REDACTED&X-Amz-Signature=REDACTED&X-Amz-SignedHeaders=REDACTED: unsupported status code 404; body: <?xml version="1.0" encoding="UTF-8"?>
+	// <Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Resource>/harbor/s3/object/name/prefix/docker/registry/v2/blobs/sha256/3d/3d8c68cd9df32f1beb4392298a123eac58aba1433a15b3258b2f3728bad4b7d1/data</Resource><RequestId>c5bb943c-1e85-5930-b455-c3e8edbbaccd</RequestId></Error>
+
+	return strings.Contains(err.Error(), "unsupported status code 404")
+}

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -248,7 +248,7 @@ func (storage *RepoStagesStorage) GetStageDescription(ctx context.Context, proje
 		return nil, nil
 	}
 
-	if docker_registry.IsBlobUnknownError(err) {
+	if docker_registry.IsBlobUnknownError(err) || docker_registry.IsHarbor404Error(err) {
 		return nil, ErrBrokenImage
 	}
 


### PR DESCRIPTION
These errors may occur when harbor configured to use S3 backend, which may respond with the following error:

```
GET https://domain/harbor/s3/object/name/prefix/docker/registry/v2/blobs/sha256/2d/3d8c68cd9df32f1beb4392298a123eac58aba1433a15b3258b2f3728bad4b7d1/data?X-Amz-Algorithm=REDACTED&X-Amz-Credential=REDACTED&X-Amz-Date=REDACTED&X-Amz-Expires=REDACTED&X-Amz-Signature=REDACTED&X-Amz-SignedHeaders=REDACTED: unsupported status code 404; body: <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Resource>/harbor/s3/object/name/prefix/docker/registry/v2/blobs/sha256/3d/3d8c68cd9df32f1beb4392298a123eac58aba1433a15b3258b2f3728bad4b7d1/data</Resource><RequestId>c5bb943c-1e85-5930-b455-c3e8edbbaccd</RequestId></Error>
```