### PR TITLE
fix(multiarch): custom tags not working

### DIFF
--- a/pkg/docker_registry/interface.go
+++ b/pkg/docker_registry/interface.go
@@ -40,7 +40,6 @@ type ArchiveOpener interface {
 }
 
 type ManifestListOptions struct {
-	PushImageOptions
 	Manifests []*image.Info
 }
 

--- a/pkg/storage/local_stages_storage.go
+++ b/pkg/storage/local_stages_storage.go
@@ -404,7 +404,7 @@ func (storage *LocalStagesStorage) GetStageCustomTagMetadata(ctx context.Context
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (storage *LocalStagesStorage) RegisterStageCustomTag(ctx context.Context, stageDescription *image.StageDescription, tag string) error {
+func (storage *LocalStagesStorage) RegisterStageCustomTag(ctx context.Context, projectName string, stageDescription *image.StageDescription, tag string) error {
 	return nil
 }
 

--- a/pkg/storage/primary_stages_storage.go
+++ b/pkg/storage/primary_stages_storage.go
@@ -11,6 +11,6 @@ type PrimaryStagesStorage interface {
 
 	GetStageCustomTagMetadataIDs(ctx context.Context, opts ...Option) ([]string, error)
 	GetStageCustomTagMetadata(ctx context.Context, tagOrID string) (*CustomTagMetadata, error)
-	RegisterStageCustomTag(ctx context.Context, stageDescription *image.StageDescription, tag string) error
+	RegisterStageCustomTag(ctx context.Context, projectName string, stageDescription *image.StageDescription, tag string) error
 	UnregisterStageCustomTag(ctx context.Context, tag string) error
 }


### PR DESCRIPTION
Fixed panic and incorrect publishing of manifest list in case of custom tags usage. Now first publish manifest list by digest, then post custom tag as an alias to this digest tag.