### PR TITLE
fix(build): initialize ondemandKubeInitializer for custom sync server in Kubernetes

### DIFF
--- a/cmd/werf/build/main.go
+++ b/cmd/werf/build/main.go
@@ -183,6 +183,11 @@ func runMain(ctx context.Context, imagesToProcess build.ImagesToProcess) error {
 		}
 	}()
 
+	common.SetupOndemandKubeInitializer(*commonCmdData.KubeContext, *commonCmdData.KubeConfig, *commonCmdData.KubeConfigBase64, *commonCmdData.KubeConfigPathMergeList)
+	if err := common.GetOndemandKubeInitializer().Init(ctx); err != nil {
+		return err
+	}
+
 	if *commonCmdData.Follow {
 		logboek.LogOptionalLn()
 		return common.FollowGitHead(ctx, &commonCmdData, func(ctx context.Context, headCommitGiterminismManager giterminism_manager.Interface) error {


### PR DESCRIPTION
This commit addresses an issue where the 'build' command was failing when using a custom synchronization server in Kubernetes. It ensures that the necessary initialization is performed, consistent with other commands, to prevent failures.