### PR TITLE
docs(buildah): improve buildah docs

### DIFF
--- a/docs/documentation/_data/sidebars/_documentation.yml
+++ b/docs/documentation/_data/sidebars/_documentation.yml
@@ -93,6 +93,9 @@ entries:
           - title: Bundles
             url: /advanced/bundles.html
 
+          - title: Buildah mode
+            url: /advanced/buildah_mode.html
+
           - title: CI/CD
             f:
 

--- a/docs/documentation/_data/sidebars/documentation.yml
+++ b/docs/documentation/_data/sidebars/documentation.yml
@@ -422,6 +422,9 @@ entries:
           - title: Bundles
             url: /advanced/bundles.html
 
+          - title: Buildah mode
+            url: /advanced/buildah_mode.html
+
           - title: CI/CD
             f:
 

--- a/docs/documentation/pages_en/advanced/buildah_mode.md
+++ b/docs/documentation/pages_en/advanced/buildah_mode.md
@@ -1,0 +1,34 @@
+---
+title: Buildah mode
+permalink: advanced/buildah_mode.html
+---
+
+werf currently supports building of images _with docker server_ or _without docker server_ (in experimental mode).  This page contains information, which is only applicable for experimental mode _without docker server_. Only dockerfile-images builder is available for this mode for now. Stapel-images builder will be available soon.
+
+In experimental mode _without docker server_ werf uses built-in buildah in rootless mode.
+
+## Enable buildah
+
+Buildah is enabled by setting `WERF_BUILDAH_MODE` environment variable to one of the options: `auto`, `native-chroot`, `native-rootless` or `docker-with-fuse`.
+
+* `auto` — select mode automatically based on your platform and environment.
+* `native-chroot` works only in Linux and uses `chroot` isolation level when running build containers.
+* `native-rootless` works only in Linux and uses `rootless` isolation leven when running build containers. In this isolation level werf will use container runtime (runc or crun).
+* `docker-with-fuse` is crossplatform mode, and it is the only available choice in MacOS or Windows.
+
+Most users should just set `WERF_BUILDAH_MODE=auto` to enable experimental buildah mode.
+
+## Storage driver
+
+Werf may use `overlay` or `vfs` storage driver:
+
+* `overlay` enables usage of overlayfs filesystem. Either native linux kernel overlayfs could be used if available or fuse-overlayfs. It is the default and recommended choice.
+* `vfs` enables usage of virtual filesystem emulation instead of overlayfs. This filesystem has worse performance and requires privileged container, thus it is not recommended. But it may be required in some cases.
+
+Generally user should just use default `overlay`. Storage driver could be selected with the `WERF_BUILDAH_STORAGE_DRIVER` environment variable.
+
+### System requirements
+
+Starting with Linux kernel version 5.11 rootless overlayfs is available (technically from 5.13 version, which contains bugfix to enable rootless overlayfs with SELinux, but most major linux distributions has been backported this bugfix to 5.11 kernel).
+
+If your kernel does not support rootless overlayfs, then fuse-overlayfs will be used.

--- a/docs/documentation/pages_en/advanced/ci_cd/run_in_container/how_it_works.md
+++ b/docs/documentation/pages_en/advanced/ci_cd/run_in_container/how_it_works.md
@@ -5,39 +5,15 @@ permalink: advanced/ci_cd/run_in_container/how_it_works.html
 
 werf currently supports building of images _with docker server_ or _without docker server_ (in experimental mode).  This page contains information, which is only applicable for experimental mode _without docker server_. Only dockerfile-images builder is available for this mode for now. Stapel-images builder will be available soon.
 
-In experimental mode _without docker server_ werf uses built-in buildah in rootless mode.
-
-## Enable buildah
-
-Experimental buildah support is enabled by setting `WERF_BUILDAH_MODE` environment variable to one of the options: `auto`, `native-chroot`, `native-rootless` or `docker-with-fuse`.
-
-* `auto` — select mode automatically based on your platform and environment.
-* `native-chroot` works only in Linux and uses `chroot` isolation level when running build containers.
-* `native-rootless` works only in Linux and uses `rootless` isolation leven when running build containers. In this isolation level werf will use container runtime (runc or crun).
-* `docker-with-fuse` is crossplatform mode, and it is the only available choice in MacOS or Windows.
-
-Most users should just set `WERF_BUILDAH_MODE=auto` to enable experimental buildah mode.
-
-## Storage driver
-
-Werf may use `overlay` or `vfs` storage driver:
-
-* `overlay` enables usage of overlayfs filesystem. Either native linux kernel overlayfs could be used if available or fuse-overlayfs. It is the default and recommended choice.
-* `vfs` enables usage of virtual filesystem emulation instead of overlayfs. This filesystem has worse performance and requires privileged container, thus it is not recommended. But it may be required in some cases.
-
-Generally user should just use default `overlay`. Storage driver could be selected with the `WERF_BUILDAH_STORAGE_DRIVER` environment variable.
-
-### System requirements
-
-Starting with Linux kernel version 5.11 rootless overlayfs is available (technically from 5.13 version, which contains bugfix to enable rootless overlayfs with SELinux, but most major linux distributions has been backported this bugfix to 5.11 kernel).
+General info how to enable buildah in werf is available at [buildah mode page]({{ "/advanced/buildah_mode.html" | true_relative_url }}).
 
 ## Modes of operation
 
