### PR TITLE
fix: use 'built image' instead of 'cache image'

### DIFF
--- a/integration/suites/build/stapel_image/build_phase/build_phase_test.go
+++ b/integration/suites/build/stapel_image/build_phase/build_phase_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Build phase", func() {
 					"WERF_CONFIG": "werf_2.yaml",
 				},
 				OutputLineHandler: func(line string) {
-					if strings.Contains(line, "Use cache image for ~/install") {
+					if strings.Contains(line, "Use previously built image for ~/install") {
 						useCachedInstall = true
 						stageParserState = "usingCachedInstall"
 					}

--- a/integration/suites/build/stapel_image/git/stages_test.go
+++ b/integration/suites/build/stapel_image/git/stages_test.go
@@ -57,7 +57,7 @@ var _ = Describe("git stages", func() {
 				checkResultedFilesChecksum: true,
 				expectedOutputMatchers: []types.GomegaMatcher{
 					Not(ContainSubstring("stage image/gitLatestPatch")),
-					ContainSubstring("Use cache image for image/gitArchive"),
+					ContainSubstring("Use previously built image for image/gitArchive"),
 					ContainSubstring("Building stage image/gitCache"),
 				},
 			}
@@ -70,7 +70,7 @@ var _ = Describe("git stages", func() {
 				checkResultedFilesChecksum: true,
 				expectedOutputMatchers: []types.GomegaMatcher{
 					Not(ContainSubstring("stage image/gitCache")),
-					ContainSubstring("Use cache image for image/gitArchive"),
+					ContainSubstring("Use previously built image for image/gitArchive"),
 					ContainSubstring("Building stage image/gitLatestPatch"),
 				},
 			}
@@ -98,7 +98,7 @@ var _ = Describe("git stages", func() {
 					checkResultedFilesChecksum: true,
 					expectedOutputMatchers: []types.GomegaMatcher{
 						Not(ContainSubstring("stage image/gitLatestPatch")),
-						ContainSubstring("Use cache image for image/gitArchive"),
+						ContainSubstring("Use previously built image for image/gitArchive"),
 						ContainSubstring("Building stage image/gitCache"),
 					},
 				}
@@ -110,8 +110,8 @@ var _ = Describe("git stages", func() {
 					},
 					checkResultedFilesChecksum: true,
 					expectedOutputMatchers: []types.GomegaMatcher{
-						ContainSubstring("Use cache image for image/gitCache"),
-						ContainSubstring("Use cache image for image/gitArchive"),
+						ContainSubstring("Use previously built image for image/gitCache"),
+						ContainSubstring("Use previously built image for image/gitArchive"),
 						ContainSubstring("Building stage image/gitLatestPatch"),
 					},
 				}
@@ -167,7 +167,7 @@ var _ = Describe("git stages", func() {
 			checkResultedFilesChecksum: false,
 			expectedOutputMatchers: []types.GomegaMatcher{
 				Not(ContainSubstring("Building stage")),
-				ContainSubstring("Use cache image for artifact/gitArchive"),
+				ContainSubstring("Use previously built image for artifact/gitArchive"),
 			},
 		}
 
@@ -227,7 +227,7 @@ var _ = Describe("user stages", func() {
 			checkResultedFilesChecksum: true,
 			expectedOutputMatchers: []types.GomegaMatcher{
 				Not(ContainSubstring("stage image/gitLatestPatch")),
-				ContainSubstring("Use cache image for image/gitArchive"),
+				ContainSubstring("Use previously built image for image/gitArchive"),
 				ContainSubstring("Building stage image/gitCache"),
 			},
 		}
@@ -240,7 +240,7 @@ var _ = Describe("user stages", func() {
 			checkResultedFilesChecksum: true,
 			expectedOutputMatchers: []types.GomegaMatcher{
 				Not(ContainSubstring("stage image/gitCache")),
-				ContainSubstring("Use cache image for image/gitArchive"),
+				ContainSubstring("Use previously built image for image/gitArchive"),
 				ContainSubstring("Building stage image/gitLatestPatch"),
 			},
 		}
@@ -392,7 +392,7 @@ var _ = Describe("user stages", func() {
 			checkResultedFilesChecksum: false,
 			expectedOutputMatchers: []types.GomegaMatcher{
 				Not(ContainSubstring("Building stage")),
-				ContainSubstring("Use cache image for artifact/gitArchive"),
+				ContainSubstring("Use previously built image for artifact/gitArchive"),
 			},
 		}
 

--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -715,7 +715,7 @@ func (phase *BuildPhase) onImageStage(ctx context.Context, img *image.Image, stg
 	}
 
 	if foundSuitableStage {
-		logboek.Context(ctx).Default().LogFHighlight("Use cache image for %s\n", stg.LogDetailedName())
+		logboek.Context(ctx).Default().LogFHighlight("Use previously built image for %s\n", stg.LogDetailedName())
 		container_backend.LogImageInfo(ctx, stg.GetStageImage().Image, phase.getPrevNonEmptyStageImageSize(), img.ShouldLogPlatform())
 
 		logboek.Context(ctx).LogOptionalLn()
@@ -796,7 +796,7 @@ func (phase *BuildPhase) findAndFetchStageFromSecondaryStagesStorage(ctx context
 				i.Image.SetStageDescription(copiedStageDesc)
 				stg.SetStageImage(i)
 
-				logboek.Context(ctx).Default().LogFHighlight("Use cache image for %s\n", stg.LogDetailedName())
+				logboek.Context(ctx).Default().LogFHighlight("Use previously built image for %s\n", stg.LogDetailedName())
 				container_backend.LogImageInfo(ctx, stg.GetStageImage().Image, phase.getPrevNonEmptyStageImageSize(), img.ShouldLogPlatform())
 
 				return nil

--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -669,7 +669,7 @@ func (m *StorageManager) CopyStageIntoFinalStorage(ctx context.Context, stageID 
 			if desc != nil {
 				logboek.Context(ctx).Info().LogF("Stage %s already exists in the final repo, skipping\n", stageID.String())
 
-				logboek.Context(ctx).Default().LogFHighlight("Use cache final image for %s\n", opts.LogDetailedName)
+				logboek.Context(ctx).Default().LogFHighlight("Use previously built final image for %s\n", opts.LogDetailedName)
 				container_backend.LogImageName(ctx, finalImageName)
 
 				return desc, nil

--- a/test/e2e/build/complex_test.go
+++ b/test/e2e/build/complex_test.go
@@ -40,11 +40,11 @@ var _ = Describe("Complex build", Label("e2e", "build", "complex"), func() {
 				werfProject := werf.NewProject(SuiteData.WerfBinPath, SuiteData.GetTestRepoPath(repoDirname))
 				buildOut, buildReport := werfProject.BuildWithReport(SuiteData.GetBuildReportPath(buildReportName), nil)
 				Expect(buildOut).To(ContainSubstring("Building stage"))
-				Expect(buildOut).NotTo(ContainSubstring("Use cache image"))
+				Expect(buildOut).NotTo(ContainSubstring("Use previously built image"))
 
 				By("state0: rebuilding same images")
 				Expect(werfProject.Build(nil)).To(And(
-					ContainSubstring("Use cache image"),
+					ContainSubstring("Use previously built image"),
 					Not(ContainSubstring("Building stage")),
 				))
 
@@ -174,7 +174,7 @@ var _ = Describe("Complex build", Label("e2e", "build", "complex"), func() {
 
 				By("state1: rebuilding same images")
 				Expect(werfProject.Build(nil)).To(And(
-					ContainSubstring("Use cache image"),
+					ContainSubstring("Use previously built image"),
 					Not(ContainSubstring("Building stage")),
 				))
 

--- a/test/e2e/build/simple_test.go
+++ b/test/e2e/build/simple_test.go
@@ -37,11 +37,11 @@ var _ = Describe("Simple build", Label("e2e", "build", "simple"), func() {
 				werfProject := werf.NewProject(SuiteData.WerfBinPath, SuiteData.GetTestRepoPath(repoDirname))
 				buildOut, buildReport := werfProject.BuildWithReport(SuiteData.GetBuildReportPath(buildReportName), nil)
 				Expect(buildOut).To(ContainSubstring("Building stage"))
-				Expect(buildOut).NotTo(ContainSubstring("Use cache image"))
+				Expect(buildOut).NotTo(ContainSubstring("Use previously built image"))
 
 				By("state0: rebuilding same images")
 				Expect(werfProject.Build(nil)).To(And(
-					ContainSubstring("Use cache image"),
+					ContainSubstring("Use previously built image"),
 					Not(ContainSubstring("Building stage")),
 				))
 


### PR DESCRIPTION
Use the term 'built image' to not confuse users.
Werf cache consists of 'real' images in repo, it is different from the local docker build cache.