### PR TITLE
fix(build): do not store images into final repo when --skip-build is set

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -25,6 +25,7 @@ import (
 	imagePkg "github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/stapel"
 	"github.com/werf/werf/pkg/storage"
+	"github.com/werf/werf/pkg/storage/manager"
 	"github.com/werf/werf/pkg/util"
 	"github.com/werf/werf/pkg/werf"
 )
@@ -248,7 +249,7 @@ func (phase *BuildPhase) AfterImageStages(ctx context.Context, img *Image) error
 	}
 
 	if phase.Conveyor.StorageManager.GetFinalStagesStorage() != nil {
-		if err := phase.Conveyor.StorageManager.CopyStageIntoFinalStorage(ctx, img.GetLastNonEmptyStage(), phase.Conveyor.ContainerRuntime); err != nil {
+		if err := phase.Conveyor.StorageManager.CopyStageIntoFinalStorage(ctx, img.GetLastNonEmptyStage(), phase.Conveyor.ContainerRuntime, manager.CopyStageIntoFinalStorageOptions{ShouldBeBuiltMode: phase.ShouldBeBuiltMode}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
~* By default in 'werf converge', 'werf bundle publish', 'werf bundle export', 'werf export', 'werf render' and 'werf run' commands.~
~* In the 'werf build' command only when `--verify-built-images` option specified.~
* Respect --skip-build option when final-repo is used:
    * do not push into final repo built images from the primary repo;
    * only check stage image existance in the final repo in such case.
