### PR TITLE
fix(render): do not set empty env in werf render without repo param

### DIFF
--- a/pkg/deploy/helm/chart_extender/helpers/service_values.go
+++ b/pkg/deploy/helm/chart_extender/helpers/service_values.go
@@ -70,9 +70,6 @@ func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGe
 	if opts.Env != "" {
 		globalInfo["env"] = opts.Env
 		werfInfo["env"] = opts.Env
-	} else if opts.IsStub {
-		globalInfo["env"] = ""
-		werfInfo["env"] = ""
 	}
 
 	if opts.Namespace != "" {


### PR DESCRIPTION
Make werf render work the same way without --repo param as with this param.

Closes https://github.com/werf/werf/issues/4659

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>