### PR TITLE
fix: "unable to switch worktree" in gitlab

### DIFF
--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -3,6 +3,7 @@ package util
 import (
 	"os"
 	"strings"
+	"reflect"
 )
 
 // FileExists returns true if path exists
@@ -38,4 +39,29 @@ func isNotExistError(err error) bool {
 
 func IsNotADirectoryError(err error) bool {
 	return strings.HasSuffix(err.Error(), "not a directory")
+}
+
+func IsSubpathOfBasePath(basePath, path string) bool {
+	basePathParts := SplitFilepath(basePath)
+	pathParts := SplitFilepath(path)
+
+	if len(basePathParts) > len(pathParts) {
+		return false
+	}
+
+	if reflect.DeepEqual(basePathParts, pathParts) {
+		return false
+	}
+
+	for ind := range basePathParts {
+		if basePathParts[ind] == "" {
+			continue
+		}
+
+		if basePathParts[ind] != pathParts[ind] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/util/lines.go
+++ b/pkg/util/lines.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"bufio"
+	"strings"
+)
+
+func SplitLines(s string) []string {
+	var lines []string
+	sc := bufio.NewScanner(strings.NewReader(s))
+	sc.Split(bufio.ScanLines)
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	return lines
+}


### PR DESCRIPTION
Automatically invalidate inconsistent service git worktree which werf creates in the ~/.werf/local_cache/git_worktrees.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>