### PR TITLE
fix(cleanup): ignore WERF_KUBE_CONTEXT env var, support option --scan-context-only

### DIFF
--- a/cmd/werf/common/cleanup_namespaces_scan.go
+++ b/cmd/werf/common/cleanup_namespaces_scan.go
@@ -15,21 +15,21 @@ func SetupScanContextNamespaceOnly(cmdData *CmdData, cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(cmdData.ScanContextNamespaceOnly, "scan-context-namespace-only", "", util.GetBoolEnvironmentDefaultFalse("WERF_SCAN_CONTEXT_NAMESPACE_ONLY"), "Scan for used images only in namespace linked with context for each available context in kube-config (or only for the context specified with option --kube-context). When disabled will scan all namespaces in all contexts (or only for the context specified with option --kube-context). (Default $WERF_SCAN_CONTEXT_NAMESPACE_ONLY)")
 }
 
-func GetKubernetesContextClients(cmdData *CmdData) ([]*kube.ContextClient, error) {
+func GetKubernetesContextClients(configPath, configDataBase64 string, configPathMergeList []string, kubeContext string) ([]*kube.ContextClient, error) {
 	var res []*kube.ContextClient
-	if contextClients, err := kube.GetAllContextsClients(kube.GetAllContextsClientsOptions{ConfigPath: *cmdData.KubeConfig, ConfigDataBase64: *cmdData.KubeConfigBase64, ConfigPathMergeList: *cmdData.KubeConfigPathMergeList}); err != nil {
+	if contextClients, err := kube.GetAllContextsClients(kube.GetAllContextsClientsOptions{ConfigPath: configPath, ConfigDataBase64: configDataBase64, ConfigPathMergeList: configPathMergeList}); err != nil {
 		return nil, err
 	} else {
-		if *cmdData.KubeContext != "" {
+		if kubeContext != "" {
 			for _, cc := range contextClients {
-				if cc.ContextName == *cmdData.KubeContext {
+				if cc.ContextName == kubeContext {
 					res = append(res, cc)
 					break
 				}
 			}
 
 			if len(res) == 0 {
-				return nil, fmt.Errorf("cannot find specified kube context %q", *cmdData.KubeContext)
+				return nil, fmt.Errorf("cannot find specified kube context %q", kubeContext)
 			}
 		} else {
 			res = contextClients

--- a/docs/_includes/reference/cli/werf_cleanup.md
+++ b/docs/_includes/reference/cli/werf_cleanup.md
@@ -138,7 +138,8 @@ werf cleanup [options]
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kube-context=''
-            Kubernetes config context (default $WERF_KUBE_CONTEXT)
+            Scan for used images only in the specified kube context, scan all contexts from kube    
+            config otherwise (default false or $WERF_SCAN_CONTEXT_ONLY)
       --log-color-mode='auto'
             Set log color mode.
             Supported on, off and auto (based on the stdout’s file descriptor referring to a        
@@ -209,6 +210,9 @@ werf cleanup [options]
             in kube-config (or only for the context specified with option --kube-context). When     
             disabled will scan all namespaces in all contexts (or only for the context specified    
             with option --kube-context). (Default $WERF_SCAN_CONTEXT_NAMESPACE_ONLY)
+      --scan-context-only=''
+            Scan for used images only in the specified kube context, scan all contexts from kube    
+            config otherwise (default false or $WERF_SCAN_CONTEXT_ONLY)
       --secondary-repo=[]
             Specify one or multiple secondary read-only repos with images that will be used as a    
             cache.


### PR DESCRIPTION
Use werf cleanup `--scan-context-only` option (or `--kube-context` alias) or `WERF_SCAN_CONTEXT_ONLY` environment variable to scan for deployed images only in the specified kube config context. By default werf cleanup will scan all kube contexts available in the kube config.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>