### PR TITLE
feat(staged-dockerfile): implement whether stage uses build-context correctly

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -695,6 +695,7 @@ func (phase *BuildPhase) prepareStageInstructions(ctx context.Context, img *imag
 			return stageImage.Builder.DockerfileBuilder().Cleanup(ctx)
 		})
 	} else {
+		stageImage.Builder.DockerfileStageBuilder().SetBuildContextArchive(phase.buildContextArchive)
 		stageImage.Builder.DockerfileStageBuilder().AppendPostInstruction(backend_instruction.NewLabel(*dockerfile_instruction.NewLabel(serviceLabels)))
 	}
 

--- a/pkg/build/image/dockerfile.go
+++ b/pkg/build/image/dockerfile.go
@@ -118,7 +118,7 @@ func mapDockerfileToImagesSets(ctx context.Context, cfg *dockerfile.Dockerfile, 
 		}
 
 		for ind, instr := range stg.Instructions {
-			stageName := stage.StageName(fmt.Sprintf("%d-%s", ind, instr.GetInstructionData().Name()))
+			stageName := stage.StageName(fmt.Sprintf("%s%d", instr.GetInstructionData().Name(), ind))
 			isFirstStage := (len(img.stages) == 0)
 			baseStageOptions := &stage.BaseStageOptions{
 				ImageName:        img.Name,

--- a/pkg/build/stage/instruction/add.go
+++ b/pkg/build/stage/instruction/add.go
@@ -17,7 +17,7 @@ type Add struct {
 }
 
 func NewAdd(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Add], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Add {
-	return &Add{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Add{Base: NewBase(name, i, backend_instruction.NewAdd(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Add) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -28,8 +28,4 @@ func (stage *Add) GetDependencies(ctx context.Context, c stage.Conveyor, cb cont
 	args = append(args, stage.instruction.Data.Chown)
 	args = append(args, stage.instruction.Data.Chmod)
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Add) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewAdd(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/cmd.go
+++ b/pkg/build/stage/instruction/cmd.go
@@ -18,7 +18,7 @@ type Cmd struct {
 }
 
 func NewCmd(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Cmd], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Cmd {
-	return &Cmd{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Cmd{Base: NewBase(name, i, backend_instruction.NewCmd(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Cmd) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,8 +27,4 @@ func (stage *Cmd) GetDependencies(ctx context.Context, c stage.Conveyor, cb cont
 	args = append(args, stage.instruction.Data.Cmd...)
 	args = append(args, fmt.Sprintf("%v", stage.instruction.Data.PrependShell))
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Cmd) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewCmd(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/copy.go
+++ b/pkg/build/stage/instruction/copy.go
@@ -17,7 +17,7 @@ type Copy struct {
 }
 
 func NewCopy(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Copy], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Copy {
-	return &Copy{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Copy{Base: NewBase(name, i, backend_instruction.NewCopy(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Copy) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -29,8 +29,4 @@ func (stage *Copy) GetDependencies(ctx context.Context, c stage.Conveyor, cb con
 	args = append(args, stage.instruction.Data.Chown)
 	args = append(args, stage.instruction.Data.Chmod)
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Copy) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewCopy(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/entrypoint.go
+++ b/pkg/build/stage/instruction/entrypoint.go
@@ -18,7 +18,7 @@ type Entrypoint struct {
 }
 
 func NewEntrypoint(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Entrypoint], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Entrypoint {
-	return &Entrypoint{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Entrypoint{Base: NewBase(name, i, backend_instruction.NewEntrypoint(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Entrypoint) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,8 +27,4 @@ func (stage *Entrypoint) GetDependencies(ctx context.Context, c stage.Conveyor, 
 	args = append(args, stage.instruction.Data.Entrypoint...)
 	args = append(args, fmt.Sprintf("%v", stage.instruction.Data.PrependShell))
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Entrypoint) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewEntrypoint(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/env.go
+++ b/pkg/build/stage/instruction/env.go
@@ -17,7 +17,7 @@ type Env struct {
 }
 
 func NewEnv(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Env], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Env {
-	return &Env{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Env{Base: NewBase(name, i, backend_instruction.NewEnv(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Env) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -28,8 +28,4 @@ func (stage *Env) GetDependencies(ctx context.Context, c stage.Conveyor, cb cont
 		args = append(args, k, v)
 	}
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Env) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewEnv(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/expose.go
+++ b/pkg/build/stage/instruction/expose.go
@@ -17,7 +17,7 @@ type Expose struct {
 }
 
 func NewExpose(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Expose], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Expose {
-	return &Expose{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Expose{Base: NewBase(name, i, backend_instruction.NewExpose(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Expose) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -25,8 +25,4 @@ func (stage *Expose) GetDependencies(ctx context.Context, c stage.Conveyor, cb c
 	args = append(args, stage.instruction.Data.Name())
 	args = append(args, stage.instruction.Data.Ports...)
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Expose) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewExpose(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/healthcheck.go
+++ b/pkg/build/stage/instruction/healthcheck.go
@@ -17,7 +17,8 @@ type Healthcheck struct {
 }
 
 func NewHealthcheck(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Healthcheck], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Healthcheck {
-	return &Healthcheck{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	// FIXME(staged-dockerfile): construct backend instruction
+	return &Healthcheck{Base: NewBase(name, i, nil, dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Healthcheck) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -30,9 +31,4 @@ func (stage *Healthcheck) GetDependencies(ctx context.Context, c stage.Conveyor,
 	args = append(args, stage.instruction.Data.Config.StartPeriod.String())
 	args = append(args, fmt.Sprintf("%d", stage.instruction.Data.Config.Retries))
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Healthcheck) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	// FIXME(staged-dockerfile): construct backend instruction
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, nil)
 }

--- a/pkg/build/stage/instruction/label.go
+++ b/pkg/build/stage/instruction/label.go
@@ -17,7 +17,7 @@ type Label struct {
 }
 
 func NewLabel(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Label], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Label {
-	return &Label{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Label{Base: NewBase(name, i, backend_instruction.NewLabel(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Label) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -28,8 +28,4 @@ func (stage *Label) GetDependencies(ctx context.Context, c stage.Conveyor, cb co
 		args = append(args, k, v)
 	}
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Label) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewLabel(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/maintainer.go
+++ b/pkg/build/stage/instruction/maintainer.go
@@ -16,7 +16,8 @@ type Maintainer struct {
 }
 
 func NewMaintainer(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Maintainer], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Maintainer {
-	return &Maintainer{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	// FIXME(staged-dockerfile): no Maintainer instruction
+	return &Maintainer{Base: NewBase(name, i, nil, dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Maintainer) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -24,9 +25,4 @@ func (stage *Maintainer) GetDependencies(ctx context.Context, c stage.Conveyor, 
 	args = append(args, stage.instruction.Data.Name())
 	args = append(args, stage.instruction.Data.Maintainer)
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Maintainer) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	// FIXME(staged-dockerfile): no Maintainer instruction
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, nil)
 }

--- a/pkg/build/stage/instruction/on_build.go
+++ b/pkg/build/stage/instruction/on_build.go
@@ -17,7 +17,7 @@ type OnBuild struct {
 }
 
 func NewOnBuild(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.OnBuild], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *OnBuild {
-	return &OnBuild{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &OnBuild{Base: NewBase(name, i, backend_instruction.NewOnBuild(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *OnBuild) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -25,8 +25,4 @@ func (stage *OnBuild) GetDependencies(ctx context.Context, c stage.Conveyor, cb 
 	args = append(args, stage.instruction.Data.Name())
 	args = append(args, stage.instruction.Data.Instruction)
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *OnBuild) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewOnBuild(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/run.go
+++ b/pkg/build/stage/instruction/run.go
@@ -17,13 +17,9 @@ type Run struct {
 }
 
 func NewRun(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Run], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Run {
-	return &Run{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Run{Base: NewBase(name, i, backend_instruction.NewRun(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Run) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	return util.Sha256Hash(append([]string{stage.instruction.Data.Name()}, stage.instruction.Data.Command...)...), nil
-}
-
-func (stage *Run) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewRun(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/shell.go
+++ b/pkg/build/stage/instruction/shell.go
@@ -17,7 +17,7 @@ type Shell struct {
 }
 
 func NewShell(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Shell], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Shell {
-	return &Shell{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Shell{Base: NewBase(name, i, backend_instruction.NewShell(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Shell) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -25,8 +25,4 @@ func (stage *Shell) GetDependencies(ctx context.Context, c stage.Conveyor, cb co
 	args = append(args, stage.instruction.Data.Name())
 	args = append(args, stage.instruction.Data.Shell...)
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Shell) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewShell(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/stop_signal.go
+++ b/pkg/build/stage/instruction/stop_signal.go
@@ -17,7 +17,7 @@ type StopSignal struct {
 }
 
 func NewStopSignal(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.StopSignal], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *StopSignal {
-	return &StopSignal{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &StopSignal{Base: NewBase(name, i, backend_instruction.NewStopSignal(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *StopSignal) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -25,8 +25,4 @@ func (stage *StopSignal) GetDependencies(ctx context.Context, c stage.Conveyor, 
 	args = append(args, stage.instruction.Data.Name())
 	args = append(args, stage.instruction.Data.Signal)
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *StopSignal) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewStopSignal(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/user.go
+++ b/pkg/build/stage/instruction/user.go
@@ -17,7 +17,7 @@ type User struct {
 }
 
 func NewUser(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.User], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *User {
-	return &User{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &User{Base: NewBase(name, i, backend_instruction.NewUser(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *User) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -25,8 +25,4 @@ func (stage *User) GetDependencies(ctx context.Context, c stage.Conveyor, cb con
 	args = append(args, stage.instruction.Data.Name())
 	args = append(args, stage.instruction.Data.User)
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *User) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewUser(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/volume.go
+++ b/pkg/build/stage/instruction/volume.go
@@ -17,7 +17,7 @@ type Volume struct {
 }
 
 func NewVolume(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Volume], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Volume {
-	return &Volume{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Volume{Base: NewBase(name, i, backend_instruction.NewVolume(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Volume) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -25,8 +25,4 @@ func (stage *Volume) GetDependencies(ctx context.Context, c stage.Conveyor, cb c
 	args = append(args, stage.instruction.Data.Name())
 	args = append(args, stage.instruction.Data.Volumes...)
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Volume) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewVolume(*stage.instruction.Data))
 }

--- a/pkg/build/stage/instruction/workdir.go
+++ b/pkg/build/stage/instruction/workdir.go
@@ -17,7 +17,7 @@ type Workdir struct {
 }
 
 func NewWorkdir(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*dockerfile_instruction.Workdir], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Workdir {
-	return &Workdir{Base: NewBase(name, i, dependencies, hasPrevStage, opts)}
+	return &Workdir{Base: NewBase(name, i, backend_instruction.NewWorkdir(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stage *Workdir) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -25,8 +25,4 @@ func (stage *Workdir) GetDependencies(ctx context.Context, c stage.Conveyor, cb 
 	args = append(args, stage.instruction.Data.Name())
 	args = append(args, stage.instruction.Data.Workdir)
 	return util.Sha256Hash(args...), nil
-}
-
-func (stage *Workdir) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return stage.Base.prepareInstruction(ctx, stageImage, buildContextArchive, backend_instruction.NewWorkdir(*stage.instruction.Data))
 }

--- a/pkg/dockerfile/frontend/buildkit_dockerfile.go
+++ b/pkg/dockerfile/frontend/buildkit_dockerfile.go
@@ -102,7 +102,7 @@ func extractSrcAndDst(sourcesAndDest instructions.SourcesAndDest) ([]string, str
 		panic(fmt.Sprintf("unexpected buildkit instruction source and destination: %#v", sourcesAndDest))
 	}
 	dst := sourcesAndDest[len(sourcesAndDest)-1]
-	src := sourcesAndDest[0 : len(sourcesAndDest)-2]
+	src := sourcesAndDest[0 : len(sourcesAndDest)-1]
 	return src, dst
 }
 


### PR DESCRIPTION
This fixes panic when trying to use uninitialized build-context because of unimplemented UsesBuildContext method at the pkg/build/stage/instruction level. Also refactored pkg/build/stage/instruction a bit: common PrepareImage method implementation in Base.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>