### PR TITLE
fix(stapel-to-buildah): working build of 'from' stage

### DIFF
--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -73,11 +73,15 @@ func (runtime *BuildahBackend) BuildStapelStage(ctx context.Context, baseImage s
 	}
 
 	// TODO(stapel-to-buildah): use buildah.Change to set labels
-	fmt.Printf("Setting labels %v for build container %q\n", opts.Labels, containerID)
+	fmt.Printf("[DEBUG] Setting labels %v for build container %q\n", opts.Labels, containerID)
 
-	fmt.Printf("Committing container %q\n", containerID)
+	fmt.Printf("[DEBUG] Committing container %q\n", containerID)
+	imgID, err := runtime.buildah.Commit(ctx, containerID, buildah.CommitOpts{})
+	if err != nil {
+		return "", fmt.Errorf("unable to commit container %q: %s", containerID, err)
+	}
 
-	return "", fmt.Errorf("not implemented yet")
+	return imgID, nil
 }
 
 // GetImageInfo returns nil, nil if image not found.


### PR DESCRIPTION
Run build of stapel image with buildah with the following command:

```
WERF_BUILDAH_MODE=native-rootless WERF_BUILDAH_FOR_STAPEL_ENABLED=1 werf build --repo REPO
```

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>