### PR TITLE
fix(local-cache-cleanup): more correct GC for ~/.local_cache/git_* data

### DIFF
--- a/pkg/git_repo/gitdata/git_archive.go
+++ b/pkg/git_repo/gitdata/git_archive.go
@@ -11,10 +11,11 @@ import (
 )
 
 type GitArchiveDesc struct {
-	MetadataPath string
-	ArchivePath  string
-	Metadata     *ArchiveMetadata
-	Size         uint64
+	MetadataPath  string
+	ArchivePath   string
+	Metadata      *ArchiveMetadata
+	Size          uint64
+	CacheBasePath string
 }
 
 func (entry *GitArchiveDesc) GetPaths() []string {
@@ -27,6 +28,10 @@ func (entry *GitArchiveDesc) GetSize() uint64 {
 
 func (entry *GitArchiveDesc) GetLastAccessAt() time.Time {
 	return time.Unix(entry.Metadata.LastAccessTimestamp, 0)
+}
+
+func (entry *GitArchiveDesc) GetCacheBasePath() string {
+	return entry.CacheBasePath
 }
 
 func GetExistingGitArchives(cacheVersionRoot string) ([]*GitArchiveDesc, error) {
@@ -84,7 +89,7 @@ func GetExistingGitArchives(cacheVersionRoot string) ([]*GitArchiveDesc, error) 
 					continue
 				}
 
-				desc := &GitArchiveDesc{MetadataPath: path}
+				desc := &GitArchiveDesc{MetadataPath: path, CacheBasePath: cacheVersionRoot}
 				res = append(res, desc)
 
 				if data, err := ioutil.ReadFile(path); err != nil {

--- a/pkg/git_repo/gitdata/git_data_entry.go
+++ b/pkg/git_repo/gitdata/git_data_entry.go
@@ -6,6 +6,7 @@ type GitDataEntry interface {
 	GetPaths() []string
 	GetSize() uint64
 	GetLastAccessAt() time.Time
+	GetCacheBasePath() string
 }
 
 type GitDataLruSort []GitDataEntry

--- a/pkg/git_repo/gitdata/git_patch.go
+++ b/pkg/git_repo/gitdata/git_patch.go
@@ -11,10 +11,11 @@ import (
 )
 
 type GitPatchDesc struct {
-	MetadataPath string
-	PatchPath    string
-	Metadata     *PatchMetadata
-	Size         uint64
+	MetadataPath  string
+	PatchPath     string
+	Metadata      *PatchMetadata
+	Size          uint64
+	CacheBasePath string
 }
 
 func (entry *GitPatchDesc) GetPaths() []string {
@@ -27,6 +28,10 @@ func (entry *GitPatchDesc) GetSize() uint64 {
 
 func (entry *GitPatchDesc) GetLastAccessAt() time.Time {
 	return time.Unix(entry.Metadata.LastAccessTimestamp, 0)
+}
+
+func (entry *GitPatchDesc) GetCacheBasePath() string {
+	return entry.CacheBasePath
 }
 
 func GetExistingGitPatches(cacheVersionRoot string) ([]*GitPatchDesc, error) {

--- a/pkg/git_repo/gitdata/git_repo.go
+++ b/pkg/git_repo/gitdata/git_repo.go
@@ -12,9 +12,10 @@ import (
 )
 
 type GitRepoDesc struct {
-	Path         string
-	LastAccessAt time.Time
-	Size         uint64
+	Path          string
+	LastAccessAt  time.Time
+	Size          uint64
+	CacheBasePath string
 }
 
 func (entry *GitRepoDesc) GetPaths() []string {
@@ -27,6 +28,10 @@ func (entry *GitRepoDesc) GetSize() uint64 {
 
 func (entry *GitRepoDesc) GetLastAccessAt() time.Time {
 	return entry.LastAccessAt
+}
+
+func (entry *GitRepoDesc) GetCacheBasePath() string {
+	return entry.CacheBasePath
 }
 
 func GetExistingGitRepos(cacheVersionRoot string) ([]*GitRepoDesc, error) {
@@ -64,9 +69,10 @@ func GetExistingGitRepos(cacheVersionRoot string) ([]*GitRepoDesc, error) {
 		}
 
 		res = append(res, &GitRepoDesc{
-			Path:         repoPath,
-			Size:         size,
-			LastAccessAt: lastAccessAt,
+			Path:          repoPath,
+			Size:          size,
+			LastAccessAt:  lastAccessAt,
+			CacheBasePath: cacheVersionRoot,
 		})
 	}
 

--- a/pkg/git_repo/gitdata/git_worktree.go
+++ b/pkg/git_repo/gitdata/git_worktree.go
@@ -12,9 +12,10 @@ import (
 )
 
 type GitWorktreeDesc struct {
-	Path         string
-	LastAccessAt time.Time
-	Size         uint64
+	Path          string
+	LastAccessAt  time.Time
+	Size          uint64
+	CacheBasePath string
 }
 
 func (entry *GitWorktreeDesc) GetPaths() []string {
@@ -27,6 +28,10 @@ func (entry *GitWorktreeDesc) GetSize() uint64 {
 
 func (entry *GitWorktreeDesc) GetLastAccessAt() time.Time {
 	return entry.LastAccessAt
+}
+
+func (entry *GitWorktreeDesc) GetCacheBasePath() string {
+	return entry.CacheBasePath
 }
 
 func GetExistingGitWorktrees(cacheVersionRoot string) ([]*GitWorktreeDesc, error) {
@@ -65,9 +70,10 @@ func GetExistingGitWorktrees(cacheVersionRoot string) ([]*GitWorktreeDesc, error
 			}
 
 			res = append(res, &GitWorktreeDesc{
-				Path:         worktreePath,
-				Size:         size,
-				LastAccessAt: lastAccessAt,
+				Path:          worktreePath,
+				Size:          size,
+				LastAccessAt:  lastAccessAt,
+				CacheBasePath: dir,
 			})
 		}
 	}


### PR DESCRIPTION
Do not remove base cache dirs, which could result in recreation of these base dirs with root-permissions.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>