### PR TITLE
fix(staged-dockerfile): do not store non-target Dockerfile stages in the final-repo

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -272,6 +272,9 @@ func (phase *BuildPhase) AfterImageStages(ctx context.Context, img *image.Image)
 	if img.IsArtifact {
 		return nil
 	}
+	if img.IsDockerfileImage && !img.IsDockerfileTargetStage {
+		return nil
+	}
 
 	if phase.Conveyor.StorageManager.GetFinalStagesStorage() != nil {
 		if err := phase.Conveyor.StorageManager.CopyStageIntoFinalStorage(ctx, img.GetLastNonEmptyStage(), phase.Conveyor.ContainerBackend, manager.CopyStageIntoFinalStorageOptions{ShouldBeBuiltMode: phase.ShouldBeBuiltMode}); err != nil {

--- a/pkg/build/image/image.go
+++ b/pkg/build/image/image.go
@@ -41,8 +41,8 @@ type CommonImageOptions struct {
 
 type ImageOptions struct {
 	CommonImageOptions
-	IsArtifact, IsDockerfileImage bool
-	DockerfileImageConfig         *config.ImageFromDockerfile
+	IsArtifact, IsDockerfileImage, IsDockerfileTargetStage bool
+	DockerfileImageConfig                                  *config.ImageFromDockerfile
 
 	BaseImageReference        string
 	BaseImageName             string
@@ -58,11 +58,12 @@ func NewImage(ctx context.Context, name string, baseImageType BaseImageType, opt
 	}
 
 	i := &Image{
-		Name:                  name,
-		CommonImageOptions:    opts.CommonImageOptions,
-		IsArtifact:            opts.IsArtifact,
-		IsDockerfileImage:     opts.IsDockerfileImage,
-		DockerfileImageConfig: opts.DockerfileImageConfig,
+		Name:                    name,
+		CommonImageOptions:      opts.CommonImageOptions,
+		IsArtifact:              opts.IsArtifact,
+		IsDockerfileImage:       opts.IsDockerfileImage,
+		IsDockerfileTargetStage: opts.IsDockerfileTargetStage,
+		DockerfileImageConfig:   opts.DockerfileImageConfig,
 
 		baseImageType:             baseImageType,
 		baseImageReference:        opts.BaseImageReference,
@@ -82,10 +83,11 @@ func NewImage(ctx context.Context, name string, baseImageType BaseImageType, opt
 type Image struct {
 	CommonImageOptions
 
-	IsArtifact            bool
-	IsDockerfileImage     bool
-	Name                  string
-	DockerfileImageConfig *config.ImageFromDockerfile
+	IsArtifact              bool
+	IsDockerfileImage       bool
+	IsDockerfileTargetStage bool
+	Name                    string
+	DockerfileImageConfig   *config.ImageFromDockerfile
 
 	stages            []stage.Interface
 	lastNonEmptyStage stage.Interface

--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -74,6 +74,7 @@ var AllStages = []StageName{
 }
 
 type BaseStageOptions struct {
+	LogName          string
 	ImageName        string
 	ConfigMounts     []*config.Mount
 	ImageTmpDir      string
@@ -84,6 +85,7 @@ type BaseStageOptions struct {
 func NewBaseStage(name StageName, options *BaseStageOptions) *BaseStage {
 	s := &BaseStage{}
 	s.name = name
+	s.logName = options.LogName
 	s.imageName = options.ImageName
 	s.configMounts = options.ConfigMounts
 	s.imageTmpDir = options.ImageTmpDir
@@ -94,6 +96,7 @@ func NewBaseStage(name StageName, options *BaseStageOptions) *BaseStage {
 
 type BaseStage struct {
 	name             StageName
+	logName          string
 	imageName        string
 	digest           string
 	contentDigest    string
@@ -119,11 +122,18 @@ func (s *BaseStage) LogDetailedName() string {
 		imageName = "~"
 	}
 
-	return fmt.Sprintf("%s/%s", imageName, s.Name())
+	return fmt.Sprintf("%s/%s", imageName, s.LogName())
 }
 
 func (s *BaseStage) ImageName() string {
 	return s.imageName
+}
+
+func (s *BaseStage) LogName() string {
+	if s.logName != "" {
+		return s.logName
+	}
+	return string(s.Name())
 }
 
 func (s *BaseStage) Name() StageName {
@@ -164,7 +174,7 @@ func (s *BaseStage) getNextStageGitDependencies(ctx context.Context, c Conveyor)
 		}
 	}
 
-	logboek.Context(ctx).Debug().LogF("Stage %q next stage dependencies: %#v\n", s.Name(), args)
+	logboek.Context(ctx).Debug().LogF("Stage %q next stage dependencies: %#v\n", s.LogName(), args)
 	sort.Strings(args)
 
 	return util.Sha256Hash(args...), nil

--- a/pkg/build/stage/instruction/add.go
+++ b/pkg/build/stage/instruction/add.go
@@ -19,8 +19,8 @@ type Add struct {
 	*Base[*instructions.AddCommand, *backend_instruction.Add]
 }
 
-func NewAdd(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.AddCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Add {
-	return &Add{Base: NewBase(name, i, backend_instruction.NewAdd(i.Data), dependencies, hasPrevStage, opts)}
+func NewAdd(i *dockerfile.DockerfileStageInstruction[*instructions.AddCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Add {
+	return &Add{Base: NewBase(i, backend_instruction.NewAdd(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Add) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -29,7 +29,6 @@ func (stg *Add) GetDependencies(ctx context.Context, c stage.Conveyor, cb contai
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, append([]string{"Sources"}, stg.instruction.Data.Sources()...)...)
 	args = append(args, "Dest", stg.instruction.Data.Dest())
 	args = append(args, "Chown", stg.instruction.Data.Chown)

--- a/pkg/build/stage/instruction/add_test.go
+++ b/pkg/build/stage/instruction/add_test.go
@@ -25,7 +25,7 @@ var _ = DescribeTable("ADD digest",
 	},
 
 	Entry("ADD basic", NewTestData(
-		NewAdd("ADD",
+		NewAdd(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "/app"}, Chown: "1000:1000", Chmod: ""},
 				dockerfile.DockerfileStageInstructionOptions{},
@@ -36,7 +36,7 @@ var _ = DescribeTable("ADD digest",
 				ProjectName: "example-project",
 			},
 		),
-		"88c31da85ac26ae35d29462c6dc309c2a02997c0de92b4ccee7db2e41be17187",
+		"79d3642e997030deb225e0414f0c2d0e3c6681cc036899aaba62895f7e2ac4e3",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker;`)},
@@ -46,7 +46,7 @@ var _ = DescribeTable("ADD digest",
 	)),
 
 	Entry("ADD with changed chown", NewTestData(
-		NewAdd("ADD",
+		NewAdd(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "/app"}, Chown: "1000:1001", Chmod: ""},
 				dockerfile.DockerfileStageInstructionOptions{},
@@ -57,7 +57,7 @@ var _ = DescribeTable("ADD digest",
 				ProjectName: "example-project",
 			},
 		),
-		"846ef29e994224dd84bf0a5de47b0b3255c8681b8178e8da5611b21547cd182b",
+		"ccfda65ec4fa8667abe7a54b047a98158d122b39e224929dbb7c33ea466e7f5a",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker;`)},
@@ -68,7 +68,7 @@ var _ = DescribeTable("ADD digest",
 	)),
 
 	Entry("ADD with changed chmod", NewTestData(
-		NewAdd("ADD",
+		NewAdd(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "/app"}, Chown: "1000:1001", Chmod: "0777"},
 				dockerfile.DockerfileStageInstructionOptions{},
@@ -79,7 +79,7 @@ var _ = DescribeTable("ADD digest",
 				ProjectName: "example-project",
 			},
 		),
-		"cef21e87710631a08edeb176a9487f81ae20171c22ec4537a3dc8fbc67aca868",
+		"19e86e1145aecd554d7d492add3c6c6ed51b022279f059f6c8c54a4eac9d07f0",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker;`)},
@@ -90,7 +90,7 @@ var _ = DescribeTable("ADD digest",
 	)),
 
 	Entry("ADD with changed sources paths", NewTestData(
-		NewAdd("ADD",
+		NewAdd(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "pom.xml", "/app"}, Chown: "1000:1001", Chmod: "0777"},
 				dockerfile.DockerfileStageInstructionOptions{},
@@ -101,7 +101,7 @@ var _ = DescribeTable("ADD digest",
 				ProjectName: "example-project",
 			},
 		),
-		"97f3f8a240902d73ec9a209f6c8368047b56d9247bdf9da88a40ac5dba925209",
+		"4d17db1e6926bbe9e4f7b70d18bb055b7735f6bfb6db35452524bde561e8b95f",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker;`)},
@@ -112,7 +112,7 @@ var _ = DescribeTable("ADD digest",
 	)),
 
 	Entry("ADD with changed source files", NewTestData(
-		NewAdd("ADD",
+		NewAdd(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "pom.xml", "/app"}, Chown: "1000:1001", Chmod: "0777"},
 				dockerfile.DockerfileStageInstructionOptions{},
@@ -123,7 +123,7 @@ var _ = DescribeTable("ADD digest",
 				ProjectName: "example-project",
 			},
 		),
-		"60178e0b174bd1bce1cd29f8132ea84cc7212773b6fce9fad3ddff842d5cf2e0",
+		"372ed0cb6fff0a58e087fa8bf19e1f62a146d3983ca4510c496c452db8a7080e",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker2;`)},
@@ -134,7 +134,7 @@ var _ = DescribeTable("ADD digest",
 	)),
 
 	Entry("ADD with changed destination path", NewTestData(
-		NewAdd("ADD",
+		NewAdd(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.AddCommand{SourcesAndDest: []string{"src", "pom.xml", "/app2"}, Chown: "1000:1001", Chmod: "0777"},
 				dockerfile.DockerfileStageInstructionOptions{},
@@ -145,7 +145,7 @@ var _ = DescribeTable("ADD digest",
 				ProjectName: "example-project",
 			},
 		),
-		"c1f03d5701951fe9c5836957c753c9486f22e14b2d9291780ae70f288e531e1c",
+		"825c66ecb926ed7897fc99f7686ed4fc2a7f8133d6a66860c8755772764d0293",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker2;`)},

--- a/pkg/build/stage/instruction/base.go
+++ b/pkg/build/stage/instruction/base.go
@@ -19,9 +19,9 @@ type Base[T dockerfile.InstructionDataInterface, BT container_backend.Instructio
 	hasPrevStage       bool
 }
 
-func NewBase[T dockerfile.InstructionDataInterface, BT container_backend.InstructionInterface](name stage.StageName, instruction *dockerfile.DockerfileStageInstruction[T], backendInstruction BT, dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Base[T, BT] {
+func NewBase[T dockerfile.InstructionDataInterface, BT container_backend.InstructionInterface](instruction *dockerfile.DockerfileStageInstruction[T], backendInstruction BT, dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Base[T, BT] {
 	return &Base[T, BT]{
-		BaseStage:          stage.NewBaseStage(name, opts),
+		BaseStage:          stage.NewBaseStage(stage.StageName(instruction.Data.Name()), opts),
 		instruction:        instruction,
 		backendInstruction: backendInstruction,
 		dependencies:       dependencies,

--- a/pkg/build/stage/instruction/cmd.go
+++ b/pkg/build/stage/instruction/cmd.go
@@ -18,8 +18,8 @@ type Cmd struct {
 	*Base[*instructions.CmdCommand, *backend_instruction.Cmd]
 }
 
-func NewCmd(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.CmdCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Cmd {
-	return &Cmd{Base: NewBase(name, i, backend_instruction.NewCmd(i.Data), dependencies, hasPrevStage, opts)}
+func NewCmd(i *dockerfile.DockerfileStageInstruction[*instructions.CmdCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Cmd {
+	return &Cmd{Base: NewBase(i, backend_instruction.NewCmd(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Cmd) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -28,7 +28,6 @@ func (stg *Cmd) GetDependencies(ctx context.Context, c stage.Conveyor, cb contai
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, append([]string{"Cmd"}, stg.instruction.Data.CmdLine...)...)
 	args = append(args, "PrependShell", fmt.Sprintf("%v", stg.instruction.Data.PrependShell))
 

--- a/pkg/build/stage/instruction/cmd_test.go
+++ b/pkg/build/stage/instruction/cmd_test.go
@@ -25,7 +25,7 @@ var _ = DescribeTable("CMD digest",
 	},
 
 	Entry("CMD basic", NewTestData(
-		NewCmd("CMD",
+		NewCmd(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.CmdCommand{ShellDependantCmdLine: instructions.ShellDependantCmdLine{CmdLine: []string{"/bin/bash", "-lec", "while true ; do date ; sleep 1 ; done"}, PrependShell: false}},
 				dockerfile.DockerfileStageInstructionOptions{},
@@ -36,7 +36,7 @@ var _ = DescribeTable("CMD digest",
 				ProjectName: "example-project",
 			},
 		),
-		"c52718afd8fe6f79c1039464791418dbca4ac242a48fc1dae0494880fa858c56",
+		"6c176ed20cfc341dc35111c329a50d33a672556432524e30fe77c794fd19a41f",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker;`)},
@@ -46,7 +46,7 @@ var _ = DescribeTable("CMD digest",
 	)),
 
 	Entry("CMD with shell", NewTestData(
-		NewCmd("CMD",
+		NewCmd(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.CmdCommand{ShellDependantCmdLine: instructions.ShellDependantCmdLine{CmdLine: []string{"/bin/bash", "-lec", "while true ; do date ; sleep 1 ; done"}, PrependShell: true}},
 				dockerfile.DockerfileStageInstructionOptions{},
@@ -57,7 +57,7 @@ var _ = DescribeTable("CMD digest",
 				ProjectName: "example-project",
 			},
 		),
-		"a763588e431e8f3f3ff846898525730ec3d19535328608d9c7b0301345d101f4",
+		"1ba4c1cdfa5bce43a107e540d20c7d2655fcaeeba20e6b1f4feac2284a06f27a",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker;`)},
@@ -67,7 +67,7 @@ var _ = DescribeTable("CMD digest",
 	)),
 
 	Entry("CMD with changed context", NewTestData(
-		NewCmd("CMD",
+		NewCmd(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.CmdCommand{ShellDependantCmdLine: instructions.ShellDependantCmdLine{CmdLine: []string{"/bin/bash", "-lec", "while true ; do date ; sleep 1 ; done"}, PrependShell: true}},
 				dockerfile.DockerfileStageInstructionOptions{},
@@ -78,7 +78,7 @@ var _ = DescribeTable("CMD digest",
 				ProjectName: "example-project",
 			},
 		),
-		"a763588e431e8f3f3ff846898525730ec3d19535328608d9c7b0301345d101f4",
+		"1ba4c1cdfa5bce43a107e540d20c7d2655fcaeeba20e6b1f4feac2284a06f27a",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker2;`)},

--- a/pkg/build/stage/instruction/copy.go
+++ b/pkg/build/stage/instruction/copy.go
@@ -18,8 +18,8 @@ type Copy struct {
 	*Base[*instructions.CopyCommand, *backend_instruction.Copy]
 }
 
-func NewCopy(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.CopyCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Copy {
-	return &Copy{Base: NewBase(name, i, backend_instruction.NewCopy(i.Data), dependencies, hasPrevStage, opts)}
+func NewCopy(i *dockerfile.DockerfileStageInstruction[*instructions.CopyCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Copy {
+	return &Copy{Base: NewBase(i, backend_instruction.NewCopy(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Copy) ExpandInstruction(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
@@ -43,7 +43,6 @@ func (stg *Copy) GetDependencies(ctx context.Context, c stage.Conveyor, cb conta
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, "From", stg.instruction.Data.From)
 	args = append(args, append([]string{"Sources"}, stg.instruction.Data.Sources()...)...)
 	args = append(args, "Dest", stg.instruction.Data.Dest())

--- a/pkg/build/stage/instruction/copy_test.go
+++ b/pkg/build/stage/instruction/copy_test.go
@@ -25,7 +25,7 @@ var _ = DescribeTable("COPY digest",
 	},
 
 	Entry("COPY basic", NewTestData(
-		NewCopy("COPY",
+		NewCopy(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.CopyCommand{
 					SourcesAndDest: []string{"src/", "doc/", "/app"},
@@ -38,7 +38,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"35bf3e72310b96b9fc7861ca705b0093935d3d830388dd3ebc47e89dad68151a",
+		"b37df6b6878045c3bf0e9972e4618d6157dfa06bec990a83e0a1881ec12621b1",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker;`)},
@@ -49,7 +49,7 @@ var _ = DescribeTable("COPY digest",
 	)),
 
 	Entry("COPY with changed context files", NewTestData(
-		NewCopy("COPY",
+		NewCopy(
 			dockerfile.NewDockerfileStageInstruction(
 				&instructions.CopyCommand{
 					SourcesAndDest: []string{"src/", "doc/", "/app"},
@@ -62,7 +62,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"2df11ae4260a97665e30f69eea0c86057e5a277ade1ad273af1b3a8c85b6a651",
+		"88158fb775544cccd8bd1a345a89bda08434620dda37efe3867df077007602e1",
 		TestDataOptions{
 			Files: []*FileData{
 				{Name: "src/main/java/worker/Worker.java", Data: []byte(`package worker;`)},
@@ -73,7 +73,7 @@ var _ = DescribeTable("COPY digest",
 	)),
 
 	Entry("COPY from stage", NewTestData(
-		NewCopy("COPY",
+		NewCopy(
 			NewDockerfileStageInstructionWithDependencyStages(
 				&instructions.CopyCommand{
 					From:           "base",
@@ -87,7 +87,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"bb6495521017b98b1a6ebd5c24ae8881e2565cd64a09a825ffe7f5208da857e8",
+		"f49fa51e16c8cf0728f1cb9bd2be873555c5825d00cfac406057e6357d9900ed",
 		TestDataOptions{
 			LastStageImageNameByWerfImage: map[string]string{
 				"stage/base": "ghcr.io/werf/instruction-test:a71052baf9c6ace8171e59a2ae5ea1aede3fb89aa95d160ec354b205-1661868399091",
@@ -96,7 +96,7 @@ var _ = DescribeTable("COPY digest",
 	)),
 
 	Entry("COPY from changed stage", NewTestData(
-		NewCopy("COPY",
+		NewCopy(
 			NewDockerfileStageInstructionWithDependencyStages(
 				&instructions.CopyCommand{
 					From:           "base",
@@ -110,7 +110,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"60554221561909f478206d108bed14b781c6e642dee87a53b8ef6a961372d887",
+		"a1374babfa54a99e2efa0dc16e0c267395e2adfa6ee66d177ba9813b1745f0fa",
 		TestDataOptions{
 			LastStageImageNameByWerfImage: map[string]string{
 				"stage/base": "ghcr.io/werf/instruction-test:4930d562bfbee9c931413c826137d49eff6a2e7d39519c1c9488a747-1655913653892",
@@ -119,7 +119,7 @@ var _ = DescribeTable("COPY digest",
 	)),
 
 	Entry("COPY from same stage, with changed context", NewTestData(
-		NewCopy("COPY",
+		NewCopy(
 			NewDockerfileStageInstructionWithDependencyStages(
 				&instructions.CopyCommand{
 					From:           "base",
@@ -133,7 +133,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"60554221561909f478206d108bed14b781c6e642dee87a53b8ef6a961372d887",
+		"a1374babfa54a99e2efa0dc16e0c267395e2adfa6ee66d177ba9813b1745f0fa",
 		TestDataOptions{
 			LastStageImageNameByWerfImage: map[string]string{
 				"stage/base": "ghcr.io/werf/instruction-test:4930d562bfbee9c931413c826137d49eff6a2e7d39519c1c9488a747-1655913653892",
@@ -147,7 +147,7 @@ var _ = DescribeTable("COPY digest",
 	)),
 
 	Entry("COPY from same stage, with changed destination", NewTestData(
-		NewCopy("COPY",
+		NewCopy(
 			NewDockerfileStageInstructionWithDependencyStages(
 				&instructions.CopyCommand{
 					From:           "base",
@@ -161,7 +161,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"987f2b58c05b5b53fa523ac6c25169d9bbf29826f450d541fec0ed69354dbfe2",
+		"834afb3164923c905c25b6238e1366e533d7b65c0e8c1011163131399e200d36",
 		TestDataOptions{
 			LastStageImageNameByWerfImage: map[string]string{
 				"stage/base": "ghcr.io/werf/instruction-test:4930d562bfbee9c931413c826137d49eff6a2e7d39519c1c9488a747-1655913653892",
@@ -175,7 +175,7 @@ var _ = DescribeTable("COPY digest",
 	)),
 
 	Entry("COPY from same stage, with changed owner and modes", NewTestData(
-		NewCopy("COPY",
+		NewCopy(
 			NewDockerfileStageInstructionWithDependencyStages(
 				&instructions.CopyCommand{
 					From:           "base",
@@ -191,7 +191,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"7cb785382f1e347e16b87f397ed7ea06b000dc04a7de74b47f583e7cf85db2b5",
+		"919c20233b0060d5726cf23c99c199f6055d0db050bea6f95d29ca3796397912",
 		TestDataOptions{
 			LastStageImageNameByWerfImage: map[string]string{
 				"stage/base": "ghcr.io/werf/instruction-test:4930d562bfbee9c931413c826137d49eff6a2e7d39519c1c9488a747-1655913653892",

--- a/pkg/build/stage/instruction/entrypoint.go
+++ b/pkg/build/stage/instruction/entrypoint.go
@@ -18,8 +18,8 @@ type Entrypoint struct {
 	*Base[*instructions.EntrypointCommand, *backend_instruction.Entrypoint]
 }
 
-func NewEntrypoint(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.EntrypointCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Entrypoint {
-	return &Entrypoint{Base: NewBase(name, i, backend_instruction.NewEntrypoint(i.Data), dependencies, hasPrevStage, opts)}
+func NewEntrypoint(i *dockerfile.DockerfileStageInstruction[*instructions.EntrypointCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Entrypoint {
+	return &Entrypoint{Base: NewBase(i, backend_instruction.NewEntrypoint(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Entrypoint) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -28,7 +28,6 @@ func (stg *Entrypoint) GetDependencies(ctx context.Context, c stage.Conveyor, cb
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, append([]string{"Entrypoint"}, stg.instruction.Data.CmdLine...)...)
 	args = append(args, "PrependShell", fmt.Sprintf("%v", stg.instruction.Data.PrependShell))
 	return util.Sha256Hash(args...), nil

--- a/pkg/build/stage/instruction/env.go
+++ b/pkg/build/stage/instruction/env.go
@@ -17,8 +17,8 @@ type Env struct {
 	*Base[*instructions.EnvCommand, *backend_instruction.Env]
 }
 
-func NewEnv(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.EnvCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Env {
-	return &Env{Base: NewBase(name, i, backend_instruction.NewEnv(i.Data), dependencies, hasPrevStage, opts)}
+func NewEnv(i *dockerfile.DockerfileStageInstruction[*instructions.EnvCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Env {
+	return &Env{Base: NewBase(i, backend_instruction.NewEnv(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Env) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,7 +27,6 @@ func (stg *Env) GetDependencies(ctx context.Context, c stage.Conveyor, cb contai
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	if len(stg.instruction.Data.Env) > 0 {
 		args = append(args, "Env")
 		for _, item := range stg.instruction.Data.Env {

--- a/pkg/build/stage/instruction/expose.go
+++ b/pkg/build/stage/instruction/expose.go
@@ -17,8 +17,8 @@ type Expose struct {
 	*Base[*instructions.ExposeCommand, *backend_instruction.Expose]
 }
 
-func NewExpose(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.ExposeCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Expose {
-	return &Expose{Base: NewBase(name, i, backend_instruction.NewExpose(i.Data), dependencies, hasPrevStage, opts)}
+func NewExpose(i *dockerfile.DockerfileStageInstruction[*instructions.ExposeCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Expose {
+	return &Expose{Base: NewBase(i, backend_instruction.NewExpose(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Expose) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,7 +27,6 @@ func (stg *Expose) GetDependencies(ctx context.Context, c stage.Conveyor, cb con
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, append([]string{"Ports"}, stg.instruction.Data.Ports...)...)
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/healthcheck.go
+++ b/pkg/build/stage/instruction/healthcheck.go
@@ -18,8 +18,8 @@ type Healthcheck struct {
 	*Base[*instructions.HealthCheckCommand, *backend_instruction.Healthcheck]
 }
 
-func NewHealthcheck(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.HealthCheckCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Healthcheck {
-	return &Healthcheck{Base: NewBase(name, i, backend_instruction.NewHealthcheck(i.Data), dependencies, hasPrevStage, opts)}
+func NewHealthcheck(i *dockerfile.DockerfileStageInstruction[*instructions.HealthCheckCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Healthcheck {
+	return &Healthcheck{Base: NewBase(i, backend_instruction.NewHealthcheck(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Healthcheck) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -28,7 +28,6 @@ func (stg *Healthcheck) GetDependencies(ctx context.Context, c stage.Conveyor, c
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, append([]string{"Test"}, stg.instruction.Data.Health.Test...)...)
 	args = append(args, "Interval", stg.instruction.Data.Health.Interval.String())
 	args = append(args, "Timeout", stg.instruction.Data.Health.Timeout.String())

--- a/pkg/build/stage/instruction/label.go
+++ b/pkg/build/stage/instruction/label.go
@@ -17,8 +17,8 @@ type Label struct {
 	*Base[*instructions.LabelCommand, *backend_instruction.Label]
 }
 
-func NewLabel(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.LabelCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Label {
-	return &Label{Base: NewBase(name, i, backend_instruction.NewLabel(i.Data), dependencies, hasPrevStage, opts)}
+func NewLabel(i *dockerfile.DockerfileStageInstruction[*instructions.LabelCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Label {
+	return &Label{Base: NewBase(i, backend_instruction.NewLabel(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Label) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,7 +27,6 @@ func (stg *Label) GetDependencies(ctx context.Context, c stage.Conveyor, cb cont
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	if len(stg.instruction.Data.Labels) > 0 {
 		args = append(args, "Labels")
 		for _, item := range stg.instruction.Data.Labels {

--- a/pkg/build/stage/instruction/maintainer.go
+++ b/pkg/build/stage/instruction/maintainer.go
@@ -17,8 +17,8 @@ type Maintainer struct {
 	*Base[*instructions.MaintainerCommand, *backend_instruction.Maintainer]
 }
 
-func NewMaintainer(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.MaintainerCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Maintainer {
-	return &Maintainer{Base: NewBase(name, i, backend_instruction.NewMaintainer(i.Data), dependencies, hasPrevStage, opts)}
+func NewMaintainer(i *dockerfile.DockerfileStageInstruction[*instructions.MaintainerCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Maintainer {
+	return &Maintainer{Base: NewBase(i, backend_instruction.NewMaintainer(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Maintainer) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,7 +27,6 @@ func (stg *Maintainer) GetDependencies(ctx context.Context, c stage.Conveyor, cb
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, "Maintainer", stg.instruction.Data.Maintainer)
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/on_build.go
+++ b/pkg/build/stage/instruction/on_build.go
@@ -17,8 +17,8 @@ type OnBuild struct {
 	*Base[*instructions.OnbuildCommand, *backend_instruction.OnBuild]
 }
 
-func NewOnBuild(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.OnbuildCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *OnBuild {
-	return &OnBuild{Base: NewBase(name, i, backend_instruction.NewOnBuild(i.Data), dependencies, hasPrevStage, opts)}
+func NewOnBuild(i *dockerfile.DockerfileStageInstruction[*instructions.OnbuildCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *OnBuild {
+	return &OnBuild{Base: NewBase(i, backend_instruction.NewOnBuild(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *OnBuild) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,7 +27,6 @@ func (stg *OnBuild) GetDependencies(ctx context.Context, c stage.Conveyor, cb co
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, "Expression", stg.instruction.Data.Expression)
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/run.go
+++ b/pkg/build/stage/instruction/run.go
@@ -18,8 +18,8 @@ type Run struct {
 	*Base[*instructions.RunCommand, *backend_instruction.Run]
 }
 
-func NewRun(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.RunCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Run {
-	return &Run{Base: NewBase(name, i, backend_instruction.NewRun(i.Data), dependencies, hasPrevStage, opts)}
+func NewRun(i *dockerfile.DockerfileStageInstruction[*instructions.RunCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Run {
+	return &Run{Base: NewBase(i, backend_instruction.NewRun(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Run) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -32,7 +32,6 @@ func (stg *Run) GetDependencies(ctx context.Context, c stage.Conveyor, cb contai
 	security := instructions.GetSecurity(stg.instruction.Data)
 	mounts := instructions.GetMounts(stg.instruction.Data)
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, append([]string{"Command"}, stg.instruction.Data.CmdLine...)...)
 	args = append(args, "PrependShell", fmt.Sprintf("%v", stg.instruction.Data.PrependShell))
 	args = append(args, "Network", network)

--- a/pkg/build/stage/instruction/shell.go
+++ b/pkg/build/stage/instruction/shell.go
@@ -17,8 +17,8 @@ type Shell struct {
 	*Base[*instructions.ShellCommand, *backend_instruction.Shell]
 }
 
-func NewShell(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.ShellCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Shell {
-	return &Shell{Base: NewBase(name, i, backend_instruction.NewShell(i.Data), dependencies, hasPrevStage, opts)}
+func NewShell(i *dockerfile.DockerfileStageInstruction[*instructions.ShellCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Shell {
+	return &Shell{Base: NewBase(i, backend_instruction.NewShell(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Shell) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,7 +27,6 @@ func (stg *Shell) GetDependencies(ctx context.Context, c stage.Conveyor, cb cont
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, append([]string{"Shell"}, stg.instruction.Data.Shell...)...)
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/stop_signal.go
+++ b/pkg/build/stage/instruction/stop_signal.go
@@ -17,8 +17,8 @@ type StopSignal struct {
 	*Base[*instructions.StopSignalCommand, *backend_instruction.StopSignal]
 }
 
-func NewStopSignal(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.StopSignalCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *StopSignal {
-	return &StopSignal{Base: NewBase(name, i, backend_instruction.NewStopSignal(i.Data), dependencies, hasPrevStage, opts)}
+func NewStopSignal(i *dockerfile.DockerfileStageInstruction[*instructions.StopSignalCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *StopSignal {
+	return &StopSignal{Base: NewBase(i, backend_instruction.NewStopSignal(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *StopSignal) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,7 +27,6 @@ func (stg *StopSignal) GetDependencies(ctx context.Context, c stage.Conveyor, cb
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, "Signal", stg.instruction.Data.Signal)
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/user.go
+++ b/pkg/build/stage/instruction/user.go
@@ -17,8 +17,8 @@ type User struct {
 	*Base[*instructions.UserCommand, *backend_instruction.User]
 }
 
-func NewUser(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.UserCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *User {
-	return &User{Base: NewBase(name, i, backend_instruction.NewUser(i.Data), dependencies, hasPrevStage, opts)}
+func NewUser(i *dockerfile.DockerfileStageInstruction[*instructions.UserCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *User {
+	return &User{Base: NewBase(i, backend_instruction.NewUser(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *User) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,7 +27,6 @@ func (stg *User) GetDependencies(ctx context.Context, c stage.Conveyor, cb conta
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, "User", stg.instruction.Data.User)
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/volume.go
+++ b/pkg/build/stage/instruction/volume.go
@@ -17,8 +17,8 @@ type Volume struct {
 	*Base[*instructions.VolumeCommand, *backend_instruction.Volume]
 }
 
-func NewVolume(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.VolumeCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Volume {
-	return &Volume{Base: NewBase(name, i, backend_instruction.NewVolume(i.Data), dependencies, hasPrevStage, opts)}
+func NewVolume(i *dockerfile.DockerfileStageInstruction[*instructions.VolumeCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Volume {
+	return &Volume{Base: NewBase(i, backend_instruction.NewVolume(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Volume) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,7 +27,6 @@ func (stg *Volume) GetDependencies(ctx context.Context, c stage.Conveyor, cb con
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, append([]string{"Volumes"}, stg.instruction.Data.Volumes...)...)
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/workdir.go
+++ b/pkg/build/stage/instruction/workdir.go
@@ -17,8 +17,8 @@ type Workdir struct {
 	*Base[*instructions.WorkdirCommand, *backend_instruction.Workdir]
 }
 
-func NewWorkdir(name stage.StageName, i *dockerfile.DockerfileStageInstruction[*instructions.WorkdirCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Workdir {
-	return &Workdir{Base: NewBase(name, i, backend_instruction.NewWorkdir(i.Data), dependencies, hasPrevStage, opts)}
+func NewWorkdir(i *dockerfile.DockerfileStageInstruction[*instructions.WorkdirCommand], dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Workdir {
+	return &Workdir{Base: NewBase(i, backend_instruction.NewWorkdir(i.Data), dependencies, hasPrevStage, opts)}
 }
 
 func (stg *Workdir) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
@@ -27,7 +27,6 @@ func (stg *Workdir) GetDependencies(ctx context.Context, c stage.Conveyor, cb co
 		return "", err
 	}
 
-	args = append(args, "Instruction", stg.instruction.Data.Name())
 	args = append(args, "Path", stg.instruction.Data.Path)
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/dockerfile/dockerfile_stage.go
+++ b/pkg/dockerfile/dockerfile_stage.go
@@ -44,7 +44,7 @@ func (stage *DockerfileStage) WerfImageName() string {
 	if stage.HasStageName() {
 		return fmt.Sprintf("stage/%s", stage.StageName)
 	} else {
-		return fmt.Sprintf("stage/%d", stage.Index)
+		return fmt.Sprintf("stage%d", stage.Index)
 	}
 }
 


### PR DESCRIPTION
* Do not store non-target Dockerfile stages in the final-repo, nor set custom tags on non-target stages.
* Changed staged-dockerfile builder digest calculation algorithm: do not use instruction number in digest input calculation, only instruction name.

refs https://github.com/werf/werf/issues/2215

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>