### PR TITLE
docs(configurator-separate-pages): serve /documentation/X/configurator/*.html pages

### DIFF
--- a/docs/.helm/templates/20-ingress.yaml
+++ b/docs/.helm/templates/20-ingress.yaml
@@ -13,14 +13,69 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  name: {{ .Chart.Name }}-{{ .VersionDNSNormalized }}-configurator
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /documentation/{{ .VersionURLNormalized }}/configurator.html
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-Original-URI $request_uri;
+
+      set $configurator_selected_page $1;
+
+      ssi on;
+      ssi_silent_errors on;
+
+{{ include "rewrites" . | indent 6 }}
+{{- if eq .Values.werf.env "production" }}
+    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
+{{- else }}
+    nginx.ingress.kubernetes.io/auth-url: http://basic-auth.kube-basic-auth.svc.cluster.local/werfio
+{{- end }}
+spec:
+  tls:
+    - hosts:
+        - {{ $host }}
+        - ru.{{ $host }}
+{{- if eq .Values.werf.env "production" }}
+        - www.{{ $host }}
+{{- end }}
+      secretName: tls-{{ $host }}
+  rules:
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /documentation/{{ .VersionURLNormalized }}/configurator(?:/(.*))?$
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Chart.Name }}-{{ .VersionDNSNormalized }}
+                port:
+                  name: http
+    - host: ru.{{ $host }}
+      http:
+        paths:
+          - path: /documentation/{{ .VersionURLNormalized }}/configurator(?:/(.*))?$
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Chart.Name }}-{{ .VersionDNSNormalized }}
+                port:
+                  name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
   name: {{ .Chart.Name }}-{{ .VersionDNSNormalized }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header X-Original-URI         $request_uri;
+      proxy_set_header X-Original-URI $request_uri;
+
       ssi on;
       ssi_silent_errors on;
-{{- include "rewrites" . | indent 6 }}
+
+{{ include "rewrites" . | indent 6 }}
 {{- if eq .Values.werf.env "production" }}
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
 {{- else }}

--- a/docs/pages_en/configurator.md
+++ b/docs/pages_en/configurator.md
@@ -1,0 +1,7 @@
+---
+title: Install and run
+permalink: configurator.html
+toc: false
+---
+
+<!--#include virtual="/configurator/tabs/$configurator_selected_page" -->

--- a/docs/pages_ru/configurator.md
+++ b/docs/pages_ru/configurator.md
@@ -1,0 +1,7 @@
+---
+title: Установка и запуск
+permalink: configurator.html
+toc: false
+---
+
+<!--#include virtual="/configurator/tabs/$configurator_selected_page" -->


### PR DESCRIPTION
Route all /configurator/*.html pages to a single configurator page in werf-docs which will ssi-include target page.