### PR TITLE
feat(buildah): native OCI rootless mode; vfs storage driver; bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 /bin
 /tests-coverage
 /precompiled_tests_binaries
+/test/*.test
 
 /docs/\.jekyll-cache/
 /docs/site/backend/root/

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ buildah-test:
 
 
 fmt:
-	gci -w -local github.com/werf/ pkg/ cmd/
+	gci -w -local github.com/werf/ pkg/ cmd/ test/
 	gofumpt -w cmd/ pkg/
 
 lint:

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -399,7 +399,7 @@ func (c *Conveyor) checkContainerRuntimeSupported(ctx context.Context) error {
 
 Please select only dockerfile images or delete all non-dockerfile images from your werf.yaml.
 
-Or disable buildah runtime by unsetting WERF_CONTAINER_RUNTIME_BUILDAH environment variable.`, strings.Join(nonDockerfileImages, ", "))
+Or disable buildah runtime by unsetting WERF_BUILDAH_MODE environment variable.`, strings.Join(nonDockerfileImages, ", "))
 	}
 
 	return nil

--- a/pkg/buildah/types/isolation.go
+++ b/pkg/buildah/types/isolation.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"fmt"
+)
+
+type Isolation int
+
+const (
+	IsolationChroot      Isolation = 2
+	IsolationOCIRootless Isolation = 3
+)
+
+func (i Isolation) String() string {
+	switch i {
+	case IsolationChroot:
+		return "chroot"
+	case IsolationOCIRootless:
+		return "rootless"
+	}
+	return fmt.Sprintf("unrecognized isolation type %d", i)
+}

--- a/pkg/buildah/types/storageoptions.go
+++ b/pkg/buildah/types/storageoptions.go
@@ -1,0 +1,31 @@
+// This is from "github.com/containers/storage".
+//go:build !linux
+// +build !linux
+
+package types
+
+// IDMap contains a single entry for user namespace range remapping. An array
+// of IDMap entries represents the structure that will be provided to the Linux
+// kernel for creating a user namespace.
+type IDMap struct {
+	ContainerID int `json:"container_id"`
+	HostID      int `json:"host_id"`
+	Size        int `json:"size"`
+}
+
+// StoreOptions is used for passing initialization options to GetStore(), for
+// initializing a Store object and the underlying storage that it controls.
+type StoreOptions struct {
+	RunRoot             string            `json:"runroot,omitempty"`
+	GraphRoot           string            `json:"root,omitempty"`
+	RootlessStoragePath string            `toml:"rootless_storage_path"`
+	GraphDriverName     string            `json:"driver,omitempty"`
+	GraphDriverOptions  []string          `json:"driver-options,omitempty"`
+	UIDMap              []IDMap           `json:"uidmap,omitempty"`
+	GIDMap              []IDMap           `json:"gidmap,omitempty"`
+	RootAutoNsUser      string            `json:"root_auto_ns_user,omitempty"`
+	AutoNsMinSize       uint32            `json:"auto_userns_min_size,omitempty"`
+	AutoNsMaxSize       uint32            `json:"auto_userns_max_size,omitempty"`
+	PullOptions         map[string]string `toml:"pull_options"`
+	DisableVolatile     bool              `json:"disable-volatile,omitempty"`
+}

--- a/pkg/buildah/types/storageoptions_linux.go
+++ b/pkg/buildah/types/storageoptions_linux.go
@@ -1,0 +1,8 @@
+//go:build linux
+// +build linux
+
+package types
+
+import "github.com/containers/storage"
+
+type StoreOptions storage.StoreOptions

--- a/pkg/util/linux_container.go
+++ b/pkg/util/linux_container.go
@@ -35,3 +35,19 @@ func ToLinuxContainerPath(path string) string {
 		),
 	)
 }
+
+func IsInContainer() (bool, error) {
+	if dockerEnvExist, err := RegularFileExists("/.dockerenv"); err != nil {
+		return false, fmt.Errorf("unable to check for /.dockerenv existence: %s", err)
+	} else if dockerEnvExist {
+		return true, nil
+	}
+
+	if containerEnvExist, err := RegularFileExists("/run/.containerenv"); err != nil {
+		return false, fmt.Errorf("unable to check for /run/.containerenv existence: %s", err)
+	} else if containerEnvExist {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/test/pkg/contruntime/base.go
+++ b/test/pkg/contruntime/base.go
@@ -3,16 +3,13 @@ package contruntime
 import (
 	"github.com/google/uuid"
 
-	"github.com/werf/werf/test/pkg/thirdparty/contruntime/manifest"
+	"github.com/werf/werf/pkg/buildah/types"
 )
 
-type BuildahInspect struct {
-	Docker struct {
-		Config manifest.Schema2Config `json:"config"`
-	} `json:"Docker"`
+type BaseContainerRuntime struct {
+	CommonCliArgs []string
+	Isolation     types.Isolation
 }
-
-type BaseContainerRuntime struct{}
 
 func expectCmdsToSucceed(r ContainerRuntime, image string, cmds ...string) {
 	containerName := uuid.New().String()

--- a/test/pkg/contruntime/basebuildah.go
+++ b/test/pkg/contruntime/basebuildah.go
@@ -1,0 +1,11 @@
+package contruntime
+
+import (
+	"github.com/werf/werf/test/pkg/thirdparty/contruntime/manifest"
+)
+
+type BuildahInspect struct {
+	Docker struct {
+		Config manifest.Schema2Config `json:"config"`
+	} `json:"Docker"`
+}

--- a/test/pkg/contruntime/docker.go
+++ b/test/pkg/contruntime/docker.go
@@ -22,27 +22,35 @@ func (r *DockerRuntime) ExpectCmdsToSucceed(image string, cmds ...string) {
 }
 
 func (r *DockerRuntime) RunSleepingContainer(containerName, image string) {
-	utils.RunSucceedCommand("/",
-		"docker", "run", "--rm", "-d", "--entrypoint=", "--name", containerName, image, "tail", "-f", "/dev/null",
-	)
+	args := r.CommonCliArgs
+	args = append(args, "run", "--rm", "-d", "--entrypoint=", "--name", containerName, image, "tail", "-f", "/dev/null")
+	utils.RunSucceedCommand("/", "docker", args...)
 }
 
 func (r *DockerRuntime) Exec(containerName string, cmds ...string) {
 	for _, cmd := range cmds {
-		utils.RunSucceedCommand("/", "docker", "exec", containerName, "sh", "-ec", cmd)
+		args := r.CommonCliArgs
+		args = append(args, "exec", containerName, "sh", "-ec", cmd)
+		utils.RunSucceedCommand("/", "docker", args...)
 	}
 }
 
 func (r *DockerRuntime) Rm(containerName string) {
-	utils.RunSucceedCommand("/", "docker", "rm", "-fv", containerName)
+	args := r.CommonCliArgs
+	args = append(args, "rm", "-fv", containerName)
+	utils.RunSucceedCommand("/", "docker", args...)
 }
 
 func (r *DockerRuntime) Pull(image string) {
-	utils.RunSucceedCommand("/", "docker", "pull", image)
+	args := r.CommonCliArgs
+	args = append(args, "pull", image)
+	utils.RunSucceedCommand("/", "docker", args...)
 }
 
 func (r *DockerRuntime) GetImageInspectConfig(image string) (config manifest.Schema2Config) {
-	configRaw, err := utils.RunCommand("/", "docker", "image", "inspect", "-f", "{{ json .Config }}", image)
+	args := r.CommonCliArgs
+	args = append(args, "image", "inspect", "-f", "{{ json .Config }}", image)
+	configRaw, err := utils.RunCommand("/", "docker", args...)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(json.Unmarshal(configRaw, &config)).To(Succeed())
 

--- a/test/pkg/contruntime/interface.go
+++ b/test/pkg/contruntime/interface.go
@@ -5,24 +5,31 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/werf/werf/pkg/buildah"
+	bdTypes "github.com/werf/werf/pkg/buildah/types"
 	"github.com/werf/werf/test/pkg/thirdparty/contruntime/manifest"
 )
 
 var ErrRuntimeUnavailable = errors.New("requested runtime unavailable")
 
-func NewContainerRuntime(name string) (ContainerRuntime, error) {
-	switch name {
+func NewContainerRuntime(buildahMode string) (ContainerRuntime, error) {
+	switch buildahMode {
 	case "docker":
 		return NewDockerRuntime(), nil
-	case "native-rootless-buildah":
+	case "native-rootless":
 		if runtime.GOOS != "linux" {
 			return nil, ErrRuntimeUnavailable
 		}
-		return NewNativeRootlessBuildahRuntime(), nil
-	case "docker-with-fuse-buildah":
-		return NewDockerWithFuseBuildahRuntime(), nil
+		return NewNativeRootlessBuildahRuntime(bdTypes.IsolationOCIRootless, buildah.DefaultStorageDriver), nil
+	case "native-chroot":
+		if runtime.GOOS != "linux" {
+			return nil, ErrRuntimeUnavailable
+		}
+		return NewNativeRootlessBuildahRuntime(bdTypes.IsolationChroot, buildah.DefaultStorageDriver), nil
+	case "docker-with-fuse":
+		return NewDockerWithFuseBuildahRuntime(bdTypes.IsolationChroot, buildah.DefaultStorageDriver), nil
 	default:
-		panic(fmt.Sprint("unexpected name for container runtime: ", name))
+		panic(fmt.Sprintf("unexpected buildah mode: %s", buildahMode))
 	}
 }
 

--- a/test/pkg/contruntime/nativerootlessbuildah.go
+++ b/test/pkg/contruntime/nativerootlessbuildah.go
@@ -6,11 +6,25 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/werf/werf/integration/pkg/utils"
+	"github.com/werf/werf/pkg/buildah"
+	"github.com/werf/werf/pkg/buildah/types"
 	"github.com/werf/werf/test/pkg/thirdparty/contruntime/manifest"
 )
 
-func NewNativeRootlessBuildahRuntime() ContainerRuntime {
-	return &NativeRootlessBuildahRuntime{}
+func NewNativeRootlessBuildahRuntime(isolation types.Isolation, storageDriver buildah.StorageDriver) ContainerRuntime {
+	var commonCliArgs []string
+
+	commonBuildahCliArgs, err := buildah.GetCommonBuildahCliArgs(storageDriver)
+	Expect(err).NotTo(HaveOccurred())
+
+	commonCliArgs = append(commonCliArgs, commonBuildahCliArgs...)
+
+	return &NativeRootlessBuildahRuntime{
+		BaseContainerRuntime: BaseContainerRuntime{
+			CommonCliArgs: commonCliArgs,
+			Isolation:     isolation,
+		},
+	}
 }
 
 type NativeRootlessBuildahRuntime struct {
@@ -22,30 +36,39 @@ func (r *NativeRootlessBuildahRuntime) ExpectCmdsToSucceed(image string, cmds ..
 }
 
 func (r *NativeRootlessBuildahRuntime) RunSleepingContainer(containerName, image string) {
-	utils.RunSucceedCommand("/",
-		"buildah", "from", "--tls-verify=false", "--format", "docker", "--name", containerName, image,
-	)
+	args := r.CommonCliArgs
+	args = append(args, "from", "--tls-verify=false", "--isolation", r.Isolation.String(), "--format", "docker", "--name", containerName, image)
+	utils.RunSucceedCommand("/", "buildah", args...)
 }
 
 func (r *NativeRootlessBuildahRuntime) Exec(containerName string, cmds ...string) {
 	for _, cmd := range cmds {
-		utils.RunSucceedCommand("/", "buildah", "run", containerName, "--", "sh", "-ec", cmd)
+		args := r.CommonCliArgs
+		args = append(args, "run", "--isolation", r.Isolation.String(), containerName, "--", "sh", "-ec", cmd)
+		utils.RunSucceedCommand("/", "buildah", args...)
 	}
 }
 
 func (r *NativeRootlessBuildahRuntime) Rm(containerName string) {
-	utils.RunSucceedCommand("/", "buildah", "rm", containerName)
+	args := r.CommonCliArgs
+	args = append(args, "rm", containerName)
+	utils.RunSucceedCommand("/", "buildah", args...)
 }
 
 func (r *NativeRootlessBuildahRuntime) Pull(image string) {
-	utils.RunSucceedCommand("/", "buildah", "pull", "--tls-verify=false", image)
+	args := r.CommonCliArgs
+	args = append(args, "pull", "--tls-verify=false", image)
+	utils.RunSucceedCommand("/", "buildah", args...)
 }
 
 func (r *NativeRootlessBuildahRuntime) GetImageInspectConfig(image string) (config manifest.Schema2Config) {
 	r.Pull(image)
 
-	inspectRaw, err := utils.RunCommand("/", "buildah", "inspect", "--type", "image", image)
+	args := r.CommonCliArgs
+	args = append(args, "inspect", "--type", "image", image)
+	inspectRaw, err := utils.RunCommand("/", "buildah", args...)
 	Expect(err).NotTo(HaveOccurred())
+
 	var inspect BuildahInspect
 	Expect(json.Unmarshal(inspectRaw, &inspect)).To(Succeed())
 


### PR DESCRIPTION
Done:
* Added native OCI rootless Buildah mode. Provides more isolation and security in comparison to chroot mode. Works only outside of containers.
* $WERF_BUILDAH_MODE instead of $WERF_CONTAINER_RUNTIME_BUILDAN for Buidah mode/isolation configuration.
* VFS storage driver now available in addition to OverlayFS for both native and docker-with-fuse Buildah modes. Configurable via $WERF_BUILDAH_STORAGE_DRIVER.
* Lots of bugfixes. Minor refactoring. Tests.

Work in progress:

Trying to get rid of a need in external configuration, external dependencies and work environment preparations to run `werf` in
Buildah mode, especially when running `werf` in containers. As of now no /etc/containers/* configs needed anymore, lots of 
 configuration built-in, some autodetection/autoconfiguration implemented.