### PR TITLE
fix(dockerfile): support RUN with --mount from another stage

### DIFF
--- a/pkg/build/dockerfile_helpers/dockerfile_helpers.go
+++ b/pkg/build/dockerfile_helpers/dockerfile_helpers.go
@@ -18,11 +18,23 @@ func ResolveDockerStagesFromValue(stages []instructions.Stage) {
 		}
 
 		for _, cmd := range s.Commands {
-			copyCmd, ok := cmd.(*instructions.CopyCommand)
-			if ok && copyCmd.From != "" {
-				from := strings.ToLower(copyCmd.From)
-				if val, ok := nameToIndex[from]; ok {
-					copyCmd.From = val
+			switch typedCmd := cmd.(type) {
+			case *instructions.CopyCommand:
+				if typedCmd.From != "" {
+					from := strings.ToLower(typedCmd.From)
+					if val, ok := nameToIndex[from]; ok {
+						typedCmd.From = val
+					}
+				}
+
+			case *instructions.RunCommand:
+				for _, mount := range instructions.GetMounts(typedCmd) {
+					if mount.From != "" {
+						from := strings.ToLower(mount.From)
+						if val, ok := nameToIndex[from]; ok {
+							mount.From = val
+						}
+					}
 				}
 			}
 		}

--- a/pkg/build/stage/dependencies_test.go
+++ b/pkg/build/stage/dependencies_test.go
@@ -15,7 +15,7 @@ var _ = Describe("DependenciesStage", func() {
 		func(data TestDependencies) {
 			ctx := context.Background()
 
-			conveyor := NewConveyorStubForDependencies(NewGiterminismManagerStub(NewLocalGitRepoStub("9d8059842b6fde712c58315ca0ab4713d90761c0")), data.Dependencies)
+			conveyor := NewConveyorStubForDependencies(NewGiterminismManagerStub(NewLocalGitRepoStub("9d8059842b6fde712c58315ca0ab4713d90761c0"), NewGiterminismInspectorStub()), data.Dependencies)
 			containerBackend := NewContainerBackendMock()
 
 			stage := newDependenciesStage(nil, GetConfigDependencies(data.Dependencies), "example-stage", &NewBaseStageOptions{


### PR DESCRIPTION
When the following instruction used:

    RUN --mount=type=bind,from=build,source=/usr/local/test_project/dist,target=/usr/test_project/dist \
    cp -v /usr/test_project/dist/prog.py /usr/local/bin/prog

— change image digest when `from=build` stage digest has changed.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>