### PR TITLE
feat(staged-dockerfile): support werf images dependencies build-args

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -585,7 +585,13 @@ func (phase *BuildPhase) calculateStage(ctx context.Context, img *image.Image, s
 		return false, nil, err
 	}
 
-	stageDigest, err := calculateDigest(ctx, stage.GetLegacyCompatibleStageName(stg.Name()), stageDependencies, phase.StagesIterator.PrevNonEmptyStage, phase.Conveyor)
+	var opts calculateDigestOption
+	if img.IsDockerfileImage && img.DockerfileImageConfig.Staged {
+		if !stg.HasPrevStage() {
+			opts.BaseImage = img.GetBaseImageReference()
+		}
+	}
+	stageDigest, err := calculateDigest(ctx, stage.GetLegacyCompatibleStageName(stg.Name()), stageDependencies, phase.StagesIterator.PrevNonEmptyStage, phase.Conveyor, opts)
 	if err != nil {
 		return false, nil, err
 	}
@@ -614,7 +620,7 @@ func (phase *BuildPhase) calculateStage(ctx context.Context, img *image.Image, s
 		}
 	}
 
-	stageContentSig, err := calculateDigest(ctx, fmt.Sprintf("%s-content", stg.Name()), "", stg, phase.Conveyor)
+	stageContentSig, err := calculateDigest(ctx, fmt.Sprintf("%s-content", stg.Name()), "", stg, phase.Conveyor, calculateDigestOption{})
 	if err != nil {
 		return false, phase.Conveyor.GetStageDigestMutex(stg.GetDigest()).Unlock, fmt.Errorf("unable to calculate stage %s content digest: %w", stg.Name(), err)
 	}
@@ -861,7 +867,11 @@ func introspectStage(ctx context.Context, s stage.Interface) error {
 		})
 }
 
