### PR TITLE
feat: add --deploy-report-path, --build-report-path

### DIFF
--- a/cmd/werf/build/main.go
+++ b/cmd/werf/build/main.go
@@ -99,8 +99,10 @@ func NewCmd(ctx context.Context) *cobra.Command {
 	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
-	common.SetupReportPath(&commonCmdData, cmd)
-	common.SetupReportFormat(&commonCmdData, cmd)
+	common.SetupDeprecatedReportPath(&commonCmdData, cmd)
+	common.SetupDeprecatedReportFormat(&commonCmdData, cmd)
+	common.SetupBuildReportPath(&commonCmdData, cmd)
+	common.SetupBuildReportFormat(&commonCmdData, cmd)
 
 	common.SetupAddCustomTag(&commonCmdData, cmd)
 	common.SetupVirtualMerge(&commonCmdData, cmd)
@@ -236,7 +238,7 @@ func run(ctx context.Context, containerBackend container_backend.ContainerBacken
 
 	storageManager := manager.NewStorageManager(projectName, stagesStorage, finalStagesStorage, secondaryStagesStorageList, cacheStagesStorageList, storageLockManager)
 
-	buildOptions, err := common.GetBuildOptions(&commonCmdData, giterminismManager, werfConfig)
+	buildOptions, err := common.GetBuildOptions(ctx, &commonCmdData, giterminismManager, werfConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/werf/bundle/apply/apply.go
+++ b/cmd/werf/bundle/apply/apply.go
@@ -87,6 +87,8 @@ func NewCmd(ctx context.Context) *cobra.Command {
 	common.SetupSecretValues(&commonCmdData, cmd)
 	common.SetupIgnoreSecretKey(&commonCmdData, cmd)
 
+	common.SetupDeployReportPath(&commonCmdData, cmd)
+
 	common.SetupKubeConfig(&commonCmdData, cmd)
 	common.SetupKubeConfigBase64(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
@@ -227,13 +229,14 @@ func runApply(ctx context.Context) error {
 			Values:       common.GetSet(&commonCmdData),
 			FileValues:   common.GetSetFile(&commonCmdData),
 		},
-		CreateNamespace: common.NewBool(true),
-		Install:         common.NewBool(true),
-		Wait:            common.NewBool(true),
-		Atomic:          common.NewBool(cmdData.AutoRollback),
-		Timeout:         common.NewDuration(time.Duration(cmdData.Timeout) * time.Second),
-		IgnorePending:   common.NewBool(true),
-		CleanupOnFail:   common.NewBool(true),
+		CreateNamespace:  common.NewBool(true),
+		Install:          common.NewBool(true),
+		Wait:             common.NewBool(true),
+		Atomic:           common.NewBool(cmdData.AutoRollback),
+		Timeout:          common.NewDuration(time.Duration(cmdData.Timeout) * time.Second),
+		IgnorePending:    common.NewBool(true),
+		CleanupOnFail:    common.NewBool(true),
+		DeployReportPath: commonCmdData.DeployReportPath,
 	})
 
 	return command_helpers.LockReleaseWrapper(ctx, releaseName, lockManager, func() error {

--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -126,8 +126,10 @@ func NewCmd(ctx context.Context) *cobra.Command {
 	commonCmdData.SetupDisableDefaultValues(cmd)
 	commonCmdData.SetupSkipDependenciesRepoRefresh(cmd)
 
-	common.SetupReportPath(&commonCmdData, cmd)
-	common.SetupReportFormat(&commonCmdData, cmd)
+	common.SetupDeprecatedReportPath(&commonCmdData, cmd)
+	common.SetupDeprecatedReportFormat(&commonCmdData, cmd)
+	common.SetupBuildReportPath(&commonCmdData, cmd)
+	common.SetupBuildReportFormat(&commonCmdData, cmd)
 
 	common.SetupUseCustomTag(&commonCmdData, cmd)
 	common.SetupVirtualMerge(&commonCmdData, cmd)
@@ -239,7 +241,7 @@ func runExport(ctx context.Context, imagesToProcess build.ImagesToProcess) error
 		return err
 	}
 
-	buildOptions, err := common.GetBuildOptions(&commonCmdData, giterminismManager, werfConfig)
+	buildOptions, err := common.GetBuildOptions(ctx, &commonCmdData, giterminismManager, werfConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -115,8 +115,10 @@ func NewCmd(ctx context.Context) *cobra.Command {
 	commonCmdData.SetupDisableDefaultValues(cmd)
 	commonCmdData.SetupSkipDependenciesRepoRefresh(cmd)
 
-	common.SetupReportPath(&commonCmdData, cmd)
-	common.SetupReportFormat(&commonCmdData, cmd)
+	common.SetupDeprecatedReportPath(&commonCmdData, cmd)
+	common.SetupDeprecatedReportFormat(&commonCmdData, cmd)
+	common.SetupBuildReportPath(&commonCmdData, cmd)
+	common.SetupBuildReportFormat(&commonCmdData, cmd)
 
 	common.SetupUseCustomTag(&commonCmdData, cmd)
 	common.SetupAddCustomTag(&commonCmdData, cmd)
@@ -238,7 +240,7 @@ func runPublish(ctx context.Context, imagesToProcess build.ImagesToProcess) erro
 		return err
 	}
 
-	buildOptions, err := common.GetBuildOptions(&commonCmdData, giterminismManager, werfConfig)
+	buildOptions, err := common.GetBuildOptions(ctx, &commonCmdData, giterminismManager, werfConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/werf/common/cmd_data.go
+++ b/cmd/werf/common/cmd_data.go
@@ -91,8 +91,11 @@ type CmdData struct {
 	LogProjectDir    *bool
 	LogTerminalWidth *int64
 
-	ReportPath   *string
-	ReportFormat *string
+	DeprecatedReportPath   *string
+	DeprecatedReportFormat *string
+	BuildReportPath        *string
+	BuildReportFormat      *string
+	DeployReportPath       *string
 
 	VirtualMerge *bool
 

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -159,8 +159,11 @@ werf converge --repo registry.mydomain.com/web --env production`,
 	commonCmdData.SetupDisableDefaultSecretValues(cmd)
 	commonCmdData.SetupSkipDependenciesRepoRefresh(cmd)
 
-	common.SetupReportPath(&commonCmdData, cmd)
-	common.SetupReportFormat(&commonCmdData, cmd)
+	common.SetupDeprecatedReportPath(&commonCmdData, cmd)
+	common.SetupDeprecatedReportFormat(&commonCmdData, cmd)
+	common.SetupBuildReportPath(&commonCmdData, cmd)
+	common.SetupBuildReportFormat(&commonCmdData, cmd)
+	common.SetupDeployReportPath(&commonCmdData, cmd)
 
 	common.SetupUseCustomTag(&commonCmdData, cmd)
 	common.SetupAddCustomTag(&commonCmdData, cmd)
@@ -287,7 +290,7 @@ func run(ctx context.Context, containerBackend container_backend.ContainerBacken
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
-	buildOptions, err := common.GetBuildOptions(&commonCmdData, giterminismManager, werfConfig)
+	buildOptions, err := common.GetBuildOptions(ctx, &commonCmdData, giterminismManager, werfConfig)
 	if err != nil {
 		return err
 	}
@@ -483,6 +486,7 @@ func run(ctx context.Context, containerBackend container_backend.ContainerBacken
 		Timeout:                     common.NewDuration(time.Duration(cmdData.Timeout) * time.Second),
 		IgnorePending:               common.NewBool(true),
 		CleanupOnFail:               common.NewBool(true),
+		DeployReportPath:            commonCmdData.DeployReportPath,
 	})
 
 	return command_helpers.LockReleaseWrapper(ctx, releaseName, lockManager, func() error {

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -137,8 +137,10 @@ func NewCmd(ctx context.Context) *cobra.Command {
 	commonCmdData.SetupDisableDefaultSecretValues(cmd)
 	commonCmdData.SetupSkipDependenciesRepoRefresh(cmd)
 
-	common.SetupReportPath(&commonCmdData, cmd)
-	common.SetupReportFormat(&commonCmdData, cmd)
+	common.SetupDeprecatedReportPath(&commonCmdData, cmd)
+	common.SetupDeprecatedReportFormat(&commonCmdData, cmd)
+	common.SetupBuildReportPath(&commonCmdData, cmd)
+	common.SetupBuildReportFormat(&commonCmdData, cmd)
 
 	common.SetupUseCustomTag(&commonCmdData, cmd)
 	common.SetupVirtualMerge(&commonCmdData, cmd)
@@ -253,7 +255,7 @@ func runRender(ctx context.Context, imagesToProcess build.ImagesToProcess) error
 		return err
 	}
 
-	buildOptions, err := common.GetBuildOptions(&commonCmdData, giterminismManager, werfConfig)
+	buildOptions, err := common.GetBuildOptions(ctx, &commonCmdData, giterminismManager, werfConfig)
 	if err != nil {
 		return err
 	}

--- a/docs/_includes/reference/cli/werf_build.md
+++ b/docs/_includes/reference/cli/werf_build.md
@@ -67,6 +67,31 @@ werf build [IMAGE_NAME...] [options]
             until volume usage becomes below "allowed-docker-storage-volume-usage -                 
             allowed-docker-storage-volume-usage-margin" level (default 5% or                        
             $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
+      --build-report-format=''
+            Report format: json or envfile (json or $WERF_BUILD_REPORT_FORMAT by default)
+            json:
+            	{
+            	  "Images": {
+            		"<WERF_IMAGE_NAME>": {
+            			"WerfImageName": "<WERF_IMAGE_NAME>",
+            			"DockerRepo": "<REPO>",
+            			"DockerTag": "<TAG>"
+            			"DockerImageName": "<REPO>:<TAG>",
+            			"DockerImageID": "<SHA256>",
+            			"DockerImageDigest": "<SHA256>",
+            		},
+            		...
+            	  }
+            	}
+            envfile:
+            	WERF_<FORMATTED_WERF_IMAGE_NAME>_DOCKER_IMAGE_NAME=<REPO>:<TAG>
+            	...
+            <FORMATTED_WERF_IMAGE_NAME> is werf image name from werf.yaml modified according to the 
+            following rules:
+            - all characters are uppercase (app -> APP);
+            - charset /- is replaced with _ (DEV/APP-FRONTEND -> DEV_APP_FRONTEND)
+      --build-report-path=''
+            Report save path ($WERF_BUILD_REPORT_PATH by default)
       --cache-repo=[]
             Specify one or multiple cache repos with images that will be used as a cache. Cache     
             will be populated when pushing newly built images into the primary repo and when        
@@ -248,9 +273,9 @@ werf build [IMAGE_NAME...] [options]
             repo Selectel VPC (default $WERF_REPO_SELECTEL_VPC)
       --repo-selectel-vpc-id=''
             repo Selectel VPC ID (default $WERF_REPO_SELECTEL_VPC_ID)
-      --report-format='json'
-            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default)
-            json:
+      --report-format=''
+            DEPRECATED: use --build-report-format.
+            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default) json:
             	{
             	  "Images": {
             		"<WERF_IMAGE_NAME>": {
@@ -272,6 +297,7 @@ werf build [IMAGE_NAME...] [options]
             - all characters are uppercase (app -> APP);
             - charset /- is replaced with _ (DEV/APP-FRONTEND -> DEV_APP_FRONTEND)
       --report-path=''
+            DEPRECATED: use --build-report-path.
             Report save path ($WERF_REPORT_PATH by default)
       --secondary-repo=[]
             Specify one or multiple secondary read-only repos with images that will be used as a    

--- a/docs/_includes/reference/cli/werf_bundle_apply.md
+++ b/docs/_includes/reference/cli/werf_bundle_apply.md
@@ -26,6 +26,8 @@ werf bundle apply [options]
             Format: labelName=labelValue.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
+      --deploy-report-path=''
+            Deploy report save path ($WERF_DEPLOY_REPORT_PATH by default)
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)

--- a/docs/_includes/reference/cli/werf_bundle_export.md
+++ b/docs/_includes/reference/cli/werf_bundle_export.md
@@ -43,6 +43,31 @@ werf bundle export [IMAGE_NAME...] [options]
             until volume usage becomes below "allowed-docker-storage-volume-usage -                 
             allowed-docker-storage-volume-usage-margin" level (default 5% or                        
             $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
+      --build-report-format=''
+            Report format: json or envfile (json or $WERF_BUILD_REPORT_FORMAT by default)
+            json:
+            	{
+            	  "Images": {
+            		"<WERF_IMAGE_NAME>": {
+            			"WerfImageName": "<WERF_IMAGE_NAME>",
+            			"DockerRepo": "<REPO>",
+            			"DockerTag": "<TAG>"
+            			"DockerImageName": "<REPO>:<TAG>",
+            			"DockerImageID": "<SHA256>",
+            			"DockerImageDigest": "<SHA256>",
+            		},
+            		...
+            	  }
+            	}
+            envfile:
+            	WERF_<FORMATTED_WERF_IMAGE_NAME>_DOCKER_IMAGE_NAME=<REPO>:<TAG>
+            	...
+            <FORMATTED_WERF_IMAGE_NAME> is werf image name from werf.yaml modified according to the 
+            following rules:
+            - all characters are uppercase (app -> APP);
+            - charset /- is replaced with _ (DEV/APP-FRONTEND -> DEV_APP_FRONTEND)
+      --build-report-path=''
+            Report save path ($WERF_BUILD_REPORT_PATH by default)
       --cache-repo=[]
             Specify one or multiple cache repos with images that will be used as a cache. Cache     
             will be populated when pushing newly built images into the primary repo and when        
@@ -216,9 +241,9 @@ werf bundle export [IMAGE_NAME...] [options]
             repo Selectel VPC (default $WERF_REPO_SELECTEL_VPC)
       --repo-selectel-vpc-id=''
             repo Selectel VPC ID (default $WERF_REPO_SELECTEL_VPC_ID)
-      --report-format='json'
-            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default)
-            json:
+      --report-format=''
+            DEPRECATED: use --build-report-format.
+            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default) json:
             	{
             	  "Images": {
             		"<WERF_IMAGE_NAME>": {
@@ -240,6 +265,7 @@ werf bundle export [IMAGE_NAME...] [options]
             - all characters are uppercase (app -> APP);
             - charset /- is replaced with _ (DEV/APP-FRONTEND -> DEV_APP_FRONTEND)
       --report-path=''
+            DEPRECATED: use --build-report-path.
             Report save path ($WERF_REPORT_PATH by default)
       --secondary-repo=[]
             Specify one or multiple secondary read-only repos with images that will be used as a    

--- a/docs/_includes/reference/cli/werf_bundle_publish.md
+++ b/docs/_includes/reference/cli/werf_bundle_publish.md
@@ -54,6 +54,31 @@ werf bundle publish [IMAGE_NAME...] [options]
             until volume usage becomes below "allowed-docker-storage-volume-usage -                 
             allowed-docker-storage-volume-usage-margin" level (default 5% or                        
             $WERF_ALLOWED_LOCAL_CACHE_VOLUME_USAGE_MARGIN)
+      --build-report-format=''
+            Report format: json or envfile (json or $WERF_BUILD_REPORT_FORMAT by default)
+            json:
+            	{
+            	  "Images": {
+            		"<WERF_IMAGE_NAME>": {
+            			"WerfImageName": "<WERF_IMAGE_NAME>",
+            			"DockerRepo": "<REPO>",
+            			"DockerTag": "<TAG>"
+            			"DockerImageName": "<REPO>:<TAG>",
+            			"DockerImageID": "<SHA256>",
+            			"DockerImageDigest": "<SHA256>",
+            		},
+            		...
+            	  }
+            	}
+            envfile:
+            	WERF_<FORMATTED_WERF_IMAGE_NAME>_DOCKER_IMAGE_NAME=<REPO>:<TAG>
+            	...
+            <FORMATTED_WERF_IMAGE_NAME> is werf image name from werf.yaml modified according to the 
+            following rules:
+            - all characters are uppercase (app -> APP);
+            - charset /- is replaced with _ (DEV/APP-FRONTEND -> DEV_APP_FRONTEND)
+      --build-report-path=''
+            Report save path ($WERF_BUILD_REPORT_PATH by default)
       --cache-repo=[]
             Specify one or multiple cache repos with images that will be used as a cache. Cache     
             will be populated when pushing newly built images into the primary repo and when        
@@ -243,9 +268,9 @@ werf bundle publish [IMAGE_NAME...] [options]
             repo Selectel VPC (default $WERF_REPO_SELECTEL_VPC)
       --repo-selectel-vpc-id=''
             repo Selectel VPC ID (default $WERF_REPO_SELECTEL_VPC_ID)
-      --report-format='json'
-            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default)
-            json:
+      --report-format=''
+            DEPRECATED: use --build-report-format.
+            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default) json:
             	{
             	  "Images": {
             		"<WERF_IMAGE_NAME>": {
@@ -267,6 +292,7 @@ werf bundle publish [IMAGE_NAME...] [options]
             - all characters are uppercase (app -> APP);
             - charset /- is replaced with _ (DEV/APP-FRONTEND -> DEV_APP_FRONTEND)
       --report-path=''
+            DEPRECATED: use --build-report-path.
             Report save path ($WERF_REPORT_PATH by default)
       --secondary-repo=[]
             Specify one or multiple secondary read-only repos with images that will be used as a    

--- a/docs/_includes/reference/cli/werf_converge.md
+++ b/docs/_includes/reference/cli/werf_converge.md
@@ -84,6 +84,31 @@ werf converge --repo registry.mydomain.com/web --env production
   -R, --auto-rollback=false
             Enable auto rollback of the failed release to the previous deployed release version     
             when current deploy process have failed ($WERF_AUTO_ROLLBACK by default)
+      --build-report-format=''
+            Report format: json or envfile (json or $WERF_BUILD_REPORT_FORMAT by default)
+            json:
+            	{
+            	  "Images": {
+            		"<WERF_IMAGE_NAME>": {
+            			"WerfImageName": "<WERF_IMAGE_NAME>",
+            			"DockerRepo": "<REPO>",
+            			"DockerTag": "<TAG>"
+            			"DockerImageName": "<REPO>:<TAG>",
+            			"DockerImageID": "<SHA256>",
+            			"DockerImageDigest": "<SHA256>",
+            		},
+            		...
+            	  }
+            	}
+            envfile:
+            	WERF_<FORMATTED_WERF_IMAGE_NAME>_DOCKER_IMAGE_NAME=<REPO>:<TAG>
+            	...
+            <FORMATTED_WERF_IMAGE_NAME> is werf image name from werf.yaml modified according to the 
+            following rules:
+            - all characters are uppercase (app -> APP);
+            - charset /- is replaced with _ (DEV/APP-FRONTEND -> DEV_APP_FRONTEND)
+      --build-report-path=''
+            Report save path ($WERF_BUILD_REPORT_PATH by default)
       --cache-repo=[]
             Specify one or multiple cache repos with images that will be used as a cache. Cache     
             will be populated when pushing newly built images into the primary repo and when        
@@ -96,6 +121,8 @@ werf converge --repo registry.mydomain.com/web --env production
       --config-templates-dir=''
             Custom configuration templates directory (default $WERF_CONFIG_TEMPLATES_DIR or .werf   
             in working directory)
+      --deploy-report-path=''
+            Deploy report save path ($WERF_DEPLOY_REPORT_PATH by default)
       --dev=false
             Enable development mode (default $WERF_DEV).
             The mode allows working with project files without doing redundant commits during       
@@ -284,9 +311,9 @@ werf converge --repo registry.mydomain.com/web --env production
             repo Selectel VPC (default $WERF_REPO_SELECTEL_VPC)
       --repo-selectel-vpc-id=''
             repo Selectel VPC ID (default $WERF_REPO_SELECTEL_VPC_ID)
-      --report-format='json'
-            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default)
-            json:
+      --report-format=''
+            DEPRECATED: use --build-report-format.
+            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default) json:
             	{
             	  "Images": {
             		"<WERF_IMAGE_NAME>": {
@@ -308,6 +335,7 @@ werf converge --repo registry.mydomain.com/web --env production
             - all characters are uppercase (app -> APP);
             - charset /- is replaced with _ (DEV/APP-FRONTEND -> DEV_APP_FRONTEND)
       --report-path=''
+            DEPRECATED: use --build-report-path.
             Report save path ($WERF_REPORT_PATH by default)
       --secondary-repo=[]
             Specify one or multiple secondary read-only repos with images that will be used as a    

--- a/docs/_includes/reference/cli/werf_helm_install.md
+++ b/docs/_includes/reference/cli/werf_helm_install.md
@@ -82,6 +82,8 @@ werf helm install [NAME] [CHART] [flags] [options]
             create the release namespace if not present
       --dependency-update=false
             update dependencies if they are missing before installing the chart
+      --deploy-report-path=''
+            save deploy report in JSON to the specified path
       --description=''
             add a custom description
       --devel=false

--- a/docs/_includes/reference/cli/werf_helm_rollback.md
+++ b/docs/_includes/reference/cli/werf_helm_rollback.md
@@ -20,6 +20,8 @@ werf helm rollback <RELEASE> [REVISION] [flags] [options]
 ```shell
       --cleanup-on-fail=false
             allow deletion of new resources created in this rollback when rollback fails
+      --deploy-report-path=''
+            save deploy report in JSON to the specified path
       --dry-run=false
             simulate a rollback
       --force=false

--- a/docs/_includes/reference/cli/werf_helm_template.md
+++ b/docs/_includes/reference/cli/werf_helm_template.md
@@ -46,6 +46,8 @@ werf helm template [NAME] [CHART] [flags] [options]
             create the release namespace if not present
       --dependency-update=false
             update dependencies if they are missing before installing the chart
+      --deploy-report-path=''
+            save deploy report in JSON to the specified path
       --description=''
             add a custom description
       --devel=false

--- a/docs/_includes/reference/cli/werf_helm_upgrade.md
+++ b/docs/_includes/reference/cli/werf_helm_upgrade.md
@@ -52,6 +52,8 @@ werf helm upgrade [RELEASE] [CHART] [flags] [options]
             if --install is set, create the release namespace if not present
       --dependency-update=false
             update dependencies if they are missing before installing the chart
+      --deploy-report-path=''
+            save deploy report in JSON to the specified path
       --description=''
             add a custom description
       --devel=false

--- a/docs/_includes/reference/cli/werf_kubectl_get.md
+++ b/docs/_includes/reference/cli/werf_kubectl_get.md
@@ -85,7 +85,7 @@ werf kubectl get [(-o|--output=)json|yaml|name|go-template|go-template-file|temp
             print headers).
   -o, --output=''
             Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile
-            |jsonpath|jsonpath-as-json|jsonpath-file|custom-columns|custom-columns-file|wide See    
+            |jsonpath|jsonpath-as-json|jsonpath-file|custom-columns-file|custom-columns|wide See    
             custom columns [https://kubernetes.io/docs/reference/kubectl/overview/#custom-columns], 
             golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath        
             template [https://kubernetes.io/docs/reference/kubectl/jsonpath/].

--- a/docs/_includes/reference/cli/werf_render.md
+++ b/docs/_includes/reference/cli/werf_render.md
@@ -37,6 +37,31 @@ werf render [IMAGE_NAME...] [options]
             Format: labelName=labelValue.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
+      --build-report-format=''
+            Report format: json or envfile (json or $WERF_BUILD_REPORT_FORMAT by default)
+            json:
+            	{
+            	  "Images": {
+            		"<WERF_IMAGE_NAME>": {
+            			"WerfImageName": "<WERF_IMAGE_NAME>",
+            			"DockerRepo": "<REPO>",
+            			"DockerTag": "<TAG>"
+            			"DockerImageName": "<REPO>:<TAG>",
+            			"DockerImageID": "<SHA256>",
+            			"DockerImageDigest": "<SHA256>",
+            		},
+            		...
+            	  }
+            	}
+            envfile:
+            	WERF_<FORMATTED_WERF_IMAGE_NAME>_DOCKER_IMAGE_NAME=<REPO>:<TAG>
+            	...
+            <FORMATTED_WERF_IMAGE_NAME> is werf image name from werf.yaml modified according to the 
+            following rules:
+            - all characters are uppercase (app -> APP);
+            - charset /- is replaced with _ (DEV/APP-FRONTEND -> DEV_APP_FRONTEND)
+      --build-report-path=''
+            Report save path ($WERF_BUILD_REPORT_PATH by default)
       --cache-repo=[]
             Specify one or multiple cache repos with images that will be used as a cache. Cache     
             will be populated when pushing newly built images into the primary repo and when        
@@ -230,9 +255,9 @@ werf render [IMAGE_NAME...] [options]
             repo Selectel VPC (default $WERF_REPO_SELECTEL_VPC)
       --repo-selectel-vpc-id=''
             repo Selectel VPC ID (default $WERF_REPO_SELECTEL_VPC_ID)
-      --report-format='json'
-            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default)
-            json:
+      --report-format=''
+            DEPRECATED: use --build-report-format.
+            Report format: json or envfile (json or $WERF_REPORT_FORMAT by default) json:
             	{
             	  "Images": {
             		"<WERF_IMAGE_NAME>": {
@@ -254,6 +279,7 @@ werf render [IMAGE_NAME...] [options]
             - all characters are uppercase (app -> APP);
             - charset /- is replaced with _ (DEV/APP-FRONTEND -> DEV_APP_FRONTEND)
       --report-path=''
+            DEPRECATED: use --build-report-path.
             Report save path ($WERF_REPORT_PATH by default)
       --secondary-repo=[]
             Specify one or multiple secondary read-only repos with images that will be used as a    

--- a/go.mod
+++ b/go.mod
@@ -317,4 +317,4 @@ replace github.com/deislabs/oras => github.com/werf/third-party-oras v0.9.1-0.20
 
 replace github.com/go-git/go-git/v5 => github.com/ZauberNerd/go-git/v5 v5.4.3-0.20220315170230-29ec1bc1e5db
 
-replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20221017175338-b2224bd154a3
+replace helm.sh/helm/v3 => github.com/werf/3p-helm/v3 v3.0.0-20230210095639-edbba2a383bc

--- a/go.sum
+++ b/go.sum
@@ -2050,8 +2050,8 @@ github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59b
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.5.0 h1:rutRtjBJViU/YjcI5d80t4JAVvDltS6bciJg2K1HrLU=
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
-github.com/werf/3p-helm/v3 v3.0.0-20221017175338-b2224bd154a3 h1:ZfkmCgZQip5Uj2h2e2T1625EjSJe/coSf+okdmT9dnI=
-github.com/werf/3p-helm/v3 v3.0.0-20221017175338-b2224bd154a3/go.mod h1:NxtE2KObf2PrzDl6SIamPFPKyAqWi10iWuvKlQn/Yao=
+github.com/werf/3p-helm/v3 v3.0.0-20230210095639-edbba2a383bc h1:+ZZ1eJGVQ73Xm2Msuz6/XQdcIP+Cdi0Tui4W3/ATPYY=
+github.com/werf/3p-helm/v3 v3.0.0-20230210095639-edbba2a383bc/go.mod h1:NxtE2KObf2PrzDl6SIamPFPKyAqWi10iWuvKlQn/Yao=
 github.com/werf/copy-recurse v0.2.4 h1:kEyGUKhgS8WdEOjInNQKgk4lqPWzP2AgR27F3dcGsVc=
 github.com/werf/copy-recurse v0.2.4/go.mod h1:KVHSQ90p19xflWW0B7BJhLBwmSbEtuxIaBnjlUYRPhk=
 github.com/werf/helm v0.0.0-20210202111118-81e74d46da0f h1:81YscYTF9mmTf0ULOsCmm42YWQp+qWDzWi1HjWniZrg=


### PR DESCRIPTION
--build-report-path does the same as --report-path and deprecates it

Signed-off-by: Ilya Lesikov <ilya@lesikov.com>