### PR TITLE
fix(dismiss): rework uninstall-with-namespace procedure

### DIFF
--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -2,12 +2,14 @@ package dismiss
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
 	helm_v3 "helm.sh/helm/v3/cmd/helm"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/storage/driver"
 
 	"github.com/werf/kubedog/pkg/kube"
 	"github.com/werf/logboek"
@@ -240,10 +242,18 @@ func runDismiss(ctx context.Context) error {
 		DontFailIfNoRelease: &dontFailIfNoRelease,
 	})
 
+	logboek.Context(ctx).Default().LogFDetails("Using namespace: %s\n", namespace)
+	logboek.Context(ctx).Default().LogFDetails("Using release: %s\n", releaseName)
+
 	if cmdData.WithNamespace {
 		// TODO: solve lock release + delete-namespace case
 		return helmUninstallCmd.RunE(helmUninstallCmd, []string{releaseName})
 	} else {
+		if _, err := actionConfig.Releases.History(releaseName); errors.Is(err, driver.ErrReleaseNotFound) {
+			logboek.Context(ctx).Default().LogFDetails("No such release %q\n", releaseName)
+			return nil
+		}
+
 		return command_helpers.LockReleaseWrapper(ctx, releaseName, lockManager, func() error {
 			return helmUninstallCmd.RunE(helmUninstallCmd, []string{releaseName})
 		})

--- a/go.mod
+++ b/go.mod
@@ -314,6 +314,6 @@ replace k8s.io/helm => github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f
 
 replace github.com/deislabs/oras => github.com/werf/third-party-oras v0.9.1-0.20210927171747-6d045506f4c8
 
-replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220902145201-6265178e3c32
+replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20220914162629-ff5881b99e90
 
 replace github.com/go-git/go-git/v5 => github.com/ZauberNerd/go-git/v5 v5.4.3-0.20220315170230-29ec1bc1e5db

--- a/go.sum
+++ b/go.sum
@@ -2050,8 +2050,8 @@ github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59b
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.5.0 h1:rutRtjBJViU/YjcI5d80t4JAVvDltS6bciJg2K1HrLU=
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
-github.com/werf/3p-helm/v3 v3.0.0-20220902145201-6265178e3c32 h1:Z3XL0banUFF7IkIzY82onwWA2qiTvuQ0pBMERA/scis=
-github.com/werf/3p-helm/v3 v3.0.0-20220902145201-6265178e3c32/go.mod h1:NxtE2KObf2PrzDl6SIamPFPKyAqWi10iWuvKlQn/Yao=
+github.com/werf/3p-helm/v3 v3.0.0-20220914162629-ff5881b99e90 h1:Gsp+PghpTAj8vVIt68f6kEr+4qtbQsMi2/rCCSuV4ic=
+github.com/werf/3p-helm/v3 v3.0.0-20220914162629-ff5881b99e90/go.mod h1:NxtE2KObf2PrzDl6SIamPFPKyAqWi10iWuvKlQn/Yao=
 github.com/werf/copy-recurse v0.2.4 h1:kEyGUKhgS8WdEOjInNQKgk4lqPWzP2AgR27F3dcGsVc=
 github.com/werf/copy-recurse v0.2.4/go.mod h1:KVHSQ90p19xflWW0B7BJhLBwmSbEtuxIaBnjlUYRPhk=
 github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f h1:81YscYTF9mmTf0ULOsCmm42YWQp+qWDzWi1HjWniZrg=

--- a/pkg/deploy/helm/init.go
+++ b/pkg/deploy/helm/init.go
@@ -64,6 +64,9 @@ func InitActionConfig(ctx context.Context, kubeInitializer KubeInitializer, name
 	kubeClient.Extender = NewHelmKubeClientExtender()
 
 	actionConfig.RegistryClient = registryClient
+	actionConfig.Log = func(f string, a ...interface{}) {
+		logboek.Context(ctx).Default().LogFDetails(fmt.Sprintf("%s\n", f), a...)
+	}
 
 	return nil
 }


### PR DESCRIPTION
* Better logging when checking existance of release and namespace.
* Fix case when release not exists, but namespace exists and --with-namespace option specified (previously namespace was not removed in such case).
* Do not create namespace when it was not existed before running werf-dismiss.

Refs https://github.com/werf/3p-helm/pull/218/commits

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>