### PR TITLE
fix(dependencies): introduce ImageDigest mode, deprecate ImageID mode

### DIFF
--- a/docs/_data/werf_yaml.yml
+++ b/docs/_data/werf_yaml.yml
@@ -276,8 +276,8 @@ sections:
             - name: type
               value: "string"
               description:
-                en: "Type of image info: ImageName, ImageID, ImageRepo or ImageTag"
-                ru: "Тип импортируемой информации об образе: ImageName, ImageID, ImageRepo или ImageTag"
+                en: "Type of image info: ImageName, ImageDigest, ImageRepo or ImageTag"
+                ru: "Тип импортируемой информации об образе: ImageName, ImageDigest, ImageRepo или ImageTag"
             - name: targetBuildArg
               value: "string"
               description:
@@ -797,8 +797,8 @@ sections:
             - name: type
               value: "string"
               description:
-                en: "Type of image info: ImageName, ImageID, ImageRepo or ImageTag"
-                ru: "Тип импортируемой информации об образе: ImageName, ImageID, ImageRepo или ImageTag"
+                en: "Type of image info: ImageName, ImageDigest, ImageRepo or ImageTag"
+                ru: "Тип импортируемой информации об образе: ImageName, ImageDigest, ImageRepo или ImageTag"
             - name: targetEnv
               value: "string"
               description:

--- a/docs/pages_en/usage/build/images.md
+++ b/docs/pages_en/usage/build/images.md
@@ -338,13 +338,13 @@ dependencies:
   imports:
   - type: ImageName
     targetBuildArg: AUTH_IMAGE_NAME
-  - type: ImageID
+  - type: ImageDigest
     targetBuildArg: AUTH_IMAGE_DIGEST
 - image: controlplane
   imports:
   - type: ImageName
     targetBuildArg: CONTROLPLANE_IMAGE_NAME
-  - type: ImageID
+  - type: ImageDigest
     targetBuildArg: CONTROLPLANE_IMAGE_DIGEST
 ```
 

--- a/docs/pages_ru/usage/build/images.md
+++ b/docs/pages_ru/usage/build/images.md
@@ -339,13 +339,13 @@ dependencies:
   imports:
   - type: ImageName
     targetBuildArg: AUTH_IMAGE_NAME
-  - type: ImageID
+  - type: ImageDigest
     targetBuildArg: AUTH_IMAGE_DIGEST
 - image: controlplane
   imports:
   - type: ImageName
     targetBuildArg: CONTROLPLANE_IMAGE_NAME
-  - type: ImageID
+  - type: ImageDigest
     targetBuildArg: CONTROLPLANE_IMAGE_DIGEST
 ```
 

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -721,6 +721,10 @@ func (c *Conveyor) GetImageIDForLastImageStage(imageName string) string {
 	return c.GetImage(imageName).GetLastNonEmptyStage().GetStageImage().Image.GetStageDescription().Info.ID
 }
 
+func (c *Conveyor) GetImageDigestForLastImageStage(imageName string) string {
+	return c.GetImage(imageName).GetLastNonEmptyStage().GetStageImage().Image.GetStageDescription().Info.RepoDigest
+}
+
 func (c *Conveyor) GetImageIDForImageStage(imageName, stageName string) string {
 	return c.getImageStage(imageName, stageName).GetStageImage().Image.GetStageDescription().Info.ID
 }

