### PR TITLE
feat(bundles): allow usage of bundles with included secret-values as oci chart dependencies

### DIFF
--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -386,8 +386,12 @@ func runPublish(ctx context.Context, imagesToProcess build.ImagesToProcess) erro
 	helm_v3.Settings.Debug = *commonCmdData.LogDebug
 
 	loader.GlobalLoadOptions = &loader.LoadOptions{
-		ChartExtender:               wc,
-		SubchartExtenderFactoryFunc: func() chart.ChartExtender { return chart_extender.NewWerfSubchart() },
+		ChartExtender: wc,
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return chart_extender.NewWerfSubchart(ctx, secretsManager, chart_extender.WerfSubchartOptions{
+				DisableDefaultSecretValues: *commonCmdData.DisableDefaultSecretValues,
+			})
+		},
 	}
 
 	sv, err := bundles.BundleTagToChartVersion(ctx, cmdData.Tag, time.Now())

--- a/cmd/werf/bundle/render/render.go
+++ b/cmd/werf/bundle/render/render.go
@@ -88,6 +88,7 @@ func NewCmd(ctx context.Context) *cobra.Command {
 	common.SetupValues(&commonCmdData, cmd)
 	common.SetupSecretValues(&commonCmdData, cmd)
 	common.SetupIgnoreSecretKey(&commonCmdData, cmd)
+	commonCmdData.SetupDisableDefaultSecretValues(cmd)
 
 	common.SetupRelease(&commonCmdData, cmd)
 	common.SetupNamespace(&commonCmdData, cmd)
@@ -212,8 +213,12 @@ func runRender(ctx context.Context) error {
 	}
 
 	loader.GlobalLoadOptions = &loader.LoadOptions{
-		ChartExtender:               bundle,
-		SubchartExtenderFactoryFunc: func() chart.ChartExtender { return chart_extender.NewWerfSubchart() },
+		ChartExtender: bundle,
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return chart_extender.NewWerfSubchart(ctx, secretsManager, chart_extender.WerfSubchartOptions{
+				DisableDefaultSecretValues: *commonCmdData.DisableDefaultSecretValues,
+			})
+		},
 	}
 
 	var output io.Writer

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -450,8 +450,12 @@ func run(ctx context.Context, containerBackend container_backend.ContainerBacken
 	}
 
 	loader.GlobalLoadOptions = &loader.LoadOptions{
-		ChartExtender:               wc,
-		SubchartExtenderFactoryFunc: func() chart.ChartExtender { return chart_extender.NewWerfSubchart() },
+		ChartExtender: wc,
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return chart_extender.NewWerfSubchart(ctx, secretsManager, chart_extender.WerfSubchartOptions{
+				DisableDefaultSecretValues: *commonCmdData.DisableDefaultSecretValues,
+			})
+		},
 	}
 
 	valueOpts := &values.Options{

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -439,8 +439,12 @@ func runRender(ctx context.Context, imagesToProcess build.ImagesToProcess) error
 	helm_v3.Settings.Debug = *commonCmdData.LogDebug
 
 	loader.GlobalLoadOptions = &loader.LoadOptions{
-		ChartExtender:               wc,
-		SubchartExtenderFactoryFunc: func() chart.ChartExtender { return chart_extender.NewWerfSubchart() },
+		ChartExtender: wc,
+		SubchartExtenderFactoryFunc: func() chart.ChartExtender {
+			return chart_extender.NewWerfSubchart(ctx, secretsManager, chart_extender.WerfSubchartOptions{
+				DisableDefaultSecretValues: *commonCmdData.DisableDefaultSecretValues,
+			})
+		},
 	}
 
 	templateOpts := helm_v3.TemplateCmdOptions{

--- a/docs/_includes/reference/cli/werf_bundle_export.md
+++ b/docs/_includes/reference/cli/werf_bundle_export.md
@@ -78,6 +78,9 @@ werf bundle export [IMAGE_NAME...] [options]
       --disable-auto-host-cleanup=false
             Disable auto host cleanup procedure in main werf commands like werf-build,              
             werf-converge and other (default disabled or WERF_DISABLE_AUTO_HOST_CLEANUP)
+      --disable-default-secret-values=false
+            Do not use secret values from the default .helm/secret-values.yaml file (default        
+            $WERF_DISABLE_DEFAULT_SECRET_VALUES or false)
       --disable-default-values=false
             Do not use values from the default .helm/values.yaml file (default                      
             $WERF_DISABLE_DEFAULT_VALUES or false)
@@ -129,6 +132,8 @@ werf bundle export [IMAGE_NAME...] [options]
             contains .git in the current or parent directories)
       --home-dir=''
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --ignore-secret-key=false
+            Disable secrets decryption (default $WERF_IGNORE_SECRET_KEY)
       --insecure-helm-dependencies=false
             Allow insecure oci registries to be used in the .helm/Chart.yaml dependencies           
             configuration (default $WERF_INSECURE_HELM_DEPENDENCIES)

--- a/docs/_includes/reference/cli/werf_bundle_render.md
+++ b/docs/_includes/reference/cli/werf_bundle_render.md
@@ -39,6 +39,9 @@ werf bundle render [options]
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
   -b, --bundle-dir=''
             Get extracted bundle from directory instead of registry (default $WERF_BUNDLE_DIR)
+      --disable-default-secret-values=false
+            Do not use secret values from the default .helm/secret-values.yaml file (default        
+            $WERF_DISABLE_DEFAULT_SECRET_VALUES or false)
       --docker-config=''
             Specify docker config directory path. Default $WERF_DOCKER_CONFIG or $DOCKER_CONFIG or  
             ~/.docker (in the order of priority)

--- a/pkg/deploy/helm/chart_extender/helpers/chart_extender_values_merger.go
+++ b/pkg/deploy/helm/chart_extender/helpers/chart_extender_values_merger.go
@@ -1,0 +1,35 @@
+package helpers
+
+import (
+	"context"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers/secrets"
+)
+
+type ChartExtenderValuesMerger struct{}
+
+func (m *ChartExtenderValuesMerger) MergeValues(ctx context.Context, inputVals, serviceVals map[string]interface{}, secretsRuntimeData *secrets.SecretsRuntimeData) (map[string]interface{}, error) {
+	vals := make(map[string]interface{})
+
+	DebugPrintValues(ctx, "service", serviceVals)
+	chartutil.CoalesceTables(vals, serviceVals) // NOTE: service values will not be saved into the marshalled release
+
+	if secretsRuntimeData != nil {
+		if DebugSecretValues() {
+			DebugPrintValues(ctx, "secret", secretsRuntimeData.DecryptedSecretValues)
+		}
+		chartutil.CoalesceTables(vals, secretsRuntimeData.DecryptedSecretValues)
+	}
+
+	DebugPrintValues(ctx, "input", inputVals)
+	chartutil.CoalesceTables(vals, inputVals)
+
+	if DebugSecretValues() {
+		// Only print all values with secrets when secret values debug enabled
+		DebugPrintValues(ctx, "all", vals)
+	}
+
+	return vals, nil
+}

--- a/pkg/deploy/helm/chart_extender/helpers/secrets/chart_secrets_loader.go
+++ b/pkg/deploy/helm/chart_extender/helpers/secrets/chart_secrets_loader.go
@@ -19,7 +19,7 @@ const (
 	SecretDirName               = "secret"
 )
 
-func GetDefaultSecretValuesFile(chartDir string, loadedChartFiles []*chart.ChartExtenderBufferedFile) *chart.ChartExtenderBufferedFile {
+func GetDefaultSecretValuesFile(loadedChartFiles []*chart.ChartExtenderBufferedFile) *chart.ChartExtenderBufferedFile {
 	for _, file := range loadedChartFiles {
 		if file.Name == DefaultSecretValuesFileName {
 			return file

--- a/pkg/deploy/helm/chart_extender/helpers/secrets/secrets_runtime_data.go
+++ b/pkg/deploy/helm/chart_extender/helpers/secrets/secrets_runtime_data.go
@@ -39,7 +39,7 @@ func (secretsRuntimeData *SecretsRuntimeData) DecodeAndLoadSecrets(ctx context.C
 	var loadedSecretValuesFiles []*chart.ChartExtenderBufferedFile
 
 	if !opts.WithoutDefaultSecretValues {
-		if defaultSecretValues := GetDefaultSecretValuesFile(chartDir, loadedChartFiles); defaultSecretValues != nil {
+		if defaultSecretValues := GetDefaultSecretValuesFile(loadedChartFiles); defaultSecretValues != nil {
 			loadedSecretValuesFiles = append(loadedSecretValuesFiles, defaultSecretValues)
 		}
 	}

--- a/pkg/deploy/helm/chart_extender/helpers/util.go
+++ b/pkg/deploy/helm/chart_extender/helpers/util.go
@@ -1,0 +1,23 @@
+package helpers
+
+import (
+	"context"
+	"os"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/werf/logboek"
+)
+
+func DebugPrintValues(ctx context.Context, name string, vals map[string]interface{}) {
+	data, err := yaml.Marshal(vals)
+	if err != nil {
+		logboek.Context(ctx).Debug().LogF("Unable to marshal %q values: %s\n", err)
+	} else {
+		logboek.Context(ctx).Debug().LogF("%q values:\n%s---\n", name, data)
+	}
+}
+
+func DebugSecretValues() bool {
+	return os.Getenv("WERF_DEBUG_SECRET_VALUES") == "1"
+}

--- a/pkg/deploy/helm/chart_extender/werf_subchart.go
+++ b/pkg/deploy/helm/chart_extender/werf_subchart.go
@@ -1,32 +1,66 @@
 package chart_extender
 
 import (
+	"context"
+	"fmt"
 	"text/template"
 
 	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
+
+	"github.com/werf/logboek"
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers"
+	"github.com/werf/werf/pkg/deploy/helm/chart_extender/helpers/secrets"
+	"github.com/werf/werf/pkg/deploy/secrets_manager"
 )
 
 // NOTE: maybe in the future we will need a support for the werf project to be used as a chart.
 // NOTE: This extender allows to define this behaviour.
 
-func NewWerfSubchart() *WerfSubchart {
-	return &WerfSubchart{}
+type WerfSubchartOptions struct {
+	DisableDefaultSecretValues bool
+}
+
+func NewWerfSubchart(ctx context.Context, secretsManager *secrets_manager.SecretsManager, opts WerfSubchartOptions) *WerfSubchart {
+	return &WerfSubchart{
+		SecretsManager:             secretsManager,
+		ChartExtenderContextData:   helpers.NewChartExtenderContextData(ctx),
+		DisableDefaultSecretValues: opts.DisableDefaultSecretValues,
+	}
 }
 
 type WerfSubchart struct {
-	HelmChart *chart.Chart
+	HelmChart      *chart.Chart
+	SecretsManager *secrets_manager.SecretsManager
+
+	DisableDefaultSecretValues bool
+
+	*secrets.SecretsRuntimeData
+	*helpers.ChartExtenderContextData
+	*helpers.ChartExtenderValuesMerger
 }
 
 // ChartCreated method for the chart.Extender interface
 func (wc *WerfSubchart) ChartCreated(c *chart.Chart) error {
 	wc.HelmChart = c
+	wc.SecretsRuntimeData = secrets.NewSecretsRuntimeData()
 	return nil
 }
 
 // ChartLoaded method for the chart.Extender interface
 func (wc *WerfSubchart) ChartLoaded(files []*chart.ChartExtenderBufferedFile) error {
+	if wc.SecretsManager != nil {
+		if wc.DisableDefaultSecretValues {
+			logboek.Context(wc.ChartExtenderContext).Info().LogF("Disabled subchart secret values\n")
+		}
+
+		if err := wc.SecretsRuntimeData.DecodeAndLoadSecrets(wc.ChartExtenderContext, files, "", "", wc.SecretsManager, secrets.DecodeAndLoadSecretsOptions{
+			WithoutDefaultSecretValues: wc.DisableDefaultSecretValues,
+		}); err != nil {
+			return fmt.Errorf("error decoding secrets: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -37,9 +71,7 @@ func (wc *WerfSubchart) ChartDependenciesLoaded() error {
 
 // MakeValues method for the chart.Extender interface
 func (wc *WerfSubchart) MakeValues(inputVals map[string]interface{}) (map[string]interface{}, error) {
-	vals := make(map[string]interface{})
-	chartutil.CoalesceTables(vals, inputVals)
-	return vals, nil
+	return wc.MergeValues(wc.ChartExtenderContext, inputVals, nil, wc.SecretsRuntimeData)
 }
 
 // SetupTemplateFuncs method for the chart.Extender interface


### PR DESCRIPTION
Decode secret-values.yaml included into the bundle when converging a werf project with bundle enabled as a chart dependency.