### PR TITLE
feat(cleanup): optimize cleanup deployed resources images scanning regarding Jobs

### DIFF
--- a/integration/suites/deploy/helm_values_test.go
+++ b/integration/suites/deploy/helm_values_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/werf/kubedog/pkg/kube"
 	"github.com/werf/werf/pkg/util"
 	"github.com/werf/werf/test/pkg/utils"

--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -236,7 +236,7 @@ func (m *cleanupManager) deployedDockerImagesNames(ctx context.Context) ([]strin
 	for _, contextClient := range m.KubernetesContextClients {
 		if err := logboek.Context(ctx).LogProcessInline("Getting deployed docker images (context %s)", contextClient.ContextName).
 			DoError(func() error {
-				kubernetesClientDeployedDockerImagesNames, err := allow_list.DeployedDockerImages(contextClient.Client, m.KubernetesNamespaceRestrictionByContext[contextClient.ContextName])
+				kubernetesClientDeployedDockerImagesNames, err := allow_list.DeployedDockerImages(ctx, contextClient.Client, m.KubernetesNamespaceRestrictionByContext[contextClient.ContextName])
 				if err != nil {
 					return fmt.Errorf("cannot get deployed imagesStageList: %w", err)
 				}


### PR DESCRIPTION
Images that are used by completed or failed Jobs could be safely removed by the cleanup, because Job is a oneshot resource.

Refs https://github.com/werf/werf/issues/4411