### PR TITLE
fix: broken render output due to lock-related message

### DIFF
--- a/pkg/werf/main.go
+++ b/pkg/werf/main.go
@@ -99,7 +99,7 @@ func ReleaseHostLock(lock lockgate.LockHandle) error {
 func DefaultLockerOnWait(ctx context.Context) func(lockName string, doWait func() error) error {
 	return func(lockName string, doWait func() error) error {
 		logProcessMsg := fmt.Sprintf("Waiting for locked %q", lockName)
-		return logboek.Context(ctx).LogProcessInline(logProcessMsg).DoError(doWait)
+		return logboek.Context(ctx).Info().LogProcessInline(logProcessMsg).DoError(doWait)
 	}
 }
 


### PR DESCRIPTION
Globally disable all lock-related messages in default output, only print 'Wait for locked ...' message in --verbose mode.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>