### PR TITLE
fix(stapel): the user cannot use custom LD_LIBRARY_PATH with shell builder

### DIFF
--- a/pkg/build/builder/shell.go
+++ b/pkg/build/builder/shell.go
@@ -86,7 +86,7 @@ func (b *Shell) stage(cr container_backend.ContainerBackend, stageBuilder stage_
 			return err
 		}
 
-		container.AddServiceRunCommands(containerTmpScriptFilePath)
+		container.AddRunCommands(containerTmpScriptFilePath)
 	} else {
 		stageBuilder.StapelStageBuilder().AddCommands(b.stageCommands(userStageName)...)
 	}

--- a/pkg/stapel/stapel.go
+++ b/pkg/stapel/stapel.go
@@ -220,7 +220,7 @@ func CreateScript(path string, commands []string) error {
 	}
 
 	var scriptLines []string
-	scriptLines = append(scriptLines, fmt.Sprintf("#!%s -e", BashBinPath()))
+	scriptLines = append(scriptLines, "#!")
 	scriptLines = append(scriptLines, "")
 	scriptLines = append(scriptLines, commands...)
 	scriptData := []byte(strings.Join(scriptLines, "\n") + "\n")


### PR DESCRIPTION
- Do not process the user's commands as service ones because all commands are executed as follows:
```
run service commands
export custom LD_LIBRARY_PATH from the base image (optional)
run the user's commands
```

- Remove useless shebang with stapel bash path from the script with the user's commands because re-execution of stapel bash with custom LD_LIBRARY_PATH might lead to a crash (e.g., segfault).

Signed-off-by: Alexey Igrychev <alexey.igrychev@flant.com>