### PR TITLE
fix(buildah): import from image with rename not working when using includePaths

### DIFF
--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -385,17 +385,20 @@ func (runtime *BuildahBackend) applyDependenciesImports(ctx context.Context, con
 
 			copyRec, err := copyrec.New(absFrom, absTo, copyrec.Options{
 				MatchDir: func(path string) (copyrec.DirAction, error) {
+					relPath := util.GetRelativeToBaseFilepath(absFrom, path)
+
 					switch {
-					case pathMatcher.IsPathMatched(path):
+					case pathMatcher.IsPathMatched(relPath):
 						return copyrec.DirMatch, nil
-					case pathMatcher.ShouldGoThrough(path):
+					case pathMatcher.ShouldGoThrough(relPath):
 						return copyrec.DirFallThrough, nil
 					default:
 						return copyrec.DirSkip, nil
 					}
 				},
 				MatchFile: func(path string) (bool, error) {
-					return pathMatcher.IsPathMatched(path), err
+					relPath := util.GetRelativeToBaseFilepath(absFrom, path)
+					return pathMatcher.IsPathMatched(relPath), err
 				},
 				UID: uid,
 				GID: gid,

--- a/test/e2e/build/complex_test.go
+++ b/test/e2e/build/complex_test.go
@@ -123,10 +123,9 @@ var _ = Describe("Complex build", Label("e2e", "build", "complex"), func() {
 					"stat -c %u:%g /basedir/file | diff <(echo 0:0) -",
 					"echo 'content' | diff /basedir/file -",
 
-					// TODO: fix buildah: rename during import not working
-					// "test -f /basedir-imported/file",
-					// "stat -c %u:%g /basedir-imported/file | diff <(echo 1060:1061) -",
-					// "echo 'content' | diff /basedir-imported/file -",
+					"test -f /basedir-imported/file",
+					"stat -c %u:%g /basedir-imported/file | diff <(echo 1060:1061) -",
+					"echo 'content' | diff /basedir-imported/file -",
 				)
 			}
 
@@ -214,10 +213,9 @@ var _ = Describe("Complex build", Label("e2e", "build", "complex"), func() {
 					"stat -c %u:%g /basedir/file | diff <(echo 0:0) -",
 					"echo 'content' | diff /basedir/file -",
 
-					// TODO: fix buildah: rename during import not working
-					// "test -f /basedir-imported/file",
-					// "stat -c %u:%g /basedir-imported/file | diff <(echo 1060:1061) -",
-					// "echo 'content' | diff /basedir-imported/file -",
+					"test -f /basedir-imported/file",
+					"stat -c %u:%g /basedir-imported/file | diff <(echo 1060:1061) -",
+					"echo 'content' | diff /basedir-imported/file -",
 				)
 			}
 		},


### PR DESCRIPTION
Imported directory is not renamed when includePaths param used.