### PR TITLE
Add Unit tests to the Helm documentation replacers

### DIFF
--- a/cmd/werf/docs/replacers/helm/helm.go
+++ b/cmd/werf/docs/replacers/helm/helm.go
@@ -116,6 +116,10 @@ func ReplaceHelmDependencyDocs(cmd *cobra.Command) *cobra.Command {
 			cmd.Commands()[i].Annotations = map[string]string{
 				common.DocsLongMD: GetHelmDependencyUpdateDocs().LongMD,
 			}
+		case "list CHART":
+			cmd.Commands()[i].Annotations = map[string]string{
+				common.DocsLongMD: GetHelmDependencyListDocs().LongMD,
+			}
 		}
 	}
 	return cmd
@@ -127,6 +131,22 @@ func ReplaceHelmGetDocs(cmd *cobra.Command) *cobra.Command {
 		case "hooks RELEASE_NAME":
 			cmd.Commands()[i].Annotations = map[string]string{
 				common.DocsLongMD: GetHelmGetHooksDocs().LongMD,
+			}
+		case "all RELEASE_NAME":
+			cmd.Commands()[i].Annotations = map[string]string{
+				common.DocsLongMD: GetHelmGetAllDocs().LongMD,
+			}
+		case "values RELEASE_NAME":
+			cmd.Commands()[i].Annotations = map[string]string{
+				common.DocsLongMD: GetHelmGetValuesDocs().LongMD,
+			}
+		case "manifest RELEASE_NAME":
+			cmd.Commands()[i].Annotations = map[string]string{
+				common.DocsLongMD: GetHelmGetManifestDocs().LongMD,
+			}
+		case "notes RELEASE_NAME":
+			cmd.Commands()[i].Annotations = map[string]string{
+				common.DocsLongMD: GetHelmGetNotesDocs().LongMD,
 			}
 		}
 	}
@@ -147,6 +167,10 @@ func ReplaceHelmPluginDocs(cmd *cobra.Command) *cobra.Command {
 		case "update <plugin>...":
 			cmd.Commands()[i].Annotations = map[string]string{
 				common.DocsLongMD: GetHelmPluginUpdateDocs().LongMD,
+			}
+		case "install [options] <path|url>...":
+			cmd.Commands()[i].Annotations = map[string]string{
+				common.DocsLongMD: GetHelmPluginInstallDocs().LongMD,
 			}
 		}
 	}

--- a/cmd/werf/docs/replacers/helm/helm_docs.go
+++ b/cmd/werf/docs/replacers/helm/helm_docs.go
@@ -306,11 +306,58 @@ func GetHelmDependencyUpdateDocs() structs.DocsStruct {
 	return docs
 }
 
+func GetHelmDependencyListDocs() structs.DocsStruct {
+	var docs structs.DocsStruct
+
+	docs.LongMD = "List all of the dependencies declared in a chart.\n\n" +
+		"This can take chart archives and chart directories as input. It will not alter " +
+		"the contents of a chart.\n\n" +
+		"This will produce an error if the chart cannot be loaded.\n"
+
+	return docs
+}
+
 func GetHelmGetHooksDocs() structs.DocsStruct {
 	var docs structs.DocsStruct
 
 	docs.LongMD = "This command downloads hooks for a given release.\n\n" +
 		"Hooks are formatted in YAML and separated by the YAML `---\\n` separator."
+
+	return docs
+}
+
+func GetHelmGetAllDocs() structs.DocsStruct {
+	var docs structs.DocsStruct
+
+	docs.LongMD = "This command prints a human readable collection of information about the " +
+		"notes, hooks, supplied values, and generated manifest file of the given release."
+
+	return docs
+}
+
+func GetHelmGetValuesDocs() structs.DocsStruct {
+	var docs structs.DocsStruct
+
+	docs.LongMD = "This command downloads a values file for a given release."
+
+	return docs
+}
+
+func GetHelmGetManifestDocs() structs.DocsStruct {
+	var docs structs.DocsStruct
+
+	docs.LongMD = "This command fetches the generated manifest for a given release.\n\n" +
+		"A manifest is a YAML-encoded representation of the Kubernetes resources that " +
+		"were generated from this release's chart(s). If a chart is dependent on other " +
+		"charts, those resources will also be included in the manifest."
+
+	return docs
+}
+
+func GetHelmGetNotesDocs() structs.DocsStruct {
+	var docs structs.DocsStruct
+
+	docs.LongMD = "This command shows notes provided by the chart of a named release."
 
 	return docs
 }
