### PR TITLE
Fix documentation generator

### DIFF
--- a/cmd/werf/docs/replacers/kubectl/kubectl.go
+++ b/cmd/werf/docs/replacers/kubectl/kubectl.go
@@ -364,9 +364,9 @@ func setNewDocs(cmd *cobra.Command) {
 		cmd.Annotations = map[string]string{
 			common.DocsLongMD: GetExposeDocs().LongMD,
 		}
-	case "get [(-o|--output=)json|yaml|name|go-template|go-template-file|template|templatefile|" +
-		"jsonpath|jsonpath-as-json|jsonpath-file|custom-columns-file|custom-columns|wide] " +
-		"(TYPE[.VERSION][.GROUP] [NAME | -l label] | TYPE[.VERSION][.GROUP]/NAME ...) [flags]":
+	case "get [(-o|--output=)json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|" +
+		"jsonpath-as-json|jsonpath-file|custom-columns|custom-columns-file|wide] (TYPE[.VERSION][.GROUP] " +
+		"[NAME | -l label] | TYPE[.VERSION][.GROUP]/NAME ...) [flags]":
 		cmd.Annotations = map[string]string{
 			common.DocsLongMD: GetGetDocs().LongMD,
 		}

--- a/cmd/werf/docs/replacers/kubectl/kubectl.go
+++ b/cmd/werf/docs/replacers/kubectl/kubectl.go
@@ -224,6 +224,10 @@ func setNewDocs(cmd *cobra.Command) {
 		cmd.Annotations = map[string]string{
 			common.DocsLongMD: GetCreateDocs().LongMD,
 		}
+	case "token SERVICE_ACCOUNT_NAME":
+		cmd.Annotations = map[string]string{
+			common.DocsLongMD: GetCreateTokenDocs().LongMD,
+		}
 	case "clusterrole NAME --verb=verb --resource=resource.group [--resource-name=resourcename] " +
 		"[--dry-run=server|client|none]":
 		cmd.Annotations = map[string]string{

--- a/cmd/werf/docs/replacers/kubectl/kubectl.go
+++ b/cmd/werf/docs/replacers/kubectl/kubectl.go
@@ -82,6 +82,10 @@ func setNewDocs(cmd *cobra.Command) {
 		cmd.Annotations = map[string]string{
 			common.DocsLongMD: GetAuthDocs().LongMD,
 		}
+	case "whoami":
+		cmd.Annotations = map[string]string{
+			common.DocsLongMD: GetWhoamiDocs().LongMD,
+		}
 	case "can-i VERB [TYPE | TYPE/NAME | NONRESOURCEURL]":
 		cmd.Annotations = map[string]string{
 			common.DocsLongMD: GetAuthCanIDocs().LongMD,

--- a/cmd/werf/docs/replacers/kubectl/kubectl.go
+++ b/cmd/werf/docs/replacers/kubectl/kubectl.go
@@ -504,5 +504,10 @@ func setNewDocs(cmd *cobra.Command) {
 		cmd.Annotations = map[string]string{
 			common.DocsLongMD: GetWaitDocs().LongMD,
 		}
+	case "events [(-o|--output=)json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|" +
+		"jsonpath-as-json|jsonpath-file] [--for TYPE/NAME] [--watch] [--event=Normal,Warning]":
+		cmd.Annotations = map[string]string{
+			common.DocsLongMD: GetEventsDocs().LongMD,
+		}
 	}
 }

--- a/cmd/werf/docs/replacers/kubectl/kubectl_docs.go
+++ b/cmd/werf/docs/replacers/kubectl/kubectl_docs.go
@@ -1246,3 +1246,14 @@ func GetWaitDocs() structs.DocsStruct {
 
 	return docs
 }
+
+func GetEventsDocs() structs.DocsStruct {
+	var docs structs.DocsStruct
+
+	docs.LongMD = "Display events.\n\n" +
+		"Prints a table of the most important information about events.\n\n" +
+		"You can request events for a namespace, for all namespace, or filtered to only those " +
+		"pertaining to a specified resource."
+
+	return docs
+}

--- a/cmd/werf/docs/replacers/kubectl/kubectl_docs.go
+++ b/cmd/werf/docs/replacers/kubectl/kubectl_docs.go
@@ -449,6 +449,14 @@ func GetCreateDocs() structs.DocsStruct {
 	return docs
 }
 
+func GetCreateTokenDocs() structs.DocsStruct {
+	var docs structs.DocsStruct
+
+	docs.LongMD = "Request a service account token."
+
+	return docs
+}
+
 func GetCreateClusterRoleDocs() structs.DocsStruct {
 	var docs structs.DocsStruct
 

--- a/cmd/werf/docs/replacers/kubectl/kubectl_docs.go
+++ b/cmd/werf/docs/replacers/kubectl/kubectl_docs.go
@@ -142,6 +142,14 @@ func GetAuthDocs() structs.DocsStruct {
 	return docs
 }
 
+func GetWhoamiDocs() structs.DocsStruct {
+	var docs structs.DocsStruct
+
+	docs.LongMD = "Experimental: Check self subject attributes."
+
+	return docs
+}
+
 func GetAuthCanIDocs() structs.DocsStruct {
 	var docs structs.DocsStruct
 

--- a/cmd/werf/docs/replacers/kubectl/kubectl_test.go
+++ b/cmd/werf/docs/replacers/kubectl/kubectl_test.go
@@ -126,6 +126,7 @@ func checkText(ann string) bool {
 		ann != GetCreateServiceLoadBalancerDocs().LongMD &&
 		ann != GetCreateServiceNodePortDocs().LongMD &&
 		ann != GetCreateServiceAccountDocs().LongMD &&
+		ann != GetCreateTokenDocs().LongMD &&
 		ann != GetDebugDocs().LongMD &&
 		ann != GetDeleteDocs().LongMD &&
 		ann != GetDescribeDocs().LongMD &&

--- a/cmd/werf/docs/replacers/kubectl/kubectl_test.go
+++ b/cmd/werf/docs/replacers/kubectl/kubectl_test.go
@@ -169,6 +169,7 @@ func checkText(ann string) bool {
 		ann != GetTopPodDocs().LongMD &&
 		ann != GetUncordonDocs().LongMD &&
 		ann != GetVersionDocs().LongMD &&
+		ann != GetEventsDocs().LongMD &&
 		ann != GetWaitDocs().LongMD {
 		return false
 	}

--- a/cmd/werf/docs/replacers/kubectl/kubectl_test.go
+++ b/cmd/werf/docs/replacers/kubectl/kubectl_test.go
@@ -74,6 +74,7 @@ func checkText(ann string) bool {
 		ann != GetApplyViewLastAppliedDocs().LongMD &&
 		ann != GetAttachDocs().LongMD &&
 		ann != GetAuthDocs().LongMD &&
+		ann != GetWhoamiDocs().LongMD &&
 		ann != GetAuthCanIDocs().LongMD &&
 		ann != GetAuthReconcileDocs().LongMD &&
 		ann != GetAutoscaleDocs().LongMD &&

--- a/docs/_includes/reference/cli/werf_kubectl_alpha_auth_whoami.md
+++ b/docs/_includes/reference/cli/werf_kubectl_alpha_auth_whoami.md
@@ -3,11 +3,7 @@
 {% else %}
 {% assign header = "###" %}
 {% endif %}
-Experimental: Check who you are and your attributes (groups, extra).
-
-  This command is helpful to get yourself aware of the current user attributes,
-  especially when dynamic authentication, e.g., token webhook, auth proxy, or OIDC provider,
-  is enabled in the Kubernetes cluster.
+Experimental: Check self subject attributes.
 
 {{ header }} Syntax
 

--- a/docs/_includes/reference/cli/werf_kubectl_events.md
+++ b/docs/_includes/reference/cli/werf_kubectl_events.md
@@ -3,9 +3,11 @@
 {% else %}
 {% assign header = "###" %}
 {% endif %}
-Display events
+Display events.
 
- Prints a table of the most important information about events. You can request events for a namespace, for all namespace, or filtered to only those pertaining to a specified resource.
+Prints a table of the most important information about events.
+
+You can request events for a namespace, for all namespace, or filtered to only those pertaining to a specified resource.
 
 {{ header }} Syntax
 

--- a/docs/_includes/reference/cli/werf_kubectl_get.md
+++ b/docs/_includes/reference/cli/werf_kubectl_get.md
@@ -5,11 +5,11 @@
 {% endif %}
 Display one or many resources.
 
- Prints a table of the most important information about the specified resources. You can filter the list using a label selector and the --selector flag. If the desired resource type is namespaced you will only see results in your current namespace unless you pass --all-namespaces.
+Prints a table of the most important information about the specified resources. You can filter the list using a label selector and the `--selector` flag. If the desired resource type is namespaced you will only see results in your current namespace unless you pass `--all-namespaces`.
 
- By specifying the output as 'template' and providing a Go template as the value of the --template flag, you can filter the attributes of the fetched resources.
+By specifying the output as `template` and providing a Go template as the value of the `--template` flag, you can filter the attributes of the fetched resources.
 
-Use "kubectl api-resources" for a complete list of supported resources.
+Use `kubectl api-resources` for a complete list of supported resources.
 
 {{ header }} Syntax
 


### PR DESCRIPTION
After updating the dependencies, some `kubectl` commands changed, which led to a crash of unit tests — the generator ignored them and didn't add documentation.

Added replacers for `kubectl` commands:

* `events`;
* `token`;
* `whoami`.

Fixed the replacer for the `get` command.