### PR TITLE
fix(multiarch): do not override image metadata for secondary platforms [1.2.214]

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -188,6 +188,27 @@ func (phase *BuildPhase) BeforeImages(ctx context.Context) error {
 }
 
 func (phase *BuildPhase) AfterImages(ctx context.Context) error {
+	targetPlatforms, err := phase.Conveyor.GetTargetPlatforms()
+	if err != nil {
+		return fmt.Errorf("unable to get target platforms: %w", err)
+	}
+	if len(targetPlatforms) == 0 {
+		targetPlatforms = []string{""}
+	}
+
+	for imageName, imagePlatforms := range phase.Conveyor.imagesTree.GetImagePlatformsByName(true) {
+	AssertAllTargetPlatformsPresent:
+		for _, targetPlatform := range targetPlatforms {
+			for _, imagePlatform := range imagePlatforms {
+				if targetPlatform == imagePlatform {
+					logboek.Context(ctx).Debug().LogF("Found image %q built for target platform %q\n", imageName, targetPlatform)
+					continue AssertAllTargetPlatformsPresent
+				}
+			}
+			panic(fmt.Sprintf("there is no image %q built for target platform %q, please report a bug", imageName, targetPlatform))
+		}
+	}
+
 	return phase.createReport(ctx)
 }
 
@@ -362,6 +383,20 @@ func (phase *BuildPhase) addManagedImage(ctx context.Context, img *image.Image) 
 }
 
 func (phase *BuildPhase) publishImageMetadata(ctx context.Context, img *image.Image) error {
+	targetPlatforms, err := phase.Conveyor.GetTargetPlatforms()
+	if err != nil {
+		return fmt.Errorf("unable to get target platforms: %w", err)
+	}
+	if len(targetPlatforms) == 0 {
+		targetPlatforms = []string{""}
+	}
+	targetPlatform := targetPlatforms[0]
+
+	// FIXME(multiarch): publish image metadata for multiarch manifest instead of per-platform-images
+	if targetPlatform != img.TargetPlatform {
+		return nil
+	}
+
 	return logboek.Context(ctx).Info().LogProcess(fmt.Sprintf("Processing image %s git metadata", img.GetName())).
 		DoError(func() error {
 			var commits []string

--- a/pkg/build/image/image_tree.go
+++ b/pkg/build/image/image_tree.go
@@ -120,6 +120,22 @@ func (tree *ImagesTree) GetImage(name string) *Image {
 	return nil
 }
 
+func (tree *ImagesTree) GetImagePlatformsByName(finalOnly bool) map[string][]string {
+	res := make(map[string][]string)
+	for _, img := range tree.GetImages() {
+		if finalOnly {
+			for _, finalImageName := range tree.werfConfig.GetAllImages() {
+				if finalImageName.GetName() == img.Name {
+					res[img.Name] = append(res[img.Name], img.TargetPlatform)
+				}
+			}
+		} else {
+			res[img.Name] = append(res[img.Name], img.TargetPlatform)
+		}
+	}
+	return res
+}
+
 func (tree *ImagesTree) GetImages() []*Image {
 	return tree.allImages
 }


### PR DESCRIPTION
Only first specified target platform will be used during converge, so publish commit-stageID metadata only for this first target platform image.

Also added assertion to check all final built images built for all target platforms and there is no mismatch between Image.TargetPlatform setting and target platforms.