### PR TITLE
fix(staged-dockerfile): correction for ENV and ARG instructions handling

### DIFF
--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -144,6 +144,10 @@ func (s *BaseStage) Name() StageName {
 	panic("name must be defined!")
 }
 
+func (s *BaseStage) ExpandDependencies(ctx context.Context, c Conveyor, baseEnv map[string]string) error {
+	return nil
+}
+
 func (s *BaseStage) FetchDependencies(_ context.Context, _ Conveyor, _ container_backend.ContainerBackend, _ docker_registry.ApiInterface) error {
 	return nil
 }

--- a/pkg/build/stage/instruction/add.go
+++ b/pkg/build/stage/instruction/add.go
@@ -24,10 +24,7 @@ func NewAdd(i *dockerfile.DockerfileStageInstruction[*instructions.AddCommand], 
 }
 
 func (stg *Add) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, append([]string{"Sources"}, stg.instruction.Data.Sources()...)...)
 	args = append(args, "Dest", stg.instruction.Data.Dest())

--- a/pkg/build/stage/instruction/base.go
+++ b/pkg/build/stage/instruction/base.go
@@ -17,6 +17,9 @@ type Base[T dockerfile.InstructionDataInterface, BT container_backend.Instructio
 	backendInstruction BT
 	dependencies       []*config.Dependency
 	hasPrevStage       bool
+
+	baseEnv     map[string]string
+	expandedEnv map[string]string
 }
 
 func NewBase[T dockerfile.InstructionDataInterface, BT container_backend.InstructionInterface](instruction *dockerfile.DockerfileStageInstruction[T], backendInstruction BT, dependencies []*config.Dependency, hasPrevStage bool, opts *stage.BaseStageOptions) *Base[T, BT] {
@@ -41,11 +44,18 @@ func (stg *Base[T, BT]) UsesBuildContext() bool {
 	return stg.backendInstruction.UsesBuildContext()
 }
 
-func (stg *Base[T, BT]) getDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver, expander InstructionExpander) ([]string, error) {
-	if err := expander.ExpandInstruction(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive); err != nil {
-		return nil, fmt.Errorf("unable to expand instruction %q: %w", stg.instruction.Data.Name(), err)
+func (stg *Base[T, BT]) ExpandDependencies(ctx context.Context, c stage.Conveyor, baseEnv map[string]string) error {
+	return stg.doExpandDependencies(ctx, c, baseEnv, stg)
+}
+
+func (stg *Base[T, BT]) doExpandDependencies(ctx context.Context, c stage.Conveyor, baseEnv map[string]string, expander InstructionExpander) error {
+	if err := stg.expandBaseEnv(baseEnv); err != nil {
+		return fmt.Errorf("2nd stage env expansion failed: %w", err)
 	}
-	return nil, nil
+	if err := expander.ExpandInstruction(c, stg.GetExpandedEnv(c)); err != nil {
+		return fmt.Errorf("2nd stage instruction expansion failed: %w", err)
+	}
+	return nil
 }
 
 func (stg *Base[T, BT]) PrepareImage(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
@@ -53,12 +63,46 @@ func (stg *Base[T, BT]) PrepareImage(ctx context.Context, c stage.Conveyor, cb c
 	return nil
 }
 
-func (stg *Base[T, BT]) ExpandInstruction(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	dependenciesArgs := stage.ResolveDependenciesArgs(stg.dependencies, c)
-	// NOTE: do not skip unset envs during second stage expansion
-	return stg.instruction.Expand(dependenciesArgs, dockerfile.ExpandOptions{SkipUnsetEnv: false})
+func (stg *Base[T, BT]) expandBaseEnv(baseEnv map[string]string) error {
+	env := make(map[string]string)
+
+	// NOTE: default fallback builtin PATH
+	env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	for k, v := range baseEnv {
+		env[k] = v
+	}
+
+	// NOTE: this is 2nd stage expansion (without skipping unset envs)
+	instructionEnv, err := stg.instruction.ExpandEnv(env, dockerfile.ExpandOptions{})
+	if err != nil {
+		return fmt.Errorf("error expanding env: %w", err)
+	}
+	for k, v := range instructionEnv {
+		env[k] = v
+	}
+
+	stg.baseEnv = baseEnv
+	stg.expandedEnv = env
+
+	return nil
+}
+
+func (stg *Base[T, BT]) GetExpandedEnv(c stage.Conveyor) map[string]string {
+	env := make(map[string]string)
+	for k, v := range stg.expandedEnv {
+		env[k] = v
+	}
+	for k, v := range stage.ResolveDependenciesArgs(stg.dependencies, c) {
+		env[k] = v
+	}
+	return env
+}
+
+func (stg *Base[T, BT]) ExpandInstruction(_ stage.Conveyor, env map[string]string) error {
+	// NOTE: this is 2nd stage expansion (without skipping unset envs)
+	return stg.instruction.Expand(env, dockerfile.ExpandOptions{})
 }
 
 type InstructionExpander interface {
-	ExpandInstruction(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error
+	ExpandInstruction(c stage.Conveyor, env map[string]string) error
 }

--- a/pkg/build/stage/instruction/cmd.go
+++ b/pkg/build/stage/instruction/cmd.go
@@ -23,10 +23,7 @@ func NewCmd(i *dockerfile.DockerfileStageInstruction[*instructions.CmdCommand], 
 }
 
 func (stg *Cmd) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, append([]string{"Cmd"}, stg.instruction.Data.CmdLine...)...)
 	args = append(args, "PrependShell", fmt.Sprintf("%v", stg.instruction.Data.PrependShell))

--- a/pkg/build/stage/instruction/copy.go
+++ b/pkg/build/stage/instruction/copy.go
@@ -22,8 +22,12 @@ func NewCopy(i *dockerfile.DockerfileStageInstruction[*instructions.CopyCommand]
 	return &Copy{Base: NewBase(i, backend_instruction.NewCopy(i.Data), dependencies, hasPrevStage, opts)}
 }
 
-func (stg *Copy) ExpandInstruction(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
-	if err := stg.Base.ExpandInstruction(ctx, c, cb, prevBuiltImage, stageImage, buildContextArchive); err != nil {
+func (stg *Copy) ExpandDependencies(ctx context.Context, c stage.Conveyor, baseEnv map[string]string) error {
+	return stg.doExpandDependencies(ctx, c, baseEnv, stg)
+}
+
+func (stg *Copy) ExpandInstruction(c stage.Conveyor, env map[string]string) error {
+	if err := stg.Base.ExpandInstruction(c, env); err != nil {
 		return err
 	}
 
@@ -38,10 +42,7 @@ func (stg *Copy) ExpandInstruction(ctx context.Context, c stage.Conveyor, cb con
 }
 
 func (stg *Copy) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, "From", stg.instruction.Data.From)
 	args = append(args, append([]string{"Sources"}, stg.instruction.Data.Sources()...)...)

--- a/pkg/build/stage/instruction/copy_test.go
+++ b/pkg/build/stage/instruction/copy_test.go
@@ -87,7 +87,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"f49fa51e16c8cf0728f1cb9bd2be873555c5825d00cfac406057e6357d9900ed",
+		"c65e7b2d1c3a7614106b6eb061a6bf4712cf833817ce4e3b79d8af8de22c2ba0",
 		TestDataOptions{
 			LastStageImageNameByWerfImage: map[string]string{
 				"stage/base": "ghcr.io/werf/instruction-test:a71052baf9c6ace8171e59a2ae5ea1aede3fb89aa95d160ec354b205-1661868399091",
@@ -110,7 +110,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"a1374babfa54a99e2efa0dc16e0c267395e2adfa6ee66d177ba9813b1745f0fa",
+		"c65e7b2d1c3a7614106b6eb061a6bf4712cf833817ce4e3b79d8af8de22c2ba0",
 		TestDataOptions{
 			LastStageImageNameByWerfImage: map[string]string{
 				"stage/base": "ghcr.io/werf/instruction-test:4930d562bfbee9c931413c826137d49eff6a2e7d39519c1c9488a747-1655913653892",
@@ -133,7 +133,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"a1374babfa54a99e2efa0dc16e0c267395e2adfa6ee66d177ba9813b1745f0fa",
+		"c65e7b2d1c3a7614106b6eb061a6bf4712cf833817ce4e3b79d8af8de22c2ba0",
 		TestDataOptions{
 			LastStageImageNameByWerfImage: map[string]string{
 				"stage/base": "ghcr.io/werf/instruction-test:4930d562bfbee9c931413c826137d49eff6a2e7d39519c1c9488a747-1655913653892",
@@ -161,7 +161,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"834afb3164923c905c25b6238e1366e533d7b65c0e8c1011163131399e200d36",
+		"d1898898971186720898055e0682e356ff9e53178b6ac7c629f255113c6b17a0",
 		TestDataOptions{
 			LastStageImageNameByWerfImage: map[string]string{
 				"stage/base": "ghcr.io/werf/instruction-test:4930d562bfbee9c931413c826137d49eff6a2e7d39519c1c9488a747-1655913653892",
@@ -191,7 +191,7 @@ var _ = DescribeTable("COPY digest",
 				ProjectName: "example-project",
 			},
 		),
-		"919c20233b0060d5726cf23c99c199f6055d0db050bea6f95d29ca3796397912",
+		"18a8898734bef3802598b82bff90e2fd8fe37e5b4806f269553e70f017374e35",
 		TestDataOptions{
 			LastStageImageNameByWerfImage: map[string]string{
 				"stage/base": "ghcr.io/werf/instruction-test:4930d562bfbee9c931413c826137d49eff6a2e7d39519c1c9488a747-1655913653892",

--- a/pkg/build/stage/instruction/entrypoint.go
+++ b/pkg/build/stage/instruction/entrypoint.go
@@ -23,12 +23,10 @@ func NewEntrypoint(i *dockerfile.DockerfileStageInstruction[*instructions.Entryp
 }
 
 func (stg *Entrypoint) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, append([]string{"Entrypoint"}, stg.instruction.Data.CmdLine...)...)
 	args = append(args, "PrependShell", fmt.Sprintf("%v", stg.instruction.Data.PrependShell))
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/env.go
+++ b/pkg/build/stage/instruction/env.go
@@ -22,10 +22,7 @@ func NewEnv(i *dockerfile.DockerfileStageInstruction[*instructions.EnvCommand], 
 }
 
 func (stg *Env) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	if len(stg.instruction.Data.Env) > 0 {
 		args = append(args, "Env")
@@ -33,5 +30,6 @@ func (stg *Env) GetDependencies(ctx context.Context, c stage.Conveyor, cb contai
 			args = append(args, item.Key, item.Value)
 		}
 	}
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/expose.go
+++ b/pkg/build/stage/instruction/expose.go
@@ -22,11 +22,9 @@ func NewExpose(i *dockerfile.DockerfileStageInstruction[*instructions.ExposeComm
 }
 
 func (stg *Expose) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, append([]string{"Ports"}, stg.instruction.Data.Ports...)...)
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/healthcheck.go
+++ b/pkg/build/stage/instruction/healthcheck.go
@@ -23,15 +23,13 @@ func NewHealthcheck(i *dockerfile.DockerfileStageInstruction[*instructions.Healt
 }
 
 func (stg *Healthcheck) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, append([]string{"Test"}, stg.instruction.Data.Health.Test...)...)
 	args = append(args, "Interval", stg.instruction.Data.Health.Interval.String())
 	args = append(args, "Timeout", stg.instruction.Data.Health.Timeout.String())
 	args = append(args, "StartPeriod", stg.instruction.Data.Health.StartPeriod.String())
 	args = append(args, "Retries", fmt.Sprintf("%d", stg.instruction.Data.Health.Retries))
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/label.go
+++ b/pkg/build/stage/instruction/label.go
@@ -22,10 +22,7 @@ func NewLabel(i *dockerfile.DockerfileStageInstruction[*instructions.LabelComman
 }
 
 func (stg *Label) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	if len(stg.instruction.Data.Labels) > 0 {
 		args = append(args, "Labels")
@@ -33,5 +30,6 @@ func (stg *Label) GetDependencies(ctx context.Context, c stage.Conveyor, cb cont
 			args = append(args, item.Key, item.Value)
 		}
 	}
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/maintainer.go
+++ b/pkg/build/stage/instruction/maintainer.go
@@ -22,11 +22,9 @@ func NewMaintainer(i *dockerfile.DockerfileStageInstruction[*instructions.Mainta
 }
 
 func (stg *Maintainer) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, "Maintainer", stg.instruction.Data.Maintainer)
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/on_build.go
+++ b/pkg/build/stage/instruction/on_build.go
@@ -22,11 +22,9 @@ func NewOnBuild(i *dockerfile.DockerfileStageInstruction[*instructions.OnbuildCo
 }
 
 func (stg *OnBuild) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, "Expression", stg.instruction.Data.Expression)
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/shell.go
+++ b/pkg/build/stage/instruction/shell.go
@@ -22,11 +22,9 @@ func NewShell(i *dockerfile.DockerfileStageInstruction[*instructions.ShellComman
 }
 
 func (stg *Shell) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, append([]string{"Shell"}, stg.instruction.Data.Shell...)...)
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/stop_signal.go
+++ b/pkg/build/stage/instruction/stop_signal.go
@@ -22,11 +22,9 @@ func NewStopSignal(i *dockerfile.DockerfileStageInstruction[*instructions.StopSi
 }
 
 func (stg *StopSignal) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, "Signal", stg.instruction.Data.Signal)
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/user.go
+++ b/pkg/build/stage/instruction/user.go
@@ -22,11 +22,9 @@ func NewUser(i *dockerfile.DockerfileStageInstruction[*instructions.UserCommand]
 }
 
 func (stg *User) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, "User", stg.instruction.Data.User)
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/volume.go
+++ b/pkg/build/stage/instruction/volume.go
@@ -22,11 +22,9 @@ func NewVolume(i *dockerfile.DockerfileStageInstruction[*instructions.VolumeComm
 }
 
 func (stg *Volume) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, append([]string{"Volumes"}, stg.instruction.Data.Volumes...)...)
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/instruction/workdir.go
+++ b/pkg/build/stage/instruction/workdir.go
@@ -22,11 +22,9 @@ func NewWorkdir(i *dockerfile.DockerfileStageInstruction[*instructions.WorkdirCo
 }
 
 func (stg *Workdir) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
-	args, err := stg.getDependencies(ctx, c, cb, prevImage, prevBuiltImage, buildContextArchive, stg)
-	if err != nil {
-		return "", err
-	}
+	var args []string
 
 	args = append(args, "Path", stg.instruction.Data.Path)
+
 	return util.Sha256Hash(args...), nil
 }

--- a/pkg/build/stage/interface.go
+++ b/pkg/build/stage/interface.go
@@ -14,6 +14,7 @@ type Interface interface {
 
 	IsEmpty(ctx context.Context, c Conveyor, prevBuiltImage *StageImage) (bool, error)
 
+	ExpandDependencies(ctx context.Context, c Conveyor, baseEnv map[string]string) error
 	FetchDependencies(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, dockerRegistry docker_registry.ApiInterface) error
 	GetDependencies(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error)
 	GetNextStageDependencies(ctx context.Context, c Conveyor) (string, error)

--- a/pkg/build/stages_iterator.go
+++ b/pkg/build/stages_iterator.go
@@ -26,7 +26,8 @@ func (iterator *StagesIterator) GetPrevImage(img *build_image.Image, stg stage.I
 	if stg.HasPrevStage() {
 		return iterator.PrevNonEmptyStage.GetStageImage()
 	} else if stg.IsStapelStage() && stg.Name() == "from" {
-		// TODO(staged-dockerfile): this is only for compatibility with stapel-builder logic, and this should be unified with new staged-dockerfile logic
+		return img.GetBaseStageImage()
+	} else if img.IsDockerfileImage && img.DockerfileImageConfig.Staged {
 		return img.GetBaseStageImage()
 	}
 	return nil
@@ -36,7 +37,8 @@ func (iterator *StagesIterator) GetPrevBuiltImage(img *build_image.Image, stg st
 	if stg.HasPrevStage() {
 		return iterator.PrevBuiltStage.GetStageImage()
 	} else if stg.IsStapelStage() && stg.Name() == "from" {
-		// TODO(staged-dockerfile): this is only for compatibility with stapel-builder logic, and this should be unified with new staged-dockerfile logic
+		return img.GetBaseStageImage()
+	} else if img.IsDockerfileImage && img.DockerfileImageConfig.Staged {
 		return img.GetBaseStageImage()
 	}
 	return nil

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -578,6 +578,7 @@ func (runtime *BuildahBackend) GetImageInfo(ctx context.Context, ref string, opt
 		CreatedAtUnixNano: inspect.Docker.Created.UnixNano(),
 		RepoDigest:        inspect.FromImageDigest,
 		OnBuild:           inspect.Docker.Config.OnBuild,
+		Env:               inspect.Docker.Config.Env,
 		ID:                inspect.FromImageID,
 		ParentID:          parentID,
 		Size:              inspect.Docker.Size,

--- a/pkg/container_backend/instruction/run.go
+++ b/pkg/container_backend/instruction/run.go
@@ -14,10 +14,11 @@ import (
 
 type Run struct {
 	*instructions.RunCommand
+	Envs []string
 }
 
-func NewRun(i *instructions.RunCommand) *Run {
-	return &Run{RunCommand: i}
+func NewRun(i *instructions.RunCommand, envs []string) *Run {
+	return &Run{RunCommand: i, Envs: envs}
 }
 
 func (i *Run) UsesBuildContext() bool {
@@ -66,6 +67,7 @@ func (i *Run) Apply(ctx context.Context, containerName string, drv buildah.Build
 		AddCapabilities: addCapabilities,
 		NetworkType:     i.GetNetwork(),
 		RunMounts:       i.GetMounts(),
+		Envs:            i.Envs,
 	}); err != nil {
 		return fmt.Errorf("error running command %v for container %s: %w", i.CmdLine, containerName, err)
 	}

--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -161,6 +161,8 @@ func (api *api) GetRepoImage(_ context.Context, reference string) (*image.Info, 
 		RepoDigest: digest.String(),
 		ParentID:   parentID,
 		Labels:     configFile.Config.Labels,
+		OnBuild:    configFile.Config.OnBuild,
+		Env:        configFile.Config.Env,
 		Size:       totalSize,
 	}
 

--- a/pkg/image/info.go
+++ b/pkg/image/info.go
@@ -18,6 +18,7 @@ type Info struct {
 	RepoDigest string `json:"repoDigest"`
 
 	OnBuild           []string          `json:"onBuild"`
+	Env               []string          `json:"env"`
 	ID                string            `json:"ID"`
 	ParentID          string            `json:"parentID"`
 	Labels            map[string]string `json:"labels"`
@@ -44,6 +45,7 @@ func (info *Info) GetCopy() *Info {
 		Tag:               info.Tag,
 		RepoDigest:        info.RepoDigest,
 		OnBuild:           util.CopyArr(info.OnBuild),
+		Env:               util.CopyArr(info.Env),
 		ID:                info.ID,
 		ParentID:          info.ParentID,
 		Labels:            util.CopyMap(info.Labels),
@@ -75,6 +77,7 @@ func NewInfoFromInspect(ref string, inspect *types.ImageInspect) *Info {
 		Tag:               tag,
 		Labels:            inspect.Config.Labels,
 		OnBuild:           inspect.Config.OnBuild,
+		Env:               inspect.Config.Env,
 		CreatedAtUnixNano: MustParseTimestampString(inspect.Created).UnixNano(),
 		RepoDigest:        repoDigest,
 		ID:                inspect.ID,
@@ -109,6 +112,7 @@ func NewImageInfoFromRegistryConfig(ref string, cfg *v1.ConfigFile) *Info {
 		Tag:               tag,
 		Labels:            cfg.Config.Labels,
 		OnBuild:           cfg.Config.OnBuild,
+		Env:               cfg.Config.Env,
 		CreatedAtUnixNano: cfg.Created.UnixNano(),
 		RepoDigest:        "", // TODO
 		ID:                "", // TODO

--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -923,6 +923,8 @@ func ConvertStageDescriptionForStagesStorage(stageDesc *image.StageDescription, 
 			Labels:            stageDesc.Info.Labels,
 			Size:              stageDesc.Info.Size,
 			CreatedAtUnixNano: stageDesc.Info.CreatedAtUnixNano,
+			OnBuild:           stageDesc.Info.OnBuild,
+			Env:               stageDesc.Info.Env,
 		},
 	}
 }

--- a/test/e2e/build/_fixtures/complex/state0/Dockerfile
+++ b/test/e2e/build/_fixtures/complex/state0/Dockerfile
@@ -35,6 +35,23 @@ RUN echo ${BASE_STAPEL_SHELL_IMAGE_ID} >> base_image_data.txt
 RUN echo ${BASE_STAPEL_SHELL_IMAGE_REPO} >> base_image_data.txt
 RUN echo ${BASE_STAPEL_SHELL_IMAGE_TAG} >> base_image_data.txt
 
+# Complex ARG and ENV usage
+ENV TEST_ENV=$PATH:test-env1
+ENV PATH=$TEST_ENV:custom-path
+ARG TEST_ARG=${TEST_ENV}:${PATH}
+ARG TEST_ARG2=${TEST_ARG}:test-arg-2
+ARG ANOTHER_ARG=$PATH
+ENV PATH=$PATH:/opt/bin
+RUN echo ${PATH} > /PATH
+RUN echo ${ANOTHER_ARG} > /ANOTHER_ARG
+RUN echo ${TEST_ARG} > /TEST_ARG
+RUN echo ${TEST_ARG2} > /TEST_ARG2
+
+COPY script.sh /app/
+ARG USERNAME
+ARG PASSWORD
+RUN /app/script.sh
+
 ENTRYPOINT ["sh", "-ec"]
 CMD ["tail -f /dev/null"]
 VOLUME /volume10

--- a/test/e2e/build/_fixtures/complex/state0/script.sh
+++ b/test/e2e/build/_fixtures/complex/state0/script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo ${USERNAME} > /username
+echo ${PASSWORD} > /password

--- a/test/e2e/build/_fixtures/complex/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/complex/state0/werf.yaml
@@ -9,6 +9,8 @@ target: result
 network: default
 args:
   CHANGED_ARG: "was_changed"
+  USERNAME: "test-username"
+  PASSWORD: "test-password"
 dependencies:
 - image: stapel-shell
   imports:

--- a/test/e2e/build/_fixtures/complex/state1/Dockerfile
+++ b/test/e2e/build/_fixtures/complex/state1/Dockerfile
@@ -32,6 +32,23 @@ RUN echo ${BASE_STAPEL_SHELL_IMAGE_ID} >> base_image_data.txt
 RUN echo ${BASE_STAPEL_SHELL_IMAGE_REPO} >> base_image_data.txt
 RUN echo ${BASE_STAPEL_SHELL_IMAGE_TAG} >> base_image_data.txt
 
+# Complex ARG and ENV usage
+ENV TEST_ENV=$PATH:test-env1
+ENV PATH=$TEST_ENV:custom-path
+ARG TEST_ARG=${TEST_ENV}:${PATH}
+ARG TEST_ARG2=${TEST_ARG}:test-arg-2
+ARG ANOTHER_ARG=$PATH
+ENV PATH=$PATH:/opt/bin
+RUN echo ${PATH} > /PATH
+RUN echo ${ANOTHER_ARG} > /ANOTHER_ARG
+RUN echo ${TEST_ARG} > /TEST_ARG
+RUN echo ${TEST_ARG2} > /TEST_ARG2
+
+COPY script.sh /app/
+ARG USERNAME
+ARG PASSWORD
+RUN /app/script.sh
+
 ENTRYPOINT ["sh", "-ec"]
 CMD ["tail -f /dev/null"]
 ONBUILD RUN echo onbuild

--- a/test/e2e/build/_fixtures/complex/state1/script.sh
+++ b/test/e2e/build/_fixtures/complex/state1/script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo ${USERNAME} > /username
+echo ${PASSWORD} > /password

--- a/test/e2e/build/_fixtures/complex/state1/werf.yaml
+++ b/test/e2e/build/_fixtures/complex/state1/werf.yaml
@@ -9,6 +9,10 @@ target: result
 network: default
 args:
   CHANGED_ARG: "was_changed-state1"
+  USERNAME: "new-username"
+  PASSWORD: "new-password"
+  TEST_ARG: "changed-test-arg"
+  ANOTHER_ARG: "changed-another-arg"
 dependencies:
 - image: stapel-shell
   imports:

--- a/test/e2e/build/complex_test.go
+++ b/test/e2e/build/complex_test.go
@@ -102,6 +102,24 @@ var _ = Describe("Complex build", Label("e2e", "build", "complex"), func() {
 					"test -f /created-by-run-state0",
 
 					"test -d /volume10/should-exist-in-volume",
+
+					"test -f /username",
+					"echo 'test-username' | diff /username -",
+
+					"test -f /password",
+					"echo 'test-password' | diff /password -",
+
+					"test -f /PATH",
+					"echo '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:test-env1:custom-path:/opt/bin' | diff /PATH -",
+
+					"test -f /ANOTHER_ARG",
+					"echo '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:test-env1:custom-path' | diff /ANOTHER_ARG -",
+
+					"test -f /TEST_ARG",
+					"echo '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:test-env1:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:test-env1:custom-path' | diff /TEST_ARG -",
+
+					"test -f /TEST_ARG2",
+					"echo '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:test-env1:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:test-env1:custom-path:test-arg-2' | diff /TEST_ARG2 -",
 				)
 
 				By(`state0: checking "stapel-shell" image content`)
@@ -192,6 +210,24 @@ var _ = Describe("Complex build", Label("e2e", "build", "complex"), func() {
 					"! test -e /helloworld.tgz",
 
 					"test -f /created-by-run-state1",
+
+					"test -f /username",
+					"echo 'new-username' | diff /username -",
+
+					"test -f /password",
+					"echo 'new-password' | diff /password -",
+
+					"test -f /PATH",
+					"echo '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:test-env1:custom-path:/opt/bin' | diff /PATH -",
+
+					"test -f /ANOTHER_ARG",
+					"echo 'changed-another-arg' | diff /ANOTHER_ARG -",
+
+					"test -f /TEST_ARG",
+					"echo 'changed-test-arg' | diff /TEST_ARG -",
+
+					"test -f /TEST_ARG2",
+					"echo 'changed-test-arg:test-arg-2' | diff /TEST_ARG2 -",
 				)
 
 				By(`state1: checking "stapel-shell" image content`)


### PR DESCRIPTION
1. ARG should affect all RUN instruction digests which defined after ARG.
2. ARG could be used in the ENV instruction expansion.
3. ARG should not be expanded in the RUN instruction statically, instead expand it in runtime.

Internally args should be passed as env vars when running RUN instructions.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>