### PR TITLE
feat(deploy): expose commit info in Helm templates

### DIFF
--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -317,7 +317,22 @@ func runExport(ctx context.Context) error {
 		return err
 	}
 
-	if vals, err := helpers.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{Env: *commonCmdData.Environment, CustomTagFunc: useCustomTagFunc}); err != nil {
+	headHash, err := giterminismManager.LocalGitRepo().HeadCommitHash(ctx)
+	if err != nil {
+		return fmt.Errorf("getting HEAD commit hash failed: %s", err)
+	}
+
+	headTime, err := giterminismManager.LocalGitRepo().HeadCommitTime(ctx)
+	if err != nil {
+		return fmt.Errorf("getting HEAD commit time failed: %s", err)
+	}
+
+	if vals, err := helpers.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{
+		Env:           *commonCmdData.Environment,
+		CustomTagFunc: useCustomTagFunc,
+		CommitHash:    headHash,
+		CommitDate:    headTime,
+	}); err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	} else {
 		wc.SetServiceValues(vals)

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -343,7 +343,22 @@ func runPublish(ctx context.Context) error {
 		return err
 	}
 
-	if vals, err := helpers.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{Env: *commonCmdData.Environment, CustomTagFunc: useCustomTagFunc}); err != nil {
+	headHash, err := giterminismManager.LocalGitRepo().HeadCommitHash(ctx)
+	if err != nil {
+		return fmt.Errorf("getting HEAD commit hash failed: %s", err)
+	}
+
+	headTime, err := giterminismManager.LocalGitRepo().HeadCommitTime(ctx)
+	if err != nil {
+		return fmt.Errorf("getting HEAD commit time failed: %s", err)
+	}
+
+	if vals, err := helpers.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{
+		Env:           *commonCmdData.Environment,
+		CustomTagFunc: useCustomTagFunc,
+		CommitHash:    headHash,
+		CommitDate:    headTime,
+	}); err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	} else {
 		wc.SetServiceValues(vals)

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -397,12 +397,24 @@ func run(ctx context.Context, containerRuntime container_runtime.ContainerRuntim
 		return err
 	}
 
+	headHash, err := giterminismManager.LocalGitRepo().HeadCommitHash(ctx)
+	if err != nil {
+		return fmt.Errorf("getting HEAD commit hash failed: %s", err)
+	}
+
+	headTime, err := giterminismManager.LocalGitRepo().HeadCommitTime(ctx)
+	if err != nil {
+		return fmt.Errorf("getting HEAD commit time failed: %s", err)
+	}
+
 	if vals, err := helpers.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{
 		Namespace:                namespace,
 		Env:                      *commonCmdData.Environment,
 		SetDockerConfigJsonValue: *commonCmdData.SetDockerConfigJsonValue,
 		DockerConfigPath:         *commonCmdData.DockerConfig,
 		CustomTagFunc:            useCustomTagFunc,
+		CommitHash:               headHash,
+		CommitDate:               headTime,
 	}); err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	} else {

--- a/cmd/werf/helm/get_autogenerated_values.go
+++ b/cmd/werf/helm/get_autogenerated_values.go
@@ -229,7 +229,23 @@ func runGetServiceValues(ctx context.Context) error {
 		return err
 	}
 
-	serviceValues, err := helpers.GetServiceValues(ctx, projectName, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{Namespace: namespace, Env: environment, CustomTagFunc: useCustomTagFunc})
+	headHash, err := giterminismManager.LocalGitRepo().HeadCommitHash(ctx)
+	if err != nil {
+		return fmt.Errorf("getting HEAD commit hash failed: %s", err)
+	}
+
+	headTime, err := giterminismManager.LocalGitRepo().HeadCommitTime(ctx)
+	if err != nil {
+		return fmt.Errorf("getting HEAD commit time failed: %s", err)
+	}
+
+	serviceValues, err := helpers.GetServiceValues(ctx, projectName, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{
+		Namespace:     namespace,
+		Env:           environment,
+		CustomTagFunc: useCustomTagFunc,
+		CommitHash:    headHash,
+		CommitDate:    headTime,
+	})
 	if err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	}

--- a/cmd/werf/helm/helm.go
+++ b/cmd/werf/helm/helm.go
@@ -124,7 +124,14 @@ func NewCmd() *cobra.Command {
 
 				ctx := common.BackgroundContext()
 
-				if vals, err := helpers.GetServiceValues(ctx, "PROJECT", "REPO", nil, helpers.ServiceValuesOptions{Namespace: namespace, IsStub: true}); err != nil {
+				stubCommitDate := time.Unix(0, 0)
+
+				if vals, err := helpers.GetServiceValues(ctx, "PROJECT", "REPO", nil, helpers.ServiceValuesOptions{
+					Namespace:  namespace,
+					IsStub:     true,
+					CommitHash: "COMMIT_HASH",
+					CommitDate: &stubCommitDate,
+				}); err != nil {
 					return fmt.Errorf("error creating service values: %s", err)
 				} else {
 					wc.SetStubServiceValues(vals)

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -341,6 +341,16 @@ func runRender(ctx context.Context) error {
 		return err
 	}
 
+	headHash, err := giterminismManager.LocalGitRepo().HeadCommitHash(ctx)
+	if err != nil {
+		return fmt.Errorf("getting HEAD commit hash failed: %s", err)
+	}
+
+	headTime, err := giterminismManager.LocalGitRepo().HeadCommitTime(ctx)
+	if err != nil {
+		return fmt.Errorf("getting HEAD commit time failed: %s", err)
+	}
+
 	if vals, err := helpers.GetServiceValues(ctx, werfConfig.Meta.Project, imagesRepository, imagesInfoGetters, helpers.ServiceValuesOptions{
 		Namespace:                namespace,
 		Env:                      *commonCmdData.Environment,
@@ -349,6 +359,8 @@ func runRender(ctx context.Context) error {
 		SetDockerConfigJsonValue: *commonCmdData.SetDockerConfigJsonValue,
 		DockerConfigPath:         *commonCmdData.DockerConfig,
 		CustomTagFunc:            useCustomTagFunc,
+		CommitHash:               headHash,
+		CommitDate:               headTime,
 	}); err != nil {
 		return fmt.Errorf("error creating service values: %s", err)
 	} else {

--- a/pkg/deploy/helm/chart_extender/helpers/service_values.go
+++ b/pkg/deploy/helm/chart_extender/helpers/service_values.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
@@ -38,6 +39,8 @@ type ServiceValuesOptions struct {
 	IsStub          bool
 	StubImagesNames []string
 	CustomTagFunc   func(string) string
+	CommitHash      string
+	CommitDate      *time.Time
 
 	SetDockerConfigJsonValue bool
 	DockerConfigPath         string
@@ -57,6 +60,13 @@ func GetServiceValues(ctx context.Context, projectName string, repo string, imag
 		"repo":    repo,
 		"image":   map[string]interface{}{},
 		"tag":     map[string]interface{}{},
+		"commit": map[string]interface{}{
+			"hash": opts.CommitHash,
+			"date": map[string]interface{}{
+				"human": opts.CommitDate.String(),
+				"unix":  opts.CommitDate.Unix(),
+			},
+		},
 	}
 
 	if opts.Env != "" {


### PR DESCRIPTION
New Values available:
* `$.Values.werf.commit.hash`
* `$.Values.werf.commit.date.human`
* `$.Values.werf.commit.date.unix`