### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @alexey-igrychev
+* @distorhead
+* @ilya-lesikov


### PR DESCRIPTION
This is a feature that automatically suggests reviewers for the PR on the right bar based on `CODEOWNERS` file: https://github.blog/2017-07-06-introducing-code-owners/ 