### PR TITLE
fix(stapel-to-buildah): fix cleanup parent-id issue for images built with buildah

### DIFF
--- a/pkg/buildah/native_linux.go
+++ b/pkg/buildah/native_linux.go
@@ -327,6 +327,8 @@ func (b *NativeBuildah) Commit(ctx context.Context, container string, opts Commi
 		}
 	}
 
+	builder.SetLabel("werf.io/base-image-id", fmt.Sprintf("sha256:%s", builder.FromImageID))
+
 	imgID, _, _, err := builder.Commit(ctx, imageRef, buildah.CommitOptions{
 		PreferredManifestType: buildah.Dockerv2ImageManifest,
 		SignaturePolicyPath:   b.SignaturePolicyPath,

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -491,17 +491,24 @@ func (runtime *BuildahBackend) GetImageInfo(ctx context.Context, ref string, opt
 
 	repository, tag := image.ParseRepositoryAndTag(ref)
 
+	var parentID string
+	if id, ok := inspect.Docker.Config.Labels["werf.io/base-image-id"]; ok {
+		parentID = id
+	} else {
+		parentID = string(inspect.Docker.Parent)
+	}
+
 	return &image.Info{
 		Name:              ref,
 		Repository:        repository,
 		Tag:               tag,
 		Labels:            inspect.Docker.Config.Labels,
 		CreatedAtUnixNano: inspect.Docker.Created.UnixNano(),
-		// RepoDigest:        repoDigest, // FIXME
-		OnBuild:  inspect.Docker.Config.OnBuild,
-		ID:       inspect.Docker.ID,
-		ParentID: inspect.Docker.Config.Image,
-		Size:     inspect.Docker.Size,
+		RepoDigest:        inspect.FromImageDigest,
+		OnBuild:           inspect.Docker.Config.OnBuild,
+		ID:                inspect.FromImageID,
+		ParentID:          parentID,
+		Size:              inspect.Docker.Size,
 	}, nil
 }
 

--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -143,13 +143,21 @@ func (api *api) GetRepoImage(_ context.Context, reference string) (*image.Info, 
 		return nil, fmt.Errorf("unable to parse reference %q: %w", reference, err)
 	}
 
+	var parentID string
+	if baseImageID, ok := configFile.Config.Labels["werf.io/base-image-id"]; ok {
+		parentID = baseImageID
+	} else {
+		// TODO(1.3): Legacy compatibility mode
+		parentID = configFile.Config.Image
+	}
+
 	repoImage := &image.Info{
 		Name:       reference,
 		Repository: strings.Join([]string{referenceParts.registry, referenceParts.repository}, "/"),
 		ID:         manifest.Config.Digest.String(),
 		Tag:        referenceParts.tag,
 		RepoDigest: digest.String(),
-		ParentID:   configFile.Config.Image,
+		ParentID:   parentID,
 		Labels:     configFile.Config.Labels,
 		Size:       totalSize,
 	}

--- a/pkg/image/info.go
+++ b/pkg/image/info.go
@@ -45,6 +45,14 @@ func NewInfoFromInspect(ref string, inspect *types.ImageInspect) *Info {
 		repoDigest = inspect.RepoDigests[0]
 	}
 
+	var parentID string
+	if id, ok := inspect.Config.Labels["werf.io/base-image-id"]; ok {
+		parentID = id
+	} else {
+		// TODO(1.3): Legacy compatibility mode
+		parentID = inspect.Config.Image
+	}
+
 	return &Info{
 		Name:              ref,
 		Repository:        repository,
@@ -54,7 +62,7 @@ func NewInfoFromInspect(ref string, inspect *types.ImageInspect) *Info {
 		CreatedAtUnixNano: MustParseTimestampString(inspect.Created).UnixNano(),
 		RepoDigest:        repoDigest,
 		ID:                inspect.ID,
-		ParentID:          inspect.Config.Image,
+		ParentID:          parentID,
 		Size:              inspect.Size,
 	}
 }


### PR DESCRIPTION
Save base image id into the dedicated label `werf.io/base-image-id`.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>