### PR TITLE
fix(git-worktree): ignore existing locked service worktree when re-adding

### DIFF
--- a/pkg/true_git/git_cmd_test.go
+++ b/pkg/true_git/git_cmd_test.go
@@ -28,6 +28,12 @@ var _ = Describe("Git command", func() {
 		utils.RunSucceedCommand(
 			gitRepoPath,
 			"git",
+			"checkout", "-b", "main",
+		)
+
+		utils.RunSucceedCommand(
+			gitRepoPath,
+			"git",
 			"commit", "--allow-empty", "-m", "Initial commit",
 		)
 

--- a/pkg/true_git/service_branch_test.go
+++ b/pkg/true_git/service_branch_test.go
@@ -31,6 +31,13 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			"-c", "init.defaultBranch=main",
 			"init",
 		)
+
+		utils.RunSucceedCommand(
+			sourceWorkTreeDir,
+			"git",
+			"checkout", "-b", "main",
+		)
+
 		gitDir = filepath.Join(sourceWorkTreeDir, ".git")
 
 		utils.RunSucceedCommand(

--- a/pkg/true_git/work_tree.go
+++ b/pkg/true_git/work_tree.go
@@ -212,7 +212,7 @@ func switchWorkTree(ctx context.Context, repoDir, workTreeDir, commit string, wi
 	_, err := os.Stat(workTreeDir)
 	switch {
 	case os.IsNotExist(err):
-		wtAddCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "worktree", "add", "--force", "--detach", workTreeDir, commit)
+		wtAddCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "worktree", "add", "--force", "--force", "--detach", workTreeDir, commit)
 		if err = wtAddCmd.Run(ctx); err != nil {
 			return fmt.Errorf("git worktree add command failed: %w", err)
 		}


### PR DESCRIPTION
* Use git worktree add with double `--force` argument. From git docs:
   > To add a missing but locked working tree path, specify --force twice.
* Added test for locked worktree case.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>