### PR TITLE
fix: support WERF_KUBECONFIG_BASE64 in werf-cleanup command

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Checkout code
@@ -106,10 +106,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Checkout code
@@ -160,10 +160,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Checkout code
@@ -275,10 +275,10 @@ jobs:
 
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Checkout code
@@ -347,10 +347,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Checkout code
@@ -423,10 +423,10 @@ jobs:
 #    runs-on: [self-hosted, "${{ matrix.os }}"]
 #    steps:
 #
-#    - name: Set up Go 1.14
+#    - name: Set up Go 1.17
 #      uses: actions/setup-go@v1
 #      with:
-#        go-version: 1.14
+#        go-version: 1.17
 #      id: go
 #
 #    - name: Checkout code
@@ -504,10 +504,10 @@ jobs:
 #    runs-on: [self-hosted, "${{ matrix.os }}"]
 #    steps:
 #
-#    - name: Set up Go 1.14
+#    - name: Set up Go 1.17
 #      uses: actions/setup-go@v1
 #      with:
-#        go-version: 1.14
+#        go-version: 1.17
 #      id: go
 #
 #    - name: Checkout code
@@ -598,10 +598,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Checkout code

--- a/.github/workflows/docs_tests.yml
+++ b/.github/workflows/docs_tests.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.14
+      - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.17
         id: go
 
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,10 +30,10 @@ jobs:
     if: github.event_name == 'repository_dispatch' || (github.event_name == 'pull_request' && github.event.label.id == 1745044226) # run tests label
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Checkout code
@@ -91,10 +91,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Checkout code
@@ -132,10 +132,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Checkout code
@@ -188,10 +188,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Checkout code

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -125,9 +125,10 @@ func runCleanup() error {
 	ctx = ctxWithDockerCli
 
 	if err := kube.Init(kube.InitOptions{KubeConfigOptions: kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		Context:             *commonCmdData.KubeContext,
+		ConfigPath:          *commonCmdData.KubeConfig,
+		ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+		ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}

--- a/cmd/werf/common/cleanup_namespaces_scan.go
+++ b/cmd/werf/common/cleanup_namespaces_scan.go
@@ -15,7 +15,11 @@ func SetupScanContextNamespaceOnly(cmdData *CmdData, cmd *cobra.Command) {
 
 func GetKubernetesContextClients(cmdData *CmdData) ([]*kube.ContextClient, error) {
 	var res []*kube.ContextClient
-	if contextClients, err := kube.GetAllContextsClients(kube.GetAllContextsClientsOptions{KubeConfig: *cmdData.KubeConfig}); err != nil {
+	if contextClients, err := kube.GetAllContextsClients(kube.GetAllContextsClientsOptions{
+		ConfigPath:          *cmdData.KubeConfig,
+		ConfigDataBase64:    *cmdData.KubeConfigBase64,
+		ConfigPathMergeList: *cmdData.KubeConfigPathMergeList,
+	}); err != nil {
 		return nil, err
 	} else {
 		if *cmdData.KubeContext != "" {

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -56,6 +56,7 @@ type CmdData struct {
 	KubeContext                      *string
 	KubeConfig                       *string
 	KubeConfigBase64                 *string
+	KubeConfigPathMergeList          *[]string
 	HelmReleaseStorageNamespace      *string
 	HelmReleaseStorageType           *string
 	StatusProgressPeriodSeconds      *int64
@@ -300,7 +301,13 @@ func SetupKubeContext(cmdData *CmdData, cmd *cobra.Command) {
 
 func SetupKubeConfig(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.KubeConfig = new(string)
-	cmd.PersistentFlags().StringVarP(cmdData.KubeConfig, "kube-config", "", getFirstExistingEnvVarAsString("WERF_KUBE_CONFIG", "WERF_KUBECONFIG", "KUBECONFIG"), "Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or $KUBECONFIG)")
+	cmd.PersistentFlags().StringVarP(cmdData.KubeConfig, "kube-config", "", "", "Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or $KUBECONFIG)")
+
+	cmdData.KubeConfigPathMergeList = new([]string)
+	kubeConfigPathMergeListStr := getFirstExistingEnvVarAsString("WERF_KUBE_CONFIG", "WERF_KUBECONFIG", "KUBECONFIG")
+	for _, path := range filepath.SplitList(kubeConfigPathMergeListStr) {
+		*cmdData.KubeConfigPathMergeList = append(*cmdData.KubeConfigPathMergeList, path)
+	}
 }
 
 func SetupKubeConfigBase64(cmdData *CmdData, cmd *cobra.Command) {

--- a/cmd/werf/common/helm.go
+++ b/cmd/werf/common/helm.go
@@ -21,9 +21,10 @@ func NewActionConfig(ctx context.Context, namespace string, commonCmdData *CmdDa
 		StatusProgressPeriod:      time.Duration(*commonCmdData.StatusProgressPeriodSeconds) * time.Second,
 		HooksStatusProgressPeriod: time.Duration(*commonCmdData.HooksStatusProgressPeriodSeconds) * time.Second,
 		KubeConfigOptions: kube.KubeConfigOptions{
-			Context:          *commonCmdData.KubeContext,
-			ConfigPath:       *commonCmdData.KubeConfig,
-			ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+			Context:             *commonCmdData.KubeContext,
+			ConfigPath:          *commonCmdData.KubeConfig,
+			ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+			ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 		},
 		ReleasesHistoryMax: *commonCmdData.ReleasesHistoryMax,
 	}); err != nil {

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -236,9 +236,10 @@ func runConverge() error {
 	}
 
 	kubeConfigOptions := kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		Context:             *commonCmdData.KubeContext,
+		ConfigPath:          *commonCmdData.KubeConfig,
+		ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
+		ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
 	}
 
 	if err := kube.Init(kube.InitOptions{KubeConfigOptions: kubeConfigOptions}); err != nil {

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -190,9 +190,10 @@ func runDeploy() error {
 	ctx = ctxWithDockerCli
 
 	kubeConfigOptions := kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		Context:             *commonCmdData.KubeContext,
+		ConfigPath:          *commonCmdData.KubeConfig,
+		ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+		ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 	}
 
 	if err := kube.Init(kube.InitOptions{KubeConfigOptions: kubeConfigOptions}); err != nil {

--- a/cmd/werf/deploy_v2/main.go
+++ b/cmd/werf/deploy_v2/main.go
@@ -176,9 +176,10 @@ func runDeploy() error {
 	}
 
 	if err := kube.Init(kube.InitOptions{KubeConfigOptions: kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		Context:             *commonCmdData.KubeContext,
+		ConfigPath:          *commonCmdData.KubeConfig,
+		ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+		ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}

--- a/cmd/werf/diff/diff.go
+++ b/cmd/werf/diff/diff.go
@@ -257,9 +257,10 @@ func runDiff() error {
 	}
 
 	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		Context:             *commonCmdData.KubeContext,
+		ConfigPath:          *commonCmdData.KubeConfig,
+		ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+		ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -153,9 +153,10 @@ func runDismiss() error {
 	projectName := werfConfig.Meta.Project
 
 	err = kube.Init(kube.InitOptions{kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		Context:             *commonCmdData.KubeContext,
+		ConfigPath:          *commonCmdData.KubeConfig,
+		ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+		ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 	}})
 	if err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)

--- a/cmd/werf/dismiss_v2/dismiss.go
+++ b/cmd/werf/dismiss_v2/dismiss.go
@@ -136,9 +136,10 @@ func runDismiss() error {
 	logboek.LogOptionalLn()
 
 	err = kube.Init(kube.InitOptions{kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		Context:             *commonCmdData.KubeContext,
+		ConfigPath:          *commonCmdData.KubeConfig,
+		ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+		ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 	}})
 	if err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)

--- a/cmd/werf/helm/deploy_chart/main.go
+++ b/cmd/werf/helm/deploy_chart/main.go
@@ -149,9 +149,10 @@ func runDeployChart(chartDirOrChartReference string, releaseName string) error {
 	}
 
 	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		Context:             *commonCmdData.KubeContext,
+		ConfigPath:          *commonCmdData.KubeConfig,
+		ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+		ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}

--- a/cmd/werf/helm/rollback/rollback.go
+++ b/cmd/werf/helm/rollback/rollback.go
@@ -103,9 +103,10 @@ func runRollback(releaseName string, revision int32) error {
 	}
 
 	if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		Context:             *commonCmdData.KubeContext,
+		ConfigPath:          *commonCmdData.KubeConfig,
+		ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+		ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}

--- a/cmd/werf/helm_v3/helm_v3.go
+++ b/cmd/werf/helm_v3/helm_v3.go
@@ -103,9 +103,10 @@ func NewCmd() *cobra.Command {
 				ctx := common.BackgroundContext()
 
 				if err := kube.Init(kube.InitOptions{kube.KubeConfigOptions{
-					Context:          *commonCmdData.KubeContext,
-					ConfigPath:       *commonCmdData.KubeConfig,
-					ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+					Context:             *commonCmdData.KubeContext,
+					ConfigPath:          *commonCmdData.KubeConfig,
+					ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+					ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 				}}); err != nil {
 					return fmt.Errorf("cannot initialize kube: %s", err)
 				}

--- a/cmd/werf/images/cleanup/cleanup.go
+++ b/cmd/werf/images/cleanup/cleanup.go
@@ -118,9 +118,10 @@ func runCleanup() error {
 	ctx = ctxWithDockerCli
 
 	if err := kube.Init(kube.InitOptions{KubeConfigOptions: kube.KubeConfigOptions{
-		Context:          *commonCmdData.KubeContext,
-		ConfigPath:       *commonCmdData.KubeConfig,
-		ConfigDataBase64: *commonCmdData.KubeConfigBase64,
+		Context:             *commonCmdData.KubeContext,
+		ConfigPath:          *commonCmdData.KubeConfig,
+		ConfigDataBase64:    *commonCmdData.KubeConfigBase64,
+		ConfigPathMergeList: *commonCmdData.KubeConfigPathMergeList,
 	}}); err != nil {
 		return fmt.Errorf("cannot initialize kube: %s", err)
 	}

--- a/docs/_includes/cli/werf_build.md
+++ b/docs/_includes/cli/werf_build.md
@@ -87,7 +87,7 @@ werf build [IMAGE_NAME...] [options]
             gitArchive, install, importsAfterInstall, beforeSetup, importsBeforeSetup, setup,       
             importsAfterSetup, gitCache, gitLatestPatch, dockerInstructions, dockerfile
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_build_and_publish.md
+++ b/docs/_includes/cli/werf_build_and_publish.md
@@ -118,7 +118,7 @@ werf build-and-publish [IMAGE_NAME...] [options]
             gitArchive, install, importsAfterInstall, beforeSetup, importsBeforeSetup, setup,       
             importsAfterSetup, gitCache, gitLatestPatch, dockerInstructions, dockerfile
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_cleanup.md
+++ b/docs/_includes/cli/werf_cleanup.md
@@ -100,7 +100,7 @@ werf cleanup [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_converge.md
+++ b/docs/_includes/cli/werf_converge.md
@@ -115,7 +115,7 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_deploy.md
+++ b/docs/_includes/cli/werf_deploy.md
@@ -119,7 +119,7 @@ werf deploy [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_diff.md
+++ b/docs/_includes/cli/werf_diff.md
@@ -108,7 +108,7 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_dismiss.md
+++ b/docs/_includes/cli/werf_dismiss.md
@@ -57,7 +57,7 @@ werf dismiss [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_delete.md
+++ b/docs/_includes/cli/werf_helm_delete.md
@@ -25,7 +25,7 @@ werf helm delete RELEASE_NAME [options]
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_deploy_chart.md
+++ b/docs/_includes/cli/werf_helm_deploy_chart.md
@@ -56,7 +56,7 @@ werf helm deploy-chart CHART_DIR|CHART_REFERENCE RELEASE_NAME [options]
       --keyring='~/.gnupg/pubring.gpg'
             keyring containing public keys (if using CHART as a chart reference)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_get.md
+++ b/docs/_includes/cli/werf_helm_get.md
@@ -25,7 +25,7 @@ werf helm get RELEASE_NAME [options]
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_history.md
+++ b/docs/_includes/cli/werf_helm_history.md
@@ -27,7 +27,7 @@ werf helm history RELEASE_NAME [options]
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_list.md
+++ b/docs/_includes/cli/werf_helm_list.md
@@ -33,7 +33,7 @@ werf helm list [FILTER] [options]
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_rollback.md
+++ b/docs/_includes/cli/werf_helm_rollback.md
@@ -29,7 +29,7 @@ werf helm rollback RELEASE_NAME REVISION [options]
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3.md
+++ b/docs/_includes/cli/werf_helm_v3.md
@@ -16,7 +16,7 @@ Manage application deployment with helm
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_chart.md
+++ b/docs/_includes/cli/werf_helm_v3_chart.md
@@ -23,7 +23,7 @@ The subcommands can be used to push, pull, tag, list, or remove Helm charts.
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_chart_export.md
+++ b/docs/_includes/cli/werf_helm_v3_chart_export.md
@@ -33,7 +33,7 @@ werf helm-v3 chart export [ref] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_chart_list.md
+++ b/docs/_includes/cli/werf_helm_v3_chart_list.md
@@ -29,7 +29,7 @@ werf helm-v3 chart list [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_chart_pull.md
+++ b/docs/_includes/cli/werf_helm_v3_chart_pull.md
@@ -29,7 +29,7 @@ werf helm-v3 chart pull [ref] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_chart_push.md
+++ b/docs/_includes/cli/werf_helm_v3_chart_push.md
@@ -31,7 +31,7 @@ werf helm-v3 chart push [ref] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_chart_remove.md
+++ b/docs/_includes/cli/werf_helm_v3_chart_remove.md
@@ -32,7 +32,7 @@ werf helm-v3 chart remove [ref] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_chart_save.md
+++ b/docs/_includes/cli/werf_helm_v3_chart_save.md
@@ -30,7 +30,7 @@ werf helm-v3 chart save [path] [ref] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_create.md
+++ b/docs/_includes/cli/werf_helm_v3_create.md
@@ -46,7 +46,7 @@ werf helm-v3 create NAME [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_dependency.md
+++ b/docs/_includes/cli/werf_helm_v3_dependency.md
@@ -65,7 +65,7 @@ for this case.
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_dependency_build.md
+++ b/docs/_includes/cli/werf_helm_v3_dependency_build.md
@@ -38,7 +38,7 @@ werf helm-v3 dependency build CHART [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_dependency_list.md
+++ b/docs/_includes/cli/werf_helm_v3_dependency_list.md
@@ -32,7 +32,7 @@ werf helm-v3 dependency list CHART [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_dependency_update.md
+++ b/docs/_includes/cli/werf_helm_v3_dependency_update.md
@@ -44,7 +44,7 @@ werf helm-v3 dependency update CHART [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_env.md
+++ b/docs/_includes/cli/werf_helm_v3_env.md
@@ -27,7 +27,7 @@ werf helm-v3 env [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_get.md
+++ b/docs/_includes/cli/werf_helm_v3_get.md
@@ -27,7 +27,7 @@ get extended information about the release, including:
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_get_all.md
+++ b/docs/_includes/cli/werf_helm_v3_get_all.md
@@ -32,7 +32,7 @@ werf helm-v3 get all RELEASE_NAME [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_get_hooks.md
+++ b/docs/_includes/cli/werf_helm_v3_get_hooks.md
@@ -31,7 +31,7 @@ werf helm-v3 get hooks RELEASE_NAME [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_get_manifest.md
+++ b/docs/_includes/cli/werf_helm_v3_get_manifest.md
@@ -33,7 +33,7 @@ werf helm-v3 get manifest RELEASE_NAME [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_get_notes.md
+++ b/docs/_includes/cli/werf_helm_v3_get_notes.md
@@ -29,7 +29,7 @@ werf helm-v3 get notes RELEASE_NAME [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_get_values.md
+++ b/docs/_includes/cli/werf_helm_v3_get_values.md
@@ -33,7 +33,7 @@ werf helm-v3 get values RELEASE_NAME [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_history.md
+++ b/docs/_includes/cli/werf_helm_v3_history.md
@@ -43,7 +43,7 @@ werf helm-v3 history RELEASE_NAME [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_install.md
+++ b/docs/_includes/cli/werf_helm_v3_install.md
@@ -182,7 +182,7 @@ werf helm-v3 install [NAME] [CHART] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_lint.md
+++ b/docs/_includes/cli/werf_helm_v3_lint.md
@@ -47,7 +47,7 @@ werf helm-v3 lint PATH [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_list.md
+++ b/docs/_includes/cli/werf_helm_v3_list.md
@@ -81,7 +81,7 @@ werf helm-v3 list [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_package.md
+++ b/docs/_includes/cli/werf_helm_v3_package.md
@@ -53,7 +53,7 @@ werf helm-v3 package [CHART_PATH] [...] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_plugin.md
+++ b/docs/_includes/cli/werf_helm_v3_plugin.md
@@ -21,7 +21,7 @@ Manage client-side Helm plugins.
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_plugin_install.md
+++ b/docs/_includes/cli/werf_helm_v3_plugin_install.md
@@ -29,7 +29,7 @@ werf helm-v3 plugin install [options] <path|url>... [flags]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_plugin_list.md
+++ b/docs/_includes/cli/werf_helm_v3_plugin_list.md
@@ -25,7 +25,7 @@ werf helm-v3 plugin list [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_plugin_uninstall.md
+++ b/docs/_includes/cli/werf_helm_v3_plugin_uninstall.md
@@ -25,7 +25,7 @@ werf helm-v3 plugin uninstall <plugin>... [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_plugin_update.md
+++ b/docs/_includes/cli/werf_helm_v3_plugin_update.md
@@ -25,7 +25,7 @@ werf helm-v3 plugin update <plugin>... [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_pull.md
+++ b/docs/_includes/cli/werf_helm_v3_pull.md
@@ -70,7 +70,7 @@ werf helm-v3 pull [chart URL | repo/chartname] [...] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_repo.md
+++ b/docs/_includes/cli/werf_helm_v3_repo.md
@@ -23,7 +23,7 @@ It can be used to add, remove, list, and index chart repositories.
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_repo_add.md
+++ b/docs/_includes/cli/werf_helm_v3_repo_add.md
@@ -39,7 +39,7 @@ werf helm-v3 repo add [NAME] [URL] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_repo_index.md
+++ b/docs/_includes/cli/werf_helm_v3_repo_index.md
@@ -38,7 +38,7 @@ werf helm-v3 repo index [DIR] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_repo_list.md
+++ b/docs/_includes/cli/werf_helm_v3_repo_list.md
@@ -27,7 +27,7 @@ werf helm-v3 repo list [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_repo_remove.md
+++ b/docs/_includes/cli/werf_helm_v3_repo_remove.md
@@ -25,7 +25,7 @@ werf helm-v3 repo remove [REPO1 [REPO2 ...]] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_repo_update.md
+++ b/docs/_includes/cli/werf_helm_v3_repo_update.md
@@ -28,7 +28,7 @@ werf helm-v3 repo update [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_rollback.md
+++ b/docs/_includes/cli/werf_helm_v3_rollback.md
@@ -49,7 +49,7 @@ werf helm-v3 rollback <RELEASE> [REVISION] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_search.md
+++ b/docs/_includes/cli/werf_helm_v3_search.md
@@ -23,7 +23,7 @@ search subcommands to search different locations for charts.
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_search_hub.md
+++ b/docs/_includes/cli/werf_helm_v3_search_hub.md
@@ -41,7 +41,7 @@ werf helm-v3 search hub [keyword] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_search_repo.md
+++ b/docs/_includes/cli/werf_helm_v3_search_repo.md
@@ -60,7 +60,7 @@ werf helm-v3 search repo [keyword] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_show.md
+++ b/docs/_includes/cli/werf_helm_v3_show.md
@@ -21,7 +21,7 @@ This command consists of multiple subcommands to display information about a cha
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_show_all.md
+++ b/docs/_includes/cli/werf_helm_v3_show_all.md
@@ -50,7 +50,7 @@ werf helm-v3 show all [CHART] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_show_chart.md
+++ b/docs/_includes/cli/werf_helm_v3_show_chart.md
@@ -50,7 +50,7 @@ werf helm-v3 show chart [CHART] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_show_readme.md
+++ b/docs/_includes/cli/werf_helm_v3_show_readme.md
@@ -50,7 +50,7 @@ werf helm-v3 show readme [CHART] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_show_values.md
+++ b/docs/_includes/cli/werf_helm_v3_show_values.md
@@ -50,7 +50,7 @@ werf helm-v3 show values [CHART] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_status.md
+++ b/docs/_includes/cli/werf_helm_v3_status.md
@@ -38,7 +38,7 @@ werf helm-v3 status RELEASE_NAME [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_template.md
+++ b/docs/_includes/cli/werf_helm_v3_template.md
@@ -115,7 +115,7 @@ werf helm-v3 template [NAME] [CHART] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_test.md
+++ b/docs/_includes/cli/werf_helm_v3_test.md
@@ -35,7 +35,7 @@ werf helm-v3 test [RELEASE] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_uninstall.md
+++ b/docs/_includes/cli/werf_helm_v3_uninstall.md
@@ -44,7 +44,7 @@ werf helm-v3 uninstall RELEASE_NAME [...] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_upgrade.md
+++ b/docs/_includes/cli/werf_helm_v3_upgrade.md
@@ -149,7 +149,7 @@ werf helm-v3 upgrade [RELEASE] [CHART] [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_verify.md
+++ b/docs/_includes/cli/werf_helm_v3_verify.md
@@ -36,7 +36,7 @@ werf helm-v3 verify PATH [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_helm_v3_version.md
+++ b/docs/_includes/cli/werf_helm_v3_version.md
@@ -49,7 +49,7 @@ werf helm-v3 version [flags] [options]
             Hooks status progress period in seconds. Set 0 to stop showing hooks status progress.   
             Defaults to $WERF_HOOKS_STATUS_PROGRESS_PERIOD_SECONDS or status progress period value
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_host_project_purge.md
+++ b/docs/_includes/cli/werf_host_project_purge.md
@@ -32,7 +32,7 @@ werf host project purge [PROJECT_NAME ...] [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_images_cleanup.md
+++ b/docs/_includes/cli/werf_images_cleanup.md
@@ -86,7 +86,7 @@ werf images cleanup [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_images_publish.md
+++ b/docs/_includes/cli/werf_images_publish.md
@@ -73,7 +73,7 @@ werf images publish [IMAGE_NAME...] [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_images_purge.md
+++ b/docs/_includes/cli/werf_images_purge.md
@@ -57,7 +57,7 @@ werf images purge [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_managed_images_add.md
+++ b/docs/_includes/cli/werf_managed_images_add.md
@@ -33,7 +33,7 @@ werf managed-images add [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_managed_images_ls.md
+++ b/docs/_includes/cli/werf_managed_images_ls.md
@@ -32,7 +32,7 @@ werf managed-images ls [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_managed_images_rm.md
+++ b/docs/_includes/cli/werf_managed_images_rm.md
@@ -33,7 +33,7 @@ werf managed-images rm [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_publish.md
+++ b/docs/_includes/cli/werf_publish.md
@@ -73,7 +73,7 @@ werf publish [IMAGE_NAME...] [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_purge.md
+++ b/docs/_includes/cli/werf_purge.md
@@ -67,7 +67,7 @@ werf purge [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_run.md
+++ b/docs/_includes/cli/werf_run.md
@@ -61,7 +61,7 @@ werf run [options] [IMAGE_NAME] [-- COMMAND ARG...]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_stages_build.md
+++ b/docs/_includes/cli/werf_stages_build.md
@@ -87,7 +87,7 @@ werf stages build [IMAGE_NAME...] [options]
             gitArchive, install, importsAfterInstall, beforeSetup, importsBeforeSetup, setup,       
             importsAfterSetup, gitCache, gitLatestPatch, dockerInstructions, dockerfile
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_stages_cleanup.md
+++ b/docs/_includes/cli/werf_stages_cleanup.md
@@ -59,7 +59,7 @@ werf stages cleanup [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_stages_purge.md
+++ b/docs/_includes/cli/werf_stages_purge.md
@@ -37,7 +37,7 @@ werf stages purge [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_stages_switch_from_local.md
+++ b/docs/_includes/cli/werf_stages_switch_from_local.md
@@ -52,7 +52,7 @@ werf stages switch-from-local [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_stages_sync.md
+++ b/docs/_includes/cli/werf_stages_sync.md
@@ -57,7 +57,7 @@ werf stages sync [options]
       --insecure-registry=false
             Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/docs/_includes/cli/werf_synchronization.md
+++ b/docs/_includes/cli/werf_synchronization.md
@@ -21,7 +21,7 @@ werf synchronization [options]
       --host=''
             Bind synchronization server to the specified host (default localhost or $WERF_HOST)
       --kube-config=''
-            Kubernetes config file path (default $WERF_KUBE_CONFIG or $WERF_KUBECONFIG or           
+            Kubernetes config file path (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or         
             $KUBECONFIG)
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tonistiigi/fsutil v0.0.0-20200724193237-c3ed55f3b481 // indirect
 	github.com/tonistiigi/go-rosetta v0.0.0-20200727161949-f79598599c5d // indirect
-	github.com/werf/kubedog v0.4.1-0.20210609160549-c5ed5d787e86
+	github.com/werf/kubedog v0.4.1-0.20220222103049-afc67463c609
 	github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea
 	github.com/werf/logboek v0.4.7
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -1533,6 +1533,8 @@ github.com/werf/kubedog v0.4.1-0.20210604070304-fde5b6c69f6a h1:S9uj3JDE0i/Ux+DS
 github.com/werf/kubedog v0.4.1-0.20210604070304-fde5b6c69f6a/go.mod h1:7SuLhuQddKnJri0LiMPoch94b6zAor7X3GvcufmgLqY=
 github.com/werf/kubedog v0.4.1-0.20210609160549-c5ed5d787e86 h1:o+Xy3n9Kvme9wfalydgcRYv3Tjk/fIoLb5/BQOyhpd8=
 github.com/werf/kubedog v0.4.1-0.20210609160549-c5ed5d787e86/go.mod h1:7SuLhuQddKnJri0LiMPoch94b6zAor7X3GvcufmgLqY=
+github.com/werf/kubedog v0.4.1-0.20220222103049-afc67463c609 h1:gH8Zjx49Ze2YT7qgEYYnR+amdQUZeaZCaEQTGJ4HiRk=
+github.com/werf/kubedog v0.4.1-0.20220222103049-afc67463c609/go.mod h1:7SuLhuQddKnJri0LiMPoch94b6zAor7X3GvcufmgLqY=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea h1:R5tJUhL5a3YfHTrHWyuAdJW3h//fmONrpHJjjAZ79e4=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea/go.mod h1:/CeY6KDiBSCU9PUmjt7zGhqpzp8FAPg/wNVfLZHQGWI=
 github.com/werf/logboek v0.4.3 h1:aXAVLlGT/ZiD8Srj+B71Tw20PtDyuYZSEJZjODNraeA=

--- a/pkg/cleaning/images_cleanup.go
+++ b/pkg/cleaning/images_cleanup.go
@@ -233,7 +233,11 @@ func (m *imagesCleanupManager) run(ctx context.Context) error {
 	var err error
 
 	if !m.WithoutKube {
-		if err := logboek.Context(ctx).LogProcess("Skipping repo images that are being used in Kubernetes").DoError(func() error {
+		if len(m.KubernetesContextClients) == 0 {
+			logboek.Context(ctx).Warn().LogF("WARNING: No kubernetes configs found to skip images being used in the Kubernetes, pass --without-kube option (or WERF_WITHOUT_KUBE env var) to silence this warning\n")
+		}
+
+		if err := logboek.Context(ctx).LogProcess("Skipping repo images that are being used in the Kubernetes").DoError(func() error {
 			repoImagesToCleanup, exceptedRepoImages, err = exceptRepoImagesByWhitelist(ctx, repoImagesToCleanup, m.KubernetesContextClients, m.KubernetesNamespaceRestrictionByContext)
 			return err
 		}); err != nil {

--- a/pkg/deploy/helm/client_getter_from_data.go
+++ b/pkg/deploy/helm/client_getter_from_data.go
@@ -71,6 +71,6 @@ func (getter *ClientGetterFromConfigData) getRawKubeConfigLoader() (clientcmd.Cl
 	if data, err := base64.StdEncoding.DecodeString(getter.ConfigDataBase64); err != nil {
 		return nil, fmt.Errorf("unable to decode base64 config data: %s", err)
 	} else {
-		return kube.GetClientConfig(getter.Context, "", data)
+		return kube.GetClientConfig(getter.Context, "", data, []string{})
 	}
 }

--- a/pkg/deploy/helm/tiller.go
+++ b/pkg/deploy/helm/tiller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"strings"
 	"text/tabwriter"
@@ -89,7 +90,9 @@ func loadChartfile(chartPath string) (*chart.Chart, error) {
 }
 
 type InitOptions struct {
-	KubeConfig                  string
+	KubeConfig string
+	// We are using WERF_KUBE_CONFIG, WERF_KUBECONFIG and KUBECONFIG variables directly at this level (1.1 only)
+	// KubeConfigPathMergeList     []string
 	KubeConfigBase64            string
 	KubeContext                 string
 	HelmReleaseStorageNamespace string
@@ -119,6 +122,15 @@ func Init(ctx context.Context, options InitOptions) error {
 	}
 
 	HelmSettings.KubeConfig = options.KubeConfig
+
+	// Make sure WERF_KUBE_CONFIG and WERF_KUBECONFIG variables with config path merge list are supported
+	for _, env := range []string{"WERF_KUBE_CONFIG", "WERF_KUBECONFIG"} {
+		if v := os.Getenv(env); v != "" {
+			os.Setenv("KUBECONFIG", v)
+			break
+		}
+	}
+
 	HelmSettings.KubeContext = options.KubeContext
 	HelmSettings.TillerNamespace = options.HelmReleaseStorageNamespace
 


### PR DESCRIPTION
* Added support for KUBECONFIG path merge list into all commands.
* Ported to new kubedog pkg/kube package fixes from kubedog main.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>