### PR TITLE
test(bundles): integration and unit test for secret-values feature in bundles

### DIFF
--- a/integration/suites/bundles/bundles_test.go
+++ b/integration/suites/bundles/bundles_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -46,6 +47,8 @@ var _ = Describe("Bundles", func() {
 			})
 
 			It("should publish latest quickstart-application bundle, then apply into kubernetes, then export it, then render it from exported dir, then render it from registry", func() {
+				ctx := context.Background()
+
 				switch implementationName {
 				case "dockerhub":
 					Skip("Skip due to the unresolved issue: https://github.com/werf/werf/issues/3184")
@@ -53,17 +56,61 @@ var _ = Describe("Bundles", func() {
 					Skip("Skip due to the unresolved issue: https://github.com/werf/werf/issues/3182")
 				}
 
+				const secretKey = "bfd966688bbe64c1986a356be2d6ba0a"
+
+				By("preparing test application using werf/quickstart-application as a base")
+
 				Expect(liveexec.ExecCommand(".", "git", liveexec.ExecCommandOptions{}, []string{"clone", "https://github.com/werf/quickstart-application", SuiteData.ProjectName}...)).To(Succeed())
+
+				Expect(os.WriteFile(filepath.Join(SuiteData.ProjectName, ".helm", "templates", "secret.yaml"), []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+data:
+  testkey: {{ .Values.testsecrets.testkey | b64enc }}
+`), os.ModePerm)).To(Succeed())
+
+				Expect(os.WriteFile(filepath.Join(SuiteData.ProjectName, ".helm", "values.yaml"), []byte(`testsecrets:
+  testkey: DEFAULT
+`), os.ModePerm)).To(Succeed())
+
+				Expect(liveexec.ExecCommand(SuiteData.ProjectName, "git", liveexec.ExecCommandOptions{}, []string{"add", "."}...)).To(Succeed())
+				Expect(liveexec.ExecCommand(SuiteData.ProjectName, "git", liveexec.ExecCommandOptions{}, []string{"commit", "-m", "go"}...)).To(Succeed())
+
 				Expect(liveExecWerf(SuiteData.ProjectName, liveexec.ExecCommandOptions{}, "bundle", "publish")).Should(Succeed())
-				Expect(liveExecWerf(".", liveexec.ExecCommandOptions{}, "bundle", "apply", "--release", SuiteData.ProjectName, "--namespace", SuiteData.ProjectName, "--set-docker-config-json-value")).Should(Succeed())
+
+				By("applying bundle into cluster")
+
+				applyDir := filepath.Join(SuiteData.TmpDir, "apply-dir")
+				Expect(os.MkdirAll(applyDir, os.ModePerm)).To(Succeed())
+				secretFile := filepath.Join(applyDir, "secret-values.yaml")
+				Expect(os.WriteFile(secretFile, []byte(`
+testsecrets:
+  testkey: 1000b45ee4272d14b30be2d20b5963f09e372fdfe761bf3913186938f4054d09ed0e
+`), os.ModePerm)).To((Succeed()))
+
+				Expect(liveExecWerf(".", liveexec.ExecCommandOptions{
+					Env: map[string]string{"WERF_SECRET_KEY": secretKey},
+				}, "bundle", "apply", "--release", SuiteData.ProjectName, "--namespace", SuiteData.ProjectName, "--set-docker-config-json-value", "--secret-values", secretFile)).Should(Succeed())
+
+				{
+					secret, err := kube.Client.CoreV1().Secrets(SuiteData.ProjectName).Get(ctx, "test-secret", metav1.GetOptions{})
+					Expect(err).To(Succeed())
+					Expect(string(secret.Data["testkey"])).To(Equal("TOPSECRET"))
+				}
+
+				By("exporting bundle")
 
 				exportedBundleDir := utils.GetTempDir()
 				Expect(liveExecWerf(SuiteData.ProjectName, liveexec.ExecCommandOptions{}, "bundle", "export", "--destination", exportedBundleDir)).Should(Succeed())
 
 				SuiteData.Stubs.UnsetEnv("WERF_REPO")
 
+				By("rendering bundle from the directory which contains exported bundle")
+
 				gotKindDeploymentInLocalRender := false
 				Expect(liveExecWerf(exportedBundleDir, liveexec.ExecCommandOptions{
+					Env: map[string]string{"WERF_SECRET_KEY": secretKey},
 					OutputLineHandler: func(line string) {
 						if strings.TrimSpace(line) == "kind: Deployment" {
 							gotKindDeploymentInLocalRender = true
@@ -74,8 +121,11 @@ var _ = Describe("Bundles", func() {
 
 				SuiteData.Stubs.SetEnv("WERF_REPO", SuiteData.Repo)
 
+				By("rendering bundle from the project dir")
+
 				gotKindDeploymentInRemoteRender := false
 				Expect(liveExecWerf(SuiteData.ProjectName, liveexec.ExecCommandOptions{
+					Env: map[string]string{"WERF_SECRET_KEY": secretKey},
 					OutputLineHandler: func(line string) {
 						if strings.TrimSpace(line) == "kind: Deployment" {
 							gotKindDeploymentInRemoteRender = true

--- a/integration/suites/bundles/suite_test.go
+++ b/integration/suites/bundles/suite_test.go
@@ -26,4 +26,5 @@ var (
 	_ = SuiteData.SetupWerfBinary(suite_init.NewWerfBinaryData(SuiteData.SynchronizedSuiteCallbacksData))
 	_ = SuiteData.SetupProjectName(suite_init.NewProjectNameData(SuiteData.StubsData))
 	_ = SuiteData.SetupContainerRegistryPerImplementation(suite_init.NewContainerRegistryPerImplementationData(SuiteData.SynchronizedSuiteCallbacksData, false))
+	_ = SuiteData.SetupTmp(suite_init.NewTmpDirData())
 )

--- a/pkg/deploy/helm/chart_extender/bundle_test.go
+++ b/pkg/deploy/helm/chart_extender/bundle_test.go
@@ -1,0 +1,81 @@
+package chart_extender
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/werf/werf/pkg/deploy/secrets_manager"
+
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+var _ = Describe("Bundle", func() {
+	BeforeEach(func() {
+		os.Setenv("WERF_SECRET_KEY", "bfd966688bbe64c1986a356be2d6ba0a")
+	})
+
+	It("should ignore secret values file from the chart when no explicit option specified", func() {
+		ctx := context.Background()
+		bundleDir := ""
+		secretsManager := secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{})
+
+		bundle, err := NewBundle(ctx, bundleDir, helm_v3.Settings, nil, secretsManager, BundleOptions{
+			SecretValueFiles: nil,
+		})
+		Expect(err).To(Succeed())
+
+		ch := &chart.Chart{}
+		bundle.ChartCreated(ch)
+
+		files := []*chart.ChartExtenderBufferedFile{
+			{
+				Name: "secret-values.yaml",
+				Data: []byte(`
+testsecrets:
+  testkey: 1000b45ee4272d14b30be2d20b5963f09e372fdfe761bf3913186938f4054d09ed0e
+`),
+			},
+		}
+		Expect(bundle.ChartLoaded(files)).To(Succeed())
+
+		vals, err := bundle.MakeValues(map[string]interface{}{"one": 1, "two": 2})
+		Expect(err).To(Succeed())
+
+		Expect(vals).To(Equal(map[string]interface{}{"one": 1, "two": 2}))
+	})
+
+	It("should load from local FS secret values file specified with explicit option", func() {
+		ctx := context.Background()
+		bundleDir := ""
+
+		secretsManager := secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{})
+
+		secretValuesFile, err := ioutil.TempFile("", "bundle-test-*.yaml")
+		defer os.RemoveAll(secretValuesFile.Name())
+
+		Expect(err).To(Succeed())
+		Expect(os.WriteFile(secretValuesFile.Name(), []byte(`
+testsecrets:
+  testkey: 1000b45ee4272d14b30be2d20b5963f09e372fdfe761bf3913186938f4054d09ed0e
+`), os.ModePerm)).To(Succeed())
+
+		bundle, err := NewBundle(ctx, bundleDir, helm_v3.Settings, nil, secretsManager, BundleOptions{
+			SecretValueFiles: []string{secretValuesFile.Name()},
+		})
+		Expect(err).To(Succeed())
+
+		ch := &chart.Chart{}
+		bundle.ChartCreated(ch)
+
+		Expect(bundle.ChartLoaded(nil)).To(Succeed())
+
+		vals, err := bundle.MakeValues(map[string]interface{}{"one": 1, "two": 2})
+		Expect(err).To(Succeed())
+		Expect(vals).To(Equal(map[string]interface{}{"one": 1, "two": 2, "testsecrets": map[string]interface{}{"testkey": "TOPSECRET"}}))
+	})
+})

--- a/pkg/deploy/helm/chart_extender/stage_suite_test.go
+++ b/pkg/deploy/helm/chart_extender/stage_suite_test.go
@@ -1,0 +1,13 @@
+package chart_extender
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestStage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ChartExtender Suite")
+}


### PR DESCRIPTION
* test bundle-apply with the --secret-values param in the integration test;
* test secret values loading in unit test of chart-extender.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>