### PR TITLE
fix(build): files from git with spaces in path not removed on install/beforeSetup/setup patch-stages

### DIFF
--- a/pkg/true_git/diff_parser.go
+++ b/pkg/true_git/diff_parser.go
@@ -402,7 +402,10 @@ func (p *diffParser) handleNewFilePath(line string) error {
 }
 
 func (p *diffParser) trimFileBaseFilepath(path string) string {
-	return filepath.ToSlash(util.GetRelativeToBaseFilepath(filepath.FromSlash(p.PathScope), filepath.FromSlash(path)))
+	newPath := filepath.ToSlash(util.GetRelativeToBaseFilepath(filepath.FromSlash(p.PathScope), filepath.FromSlash(path)))
+	// NOTE: for some files git diff may emit tabs on the end of path-line, for example: "--- a/path with spaces/to/file.txt\t"
+	newPath = strings.TrimRight(newPath, "\t")
+	return newPath
 }
 
 func (p *diffParser) handleDeleteFilePath(line string) error {


### PR DESCRIPTION
Error was due to strange git-patch format for such files wihch contain \t symbol at the end of such lines: '--- a/aaa/bbb/path with spaces/hello.sql\t'.