### PR TITLE
test(integration): don't run tests on K8s 1.19 anymroe

### DIFF
--- a/.github/workflows/_test_integration_per-k8s-version-and-container-registry.yml
+++ b/.github/workflows/_test_integration_per-k8s-version-and-container-registry.yml
@@ -25,8 +25,6 @@ jobs:
         os:
           - ${{ inputs.linuxAmd64Runner }}
         k8s:
-          - version: 1.19
-            kubecfg_secret: WERF_TEST_K8S_BASE64_KUBECONFIG_1_19
           - version: 1.23
             kubecfg_secret: WERF_TEST_K8S_BASE64_KUBECONFIG_1_23
           - version: 1.25

--- a/.github/workflows/_test_integration_per-k8s-version.yml
+++ b/.github/workflows/_test_integration_per-k8s-version.yml
@@ -25,8 +25,6 @@ jobs:
         os:
           - ${{ inputs.linuxAmd64Runner }}
         k8s:
-          - version: 1.19
-            kubecfg_secret: WERF_TEST_K8S_BASE64_KUBECONFIG_1_19
           - version: 1.23
             kubecfg_secret: WERF_TEST_K8S_BASE64_KUBECONFIG_1_23
           - version: 1.25


### PR DESCRIPTION
We somewhat broke werf for 1.20-, but won't plan to do anything with it
since its EOL.

Signed-off-by: Ilya Lesikov <ilya@lesikov.com>