--- a/pkg/build/stage/conveyor.go
+++ b/pkg/build/stage/conveyor.go
@@ -21,6 +21,7 @@ type Conveyor interface {
 	FetchLastNonEmptyImageStage(ctx context.Context, imageName string) error
 	GetImageNameForLastImageStage(imageName string) string
 	GetImageIDForLastImageStage(imageName string) string
+	GetImageDigestForLastImageStage(imageName string) string
 
 	GetImageNameForImageStage(imageName, stageName string) string
 	GetImageIDForImageStage(imageName, stageName string) string

--- a/pkg/build/stage/data_test.go
+++ b/pkg/build/stage/data_test.go
@@ -18,19 +18,22 @@ type TestDependencies struct {
 type TestDependency struct {
 	ImageName string
 
-	TargetEnvImageName string
-	TargetEnvImageRepo string
-	TargetEnvImageTag  string
-	TargetEnvImageID   string
+	TargetEnvImageName   string
+	TargetEnvImageRepo   string
+	TargetEnvImageTag    string
+	TargetEnvImageID     string
+	TargetEnvImageDigest string
 
-	TargetBuildArgImageName string
-	TargetBuildArgImageRepo string
-	TargetBuildArgImageTag  string
-	TargetBuildArgImageID   string
+	TargetBuildArgImageName   string
+	TargetBuildArgImageRepo   string
+	TargetBuildArgImageTag    string
+	TargetBuildArgImageID     string
+	TargetBuildArgImageDigest string
 
-	DockerImageRepo string
-	DockerImageTag  string
-	DockerImageID   string
+	DockerImageRepo   string
+	DockerImageTag    string
+	DockerImageID     string
+	DockerImageDigest string
 }
 
 func (dep *TestDependency) GetDockerImageName() string {
@@ -64,6 +67,12 @@ func (dep *TestDependency) ToConfigDependency() *config.Dependency {
 			TargetEnv: dep.TargetEnvImageID,
 		})
 	}
+	if dep.TargetEnvImageDigest != "" {
+		depCfg.Imports = append(depCfg.Imports, &config.DependencyImport{
+			Type:      config.ImageDigestImport,
+			TargetEnv: dep.TargetEnvImageDigest,
+		})
+	}
 
 	if dep.TargetBuildArgImageName != "" {
 		depCfg.Imports = append(depCfg.Imports, &config.DependencyImport{
@@ -87,6 +96,12 @@ func (dep *TestDependency) ToConfigDependency() *config.Dependency {
 		depCfg.Imports = append(depCfg.Imports, &config.DependencyImport{
 			Type:           config.ImageIDImport,
 			TargetBuildArg: dep.TargetBuildArgImageID,
+		})
+	}
+	if dep.TargetBuildArgImageDigest != "" {
+		depCfg.Imports = append(depCfg.Imports, &config.DependencyImport{
+			Type:           config.ImageDigestImport,
+			TargetBuildArg: dep.TargetBuildArgImageDigest,
 		})
 	}
 
@@ -114,6 +129,9 @@ func CheckImageDependenciesAfterPrepare(img *LegacyImageStub, stageBuilder *stag
 		}
 		if dep.TargetEnvImageID != "" {
 			Expect(img._Container._ServiceCommitChangeOptions.Env[dep.TargetEnvImageID]).To(Equal(dep.DockerImageID))
+		}
+		if dep.TargetEnvImageDigest != "" {
+			Expect(img._Container._ServiceCommitChangeOptions.Env[dep.TargetEnvImageDigest]).To(Equal(dep.DockerImageDigest))
 		}
 
 		if dep.TargetBuildArgImageName != "" {

--- a/pkg/build/stage/dependencies.go
+++ b/pkg/build/stage/dependencies.go
@@ -127,6 +127,7 @@ func (s *DependenciesStage) prepareImageWithLegacyStapelBuilder(ctx context.Cont
 
 		depImageName := c.GetImageNameForLastImageStage(dep.ImageName)
 		depImageID := c.GetImageIDForLastImageStage(dep.ImageName)
+		depImageDigest := c.GetImageDigestForLastImageStage(dep.ImageName)
 		depImageRepo, depImageTag := imagePkg.ParseRepositoryAndTag(depImageName)
 
 		for _, img := range dep.Imports {
@@ -146,6 +147,10 @@ func (s *DependenciesStage) prepareImageWithLegacyStapelBuilder(ctx context.Cont
 			case config.ImageIDImport:
 				depImageServiceOptions.AddEnv(map[string]string{
 					img.TargetEnv: depImageID,
+				})
+			case config.ImageDigestImport:
+				depImageServiceOptions.AddEnv(map[string]string{
+					img.TargetEnv: depImageDigest,
 				})
 			}
 		}
@@ -182,6 +187,7 @@ func (s *DependenciesStage) prepareImage(ctx context.Context, c Conveyor, cr con
 	for _, dep := range s.dependencies {
 		depImageName := c.GetImageNameForLastImageStage(dep.ImageName)
 		depImageID := c.GetImageIDForLastImageStage(dep.ImageName)
+		depImageDigest := c.GetImageDigestForLastImageStage(dep.ImageName)
 		depImageRepo, depImageTag := imagePkg.ParseRepositoryAndTag(depImageName)
 
 		for _, img := range dep.Imports {
@@ -201,6 +207,10 @@ func (s *DependenciesStage) prepareImage(ctx context.Context, c Conveyor, cr con
 			case config.ImageIDImport:
 				stageImage.Builder.StapelStageBuilder().AddEnvs(map[string]string{
 					img.TargetEnv: depImageID,
+				})
+			case config.ImageDigestImport:
+				stageImage.Builder.StapelStageBuilder().AddEnvs(map[string]string{
+					img.TargetEnv: depImageDigest,
 				})
 			}
 		}

--- a/pkg/build/stage/dependencies_test.go
+++ b/pkg/build/stage/dependencies_test.go
@@ -2,6 +2,7 @@ package stage
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,6 +33,9 @@ var _ = Describe("DependenciesStage", func() {
 
 			digest, err := stage.GetDependencies(ctx, conveyor, containerBackend, nil, stageImage, nil)
 			Expect(err).To(Succeed())
+
+			fmt.Printf("Calculated digest: %q\n", digest)
+			fmt.Printf("Expected digest: %q\n", data.ExpectedDigest)
 			Expect(digest).To(Equal(data.ExpectedDigest))
 
 			err = stage.PrepareImage(ctx, conveyor, containerBackend, nil, stageImage, nil)
@@ -46,7 +50,7 @@ var _ = Describe("DependenciesStage", func() {
 
 		Entry("should change stage digest and set configured environment variables when dependencies are set",
 			TestDependencies{
-				ExpectedDigest: "84f7d49084ba98f8247feba78a217382c6801c7df27cce294566cac69c43d58d",
+				ExpectedDigest: "62b956afc89d0918164545c6336ecbcf3d29415cb42724368c6d331439bee956",
 				Dependencies: []*TestDependency{
 					{
 						ImageName:          "one",
@@ -54,38 +58,43 @@ var _ = Describe("DependenciesStage", func() {
 						TargetEnvImageRepo: "IMAGE_ONE_REPO",
 						TargetEnvImageTag:  "IMAGE_ONE_TAG",
 
-						DockerImageRepo: "ONE_REPO",
-						DockerImageTag:  "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
-						DockerImageID:   "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageRepo:   "ONE_REPO",
+						DockerImageTag:    "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
+						DockerImageID:     "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageDigest: "sha256:6a86a39f70f4dac3df671119ffe66a1d76958e7504e72b1ee9f893a152ef772b",
 					},
 					{
-						ImageName:          "two",
-						TargetEnvImageName: "TWO_NAME",
-						TargetEnvImageRepo: "TWO_REPO",
-						TargetEnvImageTag:  "TWO_TAG",
-						TargetEnvImageID:   "TWO_ID",
+						ImageName:            "two",
+						TargetEnvImageName:   "TWO_NAME",
+						TargetEnvImageRepo:   "TWO_REPO",
+						TargetEnvImageTag:    "TWO_TAG",
+						TargetEnvImageID:     "TWO_ID",
+						TargetEnvImageDigest: "TWO_DIGEST",
 
-						DockerImageRepo: "TWO_REPO",
-						DockerImageTag:  "bc6db8dde5c051349b85dbb8f858f4c80a519a17723d2c67dc9f890c-1643039584147",
-						DockerImageID:   "sha256:5a46fe1fe7f2867aeb0a74cfc5aea79b1003b8d6095e2350332d3c99d7e1df6b",
+						DockerImageRepo:   "TWO_REPO",
+						DockerImageTag:    "bc6db8dde5c051349b85dbb8f858f4c80a519a17723d2c67dc9f890c-1643039584147",
+						DockerImageID:     "sha256:5a46fe1fe7f2867aeb0a74cfc5aea79b1003b8d6095e2350332d3c99d7e1df6b",
+						DockerImageDigest: "sha256:0476c17a17b746284ea1622b4c97f8a9c986a1f1919ea3a9763cf06d8609b425",
 					},
 					{
-						ImageName:          "one",
-						TargetEnvImageName: "ONE_NAME",
-						TargetEnvImageRepo: "ONE_REPO",
-						TargetEnvImageTag:  "ONE_TAG",
-						TargetEnvImageID:   "ONE_ID",
+						ImageName:            "one",
+						TargetEnvImageName:   "ONE_NAME",
+						TargetEnvImageRepo:   "ONE_REPO",
+						TargetEnvImageTag:    "ONE_TAG",
+						TargetEnvImageID:     "ONE_ID",
+						TargetEnvImageDigest: "ONE_DIGEST",
 
-						DockerImageRepo: "ONE_REPO",
-						DockerImageTag:  "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
-						DockerImageID:   "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageRepo:   "ONE_REPO",
+						DockerImageTag:    "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
+						DockerImageID:     "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageDigest: "sha256:87f5ff85f0ff92c6185e6267a2039eff406337a5726c6b668831cdf1262b76e8",
 					},
 				},
 			}),
 
 		Entry("new image added into dependencies should change stage digest and environment variables",
 			TestDependencies{
-				ExpectedDigest: "d1af66208228e2be40cd861ac80d14d068f2c649d9fd345458efe3a48c2927b5",
+				ExpectedDigest: "69812782590820b507d9c8a2f74ed54d6544070ea28028e6fced4bf70f40112e",
 				Dependencies: []*TestDependency{
 					{
 						ImageName:          "one",
@@ -93,46 +102,52 @@ var _ = Describe("DependenciesStage", func() {
 						TargetEnvImageRepo: "IMAGE_ONE_REPO",
 						TargetEnvImageTag:  "IMAGE_ONE_TAG",
 
-						DockerImageRepo: "ONE_REPO",
-						DockerImageTag:  "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
-						DockerImageID:   "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageRepo:   "ONE_REPO",
+						DockerImageTag:    "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
+						DockerImageID:     "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageDigest: "sha256:6a86a39f70f4dac3df671119ffe66a1d76958e7504e72b1ee9f893a152ef772b",
 					},
 					{
-						ImageName:          "two",
-						TargetEnvImageName: "TWO_NAME",
-						TargetEnvImageRepo: "TWO_REPO",
-						TargetEnvImageTag:  "TWO_TAG",
-						TargetEnvImageID:   "TWO_ID",
+						ImageName:            "two",
+						TargetEnvImageName:   "TWO_NAME",
+						TargetEnvImageRepo:   "TWO_REPO",
+						TargetEnvImageTag:    "TWO_TAG",
+						TargetEnvImageID:     "TWO_ID",
+						TargetEnvImageDigest: "TWO_DIGEST",
 
-						DockerImageRepo: "TWO_REPO",
-						DockerImageTag:  "bc6db8dde5c051349b85dbb8f858f4c80a519a17723d2c67dc9f890c-1643039584147",
-						DockerImageID:   "sha256:5a46fe1fe7f2867aeb0a74cfc5aea79b1003b8d6095e2350332d3c99d7e1df6b",
+						DockerImageRepo:   "TWO_REPO",
+						DockerImageTag:    "bc6db8dde5c051349b85dbb8f858f4c80a519a17723d2c67dc9f890c-1643039584147",
+						DockerImageID:     "sha256:5a46fe1fe7f2867aeb0a74cfc5aea79b1003b8d6095e2350332d3c99d7e1df6b",
+						DockerImageDigest: "sha256:0476c17a17b746284ea1622b4c97f8a9c986a1f1919ea3a9763cf06d8609b425",
 					},
 					{
-						ImageName:          "one",
-						TargetEnvImageName: "ONE_NAME",
-						TargetEnvImageRepo: "ONE_REPO",
-						TargetEnvImageTag:  "ONE_TAG",
-						TargetEnvImageID:   "ONE_ID",
+						ImageName:            "one",
+						TargetEnvImageName:   "ONE_NAME",
+						TargetEnvImageRepo:   "ONE_REPO",
+						TargetEnvImageTag:    "ONE_TAG",
+						TargetEnvImageID:     "ONE_ID",
+						TargetEnvImageDigest: "ONE_DIGEST",
 
-						DockerImageRepo: "ONE_REPO",
-						DockerImageTag:  "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
-						DockerImageID:   "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageRepo:   "ONE_REPO",
+						DockerImageTag:    "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
+						DockerImageID:     "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageDigest: "sha256:6a86a39f70f4dac3df671119ffe66a1d76958e7504e72b1ee9f893a152ef772b",
 					},
 					{
 						ImageName:          "three",
 						TargetEnvImageName: "THREE_IMAGE_NAME",
 
-						DockerImageRepo: "THREE_REPO",
-						DockerImageTag:  "custom-tag",
-						DockerImageID:   "sha256:6f510109a5ca7657babd6f3f48fd16c1b887d63857ac411f636967de5aa48d31",
+						DockerImageRepo:   "THREE_REPO",
+						DockerImageTag:    "custom-tag",
+						DockerImageID:     "sha256:6f510109a5ca7657babd6f3f48fd16c1b887d63857ac411f636967de5aa48d31",
+						DockerImageDigest: "sha256:bc18c2bf466481a9773822f3d29f681d866f7291895552609e75f2e7d76b9bcb",
 					},
 				},
 			}),
 
 		Entry("should change stage digest and environment variables when previously added image dependency params has been changed",
 			TestDependencies{
-				ExpectedDigest: "d214e5d775ea7493e2fbe2f1d598d5c613a1c7fd605a55a4c4d98ab9d5161853",
+				ExpectedDigest: "686672be02deb993edb8d41cd97eafdf26ebcfa5b878063ddd887ec623d84a1c",
 				Dependencies: []*TestDependency{
 					{
 						ImageName:          "one",
@@ -140,38 +155,43 @@ var _ = Describe("DependenciesStage", func() {
 						TargetEnvImageRepo: "IMAGE_ONE_REPO",
 						TargetEnvImageTag:  "IMAGE_ONE_TAG",
 
-						DockerImageRepo: "ONE_REPO",
-						DockerImageTag:  "b7aebf280be3fbb7d207d3b659bfc1a49338441ea933c1eac5766a5f-1638863693022",
-						DockerImageID:   "sha256:c62467775792f47c1bb39ceb5dccdafa02db1734f12c8aa07dbb6d618c501166",
+						DockerImageRepo:   "ONE_REPO",
+						DockerImageTag:    "b7aebf280be3fbb7d207d3b659bfc1a49338441ea933c1eac5766a5f-1638863693022",
+						DockerImageID:     "sha256:c62467775792f47c1bb39ceb5dccdafa02db1734f12c8aa07dbb6d618c501166",
+						DockerImageDigest: "sha256:4d0e8f47643342b529b426aebcaac5c67d4744ee2ba54f967433e6b6fc075312",
 					},
 					{
-						ImageName:          "two",
-						TargetEnvImageName: "TWO_NAME",
-						TargetEnvImageRepo: "TWO_REPO",
-						TargetEnvImageTag:  "TWO_TAG",
-						TargetEnvImageID:   "TWO_ID",
+						ImageName:            "two",
+						TargetEnvImageName:   "TWO_NAME",
+						TargetEnvImageRepo:   "TWO_REPO",
+						TargetEnvImageTag:    "TWO_TAG",
+						TargetEnvImageID:     "TWO_ID",
+						TargetEnvImageDigest: "TWO_DIGEST",
 
-						DockerImageRepo: "TWO_REPO",
-						DockerImageTag:  "bc6db8dde5c051349b85dbb8f858f4c80a519a17723d2c67dc9f890c-1643039584147",
-						DockerImageID:   "sha256:5a46fe1fe7f2867aeb0a74cfc5aea79b1003b8d6095e2350332d3c99d7e1df6b",
+						DockerImageRepo:   "TWO_REPO",
+						DockerImageTag:    "bc6db8dde5c051349b85dbb8f858f4c80a519a17723d2c67dc9f890c-1643039584147",
+						DockerImageID:     "sha256:5a46fe1fe7f2867aeb0a74cfc5aea79b1003b8d6095e2350332d3c99d7e1df6b",
+						DockerImageDigest: "sha256:0476c17a17b746284ea1622b4c97f8a9c986a1f1919ea3a9763cf06d8609b425",
 					},
 					{
-						ImageName:          "one",
-						TargetEnvImageName: "ONE_NAME",
-						TargetEnvImageRepo: "ONE_REPO",
-						TargetEnvImageTag:  "ONE_TAG",
-						TargetEnvImageID:   "ONE_ID",
+						ImageName:            "one",
+						TargetEnvImageName:   "ONE_NAME",
+						TargetEnvImageRepo:   "ONE_REPO",
+						TargetEnvImageTag:    "ONE_TAG",
+						TargetEnvImageID:     "ONE_ID",
+						TargetEnvImageDigest: "ONE_DIGEST",
 
-						DockerImageRepo: "ONE_REPO",
-						DockerImageTag:  "b7aebf280be3fbb7d207d3b659bfc1a49338441ea933c1eac5766a5f-1638863693022",
-						DockerImageID:   "sha256:c62467775792f47c1bb39ceb5dccdafa02db1734f12c8aa07dbb6d618c501166",
+						DockerImageRepo:   "ONE_REPO",
+						DockerImageTag:    "b7aebf280be3fbb7d207d3b659bfc1a49338441ea933c1eac5766a5f-1638863693022",
+						DockerImageID:     "sha256:c62467775792f47c1bb39ceb5dccdafa02db1734f12c8aa07dbb6d618c501166",
+						DockerImageDigest: "sha256:4d0e8f47643342b529b426aebcaac5c67d4744ee2ba54f967433e6b6fc075312",
 					},
 				},
 			}),
 
 		Entry("should change stage digest and set configured environment variables when dependant image environment variable has been changed",
 			TestDependencies{
-				ExpectedDigest: "d0f6634579c776b6db5789d9c20e1f36a4c03bc7057a575d6965e4513fa27f8c",
+				ExpectedDigest: "1aa753aa608f9f19c85732d338e2f96236c2d2463de776b84936bedade37e9ce",
 				Dependencies: []*TestDependency{
 					{
 						ImageName:          "one",
@@ -179,31 +199,36 @@ var _ = Describe("DependenciesStage", func() {
 						TargetEnvImageRepo: "IMAGE_ONE_REPO",
 						TargetEnvImageTag:  "IMAGE_ONE_TAG_VARIABLE",
 
-						DockerImageRepo: "ONE_REPO",
-						DockerImageTag:  "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
-						DockerImageID:   "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageRepo:   "ONE_REPO",
+						DockerImageTag:    "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
+						DockerImageID:     "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageDigest: "sha256:6a86a39f70f4dac3df671119ffe66a1d76958e7504e72b1ee9f893a152ef772b",
 					},
 					{
-						ImageName:          "two",
-						TargetEnvImageName: "TWO_NAME",
-						TargetEnvImageRepo: "TWO_REPO",
-						TargetEnvImageTag:  "TWO_TAG",
-						TargetEnvImageID:   "TWO_ID",
+						ImageName:            "two",
+						TargetEnvImageName:   "TWO_NAME",
+						TargetEnvImageRepo:   "TWO_REPO",
+						TargetEnvImageTag:    "TWO_TAG",
+						TargetEnvImageID:     "TWO_ID",
+						TargetEnvImageDigest: "TWO_DIGEST",
 
-						DockerImageRepo: "TWO_REPO",
-						DockerImageTag:  "bc6db8dde5c051349b85dbb8f858f4c80a519a17723d2c67dc9f890c-1643039584147",
-						DockerImageID:   "sha256:5a46fe1fe7f2867aeb0a74cfc5aea79b1003b8d6095e2350332d3c99d7e1df6b",
+						DockerImageRepo:   "TWO_REPO",
+						DockerImageTag:    "bc6db8dde5c051349b85dbb8f858f4c80a519a17723d2c67dc9f890c-1643039584147",
+						DockerImageID:     "sha256:5a46fe1fe7f2867aeb0a74cfc5aea79b1003b8d6095e2350332d3c99d7e1df6b",
+						DockerImageDigest: "sha256:0476c17a17b746284ea1622b4c97f8a9c986a1f1919ea3a9763cf06d8609b425",
 					},
 					{
-						ImageName:          "one",
-						TargetEnvImageName: "ONE_NAME",
-						TargetEnvImageRepo: "ONE_REPO",
-						TargetEnvImageTag:  "ONE_TAG",
-						TargetEnvImageID:   "ONE_ID",
+						ImageName:            "one",
+						TargetEnvImageName:   "ONE_NAME",
+						TargetEnvImageRepo:   "ONE_REPO",
+						TargetEnvImageTag:    "ONE_TAG",
+						TargetEnvImageID:     "ONE_ID",
+						TargetEnvImageDigest: "ONE_DIGEST",
 
-						DockerImageRepo: "ONE_REPO",
-						DockerImageTag:  "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
-						DockerImageID:   "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageRepo:   "ONE_REPO",
+						DockerImageTag:    "796e905d0cc975e718b3f8b3ea0199ea4d52668ecc12c4dbf85a136d-1638863657513",
+						DockerImageID:     "sha256:d19deb06171086017db6aade408ce29592e7490f3b98d4da228ef6c771ddc6d5",
+						DockerImageDigest: "sha256:6a86a39f70f4dac3df671119ffe66a1d76958e7504e72b1ee9f893a152ef772b",
 					},
 				},
 			}),
@@ -274,11 +299,13 @@ var _ = Describe("getDependencies helper", func() {
 func NewConveyorStubForDependencies(giterminismManager *GiterminismManagerStub, dependencies []*TestDependency) *ConveyorStub {
 	lastStageImageNameByImageName := make(map[string]string)
 	lastStageImageIDByImageName := make(map[string]string)
+	lastStageImageDigestByImageName := make(map[string]string)
 
 	for _, dep := range dependencies {
 		lastStageImageNameByImageName[dep.ImageName] = dep.GetDockerImageName()
 		lastStageImageIDByImageName[dep.ImageName] = dep.DockerImageID
+		lastStageImageDigestByImageName[dep.ImageName] = dep.DockerImageDigest
 	}
 
-	return NewConveyorStub(giterminismManager, lastStageImageNameByImageName, lastStageImageIDByImageName)
+	return NewConveyorStub(giterminismManager, lastStageImageNameByImageName, lastStageImageIDByImageName, lastStageImageDigestByImageName)
 }

--- a/pkg/build/stage/dependencies_utils.go
+++ b/pkg/build/stage/dependencies_utils.go
@@ -20,6 +20,7 @@ func ResolveDependenciesArgs(dependencies []*config.Dependency, c Conveyor) map[
 	for _, dep := range dependencies {
 		depImageName := c.GetImageNameForLastImageStage(dep.ImageName)
 		depImageID := c.GetImageIDForLastImageStage(dep.ImageName)
+		depImageDigest := c.GetImageDigestForLastImageStage(dep.ImageName)
 		depImageRepo, depImageTag := image.ParseRepositoryAndTag(depImageName)
 
 		for _, imp := range dep.Imports {
@@ -32,6 +33,8 @@ func ResolveDependenciesArgs(dependencies []*config.Dependency, c Conveyor) map[
 				resolved[imp.TargetBuildArg] = depImageName
 			case config.ImageIDImport:
 				resolved[imp.TargetBuildArg] = depImageID
+			case config.ImageDigestImport:
+				resolved[imp.TargetBuildArg] = depImageDigest
 			}
 		}
 	}

--- a/pkg/build/stage/instruction/stubs_test.go
+++ b/pkg/build/stage/instruction/stubs_test.go
@@ -32,8 +32,8 @@ type TestData struct {
 }
 
 type TestDataOptions struct {
-	Files                                                      []*FileData
-	LastStageImageNameByWerfImage, LastStageImageIDByWerfImage map[string]string
+	Files                                                                                       []*FileData
+	LastStageImageNameByWerfImage, LastStageImageIDByWerfImage, LastStageImageDigestByWerfImage map[string]string
 }
 
 func NewTestData(stg stage.Interface, expectedDigest string, opts TestDataOptions) *TestData {
@@ -41,6 +41,7 @@ func NewTestData(stg stage.Interface, expectedDigest string, opts TestDataOption
 		stage.NewGiterminismManagerStub(stage.NewLocalGitRepoStub("9d8059842b6fde712c58315ca0ab4713d90761c0"), stage.NewGiterminismInspectorStub()),
 		opts.LastStageImageNameByWerfImage,
 		opts.LastStageImageIDByWerfImage,
+		opts.LastStageImageDigestByWerfImage,
 	)
 	containerBackend := stage.NewContainerBackendStub()
 

--- a/pkg/build/stage/stubs.go
+++ b/pkg/build/stage/stubs.go
@@ -65,16 +65,18 @@ func (opts *LegacyContainerOptionsStub) AddEnv(envs map[string]string) {
 type ConveyorStub struct {
 	Conveyor
 
-	giterminismManager            *GiterminismManagerStub
-	lastStageImageNameByImageName map[string]string
-	lastStageImageIDByImageName   map[string]string
+	giterminismManager              *GiterminismManagerStub
+	lastStageImageNameByImageName   map[string]string
+	lastStageImageIDByImageName     map[string]string
+	lastStageImageDigestByImageName map[string]string
 }
 
-func NewConveyorStub(giterminismManager *GiterminismManagerStub, lastStageImageNameByImageName, lastStageImageIDByImageName map[string]string) *ConveyorStub {
+func NewConveyorStub(giterminismManager *GiterminismManagerStub, lastStageImageNameByImageName, lastStageImageIDByImageName, lastStageImageDigestByImageName map[string]string) *ConveyorStub {
 	return &ConveyorStub{
-		giterminismManager:            giterminismManager,
-		lastStageImageNameByImageName: lastStageImageNameByImageName,
-		lastStageImageIDByImageName:   lastStageImageIDByImageName,
+		giterminismManager:              giterminismManager,
+		lastStageImageNameByImageName:   lastStageImageNameByImageName,
+		lastStageImageIDByImageName:     lastStageImageIDByImageName,
+		lastStageImageDigestByImageName: lastStageImageDigestByImageName,
 	}
 }
 
@@ -88,6 +90,10 @@ func (c *ConveyorStub) GetImageNameForLastImageStage(imageName string) string {
 
 func (c *ConveyorStub) GetImageIDForLastImageStage(imageName string) string {
 	return c.lastStageImageIDByImageName[imageName]
+}
+
+func (c *ConveyorStub) GetImageDigestForLastImageStage(imageName string) string {
+	return c.lastStageImageDigestByImageName[imageName]
 }
 
 func (c *ConveyorStub) GiterminismManager() giterminism_manager.Interface {

--- a/pkg/config/dependency_import.go
+++ b/pkg/config/dependency_import.go
@@ -15,9 +15,9 @@ type DependencyImport struct {
 
 func (i *DependencyImport) validate() error {
 	switch i.Type {
-	case ImageNameImport, ImageTagImport, ImageRepoImport, ImageIDImport:
+	case ImageNameImport, ImageTagImport, ImageRepoImport, ImageIDImport, ImageDigestImport:
 	default:
-		return newDetailedConfigError(fmt.Sprintf("invalid `type: %s` for dependency import, expected one of: %s", i.Type, strings.Join([]string{string(ImageNameImport), string(ImageTagImport), string(ImageRepoImport)}, ", ")), i.raw, i.raw.rawDependency.doc())
+		return newDetailedConfigError(fmt.Sprintf("invalid `type: %s` for dependency import, expected one of: %s", i.Type, strings.Join([]string{string(ImageNameImport), string(ImageTagImport), string(ImageRepoImport), string(ImageIDImport), string(ImageDigestImport)}, ", ")), i.raw, i.raw.rawDependency.doc())
 	}
 
 	switch imgType := i.raw.rawDependency.imageType(); imgType {

--- a/pkg/config/dependency_import_type.go
+++ b/pkg/config/dependency_import_type.go
@@ -3,8 +3,9 @@ package config
 type DependencyImportType string
 
 const (
-	ImageNameImport DependencyImportType = "ImageName"
-	ImageTagImport  DependencyImportType = "ImageTag"
-	ImageRepoImport DependencyImportType = "ImageRepo"
-	ImageIDImport   DependencyImportType = "ImageID"
+	ImageNameImport   DependencyImportType = "ImageName"
+	ImageTagImport    DependencyImportType = "ImageTag"
+	ImageRepoImport   DependencyImportType = "ImageRepo"
+	ImageIDImport     DependencyImportType = "ImageID"
+	ImageDigestImport DependencyImportType = "ImageDigest"
 )

--- a/pkg/config/raw_image_from_dockerfile_test.go
+++ b/pkg/config/raw_image_from_dockerfile_test.go
@@ -130,6 +130,10 @@ var _ = Describe("rawImageFromDockerfile", func() {
 								"targetBuildArg": "IMAGE_ID_2",
 							},
 							{
+								"type":           string(ImageDigestImport),
+								"targetBuildArg": "IMAGE_DIGEST_2",
+							},
+							{
 								"type":           string(ImageRepoImport),
 								"targetBuildArg": "IMAGE_REPO_2",
 							},
@@ -168,6 +172,10 @@ var _ = Describe("rawImageFromDockerfile", func() {
 						{
 							Type:           ImageIDImport,
 							TargetBuildArg: "IMAGE_ID_2",
+						},
+						{
+							Type:           ImageDigestImport,
+							TargetBuildArg: "IMAGE_DIGEST_2",
 						},
 						{
 							Type:           ImageRepoImport,

--- a/pkg/config/raw_stapel_image_test.go
+++ b/pkg/config/raw_stapel_image_test.go
@@ -133,6 +133,10 @@ var _ = Describe("rawStapelImage", func() {
 								"targetEnv": "IMAGE_ID_2",
 							},
 							{
+								"type":      string(ImageDigestImport),
+								"targetEnv": "IMAGE_DIGEST_2",
+							},
+							{
 								"type":      string(ImageRepoImport),
 								"targetEnv": "IMAGE_REPO_2",
 							},
@@ -174,6 +178,10 @@ var _ = Describe("rawStapelImage", func() {
 						{
 							Type:      ImageIDImport,
 							TargetEnv: "IMAGE_ID_2",
+						},
+						{
+							Type:      ImageDigestImport,
+							TargetEnv: "IMAGE_DIGEST_2",
 						},
 						{
 							Type:      ImageRepoImport,


### PR DESCRIPTION
ImageID mode uses local docker image id which is useless and should be deprecated. ImageDigest mode uses manifest checksum (repo-digest) of image published into container registry.