### PR TITLE
feature(buildah): 4 new base Docker images to run werf

### DIFF
--- a/pkg/buildah/native_rootless_buildah_linux.go
+++ b/pkg/buildah/native_rootless_buildah_linux.go
@@ -157,9 +157,7 @@ func (b *NativeRootlessBuildah) Push(ctx context.Context, ref string, opts PushO
 
 func (b *NativeRootlessBuildah) BuildFromDockerfile(ctx context.Context, dockerfile []byte, opts BuildFromDockerfileOpts) (string, error) {
 	buildOpts := define.BuildOptions{
-		Isolation: define.Isolation(b.Isolation),
-		// FIXME(ilya-lesikov):
-		// IDMappingOptions: nil,
+		Isolation:    define.Isolation(b.Isolation),
 		OutputFormat: buildah.Dockerv2ImageManifest,
 		CommonBuildOpts: &define.CommonBuildOptions{
 			ShmSize: DefaultShmSize,
@@ -387,10 +385,5 @@ func NewNativeStoreOptions(rootlessUID int, driver StorageDriver) (*types.StoreO
 		RootlessStoragePath: rootlessStoragePath,
 		GraphDriverName:     string(driver),
 		GraphDriverOptions:  graphDriverOptions,
-		// FIXME(ilya-lesikov):
-		// AutoNsMinSize: 2000,
-		// AutoNsMaxSize: 50000,
-		// UIDMap: nil,
-		// GIDMap: nil,
 	}, nil
 }

--- a/scripts/werf-in-docker/alpine.Dockerfile
+++ b/scripts/werf-in-docker/alpine.Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.15
+
+RUN apk add --no-cache fuse-overlayfs git shadow-uidmap libcap
+
+# Fix messed up setuid/setgid capabilities.
+RUN setcap cap_setuid+ep /usr/bin/newuidmap && \
+    setcap cap_setgid+ep /usr/bin/newgidmap && \
+    chmod u-s,g-s /usr/bin/newuidmap /usr/bin/newgidmap
+
+RUN adduser -D build && echo 'build:100000:65536' | tee /etc/subuid >/etc/subgid
+USER build:build
+RUN mkdir -p /home/build/.local/share/containers
+VOLUME /home/build/.local/share/containers
+
+ENV WERF_BUILDAH_MODE=auto

--- a/scripts/werf-in-docker/centos.Dockerfile
+++ b/scripts/werf-in-docker/centos.Dockerfile
@@ -1,0 +1,16 @@
+FROM centos:8
+
+RUN dnf -y install fuse-overlayfs git && \
+    dnf clean all && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+# Fix messed up setuid/setgid capabilities.
+RUN setcap cap_setuid+ep /usr/bin/newuidmap && \
+    setcap cap_setgid+ep /usr/bin/newgidmap && \
+    chmod u-s,g-s /usr/bin/newuidmap /usr/bin/newgidmap
+
+RUN useradd build
+USER build:build
+RUN mkdir -p /home/build/.local/share/containers
+VOLUME /home/build/.local/share/containers
+
+ENV WERF_BUILDAH_MODE=auto

--- a/scripts/werf-in-docker/fedora.Dockerfile
+++ b/scripts/werf-in-docker/fedora.Dockerfile
@@ -1,0 +1,16 @@
+FROM registry.fedoraproject.org/fedora-minimal:36
+
+RUN microdnf -y install fuse-overlayfs git && \
+    microdnf clean all && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+# Fix messed up setuid/setgid capabilities.
+RUN setcap cap_setuid+ep /usr/bin/newuidmap && \
+    setcap cap_setgid+ep /usr/bin/newgidmap && \
+    chmod u-s,g-s /usr/bin/newuidmap /usr/bin/newgidmap
+
+RUN useradd build
+USER build:build
+RUN mkdir -p /home/build/.local/share/containers
+VOLUME /home/build/.local/share/containers
+
+ENV WERF_BUILDAH_MODE=auto

--- a/scripts/werf-in-docker/ubuntu.Dockerfile
+++ b/scripts/werf-in-docker/ubuntu.Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get -y update && apt-get -y install fuse-overlayfs git uidmap libcap2-bin && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/* /var/log/*
+
+# Fix messed up setuid/setgid capabilities.
+RUN setcap cap_setuid+ep /usr/bin/newuidmap && \
+    setcap cap_setgid+ep /usr/bin/newgidmap && \
+    chmod u-s,g-s /usr/bin/newuidmap /usr/bin/newgidmap
+
+RUN useradd -m build
+USER build:build
+RUN mkdir -p /home/build/.local/share/containers
+VOLUME /home/build/.local/share/containers
+
+ENV WERF_BUILDAH_MODE=auto


### PR DESCRIPTION
Alpine, Ubuntu, CentOS, Fedora-based images to run werf in Buildah mode
in them. External dependencies for werf were minimized as much as
possible previously, no improvements here.