### PR TITLE
fix(cache-repo): panic when using cache repo and fromImage directive

### DIFF
--- a/pkg/build/image.go
+++ b/pkg/build/image.go
@@ -126,7 +126,7 @@ func (i *Image) SetupBaseImage(c *Conveyor) {
 	if i.baseImageImageName != "" {
 		i.baseImageType = StageAsBaseImage
 		i.stageAsBaseImage = c.GetImage(i.baseImageImageName).GetLastNonEmptyStage()
-		i.baseImage = c.GetOrCreateStageImage(nil, i.stageAsBaseImage.GetStageImage().Image.Name())
+		i.baseImage = i.stageAsBaseImage.GetStageImage()
 	} else {
 		i.baseImageType = ImageFromRegistryAsBaseImage
 		i.baseImage = c.GetOrCreateStageImage(nil, i.baseImageName)

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -613,9 +613,11 @@ func (runtime *BuildahBackend) RenameImage(ctx context.Context, img LegacyImageI
 
 	desc := img.GetStageDescription()
 
-	repository, tag := image.ParseRepositoryAndTag(newImageName)
-	desc.Info.Repository = repository
-	desc.Info.Tag = tag
+	if desc != nil {
+		repository, tag := image.ParseRepositoryAndTag(newImageName)
+		desc.Info.Repository = repository
+		desc.Info.Tag = tag
+	}
 
 	return nil
 }

--- a/pkg/container_backend/legacy_interface.go
+++ b/pkg/container_backend/legacy_interface.go
@@ -37,6 +37,8 @@ type LegacyImageInterface interface {
 
 	SetStageDescription(stage *image.StageDescription)
 	GetStageDescription() *image.StageDescription
+
+	GetCopy() LegacyImageInterface
 }
 
 type LegacyContainer interface {

--- a/pkg/container_backend/legacy_stage_image.go
+++ b/pkg/container_backend/legacy_stage_image.go
@@ -29,6 +29,19 @@ func NewLegacyStageImage(fromImage *LegacyStageImage, name string, containerBack
 	return stage
 }
 
+func (i *LegacyStageImage) GetCopy() LegacyImageInterface {
+	ni := NewLegacyStageImage(i.fromImage, i.name, i.ContainerBackend)
+
+	if info := i.GetInfo(); info != nil {
+		ni.SetInfo(info)
+	}
+	if desc := i.GetStageDescription(); desc != nil {
+		ni.SetStageDescription(desc)
+	}
+
+	return ni
+}
+
 func (i *LegacyStageImage) BuilderContainer() LegacyBuilderContainer {
 	return &LegacyStageImageBuilderContainer{i}
 }


### PR DESCRIPTION
```
goroutine 1623 [running]:
github.com/werf/werf/pkg/build/stage.(*BaseStage).getServiceMountsFromLabels(0xc0016ed300?, 0xc001b00100)
	/home/distorhead/werf/pkg/build/stage/base.go:283 +0xc4
github.com/werf/werf/pkg/build/stage.(*BaseStage).getServiceMounts(0xc000e50d80?, 0x3bde920?)
	/home/distorhead/werf/pkg/build/stage/base.go:274 +0x36
github.com/werf/werf/pkg/build/stage.(*FromStage).PrepareImage(0xc0014c5140, {0xc001508420?, 0x3be22c8?}, {0x3be06b0, 0xc0006ac2c0}, {0x3bde920, 0xc000f622e0}, 0x0?, 0xc001b01640)
	/home/distorhead/werf/pkg/build/stage/from.go:82 +0x194
github.com/werf/werf/pkg/build.(*BuildPhase).prepareStageInstructions(0xc00188a2d0, {0x3bcc730?, 0xc001858300}, 0xc001508420, {0x3be22c8, 0xc0014c5140})
	/home/distorhead/werf/pkg/build/build_phase.go:693 +0xdff
...
```

Refactor the process of copying of stage-image descriptors objects into cache storage.
