### PR TITLE
fix(helm): restore 'werf helm *' commands behavior for an env value

### DIFF
--- a/cmd/werf/helm/lint.go
+++ b/cmd/werf/helm/lint.go
@@ -5,22 +5,31 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"helm.sh/helm/v3/cmd/helm"
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
 	"helm.sh/helm/v3/pkg/action"
 
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/deploy/helm/chart_extender"
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers"
 )
 
 var lintCmdData common.CmdData
 
 func NewLintCmd(actionConfig *action.Configuration, wc *chart_extender.WerfChartStub) *cobra.Command {
 	cmd := helm_v3.NewLintCmd(os.Stdout)
+
 	SetupRenderRelatedWerfChartParams(cmd, &lintCmdData)
+	common.SetupEnvironment(&lintCmdData, cmd)
 
 	oldRunE := cmd.RunE
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
+
+		// NOTICE: This is temporary approach to use `werf helm lint` in pipelines correctly — respect --env / WERF_ENV param,
+		// NOTICE: which is typically set by the `werf ci-env` command.
+		if *lintCmdData.Environment != "" {
+			wc.SetStubServiceValuesOverrides(helpers.GetEnvServiceValues(*lintCmdData.Environment))
+		}
 
 		if err := InitRenderRelatedWerfChartParams(ctx, &lintCmdData, wc); err != nil {
 			return fmt.Errorf("unable to init werf chart: %w", err)

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -391,6 +391,7 @@ func runRender(ctx context.Context) error {
 		Namespace:                namespace,
 		Env:                      *commonCmdData.Environment,
 		IsStub:                   isStub,
+		DisableEnvStub:           true,
 		StubImagesNames:          stubImagesNames,
 		SetDockerConfigJsonValue: *commonCmdData.SetDockerConfigJsonValue,
 		DockerConfigPath:         *commonCmdData.DockerConfig,

--- a/docs/_includes/reference/cli/werf_helm_lint.md
+++ b/docs/_includes/reference/cli/werf_helm_lint.md
@@ -32,6 +32,8 @@ werf helm lint PATH [flags] [options]
             Format: labelName=labelValue.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
+      --env=''
+            Use specified environment (default $WERF_ENV)
       --ignore-secret-key=false
             Disable secrets decryption (default $WERF_IGNORE_SECRET_KEY)
       --secret-values=[]

--- a/pkg/deploy/helm/chart_extender/helpers/service_values.go
+++ b/pkg/deploy/helm/chart_extender/helpers/service_values.go
@@ -70,6 +70,9 @@ func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGe
 	if opts.Env != "" {
 		globalInfo["env"] = opts.Env
 		werfInfo["env"] = opts.Env
+	} else if opts.IsStub {
+		globalInfo["env"] = ""
+		werfInfo["env"] = ""
 	}
 
 	if opts.Namespace != "" {

--- a/pkg/deploy/helm/chart_extender/helpers/service_values.go
+++ b/pkg/deploy/helm/chart_extender/helpers/service_values.go
@@ -37,11 +37,20 @@ type ServiceValuesOptions struct {
 	Env             string
 	IsStub          bool
 	StubImagesNames []string
-	CommitHash      string
-	CommitDate      *time.Time
+	// disable env stub used in the werf-render command
+	DisableEnvStub bool
+	CommitHash     string
+	CommitDate     *time.Time
 
 	SetDockerConfigJsonValue bool
 	DockerConfigPath         string
+}
+
+func GetEnvServiceValues(env string) map[string]interface{} {
+	return map[string]interface{}{
+		"werf":   map[string]interface{}{"env": env},
+		"global": map[string]interface{}{"env": env},
+	}
 }
 
 func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGetters []*image.InfoGetter, opts ServiceValuesOptions) (map[string]interface{}, error) {
@@ -70,7 +79,7 @@ func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGe
 	if opts.Env != "" {
 		globalInfo["env"] = opts.Env
 		werfInfo["env"] = opts.Env
-	} else if opts.IsStub {
+	} else if opts.IsStub && !opts.DisableEnvStub {
 		globalInfo["env"] = ""
 		werfInfo["env"] = ""
 	}

--- a/pkg/deploy/helm/chart_extender/werf_chart_stub.go
+++ b/pkg/deploy/helm/chart_extender/werf_chart_stub.go
@@ -31,6 +31,7 @@ type WerfChartStub struct {
 	SecretValueFiles []string
 
 	extraAnnotationsAndLabelsPostRenderer *helm.ExtraAnnotationsAndLabelsPostRenderer
+	stubServiceValuesOverrides            map[string]interface{}
 	stubServiceValues                     map[string]interface{}
 
 	*secrets.SecretsRuntimeData
@@ -105,6 +106,7 @@ func (wc *WerfChartStub) ChartDependenciesLoaded() error {
 // MakeValues method for the chart.Extender interface
 func (wc *WerfChartStub) MakeValues(inputVals map[string]interface{}) (map[string]interface{}, error) {
 	vals := make(map[string]interface{})
+	chartutil.CoalesceTables(vals, wc.stubServiceValuesOverrides)
 	chartutil.CoalesceTables(vals, wc.stubServiceValues)
 	chartutil.CoalesceTables(vals, wc.SecretsRuntimeData.DecodedSecretValues)
 	chartutil.CoalesceTables(vals, inputVals)
@@ -137,4 +139,8 @@ func (wc *WerfChartStub) ReadFile(filePath string) (bool, []byte, error) {
 
 func (wc *WerfChartStub) SetStubServiceValues(vals map[string]interface{}) {
 	wc.stubServiceValues = vals
+}
+
+func (wc *WerfChartStub) SetStubServiceValuesOverrides(vals map[string]interface{}) {
+	wc.stubServiceValuesOverrides = vals
 }


### PR DESCRIPTION
* `werf helm *` commands set stub empty string into .Values.global.env and .Values.werf.env.
* `werf helm lint` command respects --env / WERF_ENV param to allow more correct usage in CI/CD params due to the lack of `werf lint` command.
* `werf render` command behaves the same way as `werf converge` command: set .Values.global.env and .Values.werf.env to nil (not empty string).

Closes https://github.com/werf/werf/issues/4659