### PR TITLE
fix(helm): fix 'werf helm *' commands to correctly initialize namespace

### DIFF
--- a/cmd/werf/helm/helm.go
+++ b/cmd/werf/helm/helm.go
@@ -41,8 +41,9 @@ func NewCmd() *cobra.Command {
 	actionConfig := new(action.Configuration)
 
 	cmd := &cobra.Command{
-		Use:   "helm",
-		Short: "Manage application deployment with helm",
+		Use:          "helm",
+		Short:        "Manage application deployment with helm",
+		SilenceUsage: true,
 	}
 
 	ctx := common.GetContext()
@@ -206,6 +207,9 @@ func NewCmd() *cobra.Command {
 			}
 		}
 	}
+
+	cmd.PersistentFlags().ParseErrorsWhitelist.UnknownFlags = true
+	cmd.PersistentFlags().Parse(os.Args[1:])
 
 	return cmd
 }


### PR DESCRIPTION
* Initialize global 'werf helm *' flags early, the same way as original helm does.
* Fix 'werf helm PLUGIN' not uses --namespace param.
* Fix 'werf helm *' commands not to print help on command failure.
    
Fixes https://github.com/werf/werf/issues/4524

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>