### PR TITLE
docs(buildah): buildah-mode docs fixes

### DIFF
--- a/docs/pages_en/advanced/buildah_mode.md
+++ b/docs/pages_en/advanced/buildah_mode.md
@@ -3,37 +3,37 @@ title: Buildah mode
 permalink: advanced/buildah_mode.html
 ---
 
-werf currently supports building images _with the Docker server_ or _without the Docker server_ (in experimental mode).  This page contains information applicable only to the experimental mode _without the Docker server_. For now, only the Dockerfile image builder is available for this mode. The Stapel image builder will be available soon.
-> NOTICE: werf supports building images _with the Docker server_ or _with Buildah_. This page contains information applicable only to the mode _with Buildah_. Buildah supports building either Dockerfile images or stapel images.
+werf supports building images _with the Docker server_ or _without the Docker server_ (using buildah).  This page contains information applicable only to the mode _without the Docker server_. Both dockerfile and stapel images builders are supported in this mode.
 
 werf uses built-in Buildah in rootless mode to build images without Docker server.
 
 ## System requirements
 
 Host requirements for running werf in Buildah mode on a host system without Docker/Kubernetes can be found in the [installation instructions](/installation.html). But for running werf in Kubernetes or in Docker containers the requirements are as follows:
-* If your Linux kernel version is 5.13+ (5.11+ for some distros), make sure `overlay` kernel module is loaded with `lsmod | grep overlay`. If your kernel is older or if you can't activate `overlay` kernel module, then install `fuse-overlayfs`, which should be available in your distro package repos. As a last resort, `vfs` storage driver can be used.
-* Command `sysctl kernel.unprivileged_userns_clone` should return `1`. Else execute:
-  ```shell
-  echo 'kernel.unprivileged_userns_clone = 1' | sudo tee -a /etc/sysctl.conf
-  sudo sysctl -p
-  ```
-* Command `sysctl user.max_user_namespaces` should return at least `15000`. Else execute:
-  ```shell
-  echo 'user.max_user_namespaces = 15000' | sudo tee -a /etc/sysctl.conf
-  sudo sysctl -p
-  ```
+* If your Linux kernel version is 5.13+ (5.11+ for some distros) it is **recommended** to use native `overlay` kernel module:
+    * Make sure `overlay` kernel module is loaded with `lsmod | grep overlay`. 
+    * Make sure `CONFIG_USER_NS=y` configuration flag enabled in your kernel with `grep CONFIG_USER_NS /boot/config-VERSION`.
+    * In debian based kernel command `sysctl kernel.unprivileged_userns_clone` should return `1`. Else execute:
+      ```shell
+      echo 'kernel.unprivileged_userns_clone = 1' | sudo tee -a /etc/sysctl.conf
+      sudo sysctl -p
+      ```
+    * Command `sysctl user.max_user_namespaces` should return at least `15000`. Else execute:
+      ```shell
+      echo 'user.max_user_namespaces = 15000' | sudo tee -a /etc/sysctl.conf
+      sudo sysctl -p
+      ```
+* If your kernel is older or if you can't activate `overlay` kernel module, then install `fuse-overlayfs`, which should be available in your distro package repos. As a last resort, `vfs` storage driver can be used.
 
 ## Enable Buildah
 
-Buildah is enabled by setting the `WERF_BUILDAH_MODE` environment variable to one of the following: `auto`, `native-chroot` or `native-rootless`.
+Buildah is enabled by setting the `WERF_BUILDAH_MODE` environment variable to one of the following: `auto`, `native-chroot` or `native-rootless`. Most users only need to set `WERF_BUILDAH_MODE=auto` to enable the Buildah-based mode.
 
 * `auto` — select the mode automatically based on your platform and environment.
 * `native-rootless` works only on Linux and uses the `rootless` isolation level when running build containers. At this isolation level werf will use container runtime (runc, crun, kata or runsc).
 * `native-chroot` works only on Linux and uses the `chroot` isolation level when running build containers.
 
-Most users only need to set `WERF_BUILDAH_MODE=auto` to enable the experimental Buildah-based mode.
-
-> NOTICE: Currently Buildah backend only works for Linux users and Windows users with WSL2. Use virtual machine to enable buildah for MacOS. Native support for MacOS is planned but is not available yet.
+> NOTICE: Currently Buildah backend only works for Linux users and Windows users with WSL2. Use virtual machine to enable buildah for MacOS.
 
 ## Storage driver
 

