### PR TITLE
fix: remove abandoned linters, use unused linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,11 +25,9 @@ linters:
   disable-all: true
   enable:
     # Default linters.
-    - deadcode
     - ineffassign
-    - structcheck
     - typecheck
-    - varcheck
+    - unused
 
     # Extra linters.
     - asciicheck
@@ -42,3 +40,13 @@ linters:
     - gocritic
     - gofumpt
     - misspell
+    - nolintlint
+
+issues:
+  # Show all errors.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+  exclude:
+    # TODO use %w in the future.
+    - "non-wrapping format verb for fmt.Errorf" # errorlint

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -509,7 +509,7 @@ tasks:
   deps:install:golangci-lint:
     desc: "Install golangci-lint binary."
     cmds:
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin {{.golangcilintVersion | default "v1.50.0"}}
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin {{.golangcilintVersion | default "v1.52.2"}}
 
   deps:install:prettier:
     desc: "Install prettier."

--- a/pkg/buildah/common.go
+++ b/pkg/buildah/common.go
@@ -256,7 +256,9 @@ func GetDefaultIsolation() (thirdparty.Isolation, error) {
 	return thirdparty.IsolationChroot, nil
 }
 
-//nolint:deadcode,unused
+// TODO used for linux only, hide under the build flag
+//
+//nolint:nolintlint,unused
 func debug() bool {
 	return os.Getenv("WERF_BUILDAH_DEBUG") == "1"
 }

