### PR TITLE
fix: fix ssh not available in registry.werf.io/werf images

### DIFF
--- a/scripts/werf-in-image/alpine.Dockerfile
+++ b/scripts/werf-in-image/alpine.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.15
 
-RUN apk add --no-cache fuse-overlayfs git shadow-uidmap libcap
+RUN apk add --no-cache fuse-overlayfs git shadow-uidmap libcap openssh-client
 
 # Fix messed up setuid/setgid capabilities.
 RUN setcap cap_setuid+ep /usr/bin/newuidmap && \

--- a/scripts/werf-in-image/centos.Dockerfile
+++ b/scripts/werf-in-image/centos.Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-RUN dnf -y install fuse-overlayfs git && \
+RUN dnf -y install fuse-overlayfs git openssh-clients && \
     dnf clean all && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Fix messed up setuid/setgid capabilities.

--- a/scripts/werf-in-image/fedora.Dockerfile
+++ b/scripts/werf-in-image/fedora.Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:35
 
-RUN dnf -y install fuse-overlayfs git && \
+RUN dnf -y install fuse-overlayfs git openssh-clients && \
     dnf clean all && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Fix messed up setuid/setgid capabilities.

--- a/scripts/werf-in-image/ubuntu.Dockerfile
+++ b/scripts/werf-in-image/ubuntu.Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND="noninteractive"
 
-RUN apt-get -y update && apt-get -y install fuse-overlayfs git uidmap libcap2-bin && \
+RUN apt-get -y update && apt-get -y install fuse-overlayfs git uidmap libcap2-bin openssh-client && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/* /var/log/*
 
 # Fix messed up setuid/setgid capabilities.


### PR DESCRIPTION
Fix problem with git submodules fetching over ssh when running werf in the registry.werf.io/werf/werf image.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>