### PR TITLE
feat(staged-dockerfile): implement first stage of build-args expansion

### DIFF
--- a/pkg/build/stage/instruction/add_test.go
+++ b/pkg/build/stage/instruction/add_test.go
@@ -28,6 +28,7 @@ var _ = DescribeTable("ADD digest",
 		NewAdd("ADD",
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "/app"}, Chown: "1000:1000", Chmod: ""},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{
@@ -48,6 +49,7 @@ var _ = DescribeTable("ADD digest",
 		NewAdd("ADD",
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "/app"}, Chown: "1000:1001", Chmod: ""},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{
@@ -69,6 +71,7 @@ var _ = DescribeTable("ADD digest",
 		NewAdd("ADD",
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "/app"}, Chown: "1000:1001", Chmod: "0777"},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{
@@ -90,6 +93,7 @@ var _ = DescribeTable("ADD digest",
 		NewAdd("ADD",
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "pom.xml", "/app"}, Chown: "1000:1001", Chmod: "0777"},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{
@@ -111,6 +115,7 @@ var _ = DescribeTable("ADD digest",
 		NewAdd("ADD",
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "pom.xml", "/app"}, Chown: "1000:1001", Chmod: "0777"},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{
@@ -132,6 +137,7 @@ var _ = DescribeTable("ADD digest",
 		NewAdd("ADD",
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "pom.xml", "/app2"}, Chown: "1000:1001", Chmod: "0777"},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{

--- a/pkg/build/stage/instruction/cmd_test.go
+++ b/pkg/build/stage/instruction/cmd_test.go
@@ -28,6 +28,7 @@ var _ = DescribeTable("CMD digest",
 		NewCmd("CMD",
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.CmdCommand{ShellDependantCmdLine: instructions.ShellDependantCmdLine{CmdLine: []string{"/bin/bash", "-lec", "while true ; do date ; sleep 1 ; done"}, PrependShell: false}},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{
@@ -48,6 +49,7 @@ var _ = DescribeTable("CMD digest",
 		NewCmd("CMD",
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.CmdCommand{ShellDependantCmdLine: instructions.ShellDependantCmdLine{CmdLine: []string{"/bin/bash", "-lec", "while true ; do date ; sleep 1 ; done"}, PrependShell: true}},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{
@@ -68,6 +70,7 @@ var _ = DescribeTable("CMD digest",
 		NewCmd("CMD",
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.CmdCommand{ShellDependantCmdLine: instructions.ShellDependantCmdLine{CmdLine: []string{"/bin/bash", "-lec", "while true ; do date ; sleep 1 ; done"}, PrependShell: true}},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{

--- a/pkg/build/stage/instruction/copy_test.go
+++ b/pkg/build/stage/instruction/copy_test.go
@@ -30,6 +30,7 @@ var _ = DescribeTable("COPY digest",
 				&instructions.CopyCommand{
 					SourcesAndDest: []string{"src/", "doc/", "/app"},
 				},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{
@@ -53,6 +54,7 @@ var _ = DescribeTable("COPY digest",
 				&instructions.CopyCommand{
 					SourcesAndDest: []string{"src/", "doc/", "/app"},
 				},
+				dockerfile.DockerfileStageInstructionOptions{},
 			),
 			nil, false,
 			&stage.BaseStageOptions{

--- a/pkg/build/stage/instruction/stubs_test.go
+++ b/pkg/build/stage/instruction/stubs_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewDockerfileStageInstructionWithDependencyStages[T dockerfile.InstructionDataInterface](data T, dependencyStages []string) *dockerfile.DockerfileStageInstruction[T] {
-	i := dockerfile.NewDockerfileStageInstruction(data)
+	i := dockerfile.NewDockerfileStageInstruction(data, dockerfile.DockerfileStageInstructionOptions{})
 	for _, stageName := range dependencyStages {
 		i.SetDependencyByStageRef(stageName, &dockerfile.DockerfileStage{StageName: stageName})
 	}

--- a/pkg/dockerfile/instruction.go
+++ b/pkg/dockerfile/instruction.go
@@ -2,6 +2,8 @@ package dockerfile
 
 import (
 	"fmt"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 )
 
 type InstructionDataInterface interface {
@@ -13,18 +15,34 @@ type DockerfileStageInstructionInterface interface {
 	GetDependencyByStageRef(ref string) *DockerfileStage
 	GetDependenciesByStageRef() map[string]*DockerfileStage
 	GetInstructionData() InstructionDataInterface
-	// TODO(staged-dockerfile): something like Expand(args, envs map[string]string)
+	Expand(env map[string]string) error
+}
+
+type (
+	ExpandWordFunc  func(word string, env map[string]string) (string, error)
+	ExpandWordsFunc func(word string, env map[string]string) (string, error)
+)
+
+type Expander interface {
+	ProcessWordWithMap(word string, env map[string]string) (string, error)
+	ProcessWordsWithMap(word string, env map[string]string) ([]string, error)
+}
+
+type DockerfileStageInstructionOptions struct {
+	Expander Expander
 }
 
 type DockerfileStageInstruction[T InstructionDataInterface] struct {
 	Data                   T
 	DependenciesByStageRef map[string]*DockerfileStage
+	Expander               Expander
 }
 
-func NewDockerfileStageInstruction[T InstructionDataInterface](data T) *DockerfileStageInstruction[T] {
+func NewDockerfileStageInstruction[T InstructionDataInterface](data T, opts DockerfileStageInstructionOptions) *DockerfileStageInstruction[T] {
 	return &DockerfileStageInstruction[T]{
 		Data:                   data,
 		DependenciesByStageRef: make(map[string]*DockerfileStage),
+		Expander:               opts.Expander,
 	}
 }
 
@@ -48,4 +66,28 @@ func (i *DockerfileStageInstruction[T]) GetDependenciesByStageRef() map[string]*
 
 func (i *DockerfileStageInstruction[T]) GetInstructionData() InstructionDataInterface {
 	return i.Data
+}
+
+func (i *DockerfileStageInstruction[T]) Expand(env map[string]string) error {
+	switch instr := any(i.Data).(type) {
+	case instructions.SupportsSingleWordExpansion:
+		return instr.Expand(func(word string) (string, error) {
+			return i.Expander.ProcessWordWithMap(word, env)
+		})
+
+	case *instructions.ExposeCommand:
+		// NOTE: ExposeCommand does not implement Expander interface, but actually needs expansion
+
+		ports := []string{}
+		for _, p := range instr.Ports {
+			ps, err := i.Expander.ProcessWordsWithMap(p, env)
+			if err != nil {
+				return fmt.Errorf("unable to expand expose instruction port %q: %w", p, err)
+			}
+			ports = append(ports, ps...)
+		}
+		instr.Ports = ports
+	}
+
+	return nil
 }


### PR DESCRIPTION
First stage: standard expansion on dockerfile parsing stage.
Second stage: expand dependencies build-args.

* Added universal method for expansion any instruction, which would be needed for second-stage inspection, which mutates instruction data in place.
* Implemented meta-args expansion and per-stage args expansion.