### PR TITLE
feat: Added login and logout cli commands for container registry

### DIFF
--- a/cmd/werf/cr/login/login.go
+++ b/cmd/werf/cr/login/login.go
@@ -1,0 +1,145 @@
+package login
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
+	"oras.land/oras-go/pkg/auth"
+	"oras.land/oras-go/pkg/auth/docker"
+
+	"github.com/werf/logboek"
+	"github.com/werf/werf/cmd/werf/common"
+	secret_common "github.com/werf/werf/cmd/werf/helm/secret/common"
+	"github.com/werf/werf/pkg/werf"
+	"github.com/werf/werf/pkg/werf/global_warnings"
+)
+
+var commonCmdData common.CmdData
+
+var cmdData struct {
+	Username      string
+	Password      string
+	PasswordStdin bool
+}
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "login registry",
+		Short: "Login into remote registry",
+		Long:  common.GetLongCommandDescription(`Login into remote registry`),
+		Example: `# Login with username and password from command line
+werf cr login -u username -p password registry.example.com
+
+# Login with token from command line
+werf cr login -p token registry.example.com
+
+# Login into insecure registry (over http)
+werf cr login --insecure-registry registry.example.com`,
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := common.BackgroundContext()
+
+			defer global_warnings.PrintGlobalWarnings(ctx)
+
+			if err := common.ProcessLogOptions(&commonCmdData); err != nil {
+				common.PrintHelp(cmd)
+				return err
+			}
+
+			if len(args) != 1 {
+				common.PrintHelp(cmd)
+				return fmt.Errorf("registry address argument required")
+			}
+
+			return Login(ctx, args[0], LoginOptions{
+				Username:         cmdData.Username,
+				Password:         cmdData.Password,
+				PasswordStdin:    cmdData.PasswordStdin,
+				DockerConfigDir:  *commonCmdData.DockerConfig,
+				InsecureRegistry: *commonCmdData.InsecureRegistry,
+			})
+		},
+	}
+
+	common.SetupDockerConfig(&commonCmdData, cmd, "")
+	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	// common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
+	common.SetupLogOptions(&commonCmdData, cmd)
+
+	cmd.Flags().StringVarP(&cmdData.Username, "username", "u", os.Getenv("WERF_USERNAME"), "Use specified username for login (default $WERF_USERNAME)")
+	cmd.Flags().StringVarP(&cmdData.Password, "password", "p", os.Getenv("WERF_PASSWORD"), "Use specified password for login (default $WERF_PASSWORD)")
+	cmd.Flags().BoolVarP(&cmdData.PasswordStdin, "password-stdin", "", common.GetBoolEnvironmentDefaultFalse("WERF_PASSWORD_STDIN"), "Read password from stdin for login (default $WERF_PASSWORD_STDIN)")
+
+	return cmd
+}
+
+type LoginOptions struct {
+	Username         string
+	Password         string
+	PasswordStdin    bool
+	DockerConfigDir  string
+	InsecureRegistry bool
+}
+
+func Login(ctx context.Context, registry string, opts LoginOptions) error {
+	var dockerConfigDir string
+	if opts.DockerConfigDir != "" {
+		dockerConfigDir = opts.DockerConfigDir
+	} else {
+		dockerConfigDir = filepath.Join(os.Getenv("HOME"), ".docker")
+	}
+
+	cli, err := docker.NewClient(filepath.Join(dockerConfigDir, "config.json"))
+	if err != nil {
+		return fmt.Errorf("unable to create oras auth client: %s", err)
+	}
+
+	if opts.Username == "" {
+		return fmt.Errorf("provide --username")
+	}
+
+	var password string
+	if opts.PasswordStdin {
+		if opts.Password != "" {
+			return fmt.Errorf("--password and --password-stdin could not be used at the same time")
+		}
+
+		var bytePassword []byte
+		if terminal.IsTerminal(int(os.Stdin.Fd())) {
+			bytePassword, err = secret_common.InputFromInteractiveStdin("Password: ")
+			if err != nil {
+				return fmt.Errorf("error reading password from interactive stdin: %s", err)
+			}
+		} else {
+			bytePassword, err = secret_common.InputFromStdin()
+			if err != nil {
+				return fmt.Errorf("error reading password from stdin: %s", err)
+			}
+		}
+
+		password = string(bytePassword)
+	} else if opts.Password != "" {
+		password = opts.Password
+	} else {
+		return fmt.Errorf("provide --password or --password-stdin")
+	}
+
+	if err := cli.LoginWithOpts(func(settings *auth.LoginSettings) {
+		settings.Context = ctx
+		settings.Hostname = registry
+		settings.Username = opts.Username
+		settings.Secret = password
+		settings.Insecure = opts.InsecureRegistry
+		settings.UserAgent = fmt.Sprintf("werf %s", werf.Version)
+	}); err != nil {
+		return fmt.Errorf("unable to login into %q: %s", registry, err)
+	}
+
+	logboek.Context(ctx).Default().LogFHighlight("Successful login\n")
+
+	return nil
+}

