### PR TITLE
fix(multiarch): publish git metadata for multiplatform mode images

### DIFF
--- a/pkg/build/image/image_tree.go
+++ b/pkg/build/image/image_tree.go
@@ -27,6 +27,8 @@ type ImagesTree struct {
 
 	allImages  []*Image
 	imagesSets ImagesSets
+
+	multiplatformImages []*MultiplatformImage
 }
 
 type ImagesTreeOptions struct {
@@ -185,6 +187,24 @@ func (tree *ImagesTree) GetImages() []*Image {
 
 func (tree *ImagesTree) GetImagesSets() ImagesSets {
 	return tree.imagesSets
+}
+
+func (tree *ImagesTree) GetMultiplatformImage(name string) *MultiplatformImage {
+	for _, img := range tree.multiplatformImages {
+		if img.Name == name {
+			return img
+		}
+	}
+	return nil
+}
+
+func (tree *ImagesTree) SetMultiplatformImage(newImg *MultiplatformImage) {
+	for _, img := range tree.multiplatformImages {
+		if img.Name == newImg.Name {
+			return
+		}
+	}
+	tree.multiplatformImages = append(tree.multiplatformImages, newImg)
 }
 
 func getFromFields(imageBaseConfig *config.StapelImageBase) (string, string, bool) {

--- a/pkg/build/image/multiplatform_image.go
+++ b/pkg/build/image/multiplatform_image.go
@@ -1,0 +1,59 @@
+package image
+
+import (
+	common_image "github.com/werf/werf/pkg/image"
+	"github.com/werf/werf/pkg/storage/manager"
+	"github.com/werf/werf/pkg/util"
+)
+
+type MultiplatformImage struct {
+	Name   string
+	Images []*Image
+
+	MultiplatformImageOptions
+
+	calculatedDigest string
+	stageID          common_image.StageID
+}
+
+type MultiplatformImageOptions struct {
+	IsArtifact, IsDockerfileImage, IsDockerfileTargetStage bool
+}
+
+func NewMultiplatformImage(name string, images []*Image, storageManager manager.StorageManagerInterface, opts MultiplatformImageOptions) *MultiplatformImage {
+	img := &MultiplatformImage{
+		Name:                      name,
+		Images:                    images,
+		MultiplatformImageOptions: opts,
+	}
+
+	metaStageDeps := util.MapFuncToSlice(images, func(img *Image) string {
+		stageDesc := img.GetLastNonEmptyStage().GetStageImage().Image.GetStageDescription()
+		return stageDesc.StageID.String()
+	})
+	img.calculatedDigest = util.Sha3_224Hash(metaStageDeps...)
+
+	_, uniqueID := storageManager.GenerateStageUniqueID(img.GetDigest(), nil)
+	img.stageID = common_image.StageID{Digest: img.GetDigest(), UniqueID: uniqueID}
+
+	return img
+}
+
+func (img *MultiplatformImage) GetPlatforms() []string {
+	return util.MapFuncToSlice(img.Images, func(img *Image) string { return img.TargetPlatform })
+}
+
+func (img *MultiplatformImage) GetDigest() string {
+	return img.calculatedDigest
+}
+
+func (img *MultiplatformImage) GetStageID() common_image.StageID {
+	return img.stageID
+}
+
+func (img *MultiplatformImage) GetImagesInfoList() []*common_image.Info {
+	return util.MapFuncToSlice(img.Images, func(img *Image) *common_image.Info {
+		stageDesc := img.GetLastNonEmptyStage().GetStageImage().Image.GetStageDescription()
+		return stageDesc.Info
+	})
+}


### PR DESCRIPTION
Introduced MultiplatformImage descriptor to manage multiplatform images and maintain list of multiplatform images in the ImagesTree primitive.