--- a/docs/pages_ru/advanced/buildah_mode.md
+++ b/docs/pages_ru/advanced/buildah_mode.md
@@ -10,29 +10,30 @@ permalink: advanced/buildah_mode.html
 ## Системные требования
 
 Требования к хост-системе для запуска werf в Buildah-режиме без Docker/Kubernetes можно найти в [инструкциях по установке](/installation.html). А для запуска werf в Kubernetes или в Docker-контейнерах требования следующие:
-* Если ваше ядро Linux версии 5.13+ (в некоторых дистрибутивах 5.11+), то убедитесь, что модуль ядра `overlay` загружен с `lsmod | grep overlay`. Если ядро более старое или у вас не получается активировать модуль ядра `overlay`, то установите `fuse-overlayfs`, который обычно доступен в репозиториях вашего дистрибутива. В крайнем случае может быть использован драйвер хранилища `vfs`.
-* Команда `sysctl kernel.unprivileged_userns_clone` должна вернуть `1`. В ином случае выполните:
-  ```shell
-  echo 'kernel.unprivileged_userns_clone = 1' | sudo tee -a /etc/sysctl.conf
-  sudo sysctl -p
-  ```
-* Команда `sysctl user.max_user_namespaces` должна вернуть по меньшей мере `15000`. В ином случае выполните:
-  ```shell
-  echo 'user.max_user_namespaces = 15000' | sudo tee -a /etc/sysctl.conf
-  sudo sysctl -p
-  ```
+* Если ваше ядро Linux версии 5.13+ (в некоторых дистрибутивах 5.11+) **рекомендуется** режим работы через модуль ядра `overlay`:
+    * Убедитесь, что модуль ядра `overlay` загружен с `lsmod | grep overlay`. 
+    * Убедитесь, что настройка ядра `CONFIG_USER_NS=y` включена в вашем ядре с помощью `grep CONFIG_USER_NS /boot/config-VERSION`.
+    * При использовании ядра в debian-системах команда `sysctl kernel.unprivileged_userns_clone` должна вернуть `1`. В ином случае выполните:
+      ```shell
+      echo 'kernel.unprivileged_userns_clone = 1' | sudo tee -a /etc/sysctl.conf
+      sudo sysctl -p
+      ```
+    * Команда `sysctl user.max_user_namespaces` должна вернуть по меньшей мере `15000`. В ином случае выполните:
+      ```shell
+      echo 'user.max_user_namespaces = 15000' | sudo tee -a /etc/sysctl.conf
+      sudo sysctl -p
+      ```
+* Если ядро более старое или у вас не получается активировать модуль ядра `overlay`, то установите `fuse-overlayfs`, который обычно доступен в репозиториях вашего дистрибутива. В крайнем случае может быть использован драйвер хранилища `vfs`.
 
 ## Включение Buildah
 
-Buildah включается установкой переменной окружения `WERF_BUILDAH_MODE` в один из вариантов: `auto`, `native-chroot`, `native-rootless`.
+Buildah включается установкой переменной окружения `WERF_BUILDAH_MODE` в один из вариантов: `auto`, `native-chroot`, `native-rootless`. Большинству пользователей для включения режима Buildah достаточно установить `WERF_BUILDAH_MODE=auto`.
 
 * `auto` — автоматический выбор режима в зависимости от платформы и окружения;
 * `native-chroot` работает только в Linux и использует `chroot`-изоляцию для сборочных контейнеров;
 * `native-rootless` работает только в Linux и использует `rootless`-изоляцию для сборочных контейнеров. На этом уровне изоляции werf использует среду выполнения сборочных операций в контейнерах (runc, crun, kata или runsc).
 
-Большинству пользователей для включения экспериментального режима Buildah достаточно установить `WERF_BUILDAH_MODE=auto`.
-
-> ПРИМЕЧАНИЕ: На данный момент Buildah доступен только для пользователей Linux и Windows с включённой подсистемой WSL2. Полная поддержка для пользователей MacOS запланирована, но пока не доступна. Для пользователей MacOS на данный момент предлагается использование виртуальной машины для запуска werf в режиме Buildah.
+> ПРИМЕЧАНИЕ: На данный момент Buildah доступен только для пользователей Linux и Windows с включённой подсистемой WSL2. Для пользователей MacOS на данный момент предлагается использование виртуальной машины для запуска werf в режиме Buildah.
 
 ## Драйвер хранилища
 


### PR DESCRIPTION
* Stapel and Dockerfile builders supported for buildah
* Kernel checks related instructions fixed

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>