### PR TITLE
fix(staged-dockerfile): explanatory error message when building unsupported Dockerfile conf

### DIFF
--- a/pkg/build/image/dockerfile.go
+++ b/pkg/build/image/dockerfile.go
@@ -230,6 +230,12 @@ func mapDockerfileToImagesSets(ctx context.Context, cfg *dockerfile.Dockerfile, 
 			instrNum++
 		}
 
+		if werf.GetStagedDockerfileVersion() == werf.StagedDockerfileV1 {
+			if len(img.stages) == 0 {
+				return nil, fmt.Errorf("unsupported configuration, please enable staged dockerfile builder v2 by setting environment variable WERF_STAGED_DOCKERFILE_VERSION=v2")
+			}
+		}
+
 		appendImageToCurrentSet(img)
 	}
 


### PR DESCRIPTION
Print explanatory error for user to enable WERF_STAGED_DOCKERFILE_VERSION=v2 when Dockerfile contains only single FROM instruction.