### PR TITLE
fix(buildah): usage of docker.exactValues affects digest the same way for buildah and docker-server backends

### DIFF
--- a/pkg/build/stage/stapel_docker_instructions.go
+++ b/pkg/build/stage/stapel_docker_instructions.go
@@ -35,7 +35,7 @@ type StapelDockerInstructionsStage struct {
 func (s *StapelDockerInstructionsStage) GetDependencies(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 
-	if c.UseLegacyStapelBuilder(cb) && s.instructions.ExactValues {
+	if s.instructions.ExactValues {
 		args = append(args, "exact-values:::")
 	}
 


### PR DESCRIPTION
Make dockerInstructions stapel stage digest fully compatible between different container-backends (buildah or docker-server).