### PR TITLE
fix(bundles): cleanup --final-repo param usage in bundles

### DIFF
--- a/cmd/werf/bundle/apply/apply.go
+++ b/cmd/werf/bundle/apply/apply.go
@@ -63,7 +63,6 @@ func NewCmd() *cobra.Command {
 	common.SetupHomeDir(&commonCmdData, cmd, common.SetupHomeDirOptions{})
 
 	common.SetupRepoOptions(&commonCmdData, cmd, common.RepoDataOptions{})
-	common.SetupFinalRepo(&commonCmdData, cmd)
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified repo, to pull base images")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)

--- a/cmd/werf/bundle/download/download.go
+++ b/cmd/werf/bundle/download/download.go
@@ -51,7 +51,6 @@ func NewCmd() *cobra.Command {
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupRepoOptions(&commonCmdData, cmd, common.RepoDataOptions{})
-	common.SetupFinalRepo(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)
 	common.SetupLogProjectDir(&commonCmdData, cmd)

--- a/cmd/werf/bundle/render/render.go
+++ b/cmd/werf/bundle/render/render.go
@@ -66,7 +66,6 @@ func NewCmd() *cobra.Command {
 	common.SetupHomeDir(&commonCmdData, cmd, common.SetupHomeDirOptions{})
 
 	common.SetupRepoOptions(&commonCmdData, cmd, common.RepoDataOptions{})
-	common.SetupFinalRepo(&commonCmdData, cmd)
 
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified repo, to pull base images")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
@@ -117,9 +116,6 @@ func runRender(ctx context.Context) error {
 	case cmdData.BundleDir != "":
 		if *commonCmdData.Repo.Address != "" {
 			return fmt.Errorf("only one of --bundle-dir or --repo should be specified, but both provided")
-		}
-		if *commonCmdData.FinalRepo.Address != "" {
-			return fmt.Errorf("only one of --bundle-dir or --final-repo should be specified, but both provided")
 		}
 
 		isLocal = true

--- a/docs/_includes/reference/cli/werf_bundle_apply.md
+++ b/docs/_includes/reference/cli/werf_bundle_apply.md
@@ -33,28 +33,6 @@ werf bundle apply [options]
             repo, to pull base images
       --env=''
             Use specified environment (default $WERF_ENV)
-      --final-repo=''
-            Container registry storage address (default $WERF_FINAL_REPO)
-      --final-repo-container-registry=''
-            Choose final-repo container registry implementation.
-            The following container registries are supported: ecr, acr, default, dockerhub, gcr,    
-            github, gitlab, harbor, quay.
-            Default $WERF_FINAL_REPO_CONTAINER_REGISTRY or auto mode (detect container registry by  
-            repo address).
-      --final-repo-docker-hub-password=''
-            final-repo Docker Hub password (default $WERF_FINAL_REPO_DOCKER_HUB_PASSWORD)
-      --final-repo-docker-hub-token=''
-            final-repo Docker Hub token (default $WERF_FINAL_REPO_DOCKER_HUB_TOKEN)
-      --final-repo-docker-hub-username=''
-            final-repo Docker Hub username (default $WERF_FINAL_REPO_DOCKER_HUB_USERNAME)
-      --final-repo-github-token=''
-            final-repo GitHub token (default $WERF_FINAL_REPO_GITHUB_TOKEN)
-      --final-repo-harbor-password=''
-            final-repo Harbor password (default $WERF_FINAL_REPO_HARBOR_PASSWORD)
-      --final-repo-harbor-username=''
-            final-repo Harbor username (default $WERF_FINAL_REPO_HARBOR_USERNAME)
-      --final-repo-quay-token=''
-            final-repo quay.io token (default $WERF_FINAL_REPO_QUAY_TOKEN)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
       --hooks-status-progress-period=5

--- a/docs/_includes/reference/cli/werf_bundle_download.md
+++ b/docs/_includes/reference/cli/werf_bundle_download.md
@@ -18,28 +18,6 @@ werf bundle download [options]
 ```shell
   -d, --destination=''
             Download bundle into the provided directory ($WERF_DESTINATION or chart-name by default)
-      --final-repo=''
-            Container registry storage address (default $WERF_FINAL_REPO)
-      --final-repo-container-registry=''
-            Choose final-repo container registry implementation.
-            The following container registries are supported: ecr, acr, default, dockerhub, gcr,    
-            github, gitlab, harbor, quay.
-            Default $WERF_FINAL_REPO_CONTAINER_REGISTRY or auto mode (detect container registry by  
-            repo address).
-      --final-repo-docker-hub-password=''
-            final-repo Docker Hub password (default $WERF_FINAL_REPO_DOCKER_HUB_PASSWORD)
-      --final-repo-docker-hub-token=''
-            final-repo Docker Hub token (default $WERF_FINAL_REPO_DOCKER_HUB_TOKEN)
-      --final-repo-docker-hub-username=''
-            final-repo Docker Hub username (default $WERF_FINAL_REPO_DOCKER_HUB_USERNAME)
-      --final-repo-github-token=''
-            final-repo GitHub token (default $WERF_FINAL_REPO_GITHUB_TOKEN)
-      --final-repo-harbor-password=''
-            final-repo Harbor password (default $WERF_FINAL_REPO_HARBOR_PASSWORD)
-      --final-repo-harbor-username=''
-            final-repo Harbor username (default $WERF_FINAL_REPO_HARBOR_USERNAME)
-      --final-repo-quay-token=''
-            final-repo quay.io token (default $WERF_FINAL_REPO_QUAY_TOKEN)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
       --insecure-helm-dependencies=false

--- a/docs/_includes/reference/cli/werf_bundle_render.md
+++ b/docs/_includes/reference/cli/werf_bundle_render.md
@@ -46,28 +46,6 @@ werf bundle render [options]
             repo, to pull base images
       --env=''
             Use specified environment (default $WERF_ENV)
-      --final-repo=''
-            Container registry storage address (default $WERF_FINAL_REPO)
-      --final-repo-container-registry=''
-            Choose final-repo container registry implementation.
-            The following container registries are supported: ecr, acr, default, dockerhub, gcr,    
-            github, gitlab, harbor, quay.
-            Default $WERF_FINAL_REPO_CONTAINER_REGISTRY or auto mode (detect container registry by  
-            repo address).
-      --final-repo-docker-hub-password=''
-            final-repo Docker Hub password (default $WERF_FINAL_REPO_DOCKER_HUB_PASSWORD)
-      --final-repo-docker-hub-token=''
-            final-repo Docker Hub token (default $WERF_FINAL_REPO_DOCKER_HUB_TOKEN)
-      --final-repo-docker-hub-username=''
-            final-repo Docker Hub username (default $WERF_FINAL_REPO_DOCKER_HUB_USERNAME)
-      --final-repo-github-token=''
-            final-repo GitHub token (default $WERF_FINAL_REPO_GITHUB_TOKEN)
-      --final-repo-harbor-password=''
-            final-repo Harbor password (default $WERF_FINAL_REPO_HARBOR_PASSWORD)
-      --final-repo-harbor-username=''
-            final-repo Harbor username (default $WERF_FINAL_REPO_HARBOR_USERNAME)
-      --final-repo-quay-token=''
-            final-repo quay.io token (default $WERF_FINAL_REPO_QUAY_TOKEN)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
       --include-crds=true


### PR DESCRIPTION
* support --final-repo in the "werf bundle publish" param:
    * store all images in the final repo and the bundle itself;
* remove --final-repo for "werf bundle apply/download/render" commands.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>