### PR TITLE
docs: remove any CentOS image mentions

### DIFF
--- a/docs/pages_en/advanced/ci_cd/run_in_container/how_it_works.md
+++ b/docs/pages_en/advanced/ci_cd/run_in_container/how_it_works.md
@@ -47,10 +47,6 @@ Below is a list of images with built-in werf. Each image is updated as part of a
 * `registry.werf.io/werf/werf:1.2-beta-ubuntu`;
 * `registry.werf.io/werf/werf:1.2-ea-ubuntu`;
 * `registry.werf.io/werf/werf:1.2-stable-ubuntu`;
-* `registry.werf.io/werf/werf:1.2-alpha-centos`;
-* `registry.werf.io/werf/werf:1.2-beta-centos`;
-* `registry.werf.io/werf/werf:1.2-ea-centos`;
-* `registry.werf.io/werf/werf:1.2-stable-centos`;
 * `registry.werf.io/werf/werf:1.2-alpha-fedora`;
 * `registry.werf.io/werf/werf:1.2-beta-fedora`;
 * `registry.werf.io/werf/werf:1.2-ea-fedora`;

--- a/docs/pages_ru/advanced/ci_cd/run_in_container/how_it_works.md
+++ b/docs/pages_ru/advanced/ci_cd/run_in_container/how_it_works.md
@@ -47,10 +47,6 @@ permalink: advanced/ci_cd/run_in_container/how_it_works.html
 * `registry.werf.io/werf/werf:1.2-beta-ubuntu`;
 * `registry.werf.io/werf/werf:1.2-ea-ubuntu`;
 * `registry.werf.io/werf/werf:1.2-stable-ubuntu`;
-* `registry.werf.io/werf/werf:1.2-alpha-centos`;
-* `registry.werf.io/werf/werf:1.2-beta-centos`;
-* `registry.werf.io/werf/werf:1.2-ea-centos`;
-* `registry.werf.io/werf/werf:1.2-stable-centos`;
 * `registry.werf.io/werf/werf:1.2-alpha-fedora`;
 * `registry.werf.io/werf/werf:1.2-beta-fedora`;
 * `registry.werf.io/werf/werf:1.2-ea-fedora`;


### PR DESCRIPTION
CentOS image is not a recommended image again (since now it is based on CentOS
Stream). Fedora is preferred if rpm-based image needed.

Signed-off-by: Ilya Lesikov <ilya@lesikov.com>