### PR TITLE
fix: .helm/Chart.yaml chart name redefines project name from werf.yaml

### DIFF
--- a/pkg/deploy/helm/chart_extender/werf_chart.go
+++ b/pkg/deploy/helm/chart_extender/werf_chart.go
@@ -107,7 +107,7 @@ func (wc *WerfChart) ChartLoaded(files []*chart.ChartExtenderBufferedFile) error
 
 	var opts helpers.GetHelmChartMetadataOptions
 	if wc.werfConfig != nil {
-		opts.OverrideName = wc.werfConfig.Meta.Project
+		opts.DefaultName = wc.werfConfig.Meta.Project
 	}
 	opts.DefaultVersion = "1.0.0"
 	wc.HelmChart.Metadata = helpers.AutosetChartMetadata(wc.HelmChart.Metadata, opts)


### PR DESCRIPTION
By default werf uses `project` directive value as a `{{ .Chart.Name }}` when no .helm/Chart.yaml exist.
User can redefine chart name with the following `.helm/Chart.yaml`:

```
apiVersion: v2
name: custom-chart-name
```

Fixes https://github.com/werf/werf/issues/4376

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>