### PR TITLE
fix(deploy): lower releases-history-max default to 5 releases (was 10)

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -334,7 +334,7 @@ func SetupReleasesHistoryMax(cmdData *CmdData, cmd *cobra.Command) {
 	if defaultValueP != nil {
 		defaultValue = int(*defaultValueP)
 	} else {
-		defaultValue = 10
+		defaultValue = 5
 	}
 
 	cmd.Flags().IntVarP(

--- a/docs/_includes/reference/cli/werf_bundle_apply.md
+++ b/docs/_includes/reference/cli/werf_bundle_apply.md
@@ -80,7 +80,7 @@ werf bundle apply [options]
       --release=''
             Use specified Helm release name (default [[ project ]]-[[ env ]] template or            
             deploy.helmRelease custom template from werf.yaml or $WERF_RELEASE)
-      --releases-history-max=10
+      --releases-history-max=5
             Max releases to keep in release storage. Can be set by environment variable             
             $WERF_RELEASES_HISTORY_MAX. By default werf keeps all releases.
       --repo=''

--- a/docs/_includes/reference/cli/werf_converge.md
+++ b/docs/_includes/reference/cli/werf_converge.md
@@ -246,7 +246,7 @@ werf converge --repo registry.mydomain.com/web --env production
       --release=''
             Use specified Helm release name (default [[ project ]]-[[ env ]] template or            
             deploy.helmRelease custom template from werf.yaml or $WERF_RELEASE)
-      --releases-history-max=10
+      --releases-history-max=5
             Max releases to keep in release storage. Can be set by environment variable             
             $WERF_RELEASES_HISTORY_MAX. By default werf keeps all releases.
       --repo=''

--- a/docs/_includes/reference/cli/werf_dismiss.md
+++ b/docs/_includes/reference/cli/werf_dismiss.md
@@ -178,7 +178,7 @@ werf dismiss [options]
       --release=''
             Use specified Helm release name (default [[ project ]]-[[ env ]] template or            
             deploy.helmRelease custom template from werf.yaml or $WERF_RELEASE)
-      --releases-history-max=10
+      --releases-history-max=5
             Max releases to keep in release storage. Can be set by environment variable             
             $WERF_RELEASES_HISTORY_MAX. By default werf keeps all releases.
       --repo=''

--- a/docs/_includes/reference/cli/werf_helm.md
+++ b/docs/_includes/reference/cli/werf_helm.md
@@ -48,7 +48,7 @@ Manage application deployment with helm
             Enable verbose output (default $WERF_LOG_VERBOSE).
   -n, --namespace=''
             namespace scope for this request
-      --releases-history-max=10
+      --releases-history-max=5
             Max releases to keep in release storage. Can be set by environment variable             
             $WERF_RELEASES_HISTORY_MAX. By default werf keeps all releases.
       --status-progress-period=5

--- a/docs/_includes/reference/cli/werf_render.md
+++ b/docs/_includes/reference/cli/werf_render.md
@@ -191,7 +191,7 @@ werf render [options]
       --release=''
             Use specified Helm release name (default [[ project ]]-[[ env ]] template or            
             deploy.helmRelease custom template from werf.yaml or $WERF_RELEASE)
-      --releases-history-max=10
+      --releases-history-max=5
             Max releases to keep in release storage. Can be set by environment variable             
             $WERF_RELEASES_HISTORY_MAX. By default werf keeps all releases.
       --repo=''


### PR DESCRIPTION
Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>