### PR TITLE
fix: "unable to switch worktree" in gitlab

### DIFF
--- a/pkg/util/lines.go
+++ b/pkg/util/lines.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"bufio"
+	"strings"
+)
+
+func SplitLines(s string) []string {
+	var lines []string
+	sc := bufio.NewScanner(strings.NewReader(s))
+	sc.Split(bufio.ScanLines)
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	return lines
+}


### PR DESCRIPTION
Automatically invalidate inconsistent service git worktree which werf creates in the ~/.werf/local_cache/git_worktrees.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>