--- a/cmd/werf/cr/logout/logout.go
+++ b/cmd/werf/cr/logout/logout.go
@@ -1,0 +1,76 @@
+package logout
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"oras.land/oras-go/pkg/auth/docker"
+
+	"github.com/werf/logboek"
+	"github.com/werf/werf/cmd/werf/common"
+	"github.com/werf/werf/pkg/werf/global_warnings"
+)
+
+var commonCmdData common.CmdData
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "logout registry",
+		Short:                 "Logout from a remote registry",
+		Long:                  common.GetLongCommandDescription(`Logout from a remote registry`),
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := common.BackgroundContext()
+
+			defer global_warnings.PrintGlobalWarnings(ctx)
+
+			if err := common.ProcessLogOptions(&commonCmdData); err != nil {
+				common.PrintHelp(cmd)
+				return err
+			}
+
+			if len(args) != 1 {
+				common.PrintHelp(cmd)
+				return fmt.Errorf("registry address argument required")
+			}
+
+			return Logout(ctx, args[0], LogoutOptions{
+				DockerConfigDir: *commonCmdData.DockerConfig,
+			})
+		},
+	}
+
+	common.SetupDockerConfig(&commonCmdData, cmd, "")
+	common.SetupLogOptions(&commonCmdData, cmd)
+
+	return cmd
+}
+
+type LogoutOptions struct {
+	DockerConfigDir string
+}
+
+func Logout(ctx context.Context, registry string, opts LogoutOptions) error {
+	var dockerConfigDir string
+	if opts.DockerConfigDir != "" {
+		dockerConfigDir = opts.DockerConfigDir
+	} else {
+		dockerConfigDir = filepath.Join(os.Getenv("HOME"), ".docker")
+	}
+
+	cli, err := docker.NewClient(filepath.Join(dockerConfigDir, "config.json"))
+	if err != nil {
+		return fmt.Errorf("unable to create auth client: %s", err)
+	}
+
+	if err := cli.Logout(ctx, registry); err != nil {
+		return fmt.Errorf("unable to logout from %q: %s", registry, err)
+	}
+
+	logboek.Context(ctx).Default().LogFHighlight("Successful logout\n")
+
+	return nil
+}

--- a/cmd/werf/helm/secret/decrypt/decrypt.go
+++ b/cmd/werf/helm/secret/decrypt/decrypt.go
@@ -97,7 +97,7 @@ func secretDecrypt(ctx context.Context, m *secrets_manager.SecretsManager, worki
 	}
 
 	if terminal.IsTerminal(int(os.Stdin.Fd())) {
-		encodedData, err = secret_common.InputFromInteractiveStdin()
+		encodedData, err = secret_common.InputFromInteractiveStdin("Enter secret: ")
 		if err != nil {
 			return err
 		}

--- a/cmd/werf/helm/secret/encrypt/encrypt.go
+++ b/cmd/werf/helm/secret/encrypt/encrypt.go
@@ -96,7 +96,7 @@ func secretEncrypt(ctx context.Context, m *secrets_manager.SecretsManager, worki
 	}
 
 	if terminal.IsTerminal(int(os.Stdin.Fd())) {
-		data, err = secret_common.InputFromInteractiveStdin()
+		data, err = secret_common.InputFromInteractiveStdin("Enter secret: ")
 		if err != nil {
 			return err
 		}

--- a/cmd/werf/main.go
+++ b/cmd/werf/main.go
@@ -24,6 +24,8 @@ import (
 	config_list "github.com/werf/werf/cmd/werf/config/list"
 	config_render "github.com/werf/werf/cmd/werf/config/render"
 	"github.com/werf/werf/cmd/werf/converge"
+	cr_login "github.com/werf/werf/cmd/werf/cr/login"
+	cr_logout "github.com/werf/werf/cmd/werf/cr/logout"
 	"github.com/werf/werf/cmd/werf/dismiss"
 	"github.com/werf/werf/cmd/werf/docs"
 	"github.com/werf/werf/cmd/werf/export"
@@ -118,6 +120,7 @@ Find more information at https://werf.io`),
 				managedImagesCmd(),
 				hostCmd(),
 				helm.NewCmd(),
+				crCmd(),
 			},
 		},
 		{
@@ -148,6 +151,19 @@ func dockerComposeCmd() *cobra.Command {
 		compose.NewRunCmd(),
 		compose.NewUpCmd(),
 		compose.NewDownCmd(),
+	)
+
+	return cmd
+}
+
+func crCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cr",
+		Short: "Work with container registry: authenticate, list and remove images, etc.",
+	}
+	cmd.AddCommand(
+		cr_login.NewCmd(),
+		cr_logout.NewCmd(),
 	)
 
 	return cmd

