### PR TITLE
fix(server-dry-run): possible fix for 'unable to recognize ...: no matches for kind ... in version ...' (part 2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,4 +110,4 @@ replace k8s.io/helm => github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f
 
 replace github.com/deislabs/oras => github.com/werf/third-party-oras v0.9.1-0.20210927171747-6d045506f4c8
 
-replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220408101849-d8e67b909e29
+replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220408112844-a661f7cd4c64

--- a/go.sum
+++ b/go.sum
@@ -2028,6 +2028,8 @@ github.com/werf/3p-helm/v3 v3.0.0-20220408091813-c0fabb4d3be2 h1:w4Fn7kQMDDUJM9X
 github.com/werf/3p-helm/v3 v3.0.0-20220408091813-c0fabb4d3be2/go.mod h1:Nm0Z2ciZFFvR9cRKpiRE2SMhJTgqY0b+ezT2cDcyqNw=
 github.com/werf/3p-helm/v3 v3.0.0-20220408101849-d8e67b909e29 h1:IPcvabW7f8eBpBI7U2DQUaRhFmjzvMhVdDYq83X/520=
 github.com/werf/3p-helm/v3 v3.0.0-20220408101849-d8e67b909e29/go.mod h1:Nm0Z2ciZFFvR9cRKpiRE2SMhJTgqY0b+ezT2cDcyqNw=
+github.com/werf/3p-helm/v3 v3.0.0-20220408112844-a661f7cd4c64 h1:SuB96B8WTpKdBjHSc3uyCJiX3YcQJEc9HyZD4kzURzo=
+github.com/werf/3p-helm/v3 v3.0.0-20220408112844-a661f7cd4c64/go.mod h1:Nm0Z2ciZFFvR9cRKpiRE2SMhJTgqY0b+ezT2cDcyqNw=
 github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f h1:81YscYTF9mmTf0ULOsCmm42YWQp+qWDzWi1HjWniZrg=
 github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f/go.mod h1:OMONwLWU9zEENgaVjWEX+M+xik2QakejzKHG1+6mnUo=
 github.com/werf/kubedog v0.6.4-0.20220222141823-4ca722ade0ef h1:jidfI8MH4qRvWHlxGw06VKWiKRdBIfGFcjQ3pGwsquc=


### PR DESCRIPTION
* Rework dry-run resource lists preparations, refs https://github.com/werf/3p-helm/pull/148.
* Update helm 3.8.0 to 3.8.1.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>