### PR TITLE
feat(kubectl): respect a few global $WERF_* env vars

### DIFF
--- a/cmd/werf/kubectl/kubectl.go
+++ b/cmd/werf/kubectl/kubectl.go
@@ -1,11 +1,42 @@
 package kubectl
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/cmd"
+	"k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/werf/werf/cmd/werf/common"
 )
 
 func NewCmd() *cobra.Command {
-	kubectlRootCmd := cmd.NewDefaultKubectlCommand()
-	return kubectlRootCmd
+	kubectlCmd := cmd.NewDefaultKubectlCommand()
+
+	kubeConfigFlag := kubectlCmd.Flag("kubeconfig")
+	kubeConfigFlag.Usage = "Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or $WERF_KUBECONFIG, or $KUBECONFIG)"
+	if kubeConfigEnvVar := common.GetFirstExistingKubeConfigEnvVar(); kubeConfigEnvVar != "" {
+		if err := os.Setenv("KUBECONFIG", kubeConfigEnvVar); err != nil {
+			util.CheckErr(fmt.Errorf("unable to set $KUBECONFIG env var: %w", err))
+		}
+	}
+
+	kubeContextFlag := kubectlCmd.Flag("context")
+	kubeContextFlag.Usage = "The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)"
+	if werfKubeContextEnvVar := os.Getenv("WERF_KUBE_CONTEXT"); werfKubeContextEnvVar != "" {
+		if err := kubectlCmd.Flags().Set("context", werfKubeContextEnvVar); err != nil {
+			util.CheckErr(fmt.Errorf("unable to set context flag for kubectl: %w", err))
+		}
+	}
+
+	skipTlsVerifyRegistryFlag := kubectlCmd.Flag("insecure-skip-tls-verify")
+	skipTlsVerifyRegistryFlag.Usage = "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)"
+	if isSkipTlsVerifyRegistry := common.GetBoolEnvironmentDefaultFalse("WERF_SKIP_TLS_VERIFY_REGISTRY"); isSkipTlsVerifyRegistry {
+		if err := kubectlCmd.Flags().Set("insecure-skip-tls-verify", "true"); err != nil {
+			util.CheckErr(fmt.Errorf("unable to set insecure-skip-tls-verify flag for kubectl: %w", err))
+		}
+	}
+
+	return kubectlCmd
 }

