### PR TITLE
[1.2.186] fix(build): inconsistent report path when final-repo used

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -179,7 +179,24 @@ func (phase *BuildPhase) createReport(ctx context.Context) error {
 			continue
 		}
 
-		desc := img.GetLastNonEmptyStage().GetStageImage().Image.GetStageDescription()
+		var desc *imagePkg.StageDescription
+		stageImage := img.GetLastNonEmptyStage().GetStageImage()
+		stageID := stageImage.Image.GetStageDescription().StageID
+
+		if phase.Conveyor.StorageManager.GetFinalStagesStorage() != nil {
+			var err error
+			desc, err = phase.Conveyor.StorageManager.GetFinalStagesStorage().GetStageDescription(ctx, phase.Conveyor.ProjectName(), stageID.Digest, stageID.UniqueID)
+			if err != nil {
+				return fmt.Errorf("unable to get stage %s descriptor from final repo %s: %w", stageID.String(), phase.Conveyor.StorageManager.GetFinalStagesStorage().String(), err)
+			}
+		} else {
+			var err error
+			desc, err = phase.Conveyor.StorageManager.GetStagesStorage().GetStageDescription(ctx, phase.Conveyor.ProjectName(), stageID.Digest, stageID.UniqueID)
+			if err != nil {
+				return fmt.Errorf("unable to get stage %s descriptor from primary repo %s: %w", stageID.String(), phase.Conveyor.StorageManager.GetStagesStorage().String(), err)
+			}
+		}
+
 		phase.ImagesReport.SetImageRecord(img.GetName(), ReportImageRecord{
 			WerfImageName:     img.GetName(),
 			DockerRepo:        desc.Info.Repository,

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -706,10 +706,9 @@ func (runtime *BuildahBackend) RenameImage(ctx context.Context, img LegacyImageI
 		img.SetInfo(info)
 	}
 
-	desc := img.GetStageDescription()
-
-	if desc != nil {
+	if desc := img.GetStageDescription(); desc != nil {
 		repository, tag := image.ParseRepositoryAndTag(newImageName)
+		desc.Info.Name = newImageName
 		desc.Info.Repository = repository
 		desc.Info.Tag = tag
 	}

--- a/pkg/container_backend/docker_server_backend.go
+++ b/pkg/container_backend/docker_server_backend.go
@@ -154,10 +154,9 @@ func (runtime *DockerServerBackend) RenameImage(ctx context.Context, img LegacyI
 		img.SetInfo(info)
 	}
 
-	desc := img.GetStageDescription()
-
-	if desc != nil {
+	if desc := img.GetStageDescription(); desc != nil {
 		repository, tag := image.ParseRepositoryAndTag(newImageName)
+		desc.Info.Name = newImageName
 		desc.Info.Repository = repository
 		desc.Info.Tag = tag
 	}

--- a/pkg/container_backend/legacy_stage_image.go
+++ b/pkg/container_backend/legacy_stage_image.go
@@ -32,14 +32,11 @@ func NewLegacyStageImage(fromImage *LegacyStageImage, name string, containerBack
 
 func (i *LegacyStageImage) GetCopy() LegacyImageInterface {
 	ni := NewLegacyStageImage(i.fromImage, i.name, i.ContainerBackend)
-
-	if info := i.GetInfo(); info != nil {
-		ni.SetInfo(info)
-	}
 	if desc := i.GetStageDescription(); desc != nil {
-		ni.SetStageDescription(desc)
+		ni.SetStageDescription(desc.GetCopy())
+	} else if info := i.GetInfo(); info != nil {
+		ni.SetInfo(info.GetCopy())
 	}
-
 	return ni
 }
 

--- a/pkg/image/info.go
+++ b/pkg/image/info.go
@@ -36,6 +36,21 @@ func (info *Info) GetCreatedAt() time.Time {
 	return time.Unix(info.CreatedAtUnixNano/1000_000_000, info.CreatedAtUnixNano%1000_000_000)
 }
 
+func (info *Info) GetCopy() *Info {
+	return &Info{
+		Name:              info.Name,
+		Repository:        info.Repository,
+		Tag:               info.Tag,
+		RepoDigest:        info.RepoDigest,
+		OnBuild:           util.CopyArr(info.OnBuild),
+		ID:                info.ID,
+		ParentID:          info.ParentID,
+		Labels:            util.CopyMap(info.Labels),
+		Size:              info.Size,
+		CreatedAtUnixNano: info.CreatedAtUnixNano,
+	}
+}
+
 func NewInfoFromInspect(ref string, inspect *types.ImageInspect) *Info {
 	repository, tag := ParseRepositoryAndTag(ref)
 

--- a/pkg/image/stage.go
+++ b/pkg/image/stage.go
@@ -35,3 +35,10 @@ func ParseUniqueIDAsTimestamp(uniqueID string) (int64, error) {
 		return timestamp, nil
 	}
 }
+
+func (desc *StageDescription) GetCopy() *StageDescription {
+	return &StageDescription{
+		StageID: &StageID{desc.StageID.Digest, desc.StageID.UniqueID},
+		Info:    desc.Info.GetCopy(),
+	}
+}

--- a/pkg/util/copy.go
+++ b/pkg/util/copy.go
@@ -1,0 +1,14 @@
+package util
+
+func CopyArr[T any](arr []T) (ret []T) {
+	ret = append(ret, arr...)
+	return
+}
+
+func CopyMap[K comparable, V any](m map[K]V) (ret map[K]V) {
+	ret = make(map[K]V)
+	for k, v := range m {
+		ret[k] = v
+	}
+	return
+}


### PR DESCRIPTION
- Fix image descriptors copying: deep copy image.StageDescription and image.Info.
- Set final image info into report when final-repo specified.
- Fix inconsistent image rename in container backend implementations.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>