### PR TITLE
feat(bundles): publish .helm/files into bundle

### DIFF
--- a/pkg/deploy/helm/chart_extender/bundle.go
+++ b/pkg/deploy/helm/chart_extender/bundle.go
@@ -237,6 +237,7 @@ var (
 		"charts/",
 		"crds/",
 		"templates/",
+		"files/",
 	}
 )
 


### PR DESCRIPTION
.helm/files directory should be used to store various configuration files which can be included into resources templates with .Files.Get or .Files.Glob directives. .helm/files is widely used across official helm charts and bitnami helm charts, but it is just a convention directory.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>