### PR TITLE
fix(staged-dockerfile): eliminate excess manifest get request from base image registry

### DIFF
--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -155,7 +155,7 @@ func (s *BaseStage) ExpandDependencies(ctx context.Context, c Conveyor, baseEnv 
 	return nil
 }
 
-func (s *BaseStage) FetchDependencies(_ context.Context, _ Conveyor, _ container_backend.ContainerBackend, _ docker_registry.ApiInterface) error {
+func (s *BaseStage) FetchDependencies(_ context.Context, _ Conveyor, _ container_backend.ContainerBackend, _ docker_registry.GenericApiInterface) error {
 	return nil
 }
 

--- a/pkg/build/stage/full_dockerfile.go
+++ b/pkg/build/stage/full_dockerfile.go
@@ -294,7 +294,7 @@ type dockerfileInstructionInterface interface {
 	Name() string
 }
 
-func (s *FullDockerfileStage) FetchDependencies(ctx context.Context, c Conveyor, containerBackend container_backend.ContainerBackend, dockerRegistry docker_registry.ApiInterface) error {
+func (s *FullDockerfileStage) FetchDependencies(ctx context.Context, c Conveyor, containerBackend container_backend.ContainerBackend, dockerRegistry docker_registry.GenericApiInterface) error {
 	resolvedDependenciesArgsHash := ResolveDependenciesArgs(s.targetPlatform, s.dependencies, c)
 
 	resolvedDockerMetaArgsHash, err := s.resolveDockerMetaArgs(resolvedDependenciesArgsHash)

--- a/pkg/build/stage/instruction/from.go
+++ b/pkg/build/stage/instruction/from.go
@@ -48,7 +48,7 @@ func (stg *From) PrepareImage(ctx context.Context, c stage.Conveyor, cb containe
 	return nil
 }
 
-func (s *From) FetchDependencies(_ context.Context, _ stage.Conveyor, _ container_backend.ContainerBackend, _ docker_registry.ApiInterface) error {
+func (s *From) FetchDependencies(_ context.Context, _ stage.Conveyor, _ container_backend.ContainerBackend, _ docker_registry.GenericApiInterface) error {
 	return nil
 }
 

--- a/pkg/build/stage/interface.go
+++ b/pkg/build/stage/interface.go
@@ -15,7 +15,7 @@ type Interface interface {
 	IsEmpty(ctx context.Context, c Conveyor, prevBuiltImage *StageImage) (bool, error)
 
 	ExpandDependencies(ctx context.Context, c Conveyor, baseEnv map[string]string) error
-	FetchDependencies(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, dockerRegistry docker_registry.ApiInterface) error
+	FetchDependencies(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, dockerRegistry docker_registry.GenericApiInterface) error
 	GetDependencies(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error)
 	GetNextStageDependencies(ctx context.Context, c Conveyor) (string, error)
 

--- a/pkg/build/stage/stubs.go
+++ b/pkg/build/stage/stubs.go
@@ -210,7 +210,7 @@ func (containerBackend *ContainerBackendStub) Pull(ctx context.Context, ref stri
 }
 
 type DockerRegistryApiStub struct {
-	docker_registry.ApiInterface
+	docker_registry.GenericApiInterface
 }
 
 func NewDockerRegistryApiStub() *DockerRegistryApiStub {

--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -100,7 +99,7 @@ func (api *api) tryGetRepoImage(ctx context.Context, reference, implementation s
 		if IsImageNotFoundError(err) || IsBrokenImageError(err) {
 			// TODO: 1. make sure werf never ever creates rejected image records for name-unknown errors.
 			// TODO: 2. werf-cleanup should remove broken images
-			if os.Getenv("WERF_DOCKER_REGISTRY_DEBUG") == "1" {
+			if debugDockerRegistry() {
 				logboek.Context(ctx).Error().LogF("WARNING: Got an error when inspecting repo image %q: %s\n", reference, err)
 			}
 			return nil, nil

--- a/pkg/docker_registry/debug.go
+++ b/pkg/docker_registry/debug.go
@@ -1,0 +1,144 @@
+package docker_registry
+
+import (
+	"context"
+	"io"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/werf/logboek"
+	"github.com/werf/werf/pkg/image"
+)
+
+type DockerRegistryTracer struct {
+	DockerRegistry    Interface
+	DockerRegistryApi GenericApiInterface
+}
+
+func NewDockerRegistryTracer(dockerRegistry Interface, dockerRegistryApi GenericApiInterface) *DockerRegistryTracer {
+	return &DockerRegistryTracer{
+		DockerRegistry:    dockerRegistry,
+		DockerRegistryApi: dockerRegistryApi,
+	}
+}
+
+func (r *DockerRegistryTracer) CreateRepo(ctx context.Context, reference string) (err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.CreateRepo %q", reference).Do(func() {
+		err = r.DockerRegistry.CreateRepo(ctx, reference)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) DeleteRepo(ctx context.Context, reference string) (err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.DeleteRepo %q", reference).Do(func() {
+		err = r.DockerRegistry.DeleteRepo(ctx, reference)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) Tags(ctx context.Context, reference string, opts ...Option) (res []string, err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.Tags %q", reference).Do(func() {
+		res, err = r.DockerRegistry.Tags(ctx, reference, opts...)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) IsTagExist(ctx context.Context, reference string, opts ...Option) (res bool, err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.IsTagExist %q", reference).Do(func() {
+		res, err = r.DockerRegistry.IsTagExist(ctx, reference, opts...)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) TagRepoImage(ctx context.Context, repoImage *image.Info, tag string) (err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.TagRepoImage %q", tag).Do(func() {
+		err = r.DockerRegistry.TagRepoImage(ctx, repoImage, tag)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) GetRepoImage(ctx context.Context, reference string) (res *image.Info, err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.GetRepoImage %q", reference).Do(func() {
+		if r.DockerRegistry != nil {
+			res, err = r.DockerRegistry.GetRepoImage(ctx, reference)
+		} else {
+			res, err = r.DockerRegistryApi.GetRepoImage(ctx, reference)
+		}
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) TryGetRepoImage(ctx context.Context, reference string) (res *image.Info, err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.TryGetRepoImage %q", reference).Do(func() {
+		res, err = r.DockerRegistry.TryGetRepoImage(ctx, reference)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) DeleteRepoImage(ctx context.Context, repoImage *image.Info) (err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.DeleteRepoImage %v", repoImage).Do(func() {
+		err = r.DockerRegistry.DeleteRepoImage(ctx, repoImage)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) PushImage(ctx context.Context, reference string, opts *PushImageOptions) (err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.PushImage %q", reference).Do(func() {
+		err = r.DockerRegistry.PushImage(ctx, reference, opts)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) MutateAndPushImage(ctx context.Context, sourceReference, destinationReference string, mutateConfigFunc func(v1.Config) (v1.Config, error)) (err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.MutateAndPushImage %q -> %q", sourceReference, destinationReference).Do(func() {
+		if r.DockerRegistry != nil {
+			err = r.DockerRegistry.MutateAndPushImage(ctx, sourceReference, destinationReference, mutateConfigFunc)
+		} else {
+			err = r.DockerRegistryApi.MutateAndPushImage(ctx, sourceReference, destinationReference, mutateConfigFunc)
+		}
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) CopyImage(ctx context.Context, sourceReference, destinationReference string, opts CopyImageOptions) (err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.CopyImage %q -> %q", sourceReference, destinationReference).Do(func() {
+		err = r.DockerRegistry.CopyImage(ctx, sourceReference, destinationReference, opts)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) PushImageArchive(ctx context.Context, archiveOpener ArchiveOpener, reference string) (err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.PushImageArchive %q", reference).Do(func() {
+		err = r.DockerRegistry.PushImageArchive(ctx, archiveOpener, reference)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) PullImageArchive(ctx context.Context, archiveWriter io.Writer, reference string) (err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.PullImageArchive %q", reference).Do(func() {
+		err = r.DockerRegistry.PullImageArchive(ctx, archiveWriter, reference)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) PushManifestList(ctx context.Context, reference string, opts ManifestListOptions) (err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.PushManifestList %q", reference).Do(func() {
+		err = r.DockerRegistry.PushManifestList(ctx, reference, opts)
+	})
+	return
+}
+
+func (r *DockerRegistryTracer) String() (res string) {
+	return r.DockerRegistry.String()
+}
+
+func (r *DockerRegistryTracer) parseReferenceParts(reference string) (res referenceParts, err error) {
+	return r.DockerRegistry.parseReferenceParts(reference)
+}
+
+func (r *DockerRegistryTracer) GetRepoImageConfigFile(ctx context.Context, reference string) (res *v1.ConfigFile, err error) {
+	logboek.Context(ctx).Default().LogProcess("DockerRegistryTracer.GetRepoImageConfigFile %q", reference).Do(func() {
+		res, err = r.DockerRegistryApi.GetRepoImageConfigFile(ctx, reference)
+	})
+	return
+}

--- a/pkg/docker_registry/docker_registry.go
+++ b/pkg/docker_registry/docker_registry.go
@@ -110,13 +110,19 @@ func (o *DockerRegistryOptions) defaultOptions() defaultImplementationOptions {
 }
 
 func NewDockerRegistry(repositoryAddress, implementation string, options DockerRegistryOptions) (Interface, error) {
-	dockerRegistry, err := newDockerRegistry(repositoryAddress, implementation, options)
+	var res Interface
+	var err error
+
+	res, err = newDockerRegistry(repositoryAddress, implementation, options)
 	if err != nil {
 		return nil, err
 	}
+	if debugDockerRegistry() {
+		res = NewDockerRegistryTracer(res, nil)
+	}
 
-	dockerRegistryWithCache := newDockerRegistryWithCache(dockerRegistry)
-	return dockerRegistryWithCache, nil
+	res = newDockerRegistryWithCache(res)
+	return res, nil
 }
 
 func newDockerRegistry(repositoryAddress, implementation string, options DockerRegistryOptions) (Interface, error) {

--- a/pkg/docker_registry/interface.go
+++ b/pkg/docker_registry/interface.go
@@ -9,17 +9,22 @@ import (
 	"github.com/werf/werf/pkg/image"
 )
 
+type commonInterface interface {
+	GetRepoImage(ctx context.Context, reference string) (*image.Info, error)
+	MutateAndPushImage(ctx context.Context, sourceReference, destinationReference string, mutateConfigFunc func(v1.Config) (v1.Config, error)) error
+}
+
 type Interface interface {
+	commonInterface
+
 	CreateRepo(ctx context.Context, reference string) error
 	DeleteRepo(ctx context.Context, reference string) error
 	Tags(ctx context.Context, reference string, opts ...Option) ([]string, error)
 	IsTagExist(ctx context.Context, reference string, opts ...Option) (bool, error)
 	TagRepoImage(ctx context.Context, repoImage *image.Info, tag string) error
-	GetRepoImage(ctx context.Context, reference string) (*image.Info, error)
 	TryGetRepoImage(ctx context.Context, reference string) (*image.Info, error)
 	DeleteRepoImage(ctx context.Context, repoImage *image.Info) error
 	PushImage(ctx context.Context, reference string, opts *PushImageOptions) error
-	MutateAndPushImage(ctx context.Context, sourceReference, destinationReference string, mutateConfigFunc func(v1.Config) (v1.Config, error)) error
 	CopyImage(ctx context.Context, sourceReference, destinationReference string, opts CopyImageOptions) error
 
 	PushImageArchive(ctx context.Context, archiveOpener ArchiveOpener, reference string) error
@@ -31,7 +36,9 @@ type Interface interface {
 	parseReferenceParts(reference string) (referenceParts, error)
 }
 
-type ApiInterface interface {
+type GenericApiInterface interface {
+	commonInterface
+
 	GetRepoImageConfigFile(ctx context.Context, reference string) (*v1.ConfigFile, error)
 }
 

--- a/pkg/docker_registry/main.go
+++ b/pkg/docker_registry/main.go
@@ -41,8 +41,15 @@ func Init(ctx context.Context, insecureRegistry, skipTlsVerifyRegistry bool) err
 	return nil
 }
 
-func API() *genericApi {
+func API() GenericApiInterface {
+	if debugDockerRegistry() {
+		return NewDockerRegistryTracer(nil, generic)
+	}
 	return generic
+}
+
+func debugDockerRegistry() bool {
+	return os.Getenv("WERF_DOCKER_REGISTRY_DEBUG") == "1"
 }
 
 func debugDockerRegistryAPI() bool {

--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -50,7 +50,7 @@ type ForEachDeleteStageOptions struct {
 
 type StorageOptions struct {
 	ContainerBackend container_backend.ContainerBackend
-	DockerRegistry   docker_registry.ApiInterface
+	DockerRegistry   docker_registry.GenericApiInterface
 }
 
 type StorageManagerInterface interface {
@@ -379,7 +379,7 @@ func (m *StorageManager) getImageInfoFromContainerBackend(ctx context.Context, r
 	return containerBackend.GetImageInfo(ctx, ref, container_backend.GetImageInfoOpts{})
 }
 
-func (m *StorageManager) getImageInfoFromRegistry(ctx context.Context, ref string, dockerRegistry docker_registry.ApiInterface) (*image.Info, error) {
+func (m *StorageManager) getImageInfoFromRegistry(ctx context.Context, ref string, dockerRegistry docker_registry.GenericApiInterface) (*image.Info, error) {
 	cfg, err := dockerRegistry.GetRepoImageConfigFile(ctx, ref)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Manifest getter used to fetch base image manifest needed to use base ENV-variables and ONBUILD instructions. Now werf uses manifest of FROM1 stage for ENV-vars and ONBUILD instructions instead of base image manifest.

Additionally added debug tracer messages to log all requests to docker-registry api. Enable debug by setting WERF_DOCKER_REGISTRY_DEBUG=1.