### PR TITLE
fix(buildah): wrong UID/GID/workdir/entrypoint/cmd in stages

### DIFF
--- a/pkg/buildah/common.go
+++ b/pkg/buildah/common.go
@@ -53,8 +53,10 @@ type RunMount struct {
 
 type RunCommandOpts struct {
 	CommonOpts
-	Args   []string
-	Mounts []specs.Mount
+	WorkingDir string
+	User       string
+	Args       []string
+	Mounts     []specs.Mount
 }
 
 type RmiOpts struct {

--- a/pkg/buildah/native_linux.go
+++ b/pkg/buildah/native_linux.go
@@ -267,6 +267,10 @@ func (b *NativeBuildah) RunCommand(ctx context.Context, container string, comman
 		Mounts:           opts.Mounts,
 		ConfigureNetwork: define.NetworkEnabled,
 		SystemContext:    &b.DefaultSystemContext,
+		WorkingDir:       opts.WorkingDir,
+		User:             opts.User,
+		Entrypoint:       []string{},
+		Cmd:              []string{},
 	}
 
 	stderr := &bytes.Buffer{}

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -157,6 +157,8 @@ func (runtime *BuildahBackend) applyCommands(ctx context.Context, container *con
 
 	if err := runtime.buildah.RunCommand(ctx, container.Name, []string{"sh", destScriptPath}, buildah.RunCommandOpts{
 		CommonOpts: runtime.getBuildahCommonOpts(ctx, false),
+		User:       "0:0",
+		WorkingDir: "/",
 		Mounts:     mounts,
 	}); err != nil {
 		return fmt.Errorf("unable to run commands script: %w", err)
@@ -661,6 +663,8 @@ func (runtime *BuildahBackend) RemoveHostDirs(ctx context.Context, mountDir stri
 	}
 
 	return runtime.buildah.RunCommand(ctx, container.Name, append([]string{"rm", "-rf"}, containerDirs...), buildah.RunCommandOpts{
+		User:       "0:0",
+		WorkingDir: "/",
 		Mounts: []specs.Mount{
 			{
 				Type:        "bind",


### PR DESCRIPTION
Those were inherited from the original container, which is not what we want
most of the time. Now they are always set to safe defaults, but only for
stages commands.

Signed-off-by: Ilya Lesikov <ilya@lesikov.com>