@@ -335,6 +382,14 @@ func GetHelmPluginUpdateDocs() structs.DocsStruct {
 	var docs structs.DocsStruct
 
 	docs.LongMD = "Update one or more Helm plugins."
+
+	return docs
+}
+
+func GetHelmPluginInstallDocs() structs.DocsStruct {
+	var docs structs.DocsStruct
+
+	docs.LongMD = "This command allows you to install a plugin from a URL to a VCS repo or a local path."
 
 	return docs
 }

--- a/cmd/werf/docs/replacers/helm/helm_test.go
+++ b/cmd/werf/docs/replacers/helm/helm_test.go
@@ -1,0 +1,243 @@
+package helm
+
+import (
+	"os"
+	"testing"
+
+	helm_v3 "helm.sh/helm/v3/cmd/helm"
+	"helm.sh/helm/v3/pkg/action"
+
+	"github.com/werf/werf/cmd/werf/common"
+	"github.com/werf/werf/pkg/deploy/helm"
+)
+
+func TestReplaceHelmCreateDocs(t *testing.T) {
+	cmd := ReplaceHelmCreateDocs(helm_v3.NewCreateCmd(os.Stdout))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+		if ann != GetHelmCreateDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmEnvDocs(t *testing.T) {
+	cmd := ReplaceHelmEnvDocs(helm_v3.NewEnvCmd(os.Stdout))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+	} else {
+		if ann != GetHelmEnvDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmHistoryDocs(t *testing.T) {
+	actionConfig := new(action.Configuration)
+	cmd := ReplaceHelmHistoryDocs(helm_v3.NewHistoryCmd(actionConfig, os.Stdout))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+	} else {
+		if ann != GetHelmHistoryDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmLintDocs(t *testing.T) {
+	cmd := ReplaceHelmLintDocs(helm_v3.NewLintCmd(os.Stdout))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+	} else {
+		if ann != GetHelmLintDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmListDocs(t *testing.T) {
+	actionConfig := new(action.Configuration)
+	cmd := ReplaceHelmListDocs(helm_v3.NewListCmd(actionConfig, os.Stdout))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+	} else {
+		if ann != GetHelmListDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmPullDocs(t *testing.T) {
+	actionConfig := new(action.Configuration)
+	cmd := ReplaceHelmPullDocs(helm_v3.NewPullCmd(actionConfig, os.Stdout))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+	} else {
+		if ann != GetHelmPullDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmRollbackDocs(t *testing.T) {
+	var namespace string
+	actionConfig := new(action.Configuration)
+	cmd := ReplaceHelmRollbackDocs(helm_v3.NewRollbackCmd(actionConfig, os.Stdout, helm_v3.RollbackCmdOptions{
+		StagesSplitter:              helm.NewStagesSplitter(),
+		StagesExternalDepsGenerator: helm.NewStagesExternalDepsGenerator(&actionConfig.RESTClientGetter, &namespace),
+	}))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+	} else {
+		if ann != GetHelmRollbackDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmStatusDocs(t *testing.T) {
+	actionConfig := new(action.Configuration)
+	cmd := ReplaceHelmStatusDocs(helm_v3.NewStatusCmd(actionConfig, os.Stdout))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+	} else {
+		if ann != GetHelmStatusDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmUninstallDocs(t *testing.T) {
+	actionConfig := new(action.Configuration)
+	cmd := ReplaceHelmUninstallDocs(helm_v3.NewUninstallCmd(actionConfig, os.Stdout, helm_v3.UninstallCmdOptions{
+		StagesSplitter: helm.NewStagesSplitter(),
+	}))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+	} else {
+		if ann != GetHelmUninstallDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmVerifyDocs(t *testing.T) {
+	cmd := ReplaceHelmVerifyDocs(helm_v3.NewVerifyCmd(os.Stdout))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+	} else {
+		if ann != GetHelmVerifyDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmVersionDocs(t *testing.T) {
+	cmd := ReplaceHelmVersionDocs(helm_v3.NewVersionCmd(os.Stdout))
+	if ann, ok := cmd.Annotations[common.DocsLongMD]; !ok {
+		t.Error("There is no annotation!")
+	} else {
+		if ann != GetHelmVersionDocs().LongMD {
+			t.Error("The annotation does not match!")
+		}
+	}
+}
+
+func TestReplaceHelmDependencyDocs(t *testing.T) {
+	actionConfig := new(action.Configuration)
+	cmd := ReplaceHelmDependencyDocs(helm_v3.NewDependencyCmd(actionConfig, os.Stdout))
+	for i, c := range cmd.Commands() {
+		if ann, ok := c.Annotations[common.DocsLongMD]; !ok {
+			t.Errorf("There is no annotation in `%s -> %s` command!", cmd.Use, cmd.Commands()[i].Use)
+		} else {
+			if ann != GetHelmDependencyBuildDocs().LongMD &&
+				ann != GetHelmDependencyListDocs().LongMD &&
+				ann != GetHelmDependencyUpdateDocs().LongMD {
+				t.Errorf("The annotation in `%s -> %s` command does not match!", cmd.Use, cmd.Commands()[i].Use)
+			}
+		}
+	}
+}
+
+func TestReplaceHelmGetDocs(t *testing.T) {
+	actionConfig := new(action.Configuration)
+	cmd := ReplaceHelmGetDocs(helm_v3.NewGetCmd(actionConfig, os.Stdout))
+	for i, c := range cmd.Commands() {
+		if ann, ok := c.Annotations[common.DocsLongMD]; !ok {
+			t.Errorf("There is no annotation in `%s -> %s` command!", cmd.Use, cmd.Commands()[i].Use)
+		} else {
+			if ann != GetHelmGetHooksDocs().LongMD &&
+				ann != GetHelmGetAllDocs().LongMD &&
+				ann != GetHelmGetValuesDocs().LongMD &&
+				ann != GetHelmGetManifestDocs().LongMD &&
+				ann != GetHelmGetNotesDocs().LongMD {
+				t.Errorf("The annotation in `%s -> %s` command does not match!", cmd.Use, cmd.Commands()[i].Use)
+			}
+		}
+	}
+}
+
+func TestReplaceHelmPluginDocs(t *testing.T) {
+	cmd := ReplaceHelmPluginDocs(helm_v3.NewPluginCmd(os.Stdout))
+	for i, c := range cmd.Commands() {
+		if ann, ok := c.Annotations[common.DocsLongMD]; !ok {
+			t.Errorf("There is no annotation in `%s -> %s` command!", cmd.Use, cmd.Commands()[i].Use)
+		} else {
+			if ann != GetHelmPluginListDocs().LongMD &&
+				ann != GetHelmPluginUninstallDocs().LongMD &&
+				ann != GetHelmPluginUpdateDocs().LongMD &&
+				ann != GetHelmPluginInstallDocs().LongMD {
+				t.Errorf("The annotation in `%s -> %s` command does not match!", cmd.Use, cmd.Commands()[i].Use)
+			}
+		}
+	}
+}
+
+func TestReplaceHelmRepoDocs(t *testing.T) {
+	cmd := ReplaceHelmRepoDocs(helm_v3.NewRepoCmd(os.Stdout))
+	for i, c := range cmd.Commands() {
+		if ann, ok := c.Annotations[common.DocsLongMD]; !ok {
+			t.Errorf("There is no annotation in `%s -> %s` command!", cmd.Use, cmd.Commands()[i].Use)
+		} else {
+			if ann != GetHelmRepoAddDocs().LongMD &&
+				ann != GetHelmRepoIndexDocs().LongMD &&
+				ann != GetHelmRepoListDocs().LongMD &&
+				ann != GetHelmRepoRemoveDocs().LongMD &&
+				ann != GetHelmRepoUpdateDocs().LongMD {
+				t.Errorf("The annotation in `%s -> %s` command does not match!", cmd.Use, cmd.Commands()[i].Use)
+			}
+		}
+	}
+}
+
+func TestReplaceHelmSearchDocs(t *testing.T) {
+	cmd := ReplaceHelmSearchDocs(helm_v3.NewSearchCmd(os.Stdout))
+	for i, c := range cmd.Commands() {
+		if ann, ok := c.Annotations[common.DocsLongMD]; !ok {
+			t.Errorf("There is no annotation in `%s -> %s` command!", cmd.Use, cmd.Commands()[i].Use)
+		} else {
+			if ann != GetHelmSearchHubDocs().LongMD &&
+				ann != GetHelmSearchRepoDocs().LongMD {
+				t.Errorf("The annotation in `%s -> %s` command does not match!", cmd.Use, cmd.Commands()[i].Use)
+			}
+		}
+	}
+}
+
+func TestReplaceHelmShowDocs(t *testing.T) {
+	actionConfig := new(action.Configuration)
+	cmd := ReplaceHelmShowDocs(helm_v3.NewShowCmd(actionConfig, os.Stdout))
+	for i, c := range cmd.Commands() {
+		if ann, ok := c.Annotations[common.DocsLongMD]; !ok {
+			t.Errorf("There is no annotation in `%s -> %s` command!", cmd.Use, cmd.Commands()[i].Use)
+		} else {
+			if ann != GetHelmShowAllDocs().LongMD &&
+				ann != GetHelmShowChartDocs().LongMD &&
+				ann != GetHelmShowCRDsDocs().LongMD &&
+				ann != GetHelmShowReadmeDocs().LongMD &&
+				ann != GetHelmShowValuesDocs().LongMD {
+				t.Errorf("The annotation in `%s -> %s` command does not match!", cmd.Use, cmd.Commands()[i].Use)
+			}
+		}
+	}
+}

--- a/docs/_includes/reference/cli/werf_helm_dependency_list.md
+++ b/docs/_includes/reference/cli/werf_helm_dependency_list.md
@@ -3,11 +3,9 @@
 {% else %}
 {% assign header = "###" %}
 {% endif %}
-
 List all of the dependencies declared in a chart.
 
-This can take chart archives and chart directories as input. It will not alter
-the contents of a chart.
+This can take chart archives and chart directories as input. It will not alter the contents of a chart.
 
 This will produce an error if the chart cannot be loaded.
 

--- a/docs/_includes/reference/cli/werf_helm_get_all.md
+++ b/docs/_includes/reference/cli/werf_helm_get_all.md
@@ -3,10 +3,7 @@
 {% else %}
 {% assign header = "###" %}
 {% endif %}
-
-This command prints a human readable collection of information about the
-notes, hooks, supplied values, and generated manifest file of the given release.
-
+This command prints a human readable collection of information about the notes, hooks, supplied values, and generated manifest file of the given release.
 
 {{ header }} Syntax
 

--- a/docs/_includes/reference/cli/werf_helm_get_manifest.md
+++ b/docs/_includes/reference/cli/werf_helm_get_manifest.md
@@ -3,13 +3,9 @@
 {% else %}
 {% assign header = "###" %}
 {% endif %}
-
 This command fetches the generated manifest for a given release.
 
-A manifest is a YAML-encoded representation of the Kubernetes resources that
-were generated from this release's chart(s). If a chart is dependent on other
-charts, those resources will also be included in the manifest.
-
+A manifest is a YAML-encoded representation of the Kubernetes resources that were generated from this release's chart(s). If a chart is dependent on other charts, those resources will also be included in the manifest.
 
 {{ header }} Syntax
 

--- a/docs/_includes/reference/cli/werf_helm_get_notes.md
+++ b/docs/_includes/reference/cli/werf_helm_get_notes.md
@@ -3,9 +3,7 @@
 {% else %}
 {% assign header = "###" %}
 {% endif %}
-
 This command shows notes provided by the chart of a named release.
-
 
 {{ header }} Syntax
 

--- a/docs/_includes/reference/cli/werf_helm_get_values.md
+++ b/docs/_includes/reference/cli/werf_helm_get_values.md
@@ -3,9 +3,7 @@
 {% else %}
 {% assign header = "###" %}
 {% endif %}
-
 This command downloads a values file for a given release.
-
 
 {{ header }} Syntax
 

--- a/docs/_includes/reference/cli/werf_helm_plugin_install.md
+++ b/docs/_includes/reference/cli/werf_helm_plugin_install.md
@@ -3,9 +3,7 @@
 {% else %}
 {% assign header = "###" %}
 {% endif %}
-
-This command allows you to install a plugin from a url to a VCS repo or a local path.
-
+This command allows you to install a plugin from a URL to a VCS repo or a local path.
 
 {{ header }} Syntax
 

--- a/docs/_includes/reference/cli/werf_kubectl_get.md
+++ b/docs/_includes/reference/cli/werf_kubectl_get.md
@@ -14,7 +14,7 @@ Use "kubectl api-resources" for a complete list of supported resources.
 {{ header }} Syntax
 
 ```shell
-werf kubectl get [(-o|--output=)json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file|custom-columns-file|custom-columns|wide] (TYPE[.VERSION][.GROUP] [NAME | -l label] | TYPE[.VERSION][.GROUP]/NAME ...) [flags] [options]
+werf kubectl get [(-o|--output=)json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file|custom-columns|custom-columns-file|wide] (TYPE[.VERSION][.GROUP] [NAME | -l label] | TYPE[.VERSION][.GROUP]/NAME ...) [flags] [options]
 ```
 
 {{ header }} Examples
@@ -85,7 +85,7 @@ werf kubectl get [(-o|--output=)json|yaml|name|go-template|go-template-file|temp
             print headers).
   -o, --output=''
             Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile
-            |jsonpath|jsonpath-as-json|jsonpath-file|custom-columns|custom-columns-file|wide See    
+            |jsonpath|jsonpath-as-json|jsonpath-file|custom-columns-file|custom-columns|wide See    
             custom columns [https://kubernetes.io/docs/reference/kubectl/overview/#custom-columns], 
             golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath        
             template [https://kubernetes.io/docs/reference/kubectl/jsonpath/].


### PR DESCRIPTION
Add Unit tests to replacers of the documentation of commands from the Helm package implemented in the previous PR.

Each test generates a similar cobra command, calls the documentation substitution function, and checks for annotations in the processed command.