-Depending on system requirements and user needs there are 3 ways to use werf with buildah inside containers:
+Depending on user system conformance with [buildah mode system requirements]({{ "/advanced/buildah_mode.html#system-requirements" | true_relative_url }}) and depending on user needs there are 3 ways to use werf with buildah inside containers:
 
-1. Use [Linux kernel with rootless overlayfs](#system-requirements).
-2. Use [Linux kernel without rootless overlayfs](#system-requirements) and privileged container.
-3. Use [Linux kernel without rootless overlayfs](#system-requirements) and non-privileged container with additional settings.
+1. Use [Linux kernel with rootless overlayfs]({{ "/advanced/buildah_mode.html#system-requirements" | true_relative_url }}).
+2. Use [Linux kernel without rootless overlayfs]({{ "/advanced/buildah_mode.html#system-requirements" | true_relative_url }}) and privileged container.
+3. Use [Linux kernel without rootless overlayfs]({{ "/advanced/buildah_mode.html#system-requirements" | true_relative_url }}) and non-privileged container with additional settings.
 
 ### Linux kernel with rootless overlayfs
 
@@ -45,18 +21,44 @@ This way you only required to **disable apparmor** and **seccomp** profiles in a
 
 ### Linux kernel without rootless overlayfs and privileged container
 
-In the case your Linux kernel does not have [rootless overlayfs](#system-requirements), buildah and werf uses fuse-overlayfs instead.
+In the case your Linux kernel does not have [rootless overlayfs]({{ "/advanced/buildah_mode.html#system-requirements" | true_relative_url }}), buildah and werf uses fuse-overlayfs instead.
 
 To enable usage of fuse-overlayfs in such case using a **privileged container** to run werf is one option.
 
 ### Linux kernel without rootless overlayfs and non-privileged container
 
-In the case your Linux kernel does not have [rootless overlayfs](#system-requirements), buildah and werf uses fuse-overlayfs instead.
+In the case your Linux kernel does not have [rootless overlayfs]({{ "/advanced/buildah_mode.html#system-requirements" | true_relative_url }}), buildah and werf uses fuse-overlayfs instead.
 
 To enable usage of fuse-overlayfs in such case without using a privileged container, run werf in a container with the following options:
 
 1. **Disabled apparmor** and **seccomp** profiles .
 2. Enabled `/dev/fuse` device.
+
+## Available werf images
+
+Following images are provided with builtin werf. Each image will be updated through the same release process as used in the trdl package manager, [more info about release channels]({{ "installation.html#all-changes-in-werf-go-through-all-release-channels" | true_relative_url }}).
+
+* `ghcr.io/werf/werf:latest` -> `ghcr.io/werf/werf:1.2-stable`;
+* `ghcr.io/werf/werf:1.2-alpha` -> `ghcr.io/werf/werf:1.2-alpha-alpine`;
+* `ghcr.io/werf/werf:1.2-beta` -> `ghcr.io/werf/werf:1.2-beta-alpine`;
+* `ghcr.io/werf/werf:1.2-ea` -> `ghcr.io/werf/werf:1.2-ea-alpine`;
+* `ghcr.io/werf/werf:1.2-stable` -> `ghcr.io/werf/werf:1.2-stable-alpine`;
+* `ghcr.io/werf/werf:1.2-alpha-alpine`;
+* `ghcr.io/werf/werf:1.2-beta-alpine`;
+* `ghcr.io/werf/werf:1.2-ea-alpine`;
+* `ghcr.io/werf/werf:1.2-stable-alpine`;
+* `ghcr.io/werf/werf:1.2-alpha-ubuntu`;
+* `ghcr.io/werf/werf:1.2-beta-ubuntu`;
+* `ghcr.io/werf/werf:1.2-ea-ubuntu`;
+* `ghcr.io/werf/werf:1.2-stable-ubuntu`;
+* `ghcr.io/werf/werf:1.2-alpha-centos`;
+* `ghcr.io/werf/werf:1.2-beta-centos`;
+* `ghcr.io/werf/werf:1.2-ea-centos`;
+* `ghcr.io/werf/werf:1.2-stable-centos`;
+* `ghcr.io/werf/werf:1.2-alpha-fedora`;
+* `ghcr.io/werf/werf:1.2-beta-fedora`;
+* `ghcr.io/werf/werf:1.2-ea-fedora`;
+* `ghcr.io/werf/werf:1.2-stable-fedora`.
 
 ## Troubleshooting
 

--- a/docs/documentation/pages_en/internals/build_process.md
+++ b/docs/documentation/pages_en/internals/build_process.md
@@ -126,3 +126,11 @@ After building a tree of image dependencies, werf splits the assembly process in
 │ - ⛵ image app
 └ Concurrent builds plan (no more than 5 images at the same time)
 ```
+
+## Buildah
+
+Werf supports usage of buildah in experimental mode to build images. In this mode only dockerfile-images are supported for now (stapel support is planned).
+
+In this mode overall build process remains the same, only backend containers engine and storage changed from docker-server to buildah.
+
+More information about buildah is available in the [buildah mode article]({{ "/advanced/buildah_mode.html" | true_relative_url }})


### PR DESCRIPTION
* separate advanced article about buildah mode;
* build process refers to buildah mode article in advanced;
* how-it-works article only describes 3 variants to run werf+buildah in containers and troubleshooting.