### PR TITLE
fix(helm): fix 'error preparing chart dependencies... file exists'

### DIFF
--- a/pkg/deploy/helm/chart_extender/chart_dependencies_loader.go
+++ b/pkg/deploy/helm/chart_extender/chart_dependencies_loader.go
@@ -74,6 +74,15 @@ func GetPreparedChartDependenciesDir(ctx context.Context, metadataFile, metadata
 			}
 			defer werf.ReleaseHostLock(lock)
 
+			switch _, err := os.Stat(depsDir); {
+			case os.IsNotExist(err):
+			case err != nil:
+				return fmt.Errorf("error accessing %s: %w", depsDir, err)
+			default:
+				// at the time we have acquired a lock the target directory was created
+				return nil
+			}
+
 			tmpDepsDir := fmt.Sprintf("%s.tmp.%s", depsDir, uuid.NewV4().String())
 
 			buildChartDependenciesOpts.LoadOptions = &loader.LoadOptions{


### PR DESCRIPTION
Error may occur when concurrent processes fulfill cache directory.

Fixed by additional check of directory existance after lock has been acquired.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>