### PR TITLE
fix(build): fix git-patch-* stages mechanics when patches contains binaries

### DIFF
--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -953,9 +953,7 @@ func (gm *GitMapping) prepareArchiveFile(archive git_repo.Archive) (*ContainerFi
 }
 
 func (gm *GitMapping) preparePatchPathsListFile(patch git_repo.Patch) (*ContainerFileDescriptor, error) {
-	// FIXME: create this file using GitDataManager
-
-	pathsListFilePath := filepath.Join(filepath.Dir(patch.GetFilePath()), fmt.Sprintf("%s.paths_list", filepath.Base(patch.GetFilePath())))
+	pathsListFilePath := filepath.Join(filepath.Dir(patch.GetFilePath()), fmt.Sprintf("%s.%s.paths_list", filepath.Base(patch.GetFilePath()), gm.GetParamshash()))
 	containerFilePath := path.Join(gm.ContainerPatchesDir, filepath.ToSlash(util.GetRelativeToBaseFilepath(git_repo.CommonGitDataManager.GetPatchesCacheDir(), pathsListFilePath)))
 
 	fileDesc := &ContainerFileDescriptor{


### PR DESCRIPTION
Bug occurs when there are more than one git-mapping exists in the werf.yaml, and we create a patch with binary files. In such case there was patch-paths-list name conflict between different git-mappings.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>