### PR TITLE
fix(buildah): different processing of CMD/ENTRYPOINT by Stapel and Buildah backend

### DIFF
--- a/pkg/build/stage/docker_instructions.go
+++ b/pkg/build/stage/docker_instructions.go
@@ -121,7 +121,7 @@ func CmdOrEntrypointStringToSlice(cmdOrEntrypoint string) ([]string, error) {
 				return nil, fmt.Errorf("error parsing to the JSON array: %w", err)
 			}
 		} else {
-			result = []string{cmdOrEntrypoint}
+			result = []string{"/bin/sh", "-c", cmdOrEntrypoint}
 		}
 	}
 


### PR DESCRIPTION
Respect CMD/ENTRYPOINT command in shell form.

Signed-off-by: Alexey Igrychev <alexey.igrychev@flant.com>