### PR TITLE
chore(channels): v1.2 alpha to 1.2.69, beta and ea to 1.2.67+fix1, stable to 1.2.62+fix1, rock-solid to 1.2.59+fix1

### DIFF
--- a/multiwerf.json
+++ b/multiwerf.json
@@ -55,23 +55,23 @@
       "channels": [
         {
           "name": "alpha",
-          "version": "v1.2.68"
+          "version": "v1.2.69"
         },
         {
           "name": "beta",
-          "version": "v1.2.67"
+          "version": "v1.2.67+fix1"
         },
         {
           "name": "ea",
-          "version": "v1.2.67"
+          "version": "v1.2.67+fix1"
         },
         {
           "name": "stable",
-          "version": "v1.2.62"
+          "version": "v1.2.62+fix1"
         },
         {
           "name": "rock-solid",
-          "version": "v1.2.59"
+          "version": "v1.2.59+fix1"
         }
       ]
     }

--- a/trdl_channels.yaml
+++ b/trdl_channels.yaml
@@ -26,12 +26,12 @@ groups:
  - name: "1.2"
    channels:
     - name: alpha
-      version: 1.2.68 # cleaning up artifacts by git history-based policy / host cleanup and build fixes
+      version: 1.2.69 # cleaning up artifacts by git history-based policy / host cleanup and build fixes
     - name: beta
-      version: 1.2.67 # bundle render & config graph
+      version: 1.2.67+fix1 # bundle render & config graph
     - name: ea
-      version: 1.2.67 # bundle render & config graph
+      version: 1.2.67+fix1 # bundle render & config graph
     - name: stable
-      version: 1.2.62 # fix unexpected cleanup fail when getting metadata for custom tag with long name
+      version: 1.2.62+fix1 # fix unexpected cleanup fail when getting metadata for custom tag with long name
     - name: rock-solid
-      version: 1.2.59 # fixes multi-stage, quay, werf helm get-release panic
+      version: 1.2.59+fix1 # fixes multi-stage, quay, werf helm get-release panic


### PR DESCRIPTION
Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>