### PR TITLE
feat: hide build logs if --require-built-images is in use, show logs on error

### DIFF
--- a/cmd/werf/bundle/export/export.go
+++ b/cmd/werf/bundle/export/export.go
@@ -13,6 +13,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli/values"
 
 	"github.com/werf/logboek"
+	"github.com/werf/logboek/pkg/level"
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/build"
 	"github.com/werf/werf/pkg/config"
@@ -23,6 +24,7 @@ import (
 	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/git_repo/gitdata"
 	"github.com/werf/werf/pkg/image"
+	"github.com/werf/werf/pkg/logging"
 	"github.com/werf/werf/pkg/ssh_agent"
 	"github.com/werf/werf/pkg/storage/lrumeta"
 	"github.com/werf/werf/pkg/storage/manager"
@@ -297,19 +299,25 @@ func runExport(ctx context.Context, imagesToProcess build.ImagesToProcess) error
 		defer conveyorWithRetry.Terminate()
 
 		if err := conveyorWithRetry.WithRetryBlock(ctx, func(c *build.Conveyor) error {
-			if common.GetRequireBuiltImages(ctx, &commonCmdData) {
-				shouldBeBuiltOptions, err := common.GetShouldBeBuiltOptions(&commonCmdData, giterminismManager, werfConfig)
-				if err != nil {
-					return err
-				}
+			buildFunc := func(ctx context.Context) error {
+				if common.GetRequireBuiltImages(ctx, &commonCmdData) {
+					shouldBeBuiltOptions, err := common.GetShouldBeBuiltOptions(&commonCmdData, giterminismManager, werfConfig)
+					if err != nil {
+						return err
+					}
 
-				if err := c.ShouldBeBuilt(ctx, shouldBeBuiltOptions); err != nil {
-					return err
+					return c.ShouldBeBuilt(ctx, shouldBeBuiltOptions)
 				}
-			} else {
-				if err := c.Build(ctx, buildOptions); err != nil {
-					return err
-				}
+				return c.Build(ctx, buildOptions)
+			}
+
+			// Print build logs on error if --require-built-images is specified.
+			// Always print logs by default or if --log-verbose is specified.
+			requireBuiltImage := common.GetRequireBuiltImages(ctx, &commonCmdData)
+			isVerbose := logboek.Context(ctx).IsAcceptedLevel(level.Default)
+			deferLog := requireBuiltImage || !isVerbose
+			if err := logging.RunWithDeferredLog(ctx, deferLog, buildFunc); err != nil {
+				return err
 			}
 
 			imagesInfoGetters, err = c.GetImageInfoGetters(image.InfoGetterOptions{CustomTagFunc: useCustomTagFunc})

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -15,6 +15,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli/values"
 
 	"github.com/werf/logboek"
+	"github.com/werf/logboek/pkg/level"
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/build"
 	"github.com/werf/werf/pkg/config"
@@ -26,6 +27,7 @@ import (
 	"github.com/werf/werf/pkg/git_repo"
 	"github.com/werf/werf/pkg/git_repo/gitdata"
 	"github.com/werf/werf/pkg/image"
+	"github.com/werf/werf/pkg/logging"
 	"github.com/werf/werf/pkg/ssh_agent"
 	"github.com/werf/werf/pkg/storage/lrumeta"
 	"github.com/werf/werf/pkg/storage/manager"
@@ -303,19 +305,25 @@ func runPublish(ctx context.Context, imagesToProcess build.ImagesToProcess) erro
 		defer conveyorWithRetry.Terminate()
 
 		if err := conveyorWithRetry.WithRetryBlock(ctx, func(c *build.Conveyor) error {
-			if common.GetRequireBuiltImages(ctx, &commonCmdData) {
-				shouldBeBuiltOptions, err := common.GetShouldBeBuiltOptions(&commonCmdData, giterminismManager, werfConfig)
-				if err != nil {
-					return err
-				}
+			buildFunc := func(ctx context.Context) error {
+				if common.GetRequireBuiltImages(ctx, &commonCmdData) {
+					shouldBeBuiltOptions, err := common.GetShouldBeBuiltOptions(&commonCmdData, giterminismManager, werfConfig)
+					if err != nil {
+						return err
+					}
 
-				if err := c.ShouldBeBuilt(ctx, shouldBeBuiltOptions); err != nil {
-					return err
+					return c.ShouldBeBuilt(ctx, shouldBeBuiltOptions)
 				}
-			} else {
-				if err := c.Build(ctx, buildOptions); err != nil {
-					return err
-				}
+				return c.Build(ctx, buildOptions)
+			}
+
+			// Print build logs on error if --require-built-images is specified.
+			// Always print logs by default or if --log-verbose is specified.
+			requireBuiltImage := common.GetRequireBuiltImages(ctx, &commonCmdData)
+			isVerbose := logboek.Context(ctx).IsAcceptedLevel(level.Default)
+			deferLog := requireBuiltImage || !isVerbose
+			if err := logging.RunWithDeferredLog(ctx, deferLog, buildFunc); err != nil {
+				return err
 			}
 
 			imagesInfoGetters, err = c.GetImageInfoGetters(image.InfoGetterOptions{CustomTagFunc: useCustomTagFunc})

--- a/cmd/werf/compose/main.go
+++ b/cmd/werf/compose/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/werf/logboek"
+	"github.com/werf/logboek/pkg/level"
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/build"
 	"github.com/werf/werf/pkg/container_backend"
@@ -18,6 +19,7 @@ import (
 	"github.com/werf/werf/pkg/git_repo/gitdata"
 	"github.com/werf/werf/pkg/giterminism_manager"
 	"github.com/werf/werf/pkg/image"
+	"github.com/werf/werf/pkg/logging"
 	"github.com/werf/werf/pkg/ssh_agent"
 	"github.com/werf/werf/pkg/storage/lrumeta"
 	"github.com/werf/werf/pkg/storage/manager"
@@ -409,14 +411,20 @@ func run(ctx context.Context, containerBackend container_backend.ContainerBacken
 			defer conveyorWithRetry.Terminate()
 
 			if err := conveyorWithRetry.WithRetryBlock(ctx, func(c *build.Conveyor) error {
-				if common.GetRequireBuiltImages(ctx, &commonCmdData) {
-					if err := c.ShouldBeBuilt(ctx, build.ShouldBeBuiltOptions{}); err != nil {
-						return err
+				buildFunc := func(ctx context.Context) error {
+					if common.GetRequireBuiltImages(ctx, &commonCmdData) {
+						return c.ShouldBeBuilt(ctx, build.ShouldBeBuiltOptions{})
 					}
-				} else {
-					if err := c.Build(ctx, build.BuildOptions{SkipImageMetadataPublication: *commonCmdData.Dev}); err != nil {
-						return err
-					}
+					return c.Build(ctx, build.BuildOptions{SkipImageMetadataPublication: *commonCmdData.Dev})
+				}
+
+				// Print build logs on error if --require-built-images is specified.
+				// Always print logs by default or if --log-verbose is specified.
+				requireBuiltImage := common.GetRequireBuiltImages(ctx, &commonCmdData)
+				isVerbose := logboek.Context(ctx).IsAcceptedLevel(level.Default)
+				deferLog := requireBuiltImage || !isVerbose
+				if err := logging.RunWithDeferredLog(ctx, deferLog, buildFunc); err != nil {
+					return err
 				}
 
 				for _, img := range c.GetExportedImages() {

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/werf/kubedog/pkg/kube"
 	"github.com/werf/logboek"
+	"github.com/werf/logboek/pkg/level"
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/build"
 	"github.com/werf/werf/pkg/config/deploy_params"
@@ -34,6 +35,7 @@ import (
 	"github.com/werf/werf/pkg/git_repo/gitdata"
 	"github.com/werf/werf/pkg/giterminism_manager"
 	"github.com/werf/werf/pkg/image"
+	"github.com/werf/werf/pkg/logging"
 	"github.com/werf/werf/pkg/ssh_agent"
 	"github.com/werf/werf/pkg/storage/lrumeta"
 	"github.com/werf/werf/pkg/storage/manager"
@@ -345,19 +347,25 @@ func run(ctx context.Context, containerBackend container_backend.ContainerBacken
 		defer conveyorWithRetry.Terminate()
 
 		if err := conveyorWithRetry.WithRetryBlock(ctx, func(c *build.Conveyor) error {
-			if common.GetRequireBuiltImages(ctx, &commonCmdData) {
-				shouldBeBuiltOptions, err := common.GetShouldBeBuiltOptions(&commonCmdData, giterminismManager, werfConfig)
-				if err != nil {
-					return err
-				}
+			buildFunc := func(ctx context.Context) error {
+				if common.GetRequireBuiltImages(ctx, &commonCmdData) {
+					shouldBeBuiltOptions, err := common.GetShouldBeBuiltOptions(&commonCmdData, giterminismManager, werfConfig)
+					if err != nil {
+						return err
+					}
 
-				if err := c.ShouldBeBuilt(ctx, shouldBeBuiltOptions); err != nil {
-					return err
+					return c.ShouldBeBuilt(ctx, shouldBeBuiltOptions)
 				}
-			} else {
-				if err := c.Build(ctx, buildOptions); err != nil {
-					return err
-				}
+				return c.Build(ctx, buildOptions)
+			}
+
+			// Print build logs on error if --require-built-images is specified.
+			// Always print logs by default or if --log-verbose is specified.
+			requireBuiltImage := common.GetRequireBuiltImages(ctx, &commonCmdData)
+			isVerbose := logboek.Context(ctx).IsAcceptedLevel(level.Default)
+			deferLog := requireBuiltImage || !isVerbose
+			if err := logging.RunWithDeferredLog(ctx, deferLog, buildFunc); err != nil {
+				return err
 			}
 
 			imagesInfoGetters, err = c.GetImageInfoGetters(image.InfoGetterOptions{CustomTagFunc: useCustomTagFunc})

--- a/cmd/werf/kube_run/kube_run.go
+++ b/cmd/werf/kube_run/kube_run.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/werf/kubedog/pkg/kube"
 	"github.com/werf/logboek"
+	"github.com/werf/logboek/pkg/level"
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/build"
 	"github.com/werf/werf/pkg/config"
@@ -407,14 +408,20 @@ func run(ctx context.Context, pod, secret, namespace string, werfConfig *config.
 
 	var image string
 	if err := conveyorWithRetry.WithRetryBlock(ctx, func(c *build.Conveyor) error {
-		if common.GetRequireBuiltImages(ctx, &commonCmdData) {
-			if err := c.ShouldBeBuilt(ctx, build.ShouldBeBuiltOptions{}); err != nil {
-				return err
+		buildFunc := func(ctx context.Context) error {
+			if common.GetRequireBuiltImages(ctx, &commonCmdData) {
+				return c.ShouldBeBuilt(ctx, build.ShouldBeBuiltOptions{})
 			}
-		} else {
-			if err := c.Build(ctx, build.BuildOptions{}); err != nil {
-				return err
-			}
+			return c.Build(ctx, build.BuildOptions{})
+		}
+
+		// Print build logs on error if --require-built-images is specified.
+		// Always print logs by default or if --log-verbose is specified.
+		requireBuiltImage := common.GetRequireBuiltImages(ctx, &commonCmdData)
+		isVerbose := logboek.Context(ctx).IsAcceptedLevel(level.Default)
+		deferLog := requireBuiltImage || !isVerbose
+		if err := logging.RunWithDeferredLog(ctx, deferLog, buildFunc); err != nil {
+			return err
 		}
 
 		image, err = c.GetFullImageName(ctx, imageName)

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -336,27 +336,10 @@ func runRender(ctx context.Context, imagesToProcess build.ImagesToProcess) error
 
 				// Print build logs on error by default.
 				// Always print logs if --log-verbose is specified (level.Info).
-				deferLog := true
-				if logboek.Context(ctx).IsAcceptedLevel(level.Default) {
-					deferLog = false
-				}
-				if err := logging.RunWithDeferredLog(ctx, deferLog, buildFunc); err != nil {
+				isVerbose := logboek.Context(ctx).IsAcceptedLevel(level.Default)
+				if err := logging.RunWithDeferredLog(ctx, !isVerbose, buildFunc); err != nil {
 					return err
 				}
-				//if logboek.Context(ctx).IsAcceptedLevel(level.Default) {
-				//	if err := buildFunc(ctx); err != nil {
-				//		return err
-				//	}
-				//} else {
-				//	buf := new(bytes.Buffer)
-				//	bufLogger := logboek.NewLogger(buf, buf)
-				//	ctxWithBufLogger := logboek.NewContext(ctx, bufLogger)
-				//
-				//	if err := buildFunc(ctxWithBufLogger); err != nil {
-				//		fmt.Println(buf.String())
-				//		return err
-				//	}
-				//}
 
 				imagesInfoGetters, err = c.GetImageInfoGetters(image.InfoGetterOptions{CustomTagFunc: useCustomTagFunc})
 				if err != nil {

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/werf/logboek"
+	"github.com/werf/logboek/pkg/level"
 	"github.com/werf/werf/cmd/werf/common"
 	"github.com/werf/werf/pkg/build"
 	"github.com/werf/werf/pkg/container_backend"
@@ -393,14 +394,20 @@ func run(ctx context.Context, containerBackend container_backend.ContainerBacken
 
 	var dockerImageName string
 	if err := conveyorWithRetry.WithRetryBlock(ctx, func(c *build.Conveyor) error {
-		if common.GetRequireBuiltImages(ctx, &commonCmdData) {
-			if err := c.ShouldBeBuilt(ctx, build.ShouldBeBuiltOptions{}); err != nil {
-				return err
+		buildFunc := func(ctx context.Context) error {
+			if common.GetRequireBuiltImages(ctx, &commonCmdData) {
+				return c.ShouldBeBuilt(ctx, build.ShouldBeBuiltOptions{})
 			}
-		} else {
-			if err := c.Build(ctx, build.BuildOptions{SkipImageMetadataPublication: *commonCmdData.Dev}); err != nil {
-				return err
-			}
+			return c.Build(ctx, build.BuildOptions{SkipImageMetadataPublication: *commonCmdData.Dev})
+		}
+
+		// Print build logs on error if --require-built-images is specified.
+		// Always print logs by default or if --log-verbose is specified.
+		requireBuiltImage := common.GetRequireBuiltImages(ctx, &commonCmdData)
+		isVerbose := logboek.Context(ctx).IsAcceptedLevel(level.Default)
+		deferLog := requireBuiltImage || !isVerbose
+		if err := logging.RunWithDeferredLog(ctx, deferLog, buildFunc); err != nil {
+			return err
 		}
 
 		dockerImageName, err = c.GetFullImageName(ctx, imageName)

--- a/pkg/logging/main.go
+++ b/pkg/logging/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/gookit/color"
+
 	"github.com/werf/logboek"
 )
 


### PR DESCRIPTION

- Use --log-verbose to see full log anyway
- Use --log-quiet to hide build log without --require-built-images