### PR TITLE
chore(channels): rollback alpha, beta and ea to 1.2.175

### DIFF
--- a/trdl_channels.yaml
+++ b/trdl_channels.yaml
@@ -26,27 +26,28 @@ groups:
   - name: "1.2"
     channels:
       - name: alpha
-        # changed at: 28.09.2022
-        version: 1.2.176
+        # posted at: 28.09.2022
+        version: 1.2.175
 
       - name: beta
-        # changed at: 28.09.2022
-        version: 1.2.176
+        # posted at: 28.09.2022
+        version: 1.2.175
 
       - name: ea
-        # changed at: 28.09.2022
-        version: 1.2.176
+        # posted at: 28.09.2022
+        version: 1.2.175
 
       # - name: pre-stable
       #   version: 1.2.169+fix1
 
       - name: stable
-        # changed at: 28.09.2022
+        # posted at: 28.09.2022
         version: 1.2.169+fix1
 
       # - name: pre-rock-solid
+      #   posted at: unknown
       #   version: 1.2.163+fix1
 
       - name: rock-solid
-        # changed at: unknown
+        # posted at: unknown
         version: 1.2.163+fix1


### PR DESCRIPTION
Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>