--- a/docs/_includes/reference/cli/werf_kubectl.md
+++ b/docs/_includes/reference/cli/werf_kubectl.md
@@ -35,12 +35,13 @@ werf kubectl [flags] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_alpha.md
+++ b/docs/_includes/reference/cli/werf_kubectl_alpha.md
@@ -27,12 +27,13 @@ These commands correspond to alpha features that are not enabled in Kubernetes c
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_alpha_events.md
+++ b/docs/_includes/reference/cli/werf_kubectl_alpha_events.md
@@ -63,12 +63,13 @@ werf kubectl alpha events [--for TYPE/NAME] [--watch] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_annotate.md
+++ b/docs/_includes/reference/cli/werf_kubectl_annotate.md
@@ -114,12 +114,13 @@ werf kubectl annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KE
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_api_resources.md
+++ b/docs/_includes/reference/cli/werf_kubectl_api_resources.md
@@ -77,12 +77,13 @@ werf kubectl api-resources [flags] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_api_versions.md
+++ b/docs/_includes/reference/cli/werf_kubectl_api_versions.md
@@ -40,12 +40,13 @@ werf kubectl api-versions
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_apply.md
+++ b/docs/_includes/reference/cli/werf_kubectl_apply.md
@@ -126,12 +126,13 @@ werf kubectl apply (-f FILENAME | -k DIRECTORY) [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_apply_edit_last_applied.md
+++ b/docs/_includes/reference/cli/werf_kubectl_apply_edit_last_applied.md
@@ -79,12 +79,13 @@ werf kubectl apply edit-last-applied (RESOURCE/NAME | -f FILENAME) [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_apply_set_last_applied.md
+++ b/docs/_includes/reference/cli/werf_kubectl_apply_set_last_applied.md
@@ -72,12 +72,13 @@ werf kubectl apply set-last-applied -f FILENAME [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_apply_view_last_applied.md
+++ b/docs/_includes/reference/cli/werf_kubectl_apply_view_last_applied.md
@@ -65,12 +65,13 @@ werf kubectl apply view-last-applied (TYPE [NAME | -l label] | TYPE/NAME | -f FI
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_attach.md
+++ b/docs/_includes/reference/cli/werf_kubectl_attach.md
@@ -69,12 +69,13 @@ werf kubectl attach (POD | TYPE/NAME) -c CONTAINER [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_auth.md
+++ b/docs/_includes/reference/cli/werf_kubectl_auth.md
@@ -33,12 +33,13 @@ werf kubectl auth
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_auth_can_i.md
+++ b/docs/_includes/reference/cli/werf_kubectl_auth_can_i.md
@@ -75,12 +75,13 @@ werf kubectl auth can-i VERB [TYPE | TYPE/NAME | NONRESOURCEURL] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_auth_reconcile.md
+++ b/docs/_includes/reference/cli/werf_kubectl_auth_reconcile.md
@@ -80,12 +80,13 @@ werf kubectl auth reconcile -f FILENAME [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_autoscale.md
+++ b/docs/_includes/reference/cli/werf_kubectl_autoscale.md
@@ -90,12 +90,13 @@ werf kubectl autoscale (-f FILENAME | TYPE NAME | TYPE/NAME) [--min=MINPODS] --m
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_certificate.md
+++ b/docs/_includes/reference/cli/werf_kubectl_certificate.md
@@ -33,12 +33,13 @@ werf kubectl certificate SUBCOMMAND
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_certificate_approve.md
+++ b/docs/_includes/reference/cli/werf_kubectl_certificate_approve.md
@@ -70,12 +70,13 @@ werf kubectl certificate approve (-f FILENAME | NAME) [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_certificate_deny.md
+++ b/docs/_includes/reference/cli/werf_kubectl_certificate_deny.md
@@ -68,12 +68,13 @@ werf kubectl certificate deny (-f FILENAME | NAME) [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_cluster_info.md
+++ b/docs/_includes/reference/cli/werf_kubectl_cluster_info.md
@@ -40,12 +40,13 @@ werf kubectl cluster-info
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_cluster_info_dump.md
+++ b/docs/_includes/reference/cli/werf_kubectl_cluster_info_dump.md
@@ -78,12 +78,13 @@ werf kubectl cluster-info dump [flags] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_completion.md
+++ b/docs/_includes/reference/cli/werf_kubectl_completion.md
@@ -97,12 +97,13 @@ werf kubectl completion SHELL
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_config.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config.md
@@ -39,12 +39,13 @@ werf kubectl config SUBCOMMAND
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_config_current_context.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_current_context.md
@@ -40,10 +40,10 @@ werf kubectl config current-context
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_delete_cluster.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_delete_cluster.md
@@ -40,10 +40,10 @@ werf kubectl config delete-cluster NAME
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_delete_context.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_delete_context.md
@@ -40,10 +40,10 @@ werf kubectl config delete-context NAME
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_delete_user.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_delete_user.md
@@ -40,10 +40,10 @@ werf kubectl config delete-user NAME
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_get_clusters.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_get_clusters.md
@@ -40,10 +40,10 @@ werf kubectl config get-clusters
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_get_contexts.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_get_contexts.md
@@ -53,10 +53,10 @@ werf kubectl config get-contexts [(-o|--output=)name)] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_get_users.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_get_users.md
@@ -40,10 +40,10 @@ werf kubectl config get-users
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_rename_context.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_rename_context.md
@@ -46,10 +46,10 @@ werf kubectl config rename-context CONTEXT_NAME NEW_NAME
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_set.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_set.md
@@ -63,10 +63,10 @@ werf kubectl config set PROPERTY_NAME PROPERTY_VALUE [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_set_cluster.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_set_cluster.md
@@ -58,10 +58,10 @@ werf kubectl config set-cluster NAME [--server=server] [--certificate-authority=
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_set_context.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_set_context.md
@@ -49,10 +49,10 @@ werf kubectl config set-context [NAME | --current] [--cluster=cluster_nickname] 
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_set_credentials.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_set_credentials.md
@@ -100,10 +100,10 @@ werf kubectl config set-credentials NAME [--client-certificate=path/to/certfile]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_unset.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_unset.md
@@ -45,10 +45,10 @@ werf kubectl config unset PROPERTY_NAME
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_use_context.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_use_context.md
@@ -40,10 +40,10 @@ werf kubectl config use-context CONTEXT_NAME
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_config_view.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_view.md
@@ -74,10 +74,10 @@ werf kubectl config view [flags] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
             use a particular kubeconfig file
       --match-server-version=false

--- a/docs/_includes/reference/cli/werf_kubectl_cordon.md
+++ b/docs/_includes/reference/cli/werf_kubectl_cordon.md
@@ -51,12 +51,13 @@ werf kubectl cordon NODE [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_cp.md
+++ b/docs/_includes/reference/cli/werf_kubectl_cp.md
@@ -77,12 +77,13 @@ werf kubectl cp <file-spec-src> <file-spec-dest> [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create.md
@@ -93,12 +93,13 @@ werf kubectl create -f FILENAME [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_clusterrole.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_clusterrole.md
@@ -94,12 +94,13 @@ werf kubectl create clusterrole NAME --verb=verb --resource=resource.group [--re
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_clusterrolebinding.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_clusterrolebinding.md
@@ -75,12 +75,13 @@ werf kubectl create clusterrolebinding NAME --clusterrole=NAME [--user=username]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_configmap.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_configmap.md
@@ -99,12 +99,13 @@ werf kubectl create configmap NAME [--from-file=[key=]source] [--from-literal=ke
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_cronjob.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_cronjob.md
@@ -78,12 +78,13 @@ werf kubectl create cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMM
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_deployment.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_deployment.md
@@ -84,12 +84,13 @@ werf kubectl create deployment NAME --image=image -- [COMMAND] [args...] [option
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_ingress.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_ingress.md
@@ -111,12 +111,13 @@ werf kubectl create ingress NAME --rule=host/path=service:port[,tls[=secret]]  [
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_job.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_job.md
@@ -79,12 +79,13 @@ werf kubectl create job NAME --image=image [--from=cronjob/name] -- [COMMAND] [a
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_namespace.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_namespace.md
@@ -69,12 +69,13 @@ werf kubectl create namespace NAME [--dry-run=server|client|none] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_poddisruptionbudget.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_poddisruptionbudget.md
@@ -81,12 +81,13 @@ werf kubectl create poddisruptionbudget NAME --selector=SELECTOR --min-available
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_priorityclass.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_priorityclass.md
@@ -85,12 +85,13 @@ werf kubectl create priorityclass NAME --value=VALUE --global-default=BOOL [--dr
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_quota.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_quota.md
@@ -77,12 +77,13 @@ werf kubectl create quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_role.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_role.md
@@ -84,12 +84,13 @@ werf kubectl create role NAME --verb=verb --resource=resource.group/subresource 
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_rolebinding.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_rolebinding.md
@@ -77,12 +77,13 @@ werf kubectl create rolebinding NAME --clusterrole=NAME|--role=NAME [--user=user
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_secret.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_secret.md
@@ -33,12 +33,13 @@ werf kubectl create secret
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_secret_docker_registry.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_secret_docker_registry.md
@@ -98,12 +98,13 @@ werf kubectl create secret docker-registry NAME --docker-username=user --docker-
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_secret_generic.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_secret_generic.md
@@ -101,12 +101,13 @@ werf kubectl create secret generic NAME [--type=string] [--from-file=[key=]sourc
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_secret_tls.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_secret_tls.md
@@ -77,12 +77,13 @@ werf kubectl create secret tls NAME --cert=path/to/cert/file --key=path/to/key/f
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_service.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_service.md
@@ -33,12 +33,13 @@ werf kubectl create service
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_service_clusterip.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_service_clusterip.md
@@ -76,12 +76,13 @@ werf kubectl create service clusterip NAME [--tcp=<port>:<targetPort>] [--dry-ru
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_service_externalname.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_service_externalname.md
@@ -75,12 +75,13 @@ werf kubectl create service externalname NAME --external-name external.name [--d
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_service_loadbalancer.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_service_loadbalancer.md
@@ -71,12 +71,13 @@ werf kubectl create service loadbalancer NAME [--tcp=port:targetPort] [--dry-run
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_service_nodeport.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_service_nodeport.md
@@ -73,12 +73,13 @@ werf kubectl create service nodeport NAME [--tcp=port:targetPort] [--dry-run=ser
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_create_serviceaccount.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_serviceaccount.md
@@ -69,12 +69,13 @@ werf kubectl create serviceaccount NAME [--dry-run=server|client|none] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_debug.md
+++ b/docs/_includes/reference/cli/werf_kubectl_debug.md
@@ -109,12 +109,13 @@ werf kubectl debug (POD | TYPE[[.VERSION].GROUP]/NAME) [ -- COMMAND [args...] ] 
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_delete.md
+++ b/docs/_includes/reference/cli/werf_kubectl_delete.md
@@ -122,12 +122,13 @@ werf kubectl delete ([-f FILENAME] | [-k DIRECTORY] | TYPE [(NAME | -l label | -
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_describe.md
+++ b/docs/_includes/reference/cli/werf_kubectl_describe.md
@@ -87,12 +87,13 @@ werf kubectl describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME) 
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_diff.md
+++ b/docs/_includes/reference/cli/werf_kubectl_diff.md
@@ -74,12 +74,13 @@ werf kubectl diff -f FILENAME [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_drain.md
+++ b/docs/_includes/reference/cli/werf_kubectl_drain.md
@@ -86,12 +86,13 @@ werf kubectl drain NODE [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_edit.md
+++ b/docs/_includes/reference/cli/werf_kubectl_edit.md
@@ -95,12 +95,13 @@ werf kubectl edit (RESOURCE/NAME | -f FILENAME) [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_exec.md
+++ b/docs/_includes/reference/cli/werf_kubectl_exec.md
@@ -80,12 +80,13 @@ werf kubectl exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...] 
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_explain.md
+++ b/docs/_includes/reference/cli/werf_kubectl_explain.md
@@ -60,12 +60,13 @@ werf kubectl explain RESOURCE [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_expose.md
+++ b/docs/_includes/reference/cli/werf_kubectl_expose.md
@@ -139,12 +139,13 @@ werf kubectl expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP|
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_get.md
+++ b/docs/_includes/reference/cli/werf_kubectl_get.md
@@ -146,12 +146,13 @@ werf kubectl get [(-o|--output=)json|yaml|name|go-template|go-template-file|temp
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_kustomize.md
+++ b/docs/_includes/reference/cli/werf_kubectl_kustomize.md
@@ -77,12 +77,13 @@ werf kubectl kustomize DIR [flags] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_label.md
+++ b/docs/_includes/reference/cli/werf_kubectl_label.md
@@ -112,12 +112,13 @@ werf kubectl label [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_logs.md
+++ b/docs/_includes/reference/cli/werf_kubectl_logs.md
@@ -113,12 +113,13 @@ werf kubectl logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_options.md
+++ b/docs/_includes/reference/cli/werf_kubectl_options.md
@@ -40,12 +40,13 @@ werf kubectl options
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_patch.md
+++ b/docs/_includes/reference/cli/werf_kubectl_patch.md
@@ -92,12 +92,13 @@ werf kubectl patch (-f FILENAME | TYPE NAME) [-p PATCH|--patch-file FILE] [optio
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_plugin.md
+++ b/docs/_includes/reference/cli/werf_kubectl_plugin.md
@@ -37,12 +37,13 @@ werf kubectl plugin [flags]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_plugin_list.md
+++ b/docs/_includes/reference/cli/werf_kubectl_plugin_list.md
@@ -42,12 +42,13 @@ werf kubectl plugin list [flags] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_port_forward.md
+++ b/docs/_includes/reference/cli/werf_kubectl_port_forward.md
@@ -74,12 +74,13 @@ werf kubectl port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCA
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_proxy.md
+++ b/docs/_includes/reference/cli/werf_kubectl_proxy.md
@@ -95,12 +95,13 @@ werf kubectl proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_replace.md
+++ b/docs/_includes/reference/cli/werf_kubectl_replace.md
@@ -108,12 +108,13 @@ werf kubectl replace -f FILENAME [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_rollout.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout.md
@@ -49,12 +49,13 @@ werf kubectl rollout SUBCOMMAND
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_history.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_history.md
@@ -69,12 +69,13 @@ werf kubectl rollout history (TYPE NAME | TYPE/NAME) [flags] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_pause.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_pause.md
@@ -70,12 +70,13 @@ werf kubectl rollout pause RESOURCE [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_restart.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_restart.md
@@ -71,12 +71,13 @@ werf kubectl rollout restart RESOURCE [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_resume.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_resume.md
@@ -68,12 +68,13 @@ werf kubectl rollout resume RESOURCE [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_status.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_status.md
@@ -61,12 +61,13 @@ werf kubectl rollout status (TYPE NAME | TYPE/NAME) [flags] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_undo.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_undo.md
@@ -76,12 +76,13 @@ werf kubectl rollout undo (TYPE NAME | TYPE/NAME) [flags] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_run.md
+++ b/docs/_includes/reference/cli/werf_kubectl_run.md
@@ -163,12 +163,13 @@ werf kubectl run NAME --image=image [--env="key=value"] [--port=port] [--dry-run
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_scale.md
+++ b/docs/_includes/reference/cli/werf_kubectl_scale.md
@@ -100,12 +100,13 @@ werf kubectl scale [--resource-version=version] [--current-replicas=count] --rep
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_set.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set.md
@@ -35,12 +35,13 @@ werf kubectl set SUBCOMMAND
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_set_env.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_env.md
@@ -133,12 +133,13 @@ werf kubectl set env RESOURCE/NAME KEY_1=VAL_1 ... KEY_N=VAL_N [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_set_image.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_image.md
@@ -90,12 +90,13 @@ werf kubectl set image (-f FILENAME | TYPE NAME) CONTAINER_NAME_1=CONTAINER_IMAG
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_set_resources.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_resources.md
@@ -101,12 +101,13 @@ werf kubectl set resources (-f FILENAME | TYPE NAME)  ([--limits=LIMITS & --requ
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_set_selector.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_selector.md
@@ -78,12 +78,13 @@ werf kubectl set selector (-f FILENAME | TYPE NAME) EXPRESSIONS [--resource-vers
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_set_serviceaccount.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_serviceaccount.md
@@ -81,12 +81,13 @@ werf kubectl set serviceaccount (-f FILENAME | TYPE NAME) SERVICE_ACCOUNT [optio
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_set_subject.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_subject.md
@@ -87,12 +87,13 @@ werf kubectl set subject (-f FILENAME | TYPE NAME) [--user=username] [--group=gr
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_taint.md
+++ b/docs/_includes/reference/cli/werf_kubectl_taint.md
@@ -93,12 +93,13 @@ werf kubectl taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EF
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_top.md
+++ b/docs/_includes/reference/cli/werf_kubectl_top.md
@@ -37,12 +37,13 @@ werf kubectl top
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_top_node.md
+++ b/docs/_includes/reference/cli/werf_kubectl_top_node.md
@@ -62,12 +62,13 @@ werf kubectl top node [NAME | -l label] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_top_pod.md
+++ b/docs/_includes/reference/cli/werf_kubectl_top_pod.md
@@ -77,12 +77,13 @@ werf kubectl top pod [NAME | -l label] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_uncordon.md
+++ b/docs/_includes/reference/cli/werf_kubectl_uncordon.md
@@ -51,12 +51,13 @@ werf kubectl uncordon NODE [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_version.md
+++ b/docs/_includes/reference/cli/werf_kubectl_version.md
@@ -51,12 +51,13 @@ werf kubectl version [flags] [options]
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''

--- a/docs/_includes/reference/cli/werf_kubectl_wait.md
+++ b/docs/_includes/reference/cli/werf_kubectl_wait.md
@@ -99,12 +99,13 @@ werf kubectl wait ([-f FILENAME] | resource.group/resource.name | resource.group
       --cluster=''
             The name of the kubeconfig cluster to use
       --context=''
-            The name of the kubeconfig context to use
+            The name of the kubeconfig context to use (default $WERF_KUBE_CONTEXT)
       --insecure-skip-tls-verify=false
             If true, the server`s certificate will not be checked for validity. This will make your 
-            HTTPS connections insecure
+            HTTPS connections insecure (default $WERF_SKIP_TLS_VERIFY_REGISTRY)
       --kubeconfig=''
-            Path to the kubeconfig file to use for CLI requests.
+            Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
+            $WERF_KUBECONFIG, or $KUBECONFIG)
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''


### PR DESCRIPTION
Make "werf kubectl" respect $WERF_KUBE_CONFIG, $WERF_KUBECONFIG, $WERF_KUBE_CONTEXT, $WERF_SKIP_TLS_VERIFY_REGISTRY.

Signed-off-by: Ilya Lesikov <ilya@lesikov.com>