### PR TITLE
[v1.2.80] feat: support --show-only|-s helm-style render option + export-values chaining

### DIFF
--- a/docs/_includes/reference/cli/werf_kubectl_get.md
+++ b/docs/_includes/reference/cli/werf_kubectl_get.md
@@ -87,7 +87,7 @@ werf kubectl get [(-o|--output=)json|yaml|name|go-template|go-template-file|temp
             print headers).
   -o, --output=''
             Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile
-            |jsonpath|jsonpath-as-json|jsonpath-file|custom-columns-file|custom-columns|wide See    
+            |jsonpath|jsonpath-as-json|jsonpath-file|custom-columns|custom-columns-file|wide See    
             custom columns [https://kubernetes.io/docs/reference/kubectl/overview/#custom-columns], 
             golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath        
             template [https://kubernetes.io/docs/reference/kubectl/jsonpath/].

--- a/docs/_includes/reference/cli/werf_render.md
+++ b/docs/_includes/reference/cli/werf_render.md
@@ -245,6 +245,8 @@ werf render [options]
             with commas: key1=val1,key2=val2).
             Also, can be defined with $WERF_SET_STRING_* (e.g. $WERF_SET_STRING_1=key1=val1,        
             $WERF_SET_STRING_2=key2=val2)
+  -s, --show-only=[]
+            only show manifests rendered from the given templates
   -Z, --skip-build=false
             Disable building of docker images, cached images in the repo should exist in the repo   
             if werf.yaml contains at least one image description (default $WERF_SKIP_BUILD)

--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,4 @@ replace k8s.io/helm => github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f
 
 replace github.com/deislabs/oras => github.com/werf/third-party-oras v0.9.1-0.20210927171747-6d045506f4c8
 
-replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220419133137-dc8004cf1adb
+replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220426084307-62a091d4aa41

--- a/go.sum
+++ b/go.sum
@@ -2056,6 +2056,8 @@ github.com/werf/3p-helm/v3 v3.0.0-20220419131239-a2df9b725de3 h1:H3C8D/30GQ71laO
 github.com/werf/3p-helm/v3 v3.0.0-20220419131239-a2df9b725de3/go.mod h1:Nm0Z2ciZFFvR9cRKpiRE2SMhJTgqY0b+ezT2cDcyqNw=
 github.com/werf/3p-helm/v3 v3.0.0-20220419133137-dc8004cf1adb h1:1DtA1vZN0dIo2rMjxA9NBoI9qFka3m82BvsZGsZubNI=
 github.com/werf/3p-helm/v3 v3.0.0-20220419133137-dc8004cf1adb/go.mod h1:3eOeBD3Z+O/ELiuu19zynZSN8jP1ErXLuyP21SZeMq8=
+github.com/werf/3p-helm/v3 v3.0.0-20220426084307-62a091d4aa41 h1:cnvBtE+YuW1+SnZmPJ3dTzLKHPkT0u3nC3JMHh7lsWg=
+github.com/werf/3p-helm/v3 v3.0.0-20220426084307-62a091d4aa41/go.mod h1:3eOeBD3Z+O/ELiuu19zynZSN8jP1ErXLuyP21SZeMq8=
 github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f h1:81YscYTF9mmTf0ULOsCmm42YWQp+qWDzWi1HjWniZrg=
 github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f/go.mod h1:OMONwLWU9zEENgaVjWEX+M+xik2QakejzKHG1+6mnUo=
 github.com/werf/kubedog v0.6.4-0.20220222141823-4ca722ade0ef h1:jidfI8MH4qRvWHlxGw06VKWiKRdBIfGFcjQ3pGwsquc=


### PR DESCRIPTION
* Pass either `-s templates/*ingress*.yaml` path (helm compatible) or use `-s .helm/templates/*ingress*.yaml` with full path in local filesystem (with bash completion convenience).
* `export-values` in subcharts and sub-subcharts (and sub-sub-subcharts etc.) are processed now as expected.

Refs https://github.com/werf/3p-helm/pull/162
Refs https://github.com/werf/3p-helm/pull/161
