### PR TITLE
feat(converge): do not require to helm-repo-add repositories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -314,6 +314,6 @@ replace k8s.io/helm => github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f
 
 replace github.com/deislabs/oras => github.com/werf/third-party-oras v0.9.1-0.20210927171747-6d045506f4c8
 
-replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220809123044-6a58d9cb0a34
+replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220823144404-27eb1367786c
 
 replace github.com/go-git/go-git/v5 => github.com/ZauberNerd/go-git/v5 v5.4.3-0.20220315170230-29ec1bc1e5db

--- a/go.sum
+++ b/go.sum
@@ -2050,8 +2050,8 @@ github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59b
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.5.0 h1:rutRtjBJViU/YjcI5d80t4JAVvDltS6bciJg2K1HrLU=
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
-github.com/werf/3p-helm/v3 v3.0.0-20220809123044-6a58d9cb0a34 h1:ARhaLWGih7zZSU2KKnT45ZSbPMb+SFwMSytohFTj/4s=
-github.com/werf/3p-helm/v3 v3.0.0-20220809123044-6a58d9cb0a34/go.mod h1:NxtE2KObf2PrzDl6SIamPFPKyAqWi10iWuvKlQn/Yao=
+github.com/werf/3p-helm/v3 v3.0.0-20220823144404-27eb1367786c h1:/cMYGHrCXCohS+2Thjj+7fiVVG1a/LmGC4BxZOK1sYY=
+github.com/werf/3p-helm/v3 v3.0.0-20220823144404-27eb1367786c/go.mod h1:NxtE2KObf2PrzDl6SIamPFPKyAqWi10iWuvKlQn/Yao=
 github.com/werf/copy-recurse v0.2.4 h1:kEyGUKhgS8WdEOjInNQKgk4lqPWzP2AgR27F3dcGsVc=
 github.com/werf/copy-recurse v0.2.4/go.mod h1:KVHSQ90p19xflWW0B7BJhLBwmSbEtuxIaBnjlUYRPhk=
 github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f h1:81YscYTF9mmTf0ULOsCmm42YWQp+qWDzWi1HjWniZrg=

--- a/pkg/deploy/helm/command_helpers/build_chart_dependencies.go
+++ b/pkg/deploy/helm/command_helpers/build_chart_dependencies.go
@@ -46,11 +46,12 @@ func BuildChartDependenciesInDir(ctx context.Context, chartFile, chartLockFile *
 	}
 
 	man := &downloader.Manager{
-		Out:        logboek.Context(ctx).OutStream(),
-		ChartPath:  targetDir,
-		Keyring:    opts.Keyring,
-		SkipUpdate: opts.SkipUpdate,
-		Verify:     opts.Verify,
+		Out:               logboek.Context(ctx).OutStream(),
+		ChartPath:         targetDir,
+		Keyring:           opts.Keyring,
+		SkipUpdate:        opts.SkipUpdate,
+		Verify:            opts.Verify,
+		AllowMissingRepos: true,
 
 		Getters:          getter.All(helmEnvSettings),
 		RegistryClient:   registryClient,


### PR DESCRIPTION
If unknown repository used in the `.helm/Chart.yaml` dependencies then `werf converge` command will work the same way as `helm dependency update` does — it does not require repositories to be registered in the helm and query all such repositories on demand.

If you need to pass credentials though you have to use `werf helm repo add` prior running converge. But it is ok, giving that regular chart repositories become obsolete in the face of OCI helm charts published into container registries — for such charts there is no need to perform `werf helm repo add`.

Closes https://github.com/werf/werf/issues/4190
Closes https://github.com/werf/werf/issues/4761

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>