--- a/docs/_data/sidebars/_cli.yml
+++ b/docs/_data/sidebars/_cli.yml
@@ -309,6 +309,15 @@ cli: &cli
       - title: werf helm version
         url: /reference/cli/werf_helm_version.html
 
+    - title: werf cr
+      f:
+
+      - title: werf cr login
+        url: /reference/cli/werf_cr_login.html
+
+      - title: werf cr logout
+        url: /reference/cli/werf_cr_logout.html
+
   - title: Other commands
     f:
 

--- a/docs/_data/sidebars/documentation.yml
+++ b/docs/_data/sidebars/documentation.yml
@@ -314,6 +314,15 @@ cli: &cli
       - title: werf helm version
         url: /reference/cli/werf_helm_version.html
 
+    - title: werf cr
+      f:
+
+      - title: werf cr login
+        url: /reference/cli/werf_cr_login.html
+
+      - title: werf cr logout
+        url: /reference/cli/werf_cr_logout.html
+
   - title: Other commands
     f:
 
@@ -443,16 +452,16 @@ entries:
               - title: Run in containers (experimental)
                 f:
 
-                  - title: Use docker container
+                  - title: Use Docker container
                     url: /advanced/ci_cd/run_in_container/use_docker_container.html
 
-                  - title: Use kubernetes
+                  - title: Use Kubernetes
                     url: /advanced/ci_cd/run_in_container/use_kubernetes.html
 
-                  - title: Use Gitlab CI/CD with docker executor
+                  - title: Use GitLab CI/CD with Docker executor
                     url: /advanced/ci_cd/run_in_container/use_gitlab_ci_cd_with_docker_executor.html
 
-                  - title: Use Gitlab CI/CD with kubernetes executor
+                  - title: Use GitLab CI/CD with Kubernetes executor
                     url: /advanced/ci_cd/run_in_container/use_gitlab_ci_cd_with_kubernetes_executor.html
 
                   - title: How it works
@@ -645,6 +654,24 @@ entries:
 
               - title: Интеграция с GitHub Actions
                 url: /advanced/ci_cd/github_actions.html
+
+              - title: Запуск в контейнерах (experimental)
+                f:
+
+                  - title: В Docker-контейнере
+                    url: /advanced/ci_cd/run_in_container/use_docker_container.html
+
+                  - title: В Kubernetes
+                    url: /advanced/ci_cd/run_in_container/use_kubernetes.html
+
+                  - title: В GitLab CI/CD с Docker executor
+                    url: /advanced/ci_cd/run_in_container/use_gitlab_ci_cd_with_docker_executor.html
+
+                  - title: В GitLab CI/CD с Kubernetes executor
+                    url: /advanced/ci_cd/run_in_container/use_gitlab_ci_cd_with_kubernetes_executor.html
+
+                  - title: Принципы работы
+                    url: /advanced/ci_cd/run_in_container/how_it_works.html
 
           - title: Сборка образов с помощью Stapel
             f:

--- a/docs/_includes/reference/cli/werf_cr.md
+++ b/docs/_includes/reference/cli/werf_cr.md
@@ -1,0 +1,7 @@
+{% if include.header %}
+{% assign header = include.header %}
+{% else %}
+{% assign header = "###" %}
+{% endif %}
+Work with container registry: authenticate, list and remove images, etc.
+

--- a/docs/_includes/reference/cli/werf_cr.short.md
+++ b/docs/_includes/reference/cli/werf_cr.short.md
@@ -1,0 +1,1 @@
+work with container registry: authenticate, list and remove images, etc.

