### PR TITLE
feat(telemetry): anonimized cli options usage, exit-code event, tune timeouts

### DIFF
--- a/pkg/telemetry/event.go
+++ b/pkg/telemetry/event.go
@@ -1,0 +1,38 @@
+package telemetry
+
+type EventType string
+
+const (
+	CommandStartedEvent EventType = "CommandStarted"
+	CommandExitedEvent  EventType = "CommandExited"
+)
+
+type Event interface {
+	GetType() EventType
+	GetData() interface{}
+}
+
+func NewCommandStarted(commandOptions []CommandOption) *CommandStarted {
+	return &CommandStarted{commandOptions: commandOptions}
+}
+
+type CommandStarted struct {
+	commandOptions []CommandOption
+}
+
+func (e *CommandStarted) GetType() EventType { return CommandStartedEvent }
+func (e *CommandStarted) GetData() interface{} {
+	if len(e.commandOptions) > 0 {
+		return map[string]interface{}{"commandOptions": e.commandOptions}
+	}
+	return nil
+}
+
+func NewCommandExited(exitCode int) *CommandExited { return &CommandExited{exitCode: exitCode} }
+
+type CommandExited struct {
+	exitCode int
+}
+
+func (e *CommandExited) GetType() EventType   { return CommandExitedEvent }
+func (e *CommandExited) GetData() interface{} { return map[string]interface{}{"exitCode": e.exitCode} }

--- a/pkg/telemetry/event_type.go
+++ b/pkg/telemetry/event_type.go
@@ -1,7 +1,0 @@
-package telemetry
-
-type EventType string
-
-const (
-	CommandStartedEvent EventType = "CommandStarted"
-)

--- a/pkg/telemetry/helpers.go
+++ b/pkg/telemetry/helpers.go
@@ -25,7 +25,7 @@ func NewTraceExporter(url string) (*otlptrace.Exporter, error) {
 		otlptracehttp.WithEndpoint(urlObj.Host),
 		otlptracehttp.WithURLPath(urlObj.Path),
 		otlptracehttp.WithRetry(otlptracehttp.RetryConfig{Enabled: false}),
-		otlptracehttp.WithTimeout(5*time.Second),
+		otlptracehttp.WithTimeout(800*time.Millisecond),
 	)
 
 	client := otlptracehttp.NewClient(opts...)

--- a/pkg/telemetry/no_telemetrywerfio.go
+++ b/pkg/telemetry/no_telemetrywerfio.go
@@ -4,6 +4,8 @@ import "context"
 
 type NoTelemetryWerfIO struct{}
 
-func (t *NoTelemetryWerfIO) CommandStarted(context.Context)       {}
-func (t *NoTelemetryWerfIO) SetProjectID(context.Context, string) {}
-func (t *NoTelemetryWerfIO) SetCommand(context.Context, string)   {}
+func (t *NoTelemetryWerfIO) CommandStarted(context.Context)                     {}
+func (t *NoTelemetryWerfIO) SetProjectID(context.Context, string)               {}
+func (t *NoTelemetryWerfIO) SetCommand(context.Context, string)                 {}
+func (t *NoTelemetryWerfIO) CommandExited(context.Context, int)                 {}
+func (t *NoTelemetryWerfIO) SetCommandOptions(context.Context, []CommandOption) {}


### PR DESCRIPTION
* Send CommandStarted event with additional data: list of cli options names that has been specified (without values).
* Send CommandExited event with exit code.
* Lower telemetry conn timeouts to 800ms.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>