### PR TITLE
fix(harbor): detect usage of harbor without --repo-container-registry=harbor option

### DIFF
--- a/pkg/docker_registry/aws_ecr.go
+++ b/pkg/docker_registry/aws_ecr.go
@@ -29,7 +29,7 @@ type awsEcrOptions struct {
 }
 
 func newAwsEcr(options awsEcrOptions) (*awsEcr, error) {
-	d, err := newDefaultImplementation(options.defaultImplementationOptions)
+	d, err := newDefaultAPIForImplementation(AwsEcrImplementationName, options.defaultImplementationOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/docker_registry/azure_cr.go
+++ b/pkg/docker_registry/azure_cr.go
@@ -40,7 +40,7 @@ type azureCrOptions struct {
 }
 
 func newAzureCr(options azureCrOptions) (*azureCr, error) {
-	d, err := newDefaultImplementation(options.defaultImplementationOptions)
+	d, err := newDefaultAPIForImplementation(AzureCrImplementationName, options.defaultImplementationOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/docker_registry/docker_hub.go
+++ b/pkg/docker_registry/docker_hub.go
@@ -64,7 +64,7 @@ type dockerHubCredentials struct {
 }
 
 func newDockerHub(options dockerHubOptions) (*dockerHub, error) {
-	d, err := newDefaultImplementation(options.defaultImplementationOptions)
+	d, err := newDefaultAPIForImplementation(DockerHubImplementationName, options.defaultImplementationOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/docker_registry/gcr.go
+++ b/pkg/docker_registry/gcr.go
@@ -20,7 +20,7 @@ type GcrOptions struct {
 }
 
 func newGcr(options GcrOptions) (*gcr, error) {
-	d, err := newDefaultImplementation(options.defaultImplementationOptions)
+	d, err := newDefaultAPIForImplementation(GcrImplementationName, options.defaultImplementationOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/docker_registry/github_packages.go
+++ b/pkg/docker_registry/github_packages.go
@@ -68,7 +68,7 @@ type gitHubPackagesOptions struct {
 }
 
 func newGitHubPackages(options gitHubPackagesOptions) (*gitHubPackages, error) {
-	d, err := newDefaultImplementation(options.defaultImplementationOptions)
+	d, err := newDefaultAPIForImplementation(GitHubPackagesImplementationName, options.defaultImplementationOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/docker_registry/gitlab_registry.go
+++ b/pkg/docker_registry/gitlab_registry.go
@@ -41,7 +41,7 @@ type gitLabRegistryOptions struct {
 }
 
 func newGitLabRegistry(options gitLabRegistryOptions) (*gitLabRegistry, error) {
-	d, err := newDefaultImplementation(options.defaultImplementationOptions)
+	d, err := newDefaultAPIForImplementation(GitLabRegistryImplementationName, options.defaultImplementationOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/docker_registry/harbor.go
+++ b/pkg/docker_registry/harbor.go
@@ -47,7 +47,7 @@ type harborCredentials struct {
 }
 
 func newHarbor(options harborOptions) (*harbor, error) {
-	d, err := newDefaultImplementation(options.defaultImplementationOptions)
+	d, err := newDefaultAPIForImplementation(HarborImplementationName, options.defaultImplementationOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func newHarbor(options harborOptions) (*harbor, error) {
 func (r *harbor) Tags(ctx context.Context, reference string) ([]string, error) {
 	tags, err := r.defaultImplementation.Tags(ctx, reference)
 	if err != nil {
-		if IsNotFoundError(err) {
+		if IsHarborNotFoundError(err) {
 			return []string{}, nil
 		}
 		return nil, err
@@ -84,7 +84,7 @@ func (r *harbor) IsRepoImageExists(ctx context.Context, reference string) (bool,
 func (r *harbor) TryGetRepoImage(ctx context.Context, reference string) (*image.Info, error) {
 	res, err := r.api.TryGetRepoImage(ctx, reference)
 	if err != nil {
-		if IsNotFoundError(err) {
+		if IsHarborNotFoundError(err) {
 			return nil, nil
 		}
 
@@ -130,6 +130,18 @@ func (r *harbor) parseReference(reference string) (string, string, error) {
 	return parsedReference.RegistryStr(), parsedReference.RepositoryStr(), nil
 }
 
-func IsNotFoundError(err error) bool {
-	return strings.Contains(err.Error(), "NOT_FOUND")
+func IsHarborNotFoundError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "NOT_FOUND")
+}
+
+func IsHarbor404Error(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Example error:
+	// GET https://domain/harbor/s3/object/name/prefix/docker/registry/v2/blobs/sha256/2d/3d8c68cd9df32f1beb4392298a123eac58aba1433a15b3258b2f3728bad4b7d1/data?X-Amz-Algorithm=REDACTED&X-Amz-Credential=REDACTED&X-Amz-Date=REDACTED&X-Amz-Expires=REDACTED&X-Amz-Signature=REDACTED&X-Amz-SignedHeaders=REDACTED: unsupported status code 404; body: <?xml version="1.0" encoding="UTF-8"?>
+	// <Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Resource>/harbor/s3/object/name/prefix/docker/registry/v2/blobs/sha256/3d/3d8c68cd9df32f1beb4392298a123eac58aba1433a15b3258b2f3728bad4b7d1/data</Resource><RequestId>c5bb943c-1e85-5930-b455-c3e8edbbaccd</RequestId></Error>
+
+	return strings.Contains(err.Error(), "unsupported status code 404")
 }

--- a/pkg/docker_registry/quay.go
+++ b/pkg/docker_registry/quay.go
@@ -46,7 +46,7 @@ type quayCredentials struct {
 }
 
 func newQuay(options quayOptions) (*quay, error) {
-	d, err := newDefaultImplementation(options.defaultImplementationOptions)
+	d, err := newDefaultAPIForImplementation(QuayImplementationName, options.defaultImplementationOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Added warning when an error occurs which is known to be an error from the harbor.
This warning instructs user to specify --repo-container-registry=harbor option (possibly forgotten).