### PR TITLE
fix(kube-run): didn't work in Native Buildah mode

### DIFF
--- a/cmd/werf/kube_run/kube_run.go
+++ b/cmd/werf/kube_run/kube_run.go
@@ -484,7 +484,7 @@ func run(ctx context.Context, pod, secret, namespace string, werfConfig *config.
 		return common.WithoutTerminationSignalsTrap(func() error {
 			logboek.Context(ctx).LogF("Running pod %q in namespace %q ...\n", pod, namespace)
 
-			cmd := exec.Command(os.Args[0], args...)
+			cmd := exec.Command(strings.TrimSuffix(os.Args[0], "-in-a-user-namespace"), args...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stdin
 			cmd.Stdin = os.Stdin


### PR DESCRIPTION
Failed with error:
```
Error: error running pod: fork/exec werf-in-a-user-namespace: no such file or directory
```

Signed-off-by: Ilya Lesikov <ilya@lesikov.com>