### PR TITLE
fix(converge): feature gate for specific images params in werf-converge (due to compatibility issues)

### DIFF
--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -51,10 +51,22 @@ var cmdData struct {
 
 var commonCmdData common.CmdData
 
+func isSpecificImagesEnabled() bool {
+	return util.GetBoolEnvironmentDefaultFalse("WERF_CONVERGE_ENABLE_IMAGES_PARAMS")
+}
+
 func NewCmd(ctx context.Context) *cobra.Command {
 	ctx = common.NewContextWithCmdData(ctx, &commonCmdData)
+
+	var useMsg string
+	if isSpecificImagesEnabled() {
+		useMsg = "converge [IMAGE_NAME ...]"
+	} else {
+		useMsg = "converge"
+	}
+
 	cmd := common.SetCommandContext(ctx, &cobra.Command{
-		Use:   "converge [IMAGE_NAME...]",
+		Use:   useMsg,
 		Short: "Build and push images, then deploy application into Kubernetes",
 		Long:  common.GetLongCommandDescription(GetConvergeDocs().Long),
 		Example: `# Build and deploy current application state into production environment
@@ -76,12 +88,19 @@ werf converge --repo registry.mydomain.com/web --env production`,
 			common.LogVersion()
 
 			return common.LogRunningTime(func() error {
-				return runMain(ctx, common.GetImagesToProcess(args, *commonCmdData.WithoutImages))
+				var imagesToProcess build.ImagesToProcess
+				if isSpecificImagesEnabled() {
+					imagesToProcess = common.GetImagesToProcess(args, *commonCmdData.WithoutImages)
+				}
+
+				return runMain(ctx, imagesToProcess)
 			})
 		},
 	})
 
-	commonCmdData.SetupWithoutImages(cmd)
+	if isSpecificImagesEnabled() {
+		commonCmdData.SetupWithoutImages(cmd)
+	}
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupGitWorkTree(&commonCmdData, cmd)

--- a/docs/_includes/reference/cli/werf_converge.md
+++ b/docs/_includes/reference/cli/werf_converge.md
@@ -15,7 +15,7 @@ Read more info about Helm chart structure, Helm Release name, Kubernetes Namespa
 {{ header }} Syntax
 
 ```shell
-werf converge [IMAGE_NAME...] [options]
+werf converge [options]
 ```
 
 {{ header }} Examples
@@ -375,9 +375,5 @@ werf converge --repo registry.mydomain.com/web --env production
       --virtual-merge=false
             Enable virtual/ephemeral merge commit mode when building current application state      
             ($WERF_VIRTUAL_MERGE by default)
-      --without-images=false
-            Disable building of images defined in the werf.yaml (if any) and usage of such images   
-            in the .helm/templates ($WERF_WITHOUT_IMAGES or false by default — e.g. enable all      
-            images defined in the werf.yaml by default)
 ```
 


### PR DESCRIPTION
By default `werf converge` command does not accept specific images positional params to enable building and verification of only specific images from the `werf.yaml`.

When `WERF_CONVERGE_ENABLE_IMAGES_PARAMS=1` is set it is possible to specify either positional images arguments or `--without-images` option:

```
export WERF_CONVERGE_ENABLE_IMAGES_PARAMS=1
werf converge IMAGE_A IMAGE_B [--without-images] [options]
```

This feature gate only needed due to historical compatibility issues with using positional arguments in converge command.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>