### PR TITLE
feat(stapel-to-buildah): support user stages and mounts

### DIFF
--- a/pkg/build/builder/ansible.go
+++ b/pkg/build/builder/ansible.go
@@ -135,8 +135,7 @@ func (b *Ansible) stage(ctx context.Context, cr container_backend.ContainerBacke
 
 		return nil
 	} else {
-		// TODO(stapel-to-buildah)
-		panic("not implemented")
+		return fmt.Errorf("ansible builder is not supported when using buildah backend, please use shell builder instead")
 	}
 }
 

--- a/pkg/build/builder/shell.go
+++ b/pkg/build/builder/shell.go
@@ -87,12 +87,11 @@ func (b *Shell) stage(cr container_backend.ContainerBackend, stageBuilder stage_
 		}
 
 		container.AddServiceRunCommands(containerTmpScriptFilePath)
-
-		return nil
 	} else {
-		// TODO(stapel-to-buildah)
-		panic("not implemented")
+		stageBuilder.StapelStageBuilder().AddUserCommands(b.stageCommands(userStageName)...)
 	}
+
+	return nil
 }
 
 func (b *Shell) stageChecksum(ctx context.Context, userStageName string) string {

--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/werf/logboek"
 	"github.com/werf/werf/pkg/config"
 	"github.com/werf/werf/pkg/container_backend"
 	imagePkg "github.com/werf/werf/pkg/image"
@@ -99,7 +100,9 @@ func (s *FromStage) PrepareImage(ctx context.Context, c Conveyor, cr container_b
 		} else {
 			stageImage.Builder.StapelStageBuilder().AddPrepareContainerActions(container_backend.PrepareContainerActionWith(func(containerRoot string) error {
 				for _, mountpoint := range mountpoints {
-					if err := os.RemoveAll(mountpoint); err != nil {
+					logboek.Context(ctx).Info().LogF("Removing mountpoint %q in the container dir: %q\n", mountpoint, filepath.Join(containerRoot, mountpoint))
+
+					if err := os.RemoveAll(filepath.Join(containerRoot, mountpoint)); err != nil {
 						return fmt.Errorf("unable to remove %q: %s", mountpoint, err)
 					}
 				}


### PR DESCRIPTION
* Working beforeInstall, install, beforeSetup, setup stages building.
    * Run each instruction from werf.yaml in the separate shell session for now.
* Fixed mountpoints cleaning in the 'from' stage.
* Added usage of mounts for user stages.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>