### PR TITLE
feat: support --show-only|-s helm-style render option + export-values chaining

### DIFF
--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	helm_v3 "helm.sh/helm/v3/cmd/helm"
@@ -31,6 +32,7 @@ import (
 	"github.com/werf/werf/pkg/storage/manager"
 	"github.com/werf/werf/pkg/tmp_manager"
 	"github.com/werf/werf/pkg/true_git"
+	"github.com/werf/werf/pkg/util"
 	"github.com/werf/werf/pkg/werf"
 	"github.com/werf/werf/pkg/werf/global_warnings"
 )
@@ -39,6 +41,7 @@ var cmdData struct {
 	RenderOutput string
 	Validate     bool
 	IncludeCRDs  bool
+	ShowOnly     []string
 }
 
 var commonCmdData common.CmdData
@@ -127,8 +130,13 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&cmdData.IncludeCRDs, "include-crds", "", common.GetBoolEnvironmentDefaultTrue("WERF_INCLUDE_CRDS"), "Include CRDs in the templated output (default $WERF_INCLUDE_CRDS)")
 
 	cmd.Flags().StringVarP(&cmdData.RenderOutput, "output", "", os.Getenv("WERF_RENDER_OUTPUT"), "Write render output to the specified file instead of stdout ($WERF_RENDER_OUTPUT by default)")
+	cmd.Flags().StringArrayVarP(&cmdData.ShowOnly, "show-only", "s", []string{}, "only show manifests rendered from the given templates")
 
 	return cmd
