### PR TITLE
fix(cache-repo): panic when using cache-repo and building images existing in cache

### DIFF
--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -433,7 +433,7 @@ func (m *StorageManager) FetchStage(ctx context.Context, containerBackend contai
 	fetchStageFromCache := func(stagesStorage storage.StagesStorage) (container_backend.LegacyImageInterface, error) {
 		stageID := stg.GetStageImage().Image.GetStageDescription().StageID
 		imageName := stagesStorage.ConstructStageImageName(m.ProjectName, stageID.Digest, stageID.UniqueID)
-		stageImage := container_backend.NewLegacyStageImage(nil, imageName, containerBackend.(*container_backend.DockerServerBackend))
+		stageImage := container_backend.NewLegacyStageImage(nil, imageName, containerBackend)
 
 		shouldFetch, err := stagesStorage.ShouldFetchImage(ctx, stageImage)
 		if err != nil {
@@ -755,7 +755,7 @@ func (m *StorageManager) getStagesByDigestFromStagesStorage(ctx context.Context,
 }
 
 func (m *StorageManager) CopySuitableByDigestStage(ctx context.Context, stageDesc *image.StageDescription, sourceStagesStorage, destinationStagesStorage storage.StagesStorage, containerBackend container_backend.ContainerBackend) (*image.StageDescription, error) {
-	img := container_backend.NewLegacyStageImage(nil, stageDesc.Info.Name, containerBackend.(*container_backend.DockerServerBackend))
+	img := container_backend.NewLegacyStageImage(nil, stageDesc.Info.Name, containerBackend)
 
 	logboek.Context(ctx).Info().LogF("Fetching %s\n", img.Name())
 	if err := sourceStagesStorage.FetchImage(ctx, img); err != nil {


### PR DESCRIPTION
```
panic: interface conversion: container_backend.ContainerBackend is *container_backend.BuildahBackend, not *container_backend.DockerServerBackend

goroutine 29 [running]:
github.com/werf/werf/pkg/storage/manager.(*StorageManager).FetchStage.func1({0x3be8f20, 0xc00145cae0})
	/home/distorhead/werf/pkg/storage/manager/storage_manager.go:438 +0xb97
github.com/werf/werf/pkg/storage/manager.(*StorageManager).FetchStage(0xc0014660b0, {0x3bcc950?, 0xc00162e0f0}, {0x3bdeb40?, 0xc000a968a0}, {0x3be2310, 0xc000c02ff0})
	/home/distorhead/werf/pkg/storage/manager/storage_manager.go:516 +0x1738
...
```

Removed legacy interface conversion which is not needed now.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>