### PR TITLE
chore: enable telemetry by default

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -85,7 +85,7 @@ func Shutdown(ctx context.Context) error {
 }
 
 func IsEnabled() bool {
-	return util.GetBoolEnvironmentDefaultFalse("WERF_TELEMETRY")
+	return util.GetBoolEnvironmentDefaultTrue("WERF_TELEMETRY")
 }
 
 func LogF(f string, args ...interface{}) {


### PR DESCRIPTION
Disable by explicitly setting WERF_TELEMETRY=0

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>