--- a/docs/_includes/reference/cli/werf_cr_login.md
+++ b/docs/_includes/reference/cli/werf_cr_login.md
@@ -1,0 +1,61 @@
+{% if include.header %}
+{% assign header = include.header %}
+{% else %}
+{% assign header = "###" %}
+{% endif %}
+Login into remote registry
+
+{{ header }} Syntax
+
+```shell
+werf cr login registry [options]
+```
+
+{{ header }} Examples
+
+```shell
+# Login with username and password from command line
+werf cr login -u username -p password registry.example.com
+
+# Login with token from command line
+werf cr login -p token registry.example.com
+
+# Login into insecure registry (over http)
+werf cr login --insecure-registry registry.example.com
+```
+
+{{ header }} Options
+
+```shell
+      --docker-config=''
+            Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
+            ~/.docker (in the order of priority)
+      --insecure-registry=false
+            Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
+      --log-color-mode='auto'
+            Set log color mode.
+            Supported on, off and auto (based on the stdout’s file descriptor referring to a        
+            terminal) modes.
+            Default $WERF_LOG_COLOR_MODE or auto mode.
+      --log-debug=false
+            Enable debug (default $WERF_LOG_DEBUG).
+      --log-pretty=true
+            Enable emojis, auto line wrapping and log process border (default $WERF_LOG_PRETTY or   
+            true).
+      --log-quiet=false
+            Disable explanatory output (default $WERF_LOG_QUIET).
+      --log-terminal-width=-1
+            Set log terminal width.
+            Defaults to:
+            * $WERF_LOG_TERMINAL_WIDTH
+            * interactive terminal width or 140
+      --log-verbose=false
+            Enable verbose output (default $WERF_LOG_VERBOSE).
+  -p, --password=''
+            Use specified password for login (default $WERF_PASSWORD)
+      --password-stdin=false
+            Read password from stdin for login (default $WERF_PASSWORD_STDIN)
+  -u, --username=''
+            Use specified username for login (default $WERF_USERNAME)
+```
+

--- a/docs/_includes/reference/cli/werf_cr_login.short.md
+++ b/docs/_includes/reference/cli/werf_cr_login.short.md
@@ -1,0 +1,1 @@
+login into remote registry

--- a/docs/_includes/reference/cli/werf_cr_logout.md
+++ b/docs/_includes/reference/cli/werf_cr_logout.md
@@ -1,0 +1,40 @@
+{% if include.header %}
+{% assign header = include.header %}
+{% else %}
+{% assign header = "###" %}
+{% endif %}
+Logout from a remote registry
+
+{{ header }} Syntax
+
+```shell
+werf cr logout registry [options]
+```
+
+{{ header }} Options
+
+```shell
+      --docker-config=''
+            Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
+            ~/.docker (in the order of priority)
+      --log-color-mode='auto'
+            Set log color mode.
+            Supported on, off and auto (based on the stdout’s file descriptor referring to a        
+            terminal) modes.
+            Default $WERF_LOG_COLOR_MODE or auto mode.
+      --log-debug=false
+            Enable debug (default $WERF_LOG_DEBUG).
+      --log-pretty=true
+            Enable emojis, auto line wrapping and log process border (default $WERF_LOG_PRETTY or   
+            true).
+      --log-quiet=false
+            Disable explanatory output (default $WERF_LOG_QUIET).
+      --log-terminal-width=-1
+            Set log terminal width.
+            Defaults to:
+            * $WERF_LOG_TERMINAL_WIDTH
+            * interactive terminal width or 140
+      --log-verbose=false
+            Enable verbose output (default $WERF_LOG_VERBOSE).
+```
+

--- a/docs/_includes/reference/cli/werf_cr_logout.short.md
+++ b/docs/_includes/reference/cli/werf_cr_logout.short.md
@@ -1,0 +1,1 @@
+logout from a remote registry

--- a/docs/pages_en/reference/cli/overview.md
+++ b/docs/pages_en/reference/cli/overview.md
@@ -27,6 +27,7 @@ Low-level management commands:
  - [werf managed-images]({{ "/reference/cli/werf_managed_images_add.html" | true_relative_url }}) — {% include /reference/cli/werf_managed_images_add.short.md %}.
  - [werf host]({{ "/reference/cli/werf_host_cleanup.html" | true_relative_url }}) — {% include /reference/cli/werf_host_cleanup.short.md %}.
  - [werf helm]({{ "/reference/cli/werf_helm_create.html" | true_relative_url }}) — {% include /reference/cli/werf_helm_create.short.md %}.
