### PR TITLE
fix: update ruby gems

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,10 +1,13 @@
 source "https://rubygems.org"
 
 gem "jekyll-assets", git: "https://github.com/envygeeks/jekyll-assets", group: :jekyll_plugins
-gem "jekyll"
+gem "jekyll", ">= 3.5", "< 5.0"
 gem 'html-proofer', '~> 3.3'
 gem "kramdown-parser-gfm"
+gem "jekyll-include-cache", "~> 0.2"
+# Can't use jekyll-sass-converter "~> 3.0" in alpine based images: https://github.com/sass/dart-sass-embedded/issues/106#issuecomment-1374950950
+gem "jekyll-sass-converter", "~> 2.0"
 
-gem "sprockets", "~> 4.2", ">= 4.2.0"
+gem "sprockets", "~> 4.0"
 gem "nokogiri", ">= 1.12.5"
 gem "kramdown", ">= 2.3.0"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
     concurrent-ruby (1.2.2)
@@ -40,8 +40,6 @@ GEM
     fastimage (2.2.6)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (3.22.2)
-    google-protobuf (3.22.2-x86_64-linux)
     html-proofer (3.19.4)
       addressable (~> 2.3)
       mercenary (~> 0.3)
@@ -69,11 +67,13 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
     jekyll-sanity (1.6.0)
       jekyll (>= 3.1, < 5.0)
       pathutil (~> 0.16)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (2.2.0)
+      sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.4.0)
@@ -93,29 +93,19 @@ GEM
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.14.3-x86_64-linux)
-      racc (~> 1.4)
-    parallel (1.22.1)
+    parallel (1.23.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.1)
     racc (1.6.2)
-    rack (3.0.6.1)
+    rack (3.0.7)
     rainbow (3.1.1)
-    rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (4.1.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.59.3)
-      google-protobuf (~> 3.21)
-      rake (>= 10.0.0)
-    sass-embedded (1.59.3-x86_64-linux-gnu)
-      google-protobuf (~> 3.21)
-    sass-embedded (1.59.3-x86_64-linux-musl)
-      google-protobuf (~> 3.21)
     sassc (2.4.0)
       ffi (~> 1.9)
     sprockets (4.2.0)
@@ -134,17 +124,17 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux
-  x86_64-linux-musl
 
 DEPENDENCIES
   html-proofer (~> 3.3)
-  jekyll
+  jekyll (>= 3.5, < 5.0)
   jekyll-assets!
+  jekyll-include-cache (~> 0.2)
+  jekyll-sass-converter (~> 2.0)
   kramdown (>= 2.3.0)
   kramdown-parser-gfm
   nokogiri (>= 1.12.5)
-  sprockets (~> 4.2, >= 4.2.0)
+  sprockets (~> 4.0)
 
 BUNDLED WITH
-   2.2.24
+   2.4.12

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,9 +14,6 @@ site_description: Consistent delivery tool. Git as a single source of truth. Bui
 
 github_repo_path: /werf/werf
 
-assets:
-  precompile: ["**/*.*"]
-
 social_links:
   ru:
     twitter: https://twitter.com/werf_io


### PR DESCRIPTION
- Pin jekyll
- Pin jekyll-sass-converter to older 2.0 version
- Remove assets.precompile (fix for jekyll-assets plugin to work in updated jekyll/sprockets)