+}
+
+func getShowOnly() []string {
+	return append(common.PredefinedValuesByEnvNamePrefix("WERF_SHOW_ONLY"), cmdData.ShowOnly...)
 }
 
 func runRender(ctx context.Context) error {
@@ -387,7 +395,7 @@ func runRender(ctx context.Context) error {
 		SubchartExtenderFactoryFunc: func() chart.ChartExtender { return chart_extender.NewWerfSubchart() },
 	}
 
-	helmTemplateCmd, _ := helm_v3.NewTemplateCmd(actionConfig, output, helm_v3.TemplateCmdOptions{
+	templateOpts := helm_v3.TemplateCmdOptions{
 		ChainPostRenderer: wc.ChainPostRenderer,
 		ValueOpts: &values.Options{
 			ValueFiles:   common.GetValues(&commonCmdData),
@@ -397,7 +405,29 @@ func runRender(ctx context.Context) error {
 		},
 		Validate:    &cmdData.Validate,
 		IncludeCrds: &cmdData.IncludeCRDs,
-	})
+	}
+
+	fullChartDir := filepath.Join(giterminismManager.ProjectDir(), chartDir)
+
+	if showOnly := getShowOnly(); len(showOnly) > 0 {
+		var showFiles []string
+
+		for _, p := range showOnly {
+			pAbs := util.GetAbsoluteFilepath(p)
+			if strings.HasPrefix(pAbs, fullChartDir) {
+				tp := util.GetRelativeToBaseFilepath(fullChartDir, pAbs)
+				logboek.Context(ctx).Debug().LogF("Process show-only params: use path %q\n", tp)
+				showFiles = append(showFiles, tp)
+			} else {
+				logboek.Context(ctx).Debug().LogF("Process show-only params: use path %q\n", p)
+				showFiles = append(showFiles, p)
+			}
+		}
+
+		templateOpts.ShowFiles = &showFiles
+	}
+
+	helmTemplateCmd, _ := helm_v3.NewTemplateCmd(actionConfig, output, templateOpts)
 	if err := helmTemplateCmd.RunE(helmTemplateCmd, []string{releaseName, filepath.Join(giterminismManager.ProjectDir(), chartDir)}); err != nil {
 		return fmt.Errorf("helm templates rendering failed: %w", err)
 	}

--- a/docs/pages_ru/advanced/ci_cd/github_actions.md
+++ b/docs/pages_ru/advanced/ci_cd/github_actions.md
@@ -39,7 +39,7 @@ author: Sergey Lazarev <sergey.lazarev@flant.com>, Alexey Igrychev <alexey.igryc
 * Кластер Kubernetes.
 * Проект на [GitHub](https://github.com/).
 * Приложение, которое успешно собирается и деплоится с помощью werf.
-* Понимание [основных концептов GitHub Actions](https://help.github.com/en/actions/getting-started-with-github-actions/core-concepts-for-github-actions).
+* Понимание [основных концептов GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions).
   
 > Далее в примерах статьи будут использоваться виртуальные машины, предоставляемые GitHub, с OS Linux (`runs-on: ubuntu-latest`). Тем не менее, все примеры также справедливы для предустановленных self-hosted runners на базе любой OS
 
@@ -96,7 +96,7 @@ author: Sergey Lazarev <sergey.lazarev@flant.com>, Alexey Igrychev <alexey.igryc
 
 Конфигурация задания достаточно проста, поэтому хочется сделать акцент на том, чего в ней нет — явной авторизации в container registry, вызова `docker login`. 
 
-В простейшем случае, при использовании встроенного [container registry](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages), авторизация выполняется автоматически при вызове команды `werf ci-env`. В качестве необходимых аргументов используются переменные окружения GitHub, [секретная переменная `GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#about-the-github_token-secret), а также имя пользователя (`GITHUB_ACTOR`) инициировавшего запуск workflow.
+В простейшем случае, при использовании встроенного [container registry](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#external-events-repository_dispatch), авторизация выполняется автоматически при вызове команды `werf ci-env`. В качестве необходимых аргументов используются переменные окружения GitHub, [секретная переменная `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret), а также имя пользователя (`GITHUB_ACTOR`) инициировавшего запуск workflow.
 
 Если необходимо выполнить авторизацию с произвольными учётными данными или с внешним container registry, то необходимо использовать готовый action для вашего container registry или просто выполнить `docker login` перед использованием werf. 
 

--- a/docs/pages_ru/internals/how_ci_cd_integration_works/github_actions.md
+++ b/docs/pages_ru/internals/how_ci_cd_integration_works/github_actions.md
@@ -13,7 +13,7 @@ permalink: internals/how_ci_cd_integration_works/github_actions.html
 
 ## WERF_ADD_ANNOTATION_PROJECT_GIT
 
-Значение для установки переменной окружения [`WERF_ADD_ANNOTATION_PROJECT_GIT`]({{ "internals/how_ci_cd_integration_works/general_overview.html#werf_add_annotation_project_git" | true_relative_url }}) формируется на основе переменной окружения GitHub Actions [`GITHUB_REPOSITORY`](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables) следующим образом:
+Значение для установки переменной окружения [`WERF_ADD_ANNOTATION_PROJECT_GIT`]({{ "internals/how_ci_cd_integration_works/general_overview.html#werf_add_annotation_project_git" | true_relative_url }}) формируется на основе переменной окружения GitHub Actions [`GITHUB_REPOSITORY`](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) следующим образом:
 
 ```
 project.werf.io/git=https://github.com/$GITHUB_REPOSITORY
@@ -21,7 +21,7 @@ project.werf.io/git=https://github.com/$GITHUB_REPOSITORY
 
 ## WERF_ADD_ANNOTATION_CI_COMMIT
 
-Значение для установки переменной окружения [`WERF_ADD_ANNOTATION_CI_COMMIT`]({{ "internals/how_ci_cd_integration_works/general_overview.html#werf_add_annotation_ci_commit" | true_relative_url }}) формируется на основе переменной окружения GitHub Actions [`GITHUB_SHA`](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables) следующим образом:
+Значение для установки переменной окружения [`WERF_ADD_ANNOTATION_CI_COMMIT`]({{ "internals/how_ci_cd_integration_works/general_overview.html#werf_add_annotation_ci_commit" | true_relative_url }}) формируется на основе переменной окружения GitHub Actions [`GITHUB_SHA`](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) следующим образом:
 
 ```
 ci.werf.io/commit=$GITHUB_SHA
@@ -29,7 +29,7 @@ ci.werf.io/commit=$GITHUB_SHA
 
 ## WERF_ADD_ANNOTATION_GITHUB_ACTIONS_RUN_URL
 
-Значение для установки переменной окружения `WERF_ADD_ANNOTATION_GITHUB_CI_WORKFLOW_URL` формируется на основе переменной окружения GitHub Actions [`GITHUB_RUN_ID`](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables) следующим образом:
+Значение для установки переменной окружения `WERF_ADD_ANNOTATION_GITHUB_CI_WORKFLOW_URL` формируется на основе переменной окружения GitHub Actions [`GITHUB_RUN_ID`](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) следующим образом:
 
 ```
 github.ci.werf.io/workflow-run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID

--- a/go.mod
+++ b/go.mod
@@ -109,4 +109,4 @@ replace k8s.io/helm => github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f
 
 replace github.com/deislabs/oras => github.com/werf/third-party-oras v0.9.1-0.20210927171747-6d045506f4c8
 
-replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220419131239-a2df9b725de3
+replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220426084422-a22e7bc5d766

--- a/go.sum
+++ b/go.sum
@@ -2061,6 +2061,8 @@ github.com/weppos/publicsuffix-go v0.5.0 h1:rutRtjBJViU/YjcI5d80t4JAVvDltS6bciJg
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/werf/3p-helm/v3 v3.0.0-20220419131239-a2df9b725de3 h1:H3C8D/30GQ71laOCsLGJrIHZMAa4Joab48hkOfTH8KA=
 github.com/werf/3p-helm/v3 v3.0.0-20220419131239-a2df9b725de3/go.mod h1:Nm0Z2ciZFFvR9cRKpiRE2SMhJTgqY0b+ezT2cDcyqNw=
+github.com/werf/3p-helm/v3 v3.0.0-20220426084422-a22e7bc5d766 h1:Z1vzNVuptwHZBzHcSZ1rrJ8MVVdh8Sh7P39onUS9a3k=
+github.com/werf/3p-helm/v3 v3.0.0-20220426084422-a22e7bc5d766/go.mod h1:Nm0Z2ciZFFvR9cRKpiRE2SMhJTgqY0b+ezT2cDcyqNw=
 github.com/werf/copy-recurse v0.2.2 h1:OpBB+Ezsv7j+iQR02p7zUQXSefZ7UaKBtQPMg2dxi7M=
 github.com/werf/copy-recurse v0.2.2/go.mod h1:KVHSQ90p19xflWW0B7BJhLBwmSbEtuxIaBnjlUYRPhk=
 github.com/werf/copy-recurse v0.2.3 h1:bi43vHBDQiX2Qnq+Ci9IGqtm7YdzzpkBO+8MKjp6x8g=


### PR DESCRIPTION
* Pass either `-s templates/*ingress*.yaml` path (helm compatible) or use `-s .helm/templates/*ingress*.yaml` with full path in local filesystem (with bash completion convenience).
* `export-values` in subcharts and sub-subcharts (and sub-sub-subcharts etc.) are processed now as expected.

Refs https://github.com/werf/3p-helm/pull/162
Refs https://github.com/werf/3p-helm/pull/161

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>