### PR TITLE
fix: broken export-values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,4 +109,4 @@ replace k8s.io/helm => github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f
 
 replace github.com/deislabs/oras => github.com/werf/third-party-oras v0.9.1-0.20210927171747-6d045506f4c8
 
-replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220426084422-a22e7bc5d766
+replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220428190238-94f85ca83011

--- a/go.sum
+++ b/go.sum
@@ -2063,6 +2063,8 @@ github.com/werf/3p-helm/v3 v3.0.0-20220419131239-a2df9b725de3 h1:H3C8D/30GQ71laO
 github.com/werf/3p-helm/v3 v3.0.0-20220419131239-a2df9b725de3/go.mod h1:Nm0Z2ciZFFvR9cRKpiRE2SMhJTgqY0b+ezT2cDcyqNw=
 github.com/werf/3p-helm/v3 v3.0.0-20220426084422-a22e7bc5d766 h1:Z1vzNVuptwHZBzHcSZ1rrJ8MVVdh8Sh7P39onUS9a3k=
 github.com/werf/3p-helm/v3 v3.0.0-20220426084422-a22e7bc5d766/go.mod h1:Nm0Z2ciZFFvR9cRKpiRE2SMhJTgqY0b+ezT2cDcyqNw=
+github.com/werf/3p-helm/v3 v3.0.0-20220428190238-94f85ca83011 h1:/5kpc5aE+ih8HTnW8EPB7KtRixPEjLipA7Rfa1MAAic=
+github.com/werf/3p-helm/v3 v3.0.0-20220428190238-94f85ca83011/go.mod h1:Nm0Z2ciZFFvR9cRKpiRE2SMhJTgqY0b+ezT2cDcyqNw=
 github.com/werf/copy-recurse v0.2.2 h1:OpBB+Ezsv7j+iQR02p7zUQXSefZ7UaKBtQPMg2dxi7M=
 github.com/werf/copy-recurse v0.2.2/go.mod h1:KVHSQ90p19xflWW0B7BJhLBwmSbEtuxIaBnjlUYRPhk=
 github.com/werf/copy-recurse v0.2.3 h1:bi43vHBDQiX2Qnq+Ci9IGqtm7YdzzpkBO+8MKjp6x8g=


### PR DESCRIPTION
Error was introduced in the https://github.com/werf/3p-helm/pull/161, which is temporarily reverted now (https://github.com/werf/3p-helm/pull/163).

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>