--- a/pkg/buildah/thirdparty/docker.go
+++ b/pkg/buildah/thirdparty/docker.go
@@ -164,7 +164,7 @@ type V1Image struct {
 // V2Image stores the image configuration
 type V2Image struct {
 	V1Image
-	Parent     ID            `json:"parent,omitempty"` // nolint:govet
+	Parent     ID            `json:"parent,omitempty"` //nolint:govet
 	RootFS     *V2S2RootFS   `json:"rootfs,omitempty"`
 	History    []V2S2History `json:"history,omitempty"`
 	OSVersion  string        `json:"os.version,omitempty"`

--- a/pkg/cleaning/stage_manager/manager.go
+++ b/pkg/cleaning/stage_manager/manager.go
@@ -27,7 +27,7 @@ func NewManager() Manager {
 
 type stage struct {
 	stageID          string
-	isMultiplatform  bool
+	isMultiplatform  bool //nolint:unused
 	description      *image.StageDescription
 	isProtected      bool
 	protectionReason string

--- a/pkg/config/raw_stapel_image.go
+++ b/pkg/config/raw_stapel_image.go
@@ -158,6 +158,7 @@ func (c *rawStapelImage) validateStapelImageDirective(image *StapelImage) (err e
 	return nil
 }
 
+//nolint:unused
 func (c *rawStapelImage) toShellDirectiveByCommandAndStage(command, stage string) (shell *Shell) {
 	shell = &Shell{}
 	switch stage {
@@ -176,6 +177,7 @@ func (c *rawStapelImage) toShellDirectiveByCommandAndStage(command, stage string
 	return
 }
 
+//nolint:unused
 func (c *rawStapelImage) toAnsibleWithTaskByStage(task *AnsibleTask, stage string) (ansible *Ansible) {
 	ansible = &Ansible{}
 	switch stage {

--- a/pkg/docker_registry/docker_hub.go
+++ b/pkg/docker_registry/docker_hub.go
@@ -93,6 +93,8 @@ func (r *dockerHub) DeleteRepoImage(ctx context.Context, repoImage *image.Info) 
 		return err
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	resp, err := r.dockerHubApi.deleteTag(ctx, account, project, repoImage.Tag, token)
 	if err != nil {
 		return r.handleFailedApiResponse(resp, err)
@@ -112,6 +114,8 @@ func (r *dockerHub) deleteRepo(ctx context.Context, reference string) error {
 		return err
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	resp, err := r.dockerHubApi.deleteRepository(ctx, account, project, token)
 	if err != nil {
 		return r.handleFailedApiResponse(resp, err)
@@ -125,6 +129,8 @@ func (r *dockerHub) getToken(ctx context.Context) (string, error) {
 		return r.dockerHubCredentials.token, nil
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	token, resp, err := r.dockerHubApi.getToken(ctx, r.dockerHubCredentials.username, r.dockerHubCredentials.password)
 	if err != nil {
 		return "", r.handleFailedApiResponse(resp, err)

--- a/pkg/docker_registry/github_packages.go
+++ b/pkg/docker_registry/github_packages.go
@@ -102,6 +102,8 @@ func (r *gitHubPackages) DeleteRepoImage(ctx context.Context, repoImage *image.I
 	}
 
 	if isUser {
+		//nolint:bodyclose
+		// TODO: close response body
 		if resp, err := r.gitHubApi.deleteUserContainerPackageVersion(ctx, packageName, packageVersionId, r.token); err != nil {
 			return r.handleFailedApiResponse(resp, err)
 		}
@@ -109,6 +111,8 @@ func (r *gitHubPackages) DeleteRepoImage(ctx context.Context, repoImage *image.I
 		return nil
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	if resp, err := r.gitHubApi.deleteOrgContainerPackageVersion(ctx, orgOrUserName, packageName, packageVersionId, r.token); err != nil {
 		return r.handleFailedApiResponse(resp, err)
 	}
@@ -128,6 +132,8 @@ func (r *gitHubPackages) DeleteRepo(ctx context.Context, reference string) error
 	}
 
 	if isUser {
+		//nolint:bodyclose
+		// TODO: close response body
 		if resp, err := r.gitHubApi.deleteUserContainerPackage(ctx, packageName, r.token); err != nil {
 			return r.handleFailedApiResponse(resp, err)
 		}
@@ -135,6 +141,8 @@ func (r *gitHubPackages) DeleteRepo(ctx context.Context, reference string) error
 		return nil
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	if resp, err := r.gitHubApi.deleteOrgContainerPackage(ctx, orgOrUserName, packageName, r.token); err != nil {
 		return r.handleFailedApiResponse(resp, err)
 	}
@@ -178,6 +186,8 @@ func (r *gitHubPackages) populateTagIDPackageVersionIDCache(ctx context.Context,
 	}
 
 	if isUser {
+		//nolint:bodyclose
+		// TODO: close response body
 		if resp, err := r.gitHubApi.getUserContainerPackageVersionsInBatches(ctx, packageName, r.token, handleFunc); err != nil {
 			return r.handleFailedApiResponse(resp, err)
 		}
@@ -185,6 +195,8 @@ func (r *gitHubPackages) populateTagIDPackageVersionIDCache(ctx context.Context,
 		return nil
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	if resp, err := r.gitHubApi.getOrgContainerPackageVersionsInBatches(ctx, orgOrUserName, packageName, r.token, handleFunc); err != nil {
 		return r.handleFailedApiResponse(resp, err)
 	}
@@ -202,6 +214,8 @@ func (r *gitHubPackages) isUser(ctx context.Context, orgOrUserName string) (bool
 		return isUser.(bool), nil
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	user, resp, err := r.gitHubApi.getUser(ctx, orgOrUserName, r.token)
 	if err != nil {
 		return false, r.handleFailedApiResponse(resp, err)

--- a/pkg/docker_registry/selectel.go
+++ b/pkg/docker_registry/selectel.go
@@ -110,6 +110,8 @@ func (r *selectel) deleteRepoImage(ctx context.Context, repoImage *image.Info) e
 		return err
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	resp, err := r.selectelApi.deleteReference(ctx, hostname, registryID, repository, repoImage.RepoDigest, token)
 	if err != nil {
 		return r.handleFailedApiResponse(resp, err)
@@ -129,6 +131,8 @@ func (r *selectel) deleteRepo(ctx context.Context, reference string) error {
 		return err
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	resp, err := r.selectelApi.deleteRepository(ctx, hostname, registryID, repository, token)
 	if err != nil {
 		return r.handleFailedApiResponse(resp, err)
@@ -148,6 +152,8 @@ func (r *selectel) tags(ctx context.Context, reference string) ([]string, error)
 		return nil, err
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	tags, resp, err := r.selectelApi.getTags(ctx, hostname, registryID, repository, token)
 	if err != nil {
 		return nil, r.handleFailedApiResponse(resp, err)
@@ -195,6 +201,8 @@ func (r *selectel) getRegistryId(ctx context.Context, token, reference string) (
 		return "", err
 	}
 
+	//nolint:bodyclose
+	// TODO: close response body
 	registryId, resp, err := r.selectelApi.getRegistryId(ctx, hostname, registry, token)
 	if err != nil {
 		return "", r.handleFailedApiResponse(resp, err)

--- a/pkg/storage/kubernetes_stages_storage_cache.go
+++ b/pkg/storage/kubernetes_stages_storage_cache.go
@@ -73,6 +73,7 @@ func (cache *KubernetesStagesStorageCache) setCacheData(obj *v1.ConfigMap, cache
 	}
 }
 
+//nolint:unused
 func (cache *KubernetesStagesStorageCache) getConfigMapName(projectName string) string {
 	if cache.GetConfigMapNameFunc != nil {
 		return cache.GetConfigMapNameFunc(projectName)


### PR DESCRIPTION
- Update golangci-lint to 1.52.1 to support Go 1.20 (See https://github.com/golangci/golangci-lint/pull/3414)
- Remove abandoned linters
- Add 'nolint' pragmas, should refactor in the future.
- Enable nolintlint linter.
- Add max-* settings to show all errors at once.

Abandoned linters gave this warnings:
```
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [linters_context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649. 
```