-func calculateDigest(ctx context.Context, stageName, stageDependencies string, prevNonEmptyStage stage.Interface, conveyor *Conveyor) (string, error) {
+type calculateDigestOption struct {
+	BaseImage string
+}
+
+func calculateDigest(ctx context.Context, stageName, stageDependencies string, prevNonEmptyStage stage.Interface, conveyor *Conveyor, opts calculateDigestOption) (string, error) {
 	checksumArgs := []string{imagePkg.BuildCacheVersion, stageName, stageDependencies}
 	if prevNonEmptyStage != nil {
 		prevStageDependencies, err := prevNonEmptyStage.GetNextStageDependencies(ctx, conveyor)
@@ -870,6 +880,10 @@ func calculateDigest(ctx context.Context, stageName, stageDependencies string, p
 		}
 
 		checksumArgs = append(checksumArgs, prevNonEmptyStage.GetDigest(), prevStageDependencies)
+	}
+
+	if opts.BaseImage != "" {
+		checksumArgs = append(checksumArgs, opts.BaseImage)
 	}
 
 	digest := util.Sha3_224Hash(checksumArgs...)
@@ -883,6 +897,11 @@ func calculateDigest(ctx context.Context, stageName, stageDependencies string, p
 			"prevNonEmptyStage digest",
 			"prevNonEmptyStage dependencies for next stage",
 		}
+
+		if opts.BaseImage != "" {
+			checksumArgsNames = append(checksumArgsNames, "baseImage")
+		}
+
 		for ind, checksumArg := range checksumArgs {
 			logboek.Context(ctx).Debug().LogF("%s => %q\n", checksumArgsNames[ind], checksumArg)
 		}

--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -225,7 +225,9 @@ func (phase *BuildPhase) ImageProcessingShouldBeStopped(_ context.Context, _ *im
 func (phase *BuildPhase) BeforeImageStages(ctx context.Context, img *image.Image) (deferFn func(), err error) {
 	phase.StagesIterator = NewStagesIterator(phase.Conveyor)
 
-	img.SetupBaseImage()
+	if err := img.SetupBaseImage(); err != nil {
+		return nil, err
+	}
 
 	if img.UsesBuildContext() {
 		phase.buildContextArchive = image.NewBuildContextArchive(phase.Conveyor.giterminismManager, img.TmpDir)

--- a/pkg/build/image/image.go
+++ b/pkg/build/image/image.go
@@ -13,6 +13,7 @@ import (
 	"github.com/werf/werf/pkg/config"
 	"github.com/werf/werf/pkg/container_backend"
 	"github.com/werf/werf/pkg/docker_registry"
+	"github.com/werf/werf/pkg/dockerfile"
 	"github.com/werf/werf/pkg/giterminism_manager"
 	"github.com/werf/werf/pkg/image"
 	"github.com/werf/werf/pkg/logging"
@@ -43,9 +44,10 @@ type ImageOptions struct {
 	IsArtifact, IsDockerfileImage bool
 	DockerfileImageConfig         *config.ImageFromDockerfile
 
-	BaseImageReference   string
-	BaseImageName        string
-	FetchLatestBaseImage bool
+	BaseImageReference        string
+	BaseImageName             string
+	FetchLatestBaseImage      bool
+	DockerfileExpanderFactory dockerfile.ExpanderFactory
 }
 
 func NewImage(ctx context.Context, name string, baseImageType BaseImageType, opts ImageOptions) (*Image, error) {
@@ -62,9 +64,10 @@ func NewImage(ctx context.Context, name string, baseImageType BaseImageType, opt
 		IsDockerfileImage:     opts.IsDockerfileImage,
 		DockerfileImageConfig: opts.DockerfileImageConfig,
 
-		baseImageType:      baseImageType,
-		baseImageReference: opts.BaseImageReference,
-		baseImageName:      opts.BaseImageName,
+		baseImageType:             baseImageType,
+		baseImageReference:        opts.BaseImageReference,
+		baseImageName:             opts.BaseImageName,
+		dockerfileExpanderFactory: opts.DockerfileExpanderFactory,
 	}
 
 	if opts.FetchLatestBaseImage {
@@ -89,9 +92,10 @@ type Image struct {
 	contentDigest     string
 	rebuilt           bool
 
-	baseImageType      BaseImageType
-	baseImageReference string
-	baseImageName      string
+	baseImageType             BaseImageType
+	baseImageReference        string
+	baseImageName             string
+	dockerfileExpanderFactory dockerfile.ExpanderFactory
 
 	baseImageRepoId  string
 	baseStageImage   *stage.StageImage
@@ -197,18 +201,28 @@ func (i *Image) GetRebuilt() bool {
 	return i.rebuilt
 }
 
-func (i *Image) SetupBaseImage() {
+func (i *Image) SetupBaseImage() error {
 	switch i.baseImageType {
 	case StageAsBaseImage:
 		i.stageAsBaseImage = i.Conveyor.GetImage(i.baseImageName).GetLastNonEmptyStage()
 		i.baseImageReference = i.stageAsBaseImage.GetStageImage().Image.Name()
 		i.baseStageImage = i.stageAsBaseImage.GetStageImage()
 	case ImageFromRegistryAsBaseImage:
+		if i.IsDockerfileImage && i.dockerfileExpanderFactory != nil {
+			dependenciesArgs := stage.ResolveDependenciesArgs(i.DockerfileImageConfig.Dependencies, i.Conveyor)
+			ref, err := i.dockerfileExpanderFactory.GetExpander(dockerfile.ExpandOptions{SkipUnsetEnv: false}).ProcessWordWithMap(i.baseImageReference, dependenciesArgs)
+			if err != nil {
+				return fmt.Errorf("unable to expand dockerfile base image reference %q: %w", i.baseImageReference, err)
+			}
+			i.baseImageReference = ref
+		}
 		i.baseStageImage = i.Conveyor.GetOrCreateStageImage(i.baseImageReference, nil, nil, i)
 	case NoBaseImage:
 	default:
 		panic(fmt.Sprintf("unknown base image type %q", i.baseImageType))
 	}
+
+	return nil
 }
 
 // TODO(staged-dockerfile): this is only for compatibility with stapel-builder logic, and this should be unified with new staged-dockerfile logic

--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -122,6 +122,10 @@ func (s *BaseStage) LogDetailedName() string {
 	return fmt.Sprintf("%s/%s", imageName, s.Name())
 }
 
+func (s *BaseStage) ImageName() string {
+	return s.imageName
+}
+
 func (s *BaseStage) Name() StageName {
 	if s.name != "" {
 		return s.name

--- a/pkg/build/stage/dependencies_utils.go
+++ b/pkg/build/stage/dependencies_utils.go
@@ -1,0 +1,40 @@
+package stage
+
+import (
+	"github.com/werf/werf/pkg/config"
+	"github.com/werf/werf/pkg/image"
+)
+
+func GetDependenciesArgsKeys(dependencies []*config.Dependency) (res []string) {
+	for _, dep := range dependencies {
+		for _, imp := range dep.Imports {
+			res = append(res, imp.TargetBuildArg)
+		}
+	}
+	return
+}
+
+func ResolveDependenciesArgs(dependencies []*config.Dependency, c Conveyor) map[string]string {
+	resolved := make(map[string]string)
+
+	for _, dep := range dependencies {
+		depImageName := c.GetImageNameForLastImageStage(dep.ImageName)
+		depImageID := c.GetImageIDForLastImageStage(dep.ImageName)
+		depImageRepo, depImageTag := image.ParseRepositoryAndTag(depImageName)
+
+		for _, imp := range dep.Imports {
+			switch imp.Type {
+			case config.ImageRepoImport:
+				resolved[imp.TargetBuildArg] = depImageRepo
+			case config.ImageTagImport:
+				resolved[imp.TargetBuildArg] = depImageTag
+			case config.ImageNameImport:
+				resolved[imp.TargetBuildArg] = depImageName
+			case config.ImageIDImport:
+				resolved[imp.TargetBuildArg] = depImageID
+			}
+		}
+	}
+
+	return resolved
+}

--- a/pkg/build/stage/full_dockerfile.go
+++ b/pkg/build/stage/full_dockerfile.go
@@ -174,31 +174,6 @@ func (ds *DockerStages) resolveDockerMetaArg(key, value string, resolvedDockerMe
 	return resolvedKey, resolvedValue, err
 }
 
-func resolveDependenciesArgsHash(dependencies []*config.Dependency, c Conveyor) map[string]string {
-	resolved := make(map[string]string)
-
-	for _, dep := range dependencies {
-		depImageName := c.GetImageNameForLastImageStage(dep.ImageName)
-		depImageID := c.GetImageIDForLastImageStage(dep.ImageName)
-		depImageRepo, depImageTag := image.ParseRepositoryAndTag(depImageName)
-
-		for _, img := range dep.Imports {
-			switch img.Type {
-			case config.ImageRepoImport:
-				resolved[img.TargetBuildArg] = depImageRepo
-			case config.ImageTagImport:
-				resolved[img.TargetBuildArg] = depImageTag
-			case config.ImageNameImport:
-				resolved[img.TargetBuildArg] = depImageName
-			case config.ImageIDImport:
-				resolved[img.TargetBuildArg] = depImageID
-			}
-		}
-	}
-
-	return resolved
-}
-
 // resolveDockerStageArg function sets dependency arg value, or --build-arg value, or resolved dockerfile stage ARG value, or resolved meta ARG value (if stage ARG value is empty)
 func (ds *DockerStages) resolveDockerStageArg(dockerStageID int, key, value string, resolvedDockerMetaArgsHash, resolvedDependenciesArgsHash map[string]string) (string, string, error) {
 	resolvedKey, err := ds.ShlexProcessWordWithStageArgsAndEnvs(dockerStageID, key)
@@ -320,7 +295,7 @@ type dockerfileInstructionInterface interface {
 }
 
 func (s *FullDockerfileStage) FetchDependencies(ctx context.Context, c Conveyor, containerBackend container_backend.ContainerBackend, dockerRegistry docker_registry.ApiInterface) error {
-	resolvedDependenciesArgsHash := resolveDependenciesArgsHash(s.dependencies, c)
+	resolvedDependenciesArgsHash := ResolveDependenciesArgs(s.dependencies, c)
 
 	resolvedDockerMetaArgsHash, err := s.resolveDockerMetaArgs(resolvedDependenciesArgsHash)
 	if err != nil {
@@ -412,7 +387,7 @@ func isUnsupportedMediaTypeError(err error) bool {
 var errImageNotExistLocally = errors.New("IMAGE_NOT_EXIST_LOCALLY")
 
 func (s *FullDockerfileStage) GetDependencies(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	resolvedDependenciesArgsHash := resolveDependenciesArgsHash(s.dependencies, c)
+	resolvedDependenciesArgsHash := ResolveDependenciesArgs(s.dependencies, c)
 
 	resolvedDockerMetaArgsHash, err := s.resolveDockerMetaArgs(resolvedDependenciesArgsHash)
 	if err != nil {
@@ -732,7 +707,7 @@ func (s *FullDockerfileStage) SetupDockerImageBuilder(b stage_builder.Dockerfile
 		}
 	}
 
-	resolvedDependenciesArgsHash := resolveDependenciesArgsHash(s.dependencies, c)
+	resolvedDependenciesArgsHash := ResolveDependenciesArgs(s.dependencies, c)
 	if len(resolvedDependenciesArgsHash) > 0 {
 		for key, value := range resolvedDependenciesArgsHash {
 			b.AppendBuildArgs(fmt.Sprintf("%s=%v", key, value))

--- a/pkg/build/stage/instruction/base.go
+++ b/pkg/build/stage/instruction/base.go
@@ -54,7 +54,9 @@ func (stg *Base[T, BT]) PrepareImage(ctx context.Context, c stage.Conveyor, cb c
 }
 
 func (stg *Base[T, BT]) ExpandInstruction(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	return nil
+	dependenciesArgs := stage.ResolveDependenciesArgs(stg.dependencies, c)
+	// NOTE: do not skip unset envs during second stage expansion
+	return stg.instruction.Expand(dependenciesArgs, dockerfile.ExpandOptions{SkipUnsetEnv: false})
 }
 
 type InstructionExpander interface {

--- a/pkg/build/stage/instruction/copy.go
+++ b/pkg/build/stage/instruction/copy.go
@@ -23,6 +23,10 @@ func NewCopy(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*ins
 }
 
 func (stg *Copy) ExpandInstruction(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
+	if err := stg.Base.ExpandInstruction(ctx, c, cb, prevBuiltImage, stageImage, buildContextArchive); err != nil {
+		return err
+	}
+
 	if stg.instruction.Data.From != "" {
 		if ds := stg.instruction.GetDependencyByStageRef(stg.instruction.Data.From); ds != nil {
 			depStageImageName := c.GetImageNameForLastImageStage(ds.WerfImageName())

--- a/pkg/container_backend/instruction/run.go
+++ b/pkg/container_backend/instruction/run.go
@@ -3,9 +3,11 @@ package instruction
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
+	"github.com/werf/logboek"
 	"github.com/werf/werf/pkg/buildah"
 	"github.com/werf/werf/pkg/container_backend"
 )
@@ -54,6 +56,8 @@ func (i *Run) Apply(ctx context.Context, containerName string, drv buildah.Build
 	if i.GetSecurity() == "insecure" {
 		addCapabilities = []string{"all"}
 	}
+
+	logboek.Context(ctx).Default().LogF("$ %s\n", strings.Join(i.CmdLine, " "))
 
 	if err := drv.RunCommand(ctx, containerName, i.CmdLine, buildah.RunCommandOpts{
 		CommonOpts:      drvOpts,

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -5,11 +5,12 @@ import (
 )
 
 type DockerfileOptions struct {
-	Target    string
-	BuildArgs map[string]string
-	AddHost   []string
-	Network   string
-	SSH       string
+	Target               string
+	BuildArgs            map[string]string
+	DependenciesArgsKeys []string
+	AddHost              []string
+	Network              string
+	SSH                  string
 }
 
 func NewDockerfile(stages []*DockerfileStage, opts DockerfileOptions) *Dockerfile {

--- a/pkg/dockerfile/dockerfile_stage.go
+++ b/pkg/dockerfile/dockerfile_stage.go
@@ -8,14 +8,21 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 )
 
-func NewDockerfileStage(index int, baseName, stageName string, instructions []DockerfileStageInstructionInterface, platform string) *DockerfileStage {
-	return &DockerfileStage{BaseName: baseName, StageName: stageName, Instructions: instructions, Platform: platform}
+func NewDockerfileStage(index int, baseName, stageName string, instructions []DockerfileStageInstructionInterface, platform string, expanderFactory ExpanderFactory) *DockerfileStage {
+	return &DockerfileStage{
+		ExpanderFactory: expanderFactory,
+		BaseName:        baseName,
+		StageName:       stageName,
+		Instructions:    instructions,
+		Platform:        platform,
+	}
 }
 
 type DockerfileStage struct {
-	Dockerfile   *Dockerfile
-	Dependencies []*DockerfileStage
-	BaseStage    *DockerfileStage
+	Dockerfile      *Dockerfile
+	Dependencies    []*DockerfileStage
+	BaseStage       *DockerfileStage
+	ExpanderFactory ExpanderFactory
 
 	BaseName     string
 	Index        int

--- a/pkg/dockerfile/frontend/buildkit_dockerfile.go
+++ b/pkg/dockerfile/frontend/buildkit_dockerfile.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
-	"github.com/moby/buildkit/frontend/dockerfile/shell"
 
 	"github.com/werf/werf/pkg/dockerfile"
 )
@@ -24,16 +23,16 @@ func ParseDockerfileWithBuildkit(dockerfileBytes []byte, opts dockerfile.Dockerf
 		return nil, fmt.Errorf("parsing instructions tree: %w", err)
 	}
 
-	shlex := shell.NewLex(p.EscapeToken)
+	expanderFactory := NewShlexExpanderFactory(p.EscapeToken)
 
-	metaArgs, err := processMetaArgs(dockerMetaArgs, opts.BuildArgs, shlex)
+	metaArgs, err := resolveMetaArgs(dockerMetaArgs, opts.BuildArgs, opts.DependenciesArgsKeys, expanderFactory)
 	if err != nil {
 		return nil, fmt.Errorf("unable to process meta args: %w", err)
 	}
 
 	var stages []*dockerfile.DockerfileStage
 	for i, dockerStage := range dockerStages {
-		name, err := shlex.ProcessWordWithMap(dockerStage.BaseName, metaArgs)
+		name, err := expanderFactory.GetExpander(dockerfile.ExpandOptions{SkipUnsetEnv: true}).ProcessWordWithMap(dockerStage.BaseName, metaArgs)
 		if err != nil {
 			return nil, fmt.Errorf("unable to expand docker stage base image name %q: %w", dockerStage.BaseName, err)
 		}
@@ -44,7 +43,7 @@ func ParseDockerfileWithBuildkit(dockerfileBytes []byte, opts dockerfile.Dockerf
 
 		// TODO(staged-dockerfile): support meta-args expansion for dockerStage.Platform
 
-		if stage, err := NewDockerfileStageFromBuildkitStage(i, dockerStage, shlex, metaArgs, opts.BuildArgs); err != nil {
+		if stage, err := NewDockerfileStageFromBuildkitStage(i, dockerStage, expanderFactory, metaArgs, opts.BuildArgs, opts.DependenciesArgsKeys); err != nil {
 			return nil, fmt.Errorf("error converting buildkit stage to dockerfile stage: %w", err)
 		} else {
 			stages = append(stages, stage)
@@ -60,11 +59,11 @@ func ParseDockerfileWithBuildkit(dockerfileBytes []byte, opts dockerfile.Dockerf
 	return d, nil
 }
 
-func NewDockerfileStageFromBuildkitStage(index int, stage instructions.Stage, shlex *shell.Lex, metaArgs, buildArgs map[string]string) (*dockerfile.DockerfileStage, error) {
+func NewDockerfileStageFromBuildkitStage(index int, stage instructions.Stage, expanderFactory *ShlexExpanderFactory, metaArgs, buildArgs map[string]string, dependenciesArgsKeys []string) (*dockerfile.DockerfileStage, error) {
 	var stageInstructions []dockerfile.DockerfileStageInstructionInterface
 
 	env := map[string]string{}
-	opts := dockerfile.DockerfileStageInstructionOptions{Expander: shlex}
+	opts := dockerfile.DockerfileStageInstructionOptions{ExpanderFactory: expanderFactory}
 
 	for _, cmd := range stage.Commands {
 		var i dockerfile.DockerfileStageInstructionInterface
@@ -77,6 +76,8 @@ func NewDockerfileStageFromBuildkitStage(index int, stage instructions.Stage, sh
 				i = instr
 			}
 		case *instructions.ArgCommand:
+			instrData.Args = removeDependenciesArgs(instrData.Args, dependenciesArgsKeys)
+
 			if instr, err := createAndExpandInstruction(instrData, env, opts); err != nil {
 				return nil, err
 			} else {
@@ -199,18 +200,40 @@ func NewDockerfileStageFromBuildkitStage(index int, stage instructions.Stage, sh
 		stageInstructions = append(stageInstructions, i)
 	}
 
-	return dockerfile.NewDockerfileStage(index, stage.BaseName, stage.Name, stageInstructions, stage.Platform), nil
+	return dockerfile.NewDockerfileStage(index, stage.BaseName, stage.Name, stageInstructions, stage.Platform, expanderFactory), nil
 }
 
 func createAndExpandInstruction[T dockerfile.InstructionDataInterface](data T, env map[string]string, opts dockerfile.DockerfileStageInstructionOptions) (*dockerfile.DockerfileStageInstruction[T], error) {
 	i := dockerfile.NewDockerfileStageInstruction(data, opts)
-	if err := i.Expand(env); err != nil {
+
+	// NOTE: skip unset envs during first stage expansion
+	if err := i.Expand(env, dockerfile.ExpandOptions{SkipUnsetEnv: true}); err != nil {
 		return nil, fmt.Errorf("unable to expand instruction %q: %w", i.GetInstructionData().Name(), err)
 	}
+
 	return i, nil
 }
 
-func processMetaArgs(metaArgs []instructions.ArgCommand, buildArgs map[string]string, shlex *shell.Lex) (map[string]string, error) {
+func isDependencyArg(argKey string, dependenciesArgsKeys []string) bool {
+	for _, dep := range dependenciesArgsKeys {
+		if dep == argKey {
+			return true
+		}
+	}
+	return false
+}
+
+func removeDependenciesArgs(args []instructions.KeyValuePairOptional, dependenciesArgsKeys []string) (res []instructions.KeyValuePairOptional) {
+	// NOTE: dependencies will be expanded on the second stage expansion
+	for _, arg := range args {
+		if !isDependencyArg(arg.Key, dependenciesArgsKeys) {
+			res = append(res, arg)
+		}
+	}
+	return
+}
+
+func resolveMetaArgs(metaArgs []instructions.ArgCommand, buildArgs map[string]string, dependenciesArgsKeys []string, expanderFactory *ShlexExpanderFactory) (map[string]string, error) {
 	var optMetaArgs []instructions.KeyValuePairOptional
 
 	// TODO(staged-dockerfile): need to support builtin BUILD* and TARGET* args
@@ -223,8 +246,12 @@ func processMetaArgs(metaArgs []instructions.ArgCommand, buildArgs map[string]st
 
 	for _, cmd := range metaArgs {
 		for _, metaArg := range cmd.Args {
+			if isDependencyArg(metaArg.Key, dependenciesArgsKeys) {
+				continue
+			}
+
 			if metaArg.Value != nil {
-				*metaArg.Value, _ = shlex.ProcessWordWithMap(*metaArg.Value, metaArgsToMap(optMetaArgs))
+				*metaArg.Value, _ = expanderFactory.GetExpander(dockerfile.ExpandOptions{SkipUnsetEnv: true}).ProcessWordWithMap(*metaArg.Value, metaArgsToMap(optMetaArgs))
 			}
 			optMetaArgs = append(optMetaArgs, setKVValue(metaArg, buildArgs))
 		}

--- a/pkg/dockerfile/frontend/shlex_expander.go
+++ b/pkg/dockerfile/frontend/shlex_expander.go
@@ -1,0 +1,21 @@
+package frontend
+
+import (
+	"github.com/moby/buildkit/frontend/dockerfile/shell"
+
+	"github.com/werf/werf/pkg/dockerfile"
+)
+
+type ShlexExpanderFactory struct {
+	EscapeToken rune
+}
+
+func NewShlexExpanderFactory(escapeToken rune) *ShlexExpanderFactory {
+	return &ShlexExpanderFactory{EscapeToken: escapeToken}
+}
+
+func (factory *ShlexExpanderFactory) GetExpander(opts dockerfile.ExpandOptions) dockerfile.Expander {
+	shlex := shell.NewLex(factory.EscapeToken)
+	shlex.SkipUnsetEnv = opts.SkipUnsetEnv
+	return shlex
+}

--- a/test/e2e/build/_fixtures/complex/state0/Dockerfile
+++ b/test/e2e/build/_fixtures/complex/state0/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:22.04 AS builder
+ARG STAPEL_SHELL_IMAGE_NAME="no_such_image"
+
+
+FROM ${STAPEL_SHELL_IMAGE_NAME} AS builder
 
 ADD src/file* /app/added/
 ADD "https://github.com/octocat/Hello-World/tarball/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d" /helloworld.tgz
@@ -8,6 +11,11 @@ COPY src/file* /app/copied/
 FROM ubuntu:22.04 AS result
 
 ARG CHANGED_ARG="should_be_changed"
+ARG BASE_STAPEL_SHELL_IMAGE_NAME="no_such_image"
+ARG BASE_STAPEL_SHELL_IMAGE_ID="no_such_image"
+ARG BASE_STAPEL_SHELL_IMAGE_REPO="no_such_image"
+ARG BASE_STAPEL_SHELL_IMAGE_TAG="no_such_image"
+
 ENV COMPOSED_ENV="env-${CHANGED_ARG}"
 LABEL COMPOSED_LABEL="label-${CHANGED_ARG}"
 MAINTAINER "maintainer"
@@ -21,6 +29,11 @@ COPY --from=builder /helloworld.tgz /helloworld.tgz
 
 RUN touch /created-by-run-state0
 RUN mkdir -p /volume10/should-exist-in-volume
+
+RUN echo ${BASE_STAPEL_SHELL_IMAGE_NAME} >> base_image_data.txt
+RUN echo ${BASE_STAPEL_SHELL_IMAGE_ID} >> base_image_data.txt
+RUN echo ${BASE_STAPEL_SHELL_IMAGE_REPO} >> base_image_data.txt
+RUN echo ${BASE_STAPEL_SHELL_IMAGE_TAG} >> base_image_data.txt
 
 ENTRYPOINT ["sh", "-ec"]
 CMD ["tail -f /dev/null"]

--- a/test/e2e/build/_fixtures/complex/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/complex/state0/werf.yaml
@@ -9,6 +9,21 @@ target: result
 network: default
 args:
   CHANGED_ARG: "was_changed"
+dependencies:
+- image: stapel-shell
+  imports:
+  - type: ImageName
+    targetBuildArg: STAPEL_SHELL_IMAGE_NAME
+- image: base-stapel-shell
+  imports:
+  - type: ImageName
+    targetBuildArg: BASE_STAPEL_SHELL_IMAGE_NAME
+  - type: ImageID
+    targetBuildArg: BASE_STAPEL_SHELL_IMAGE_ID
+  - type: ImageRepo
+    targetBuildArg: BASE_STAPEL_SHELL_IMAGE_REPO
+  - type: ImageTag
+    targetBuildArg: BASE_STAPEL_SHELL_IMAGE_TAG
 
 ---
 image: base-stapel-shell

--- a/test/e2e/build/_fixtures/complex/state1/Dockerfile
+++ b/test/e2e/build/_fixtures/complex/state1/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:22.04 AS builder
+ARG STAPEL_SHELL_IMAGE_NAME="no_such_image"
+
+
+FROM ${STAPEL_SHELL_IMAGE_NAME} AS builder
 
 ADD src/file* /app/added/
 COPY src/file* /app/copied/
@@ -7,6 +10,11 @@ COPY src/file* /app/copied/
 FROM ubuntu:22.04 AS result
 
 ARG CHANGED_ARG="should_be_changed"
+ARG BASE_STAPEL_SHELL_IMAGE_NAME="no_such_image"
+ARG BASE_STAPEL_SHELL_IMAGE_ID="no_such_image"
+ARG BASE_STAPEL_SHELL_IMAGE_REPO="no_such_image"
+ARG BASE_STAPEL_SHELL_IMAGE_TAG="no_such_image"
+
 ENV COMPOSED_ENV="env-${CHANGED_ARG}"
 LABEL COMPOSED_LABEL="label-${CHANGED_ARG}"
 MAINTAINER "maintainer-${CHANGED_ARG}"
@@ -18,6 +26,11 @@ WORKDIR /
 COPY --from=builder /app /app
 
 RUN touch /created-by-run-state1
+
+RUN echo ${BASE_STAPEL_SHELL_IMAGE_NAME} >> base_image_data.txt
+RUN echo ${BASE_STAPEL_SHELL_IMAGE_ID} >> base_image_data.txt
+RUN echo ${BASE_STAPEL_SHELL_IMAGE_REPO} >> base_image_data.txt
+RUN echo ${BASE_STAPEL_SHELL_IMAGE_TAG} >> base_image_data.txt
 
 ENTRYPOINT ["sh", "-ec"]
 CMD ["tail -f /dev/null"]

--- a/test/e2e/build/_fixtures/complex/state1/werf.yaml
+++ b/test/e2e/build/_fixtures/complex/state1/werf.yaml
@@ -9,6 +9,21 @@ target: result
 network: default
 args:
   CHANGED_ARG: "was_changed-state1"
+dependencies:
+- image: stapel-shell
+  imports:
+  - type: ImageName
+    targetBuildArg: STAPEL_SHELL_IMAGE_NAME
+- image: base-stapel-shell
+  imports:
+  - type: ImageName
+    targetBuildArg: BASE_STAPEL_SHELL_IMAGE_NAME
+  - type: ImageID
+    targetBuildArg: BASE_STAPEL_SHELL_IMAGE_ID
+  - type: ImageRepo
+    targetBuildArg: BASE_STAPEL_SHELL_IMAGE_REPO
+  - type: ImageTag
+    targetBuildArg: BASE_STAPEL_SHELL_IMAGE_TAG
 
 ---
 image: base-stapel-shell

--- a/test/e2e/build/complex_test.go
+++ b/test/e2e/build/complex_test.go
@@ -259,19 +259,17 @@ var _ = Describe("Complex build", Label("e2e", "build", "complex"), func() {
 			WithLocalRepo:               true,
 			WithStagedDockerfileBuilder: false,
 		}),
-		// TODO(ilya-lesikov): uncomment after Staged Dockerfile builder finished
-		// // TODO(1.3): after Full Dockerfile Builder removed and Staged Dockerfile Builder enabled by default this test no longer needed
-		// Entry("with local repo using Native Buildah and Staged Dockerfile builder with rootless isolation", complexTestOptions{
-		// 	BuildahMode:                 "native-rootless",
-		// 	WithLocalRepo:               true,
-		// 	WithStagedDockerfileBuilder: true,
-		// }),
-		// TODO(ilya-lesikov): uncomment after Staged Dockerfile builder finished
-		// // TODO(1.3): after Full Dockerfile Builder removed and Staged Dockerfile Builder enabled by default this test no longer needed
-		// Entry("with local repo using Native Buildah and Staged Dockerfile builder with chroot isolation", complexTestOptions{
-		// 	BuildahMode:                 "native-chroot",
-		// 	WithLocalRepo:               true,
-		// 	WithStagedDockerfileBuilder: true,
-		// }),
+		// TODO(1.3): after Full Dockerfile Builder removed and Staged Dockerfile Builder enabled by default this test no longer needed
+		Entry("with local repo using Native Buildah and Staged Dockerfile builder with rootless isolation", complexTestOptions{
+			BuildahMode:                 "native-rootless",
+			WithLocalRepo:               true,
+			WithStagedDockerfileBuilder: true,
+		}),
+		// TODO(1.3): after Full Dockerfile Builder removed and Staged Dockerfile Builder enabled by default this test no longer needed
+		Entry("with local repo using Native Buildah and Staged Dockerfile builder with chroot isolation", complexTestOptions{
+			BuildahMode:                 "native-chroot",
+			WithLocalRepo:               true,
+			WithStagedDockerfileBuilder: true,
+		}),
 	)
 })


### PR DESCRIPTION
Implemented 2-stage build-args expansion:
1. Expand all build-args except dependencies-args on early dockerfile parsing stage.
2. Expand dependencies-args when dependencies images names are available during image conveyor processing.

refs https://github.com/werf/werf/issues/2215
