### PR TITLE
feat(bundles): enable secrets for bundle publish and apply

### DIFF
--- a/pkg/deploy/helm/chart_extender/bundle.go
+++ b/pkg/deploy/helm/chart_extender/bundle.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -120,7 +119,7 @@ func (bundle *Bundle) ChartLoaded(files []*chart.ChartExtenderBufferedFile) erro
 		if err := bundle.SecretsRuntimeData.DecodeAndLoadSecrets(bundle.ChartExtenderContext, files, bundle.Dir, wd, bundle.secretsManager, secrets.DecodeAndLoadSecretsOptions{
 			LoadFromLocalFilesystem:    true,
 			CustomSecretValueFiles:     bundle.SecretValueFiles,
-			WithoutDefaultSecretValues: true,
+			WithoutDefaultSecretValues: false,
 		}); err != nil {
 			return fmt.Errorf("error decoding secrets: %w", err)
 		}
@@ -231,41 +230,4 @@ func readBundleJsonMap(path string) (map[string]string, error) {
 	} else {
 		return res, nil
 	}
-}
-
-var (
-	AllowedBundleChartFiles = []string{
-		"Chart.yaml",
-		"LICENSE",
-		"README.md",
-		"values.yaml",
-		"values.schema.json",
-	}
-	AllowedBundleChartDirs = []string{
-		"charts/",
-		"crds/",
-		"templates/",
-		"files/",
-	}
-)
-
-func CheckBundlePathAllowed(path string) bool {
-	// TODO(bundles): provide more canonical way to whitelist/blacklist bundle files
-	if os.Getenv("WERF_BUNDLE_SCHEMA_NONSTRICT") == "1" {
-		return true
-	}
-
-	for _, p := range AllowedBundleChartFiles {
-		if p == path {
-			return true
-		}
-	}
-
-	for _, d := range AllowedBundleChartDirs {
-		if strings.HasPrefix(path, d) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/deploy/helm/chart_extender/bundle_test.go
+++ b/pkg/deploy/helm/chart_extender/bundle_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Bundle", func() {
 		os.Setenv("WERF_SECRET_KEY", "bfd966688bbe64c1986a356be2d6ba0a")
 	})
 
-	It("should ignore secret values file from the chart when no explicit option specified", func() {
+	It("should decode secret values file from the chart", func() {
 		ctx := context.Background()
 		bundleDir := ""
 		secretsManager := secrets_manager.NewSecretsManager(secrets_manager.SecretsManagerOptions{})
@@ -45,10 +45,16 @@ testsecrets:
 		vals, err := bundle.MakeValues(map[string]interface{}{"one": 1, "two": 2})
 		Expect(err).To(Succeed())
 
-		Expect(vals).To(Equal(map[string]interface{}{"one": 1, "two": 2}))
+		Expect(vals).To(Equal(map[string]interface{}{
+			"one": 1,
+			"two": 2,
+			"testsecrets": map[string]interface{}{
+				"testkey": "TOPSECRET",
+			},
+		}))
 	})
 
-	It("should load from local FS secret values file specified with explicit option", func() {
+	It("should load from local FS secret values file specified with explicit option and merge with secrets included into the bundle", func() {
 		ctx := context.Background()
 		bundleDir := ""
 
@@ -60,7 +66,7 @@ testsecrets:
 		Expect(err).To(Succeed())
 		Expect(os.WriteFile(secretValuesFile.Name(), []byte(`
 testsecrets:
-  testkey: 1000b45ee4272d14b30be2d20b5963f09e372fdfe761bf3913186938f4054d09ed0e
+  key1: 100052eb6939af0631094362dfa4183df2bdb831df8547e600eed77576c5f50d03ac714c1cee911415b9f28d81e157b76b6a
 `), os.ModePerm)).To(Succeed())
 
 		bundle, err := NewBundle(ctx, bundleDir, helm_v3.Settings, nil, secretsManager, BundleOptions{
@@ -71,10 +77,26 @@ testsecrets:
 		ch := &chart.Chart{}
 		bundle.ChartCreated(ch)
 
-		Expect(bundle.ChartLoaded(nil)).To(Succeed())
+		files := []*chart.ChartExtenderBufferedFile{
+			{
+				Name: "secret-values.yaml",
+				Data: []byte(`
+testsecrets:
+  testkey: 1000b45ee4272d14b30be2d20b5963f09e372fdfe761bf3913186938f4054d09ed0e
+`),
+			},
+		}
+		Expect(bundle.ChartLoaded(files)).To(Succeed())
 
 		vals, err := bundle.MakeValues(map[string]interface{}{"one": 1, "two": 2})
 		Expect(err).To(Succeed())
-		Expect(vals).To(Equal(map[string]interface{}{"one": 1, "two": 2, "testsecrets": map[string]interface{}{"testkey": "TOPSECRET"}}))
+		Expect(vals).To(Equal(map[string]interface{}{
+			"one": 1,
+			"two": 2,
+			"testsecrets": map[string]interface{}{
+				"testkey": "TOPSECRET",
+				"key1":    "MORE SECRET DATA",
+			},
+		}))
 	})
 })

--- a/pkg/deploy/helm/chart_extender/werf_chart.go
+++ b/pkg/deploy/helm/chart_extender/werf_chart.go
@@ -351,9 +351,6 @@ func (wc *WerfChart) CreateNewBundle(ctx context.Context, destDir, chartVersion 
 	}
 
 	for _, f := range wc.HelmChart.Files {
-		if !CheckBundlePathAllowed(f.Name) {
-			continue
-		}
 		if err := writeChartFile(ctx, destDir, f.Name, f.Data); err != nil {
 			return nil, fmt.Errorf("error writing miscellaneous chart file: %w", err)
 		}


### PR DESCRIPTION
* Include all files from .helm/ (.helm/secret-values.yaml also included) when publishing bundle into the container registry.
* Enable decryption of secret-values.yaml packed with the bundle during 'werf bundle apply' invocation.