### PR TITLE
fix: add lost fixes from v1.1.23+fix51, v1.1.23+fix52 and v1.1.23+fix53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 /docs/vendor
 /docs/.ruby-version
+docs/\.jekyll-cache/
 
 /stapel/*/omnibus/build
 /stapel/*/omnibus/vendor
@@ -22,5 +23,3 @@
 /tests/integration/three-way-merge/**/main
 /bin
 /tests-coverage
-
-docs/\.jekyll-cache/


### PR DESCRIPTION
* fix(helm-v3): fixed panic in 'werf helm-v3 *' commands

* fix(helm): change broken default charts repo (use bitnami).

* fix(cleanup): ignore harbor "unsupported 404 status code" errors

    These errors may occur when harbor configured to use S3 backend, which may respond with the following error:

    ```
    GET https://domain/harbor/s3/object/name/prefix/docker/registry/v2/blobs/sha256/2d/3d8c68cd9df32f1beb4392298a123eac58aba1433a15b3258b2f3728bad4b7d1/data?X-Amz-Algorithm=REDACTED&X-Amz-Credential=REDACTED&X-Amz-Date=REDACTED&X-Amz-Expires=REDACTED&X-Amz-Signature=REDACTED&X-Amz-SignedHeaders=REDACTED: unsupported status code 404; body: <?xml version="1.0" encoding="UTF-8"?>
    <Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Resource>/harbor/s3/object/name/prefix/docker/registry/v2/blobs/sha256/3d/3d8c68cd9df32f1beb4392298a123eac58aba1433a15b3258b2f3728bad4b7d1/data</Resource><RequestId>c5bb943c-1e85-5930-b455-c3e8edbbaccd</RequestId></Error>
    ```

* **deploy:** Remove debug-info on release failure from default logger. Log internal tiller messages on release failure only in verbose mode.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>