### PR TITLE
fix(cleanup): manage custom tags that do not have associated existent stages

### DIFF
--- a/pkg/cleaning/purge.go
+++ b/pkg/cleaning/purge.go
@@ -202,7 +202,6 @@ func deleteCustomTags(ctx context.Context, storageManager manager.StorageManager
 		}
 
 		logboek.Context(ctx).Default().LogFDetails("  tag: %s\n", tag)
-		logboek.Context(ctx).Default().LogOptionalLn()
 
 		return nil
 	}); err != nil {

--- a/pkg/cleaning/stage_manager/manager.go
+++ b/pkg/cleaning/stage_manager/manager.go
@@ -370,3 +370,7 @@ func (m *Manager) IsStageExist(stageID string) bool {
 func (m *Manager) GetCustomTagsMetadata() map[string][]string {
 	return m.stageIDCustomTagList
 }
+
+func (m *Manager) ForgetCustomTagsByStageID(stageID string) {
+	delete(m.stageIDCustomTagList, stageID)
+}

--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -247,6 +247,7 @@ func (m *StorageManager) getStageDescriptionList(ctx context.Context, opts ...st
 
 		if stageDesc == nil {
 			logboek.Context(ctx).Warn().LogF("Ignoring stage %s: cannot get stage description from %s\n", stageID.String(), m.StagesStorage.String())
+			return nil
 		}
 
 		mutex.Lock()


### PR DESCRIPTION
Keep set of custom tags without associated existent stage while any of them used in Kubernetes.