### PR TITLE
[1.2.181] fix(bundles): fix bundle-render and bundle-apply commands could not access .Values.werf.images service values

### DIFF
--- a/pkg/deploy/helm/chart_extender/bundle.go
+++ b/pkg/deploy/helm/chart_extender/bundle.go
@@ -126,7 +126,6 @@ func (bundle *Bundle) ChartLoaded(files []*chart.ChartExtenderBufferedFile) erro
 		}
 	}
 
-	bundle.HelmChart.Values = nil
 	if bundle.DisableDefaultValues {
 		logboek.Context(bundle.ChartExtenderContext).Info().LogF("Disable default werf chart values\n")
 		bundle.HelmChart.Values = nil


### PR DESCRIPTION


Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>