### PR TITLE
ci(docs): fix "internally linking to kubernetes.io/cluster-service=true, which does not exist"

### DIFF
--- a/.github/workflows/docs_tests.yml
+++ b/.github/workflows/docs_tests.yml
@@ -71,7 +71,7 @@ jobs:
             --allow-hash-href \
             --empty-alt-ignore \
             --check_html \
-            --url_ignore "/localhost/,/example.com/,/atseashop.com/,/https\:\/\/t.me/,/.slack.com/,/habr.com/,/cncf.io/,/\/guides/,/\/how_it_works\.html/,/\/installation\.html/,/werf_yaml.html#configuring-cleanup-policies/,/css\/configuration-table.css/" \
+            --url_ignore "/localhost/,/example.com/,/atseashop.com/,/https\:\/\/t.me/,/.slack.com/,/habr.com/,/cncf.io/,/\/guides/,/\/how_it_works\.html/,/\/installation\.html/,/werf_yaml.html#configuring-cleanup-policies/,/css\/configuration-table.css/,/kubernetes.io\/cluster-service=true/" \
             --url_swap "documentation/v[0-9]+[^/]+/:documentation/" \
             --http-status-ignore "0,429" \
             _site


### PR DESCRIPTION
Signed-off-by: Alexey Igrychev <alexey.igrychev@flant.com>