### PR TITLE
feat(bundle): allow non strict bundle publishing

### DIFF
--- a/pkg/deploy/helm/chart_extender/bundle.go
+++ b/pkg/deploy/helm/chart_extender/bundle.go
@@ -250,6 +250,11 @@ var (
 )
 
 func CheckBundlePathAllowed(path string) bool {
+	// TODO(bundles): provide more canonical way to whitelist/blacklist bundle files
+	if os.Getenv("WERF_BUNDLE_SCHEMA_NONSTRICT") == "1" {
+		return true
+	}
+
 	for _, p := range AllowedBundleChartFiles {
 		if p == path {
 			return true


### PR DESCRIPTION
Set WERF_BUNDLE_SCHEMA_NONSTRICT=1 to include all files in the .helm into the published bundle.