### PR TITLE
fix(stapel): custom LD_LIBRARY_PATH in the base image might lead to failed builds

### DIFF
--- a/pkg/container_backend/legacy_stage_image_container.go
+++ b/pkg/container_backend/legacy_stage_image_container.go
@@ -186,6 +186,7 @@ func (c *LegacyStageImageContainer) prepareServiceRunOptions(ctx context.Context
 	serviceRunOptions.Workdir = "/"
 	serviceRunOptions.Entrypoint = stapel.BashBinPath()
 	serviceRunOptions.User = "0:0"
+	serviceRunOptions.Env["LD_LIBRARY_PATH"] = ""
 
 	stapelContainerName, err := stapel.GetOrCreateContainer(ctx)
 	if err != nil {
@@ -248,6 +249,13 @@ func (c *LegacyStageImageContainer) prepareInheritedCommitOptions(ctx context.Co
 
 	if len(fromImageInspect.Config.Entrypoint) != 0 {
 		inheritedOptions.Entrypoint = fmt.Sprintf("[\"%s\"]", strings.Join(fromImageInspect.Config.Entrypoint, "\", \""))
+	}
+
+	for _, e := range fromImageInspect.Config.Env {
+		pair := strings.SplitN(e, "=", 2)
+		if pair[0] == "LD_LIBRARY_PATH" {
+			inheritedOptions.Env[pair[0]] = pair[1]
+		}
 	}
 
 	inheritedOptions.User = fromImageInspect.Config.User


### PR DESCRIPTION
werf overrides LD_LIBRARY_PATH to prevent unexpected behavior but only for Stapel with Docker-daemon builds.

Signed-off-by: Alexey Igrychev <alexey.igrychev@flant.com>

fixes #4745 