### PR TITLE
fix(helm): `unable to recognize "": no matches for kind "..." in version "..."` errors when base64 kubeconfig used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/werf/copy-recurse v0.2.4
-	github.com/werf/kubedog v0.6.5-0.20220524172024-3d978f3318f0
+	github.com/werf/kubedog v0.6.5-0.20220608151530-2555924b0ce9
 	github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea
 	github.com/werf/logboek v0.5.4
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4

--- a/go.sum
+++ b/go.sum
@@ -2040,6 +2040,8 @@ github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f h1:81YscYTF9mmTf0ULOsCmm
 github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f/go.mod h1:OMONwLWU9zEENgaVjWEX+M+xik2QakejzKHG1+6mnUo=
 github.com/werf/kubedog v0.6.5-0.20220524172024-3d978f3318f0 h1:PxvSQzWNc0gM4QsMBEUIg/A2SHia6zLMBbxi36Q5tvw=
 github.com/werf/kubedog v0.6.5-0.20220524172024-3d978f3318f0/go.mod h1:543dUdVbkeJeH/PaB2fiVNR++rGnWmZMmKkD9nAfjI8=
+github.com/werf/kubedog v0.6.5-0.20220608151530-2555924b0ce9 h1:EAGbbyVsin6oYLd7TerlIgr/0x/Qj6v43Nc7zzG3FlE=
+github.com/werf/kubedog v0.6.5-0.20220608151530-2555924b0ce9/go.mod h1:543dUdVbkeJeH/PaB2fiVNR++rGnWmZMmKkD9nAfjI8=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea h1:R5tJUhL5a3YfHTrHWyuAdJW3h//fmONrpHJjjAZ79e4=
 github.com/werf/lockgate v0.0.0-20200729113342-ec2c142f71ea/go.mod h1:/CeY6KDiBSCU9PUmjt7zGhqpzp8FAPg/wNVfLZHQGWI=
 github.com/werf/logboek v0.5.4 h1:BZ2UJlvngf/lSkJ2NDt0DmIY7tI1GyraURC8s8Injlk=


### PR DESCRIPTION
Refs: https://github.com/werf/kubedog/pull/253
Refs: https://github.com/kubernetes/client-go/issues/1109

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>