### PR TITLE
fix(multiarch): do not override image metadata for secondary platforms

### DIFF
--- a/pkg/build/image/image_tree.go
+++ b/pkg/build/image/image_tree.go
@@ -120,6 +120,22 @@ func (tree *ImagesTree) GetImage(name string) *Image {
 	return nil
 }
 
+func (tree *ImagesTree) GetImagePlatformsByName(finalOnly bool) map[string][]string {
+	res := make(map[string][]string)
+	for _, img := range tree.GetImages() {
+		if finalOnly {
+			for _, finalImageName := range tree.werfConfig.GetAllImages() {
+				if finalImageName.GetName() == img.Name {
+					res[img.Name] = append(res[img.Name], img.TargetPlatform)
+				}
+			}
+		} else {
+			res[img.Name] = append(res[img.Name], img.TargetPlatform)
+		}
+	}
+	return res
+}
+
 func (tree *ImagesTree) GetImages() []*Image {
 	return tree.allImages
 }


### PR DESCRIPTION
Only first specified target platform will be used during converge, so publish commit-stageID metadata only for this first target platform image.

Also added assertion to check all final built images built for all target platforms and there is no mismatch between Image.TargetPlatform setting and target platforms.