+ - [werf cr]({{ "/reference/cli/werf_cr_login.html" | true_relative_url }}) — {% include /reference/cli/werf_cr_login.short.md %}.
 
 Other commands:
  - [werf synchronization]({{ "/reference/cli/werf_synchronization.html" | true_relative_url }}) — {% include /reference/cli/werf_synchronization.short.md %}.

--- a/docs/pages_en/reference/cli/werf_cr.md
+++ b/docs/pages_en/reference/cli/werf_cr.md
@@ -1,0 +1,6 @@
+---
+title: werf cr
+permalink: reference/cli/werf_cr.html
+---
+
+{% include /reference/cli/werf_cr.md %}

--- a/docs/pages_en/reference/cli/werf_cr_login.md
+++ b/docs/pages_en/reference/cli/werf_cr_login.md
@@ -1,0 +1,6 @@
+---
+title: werf cr login
+permalink: reference/cli/werf_cr_login.html
+---
+
+{% include /reference/cli/werf_cr_login.md %}

--- a/docs/pages_en/reference/cli/werf_cr_logout.md
+++ b/docs/pages_en/reference/cli/werf_cr_logout.md
@@ -1,0 +1,6 @@
+---
+title: werf cr logout
+permalink: reference/cli/werf_cr_logout.html
+---
+
+{% include /reference/cli/werf_cr_logout.md %}

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/minio/minio v0.0.0-20210311070216-f92b7a562103
 	github.com/mitchellh/copystructure v1.1.1
 	github.com/moby/buildkit v0.8.2
+	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/mvdan/xurls v1.1.0 // indirect
 	github.com/oleiade/reflections v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.16.4
@@ -58,10 +59,9 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31
 	github.com/opencontainers/runc v1.0.3 // indirect
-	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
+	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/otiai10/copy v1.0.1
 	github.com/otiai10/curr v1.0.0 // indirect
-	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
 	github.com/prashantv/gostub v1.0.0
 	github.com/rodaine/table v1.0.0
@@ -70,7 +70,6 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.7.0
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tonistiigi/go-rosetta v0.0.0-20200727161949-f79598599c5d // indirect
 	github.com/werf/kubedog v0.6.3-0.20211020172441-2ae4bcd3d36f
@@ -80,6 +79,7 @@ require (
 	go.mongodb.org/mongo-driver v1.5.1 // indirect
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023
+	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	gopkg.in/dancannon/gorethink.v3 v3.0.5 // indirect
 	gopkg.in/errgo.v2 v2.1.0
 	gopkg.in/fatih/pool.v2 v2.0.0 // indirect
@@ -98,6 +98,7 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kubectl v0.22.1
 	mvdan.cc/xurls v1.1.0
+	oras.land/oras-go v0.4.0
 	sigs.k8s.io/yaml v1.2.1-0.20210128145534-11e43d4a8b92
 )
 

--- a/go.sum
+++ b/go.sum
@@ -186,7 +186,6 @@ github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+V
 github.com/Microsoft/hcsshim v0.8.18/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim v0.8.20/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
-github.com/Microsoft/hcsshim v0.8.22 h1:CulZ3GW8sNJExknToo+RWD+U+6ZM5kkNfuxywSDPd08=
 github.com/Microsoft/hcsshim v0.8.22/go.mod h1:91uVCVzvX2QD16sMCenoxxXo6L1wJnLMX2PSufFMtF0=
 github.com/Microsoft/hcsshim v0.8.23 h1:47MSwtKGXet80aIn+7h4YI6fwPmwIghAnsx2aOUrG2M=
 github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
@@ -340,7 +339,6 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
-github.com/checkpoint-restore/go-criu/v5 v5.0.0 h1:TW8f/UvntYoVDMN1K2HlT82qH1rb0sOjpGw3m6Ym+i4=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/cheggaaa/pb v1.0.29/go.mod h1:W40334L7FMC5JKWldsTWbdGjLo0RxUKK73K+TuPxX30=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
@@ -353,7 +351,6 @@ github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmE
 github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLIdUjrmSXlK9pkrsDlLHbO8jiB8X8JnOc=
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
-github.com/cilium/ebpf v0.6.2 h1:iHsfF/t4aW4heW2YKfeHrVPGdtYTL4C4KocpM8KTSnI=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
@@ -415,7 +412,6 @@ github.com/containerd/containerd v1.5.0-rc.0/go.mod h1:V/IXoMqNGgBlabz3tHD2TWDoT
 github.com/containerd/containerd v1.5.1/go.mod h1:0DOxVqwDy2iZvrZp2JUx/E+hS0UNTVn7dJnIOwtYR4g=
 github.com/containerd/containerd v1.5.2/go.mod h1:0DOxVqwDy2iZvrZp2JUx/E+hS0UNTVn7dJnIOwtYR4g=
 github.com/containerd/containerd v1.5.5/go.mod h1:oSTh0QpT1w6jYcGmbiSbxv9OSQYaa88mPyWIuU79zyo=
