### PR TITLE
ci: use enterprise runners for docs

### DIFF
--- a/.github/workflows/_docs_deploy.yml
+++ b/.github/workflows/_docs_deploy.yml
@@ -6,14 +6,14 @@ on:
       env:
         required: true
         type: string
-      kubeContext:
+      kubeConfig:
         required: true
         type: string
       persistent:
         default: false
         type: string
       runner:
-        default: tfprod-werf
+        default: ubuntu-latest-4-cores
         type: string
 
 defaults:
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -48,9 +48,9 @@ jobs:
         uses: werf/actions/converge@v1.2
         with:
           env: ${{ inputs.env }}
+          kube-config-base64-data: ${{ inputs.kubeConfig }}
         env:
           WERF_NAMESPACE: werfio-${{ inputs.env }}
           WERF_DIR: docs
           WERF_LOG_VERBOSE: on
-          WERF_KUBE_CONTEXT: ${{ inputs.kubeContext }}
           WERF_REPO: ghcr.io/${{ github.repository_owner }}/werfio

--- a/.github/workflows/docs_deploy_latest.yml
+++ b/.github/workflows/docs_deploy_latest.yml
@@ -14,14 +14,14 @@ jobs:
     with:
       persistent: true
       env: production
-      kubeContext: prod
+      kubeConfig: ${{ secrets.KUBECONFIG_BASE64_DPROD }}
 
   deploy-test:
     uses: ./.github/workflows/_docs_deploy.yml
     with:
       persistent: true
       env: test
-      kubeContext: dev
+      kubeConfig: ${{ secrets.KUBECONFIG_BASE64_DEV }}
 
   notify:
     if: always()

--- a/.github/workflows/docs_deploy_pr.yml
+++ b/.github/workflows/docs_deploy_pr.yml
@@ -14,7 +14,7 @@ jobs:
     uses: ./.github/workflows/_docs_deploy.yml
     with:
       env: test
-      kubeContext: dev
+      kubeConfig: ${{ secrets.KUBECONFIG_BASE64_DEV }}
 
   notify:
     if: |

--- a/.github/workflows/docs_deploy_tag.yml
+++ b/.github/workflows/docs_deploy_tag.yml
@@ -16,14 +16,14 @@ jobs:
     with:
       persistent: true
       env: production
-      kubeContext: prod
+      kubeConfig: ${{ secrets.KUBECONFIG_BASE64_PROD }}
 
   deploy-test:
     uses: ./.github/workflows/_docs_deploy.yml
     with:
       persistent: true
       env: test
-      kubeContext: dev
+      kubeConfig: ${{ secrets.KUBECONFIG_BASE64_DEV }}
 
   notify:
     if: always()

--- a/.github/workflows/release_trdl-publish.yml
+++ b/.github/workflows/release_trdl-publish.yml
@@ -30,10 +30,10 @@ jobs:
   deploy_channels_cm_prod:
     name: Deploy trdl_channels.yaml to production
     needs: publish
-    runs-on: tfprod-werf
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -41,6 +41,7 @@ jobs:
         uses: werf/actions/converge@v1.2
         with:
           env: production
+          kube-config-base64-data: ${{ secrets.KUBECONFIG_BASE64_PROD }}
         env:
           WERF_NAMESPACE: "werfio-production"
           WERF_KUBE_CONTEXT: prod


### PR DESCRIPTION
- Use enterprise runners for the documentation deployment.
- Use secrets for K8s context.