### PR TITLE
fix: add werf-cleanup command warning when no kube configs available

### DIFF
--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/werf/werf/pkg/storage"
 	"github.com/werf/werf/pkg/storage/manager"
 	"github.com/werf/werf/pkg/util"
+	"github.com/werf/werf/pkg/werf/global_warnings"
 )
 
 type CleanupOptions struct {
@@ -120,6 +121,10 @@ func (m *cleanupManager) run(ctx context.Context) error {
 
 	if m.LocalGit != nil {
 		if !m.WithoutKube {
+			if len(m.KubernetesContextClients) == 0 {
+				global_warnings.GlobalWarningLn(ctx, "No kubernetes configs found to skip images being used in the Kubernetes, pass --without-kube option (or WERF_WITHOUT_KUBE env var) to silence this warning")
+			}
+
 			deployedDockerImagesNames, err := m.deployedDockerImagesNames(ctx)
 			if err != nil {
 				return fmt.Errorf("error getting deployed docker images names from Kubernetes: %s", err)


### PR DESCRIPTION
Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>