-github.com/containerd/containerd v1.5.7 h1:rQyoYtj4KddB3bxG6SAqd4+08gePNyJjRqvOIfV3rkM=
 github.com/containerd/containerd v1.5.7/go.mod h1:gyvv6+ugqY25TiXxcZC3L5yOeYgEw0QMhscqVp1AR9c=
 github.com/containerd/containerd v1.5.8 h1:NmkCC1/QxyZFBny8JogwLpOy2f+VEbO/f6bV2Mqtwuw=
 github.com/containerd/containerd v1.5.8/go.mod h1:YdFSv5bTFLpG2HIYmfqDpSYYTDX+mc5qtSuYx1YUb/s=
@@ -460,7 +456,6 @@ github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDG
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c/go.mod h1:LPm1u0xBw8r8NOKoOdNMeVHSawSsltak+Ihv+etqsE8=
 github.com/containerd/ttrpc v1.0.1/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
-github.com/containerd/ttrpc v1.0.2 h1:2/O3oTZN36q2xRolk0a2WWGgh7/Vf/liElg5hFYLX9U=
 github.com/containerd/ttrpc v1.0.2/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
 github.com/containerd/ttrpc v1.1.0 h1:GbtyLRxb0gOLR0TYQWt3O6B0NvT8tMdorEHqIQo/lWI=
 github.com/containerd/ttrpc v1.1.0/go.mod h1:XX4ZTnoOId4HklF4edwc4DcqskFZuvXB1Evzy5KFQpQ=
@@ -833,10 +828,8 @@ github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
-github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e h1:BWhy2j3IXJhjCbC68FptL43tDKIq8FladmaTs3Xs7Z8=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godror/godror v0.24.2/go.mod h1:wZv/9vPiUib6tkoDl+AZ/QLf5YZgMravZ7jxH2eQWAE=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
@@ -1433,7 +1426,6 @@ github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:
 github.com/mozilla/tls-observatory v0.0.0-20200317151703-4fa42e1c2dee/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474/go.mod h1:OQA4XLvDbMgS8P0CevmM4m9Q3Jq4phKUzcocxuGJ5m8=
 github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976/go.mod h1:x8F1gnqOkIEiO4rqoeEEEqQbo7HjGMTvyoq3gej4iT0=
-github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/mtrmac/gpgme v0.1.2 h1:dNOmvYmsrakgW7LcgiprD0yfRuQQe8/C8F6Z+zogO3s=
 github.com/mtrmac/gpgme v0.1.2/go.mod h1:GYYHnGSuS7HK3zVS2n3y73y0okK/BeKzwnn5jgiVFNI=
@@ -1513,12 +1505,9 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283 h1:TVzvdjOalkJBNkbpPVMAr4KV9QRf2IjfxdyxwAK78Gs=
 github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31 h1:Wh4aR2I6JFwySre9m3iHJYuMnvUFE/HT6qAXozRWi/E=
 github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
-github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc10/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -1527,7 +1516,6 @@ github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rm
 github.com/opencontainers/runc v1.0.0-rc92/go.mod h1:X1zlU4p7wOlX4+WRCz+hvlRv8phdL7UqbYD+vQwNMmE=
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
 github.com/opencontainers/runc v1.0.1/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
-github.com/opencontainers/runc v1.0.2 h1:opHZMaswlyxz1OuGpBE53Dwe4/xF7EZTY0A2L/FpCOg=
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runc v1.0.3 h1:1hbqejyQWCJBvtKAfdO0b1FmaEf2z/bxnjqbARass5k=
 github.com/opencontainers/runc v1.0.3/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
@@ -1863,7 +1851,6 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/uudashr/gocognit v1.0.1/go.mod h1:j44Ayx2KW4+oB6SWMv8KsmHzZrOInQav7D3cQMJ5JUM=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
@@ -2601,7 +2588,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=


### PR DESCRIPTION
* `werf cr login REGISTRY` — to login;
* `werf cr logout REGISTRY` — to logout.

There will be more `werf cr` commands to work with container registries, like getting manifests, listing tags and deleting tags (`cr` stands for "container registry").