### PR TITLE
chore: replace satori/go.uuid with google/uuid

### DIFF
--- a/cmd/werf/bundle/apply/apply.go
+++ b/cmd/werf/bundle/apply/apply.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	helm_v3 "helm.sh/helm/v3/cmd/helm"
 	"helm.sh/helm/v3/pkg/action"
@@ -174,7 +174,7 @@ func runApply(ctx context.Context) error {
 		return err
 	}
 
-	bundleTmpDir := filepath.Join(werf.GetServiceDir(), "tmp", "bundles", uuid.NewV4().String())
+	bundleTmpDir := filepath.Join(werf.GetServiceDir(), "tmp", "bundles", uuid.NewString())
 	defer os.RemoveAll(bundleTmpDir)
 
 	if err := bundles.Pull(ctx, fmt.Sprintf("%s:%s", repoAddress, cmdData.Tag), bundleTmpDir, bundlesRegistryClient); err != nil {

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	helm_v3 "helm.sh/helm/v3/cmd/helm"
 	"helm.sh/helm/v3/pkg/chart"
@@ -406,7 +406,7 @@ func runPublish(ctx context.Context, imagesToProcess build.ImagesToProcess) erro
 	}
 	chartVersion := sv.String()
 
-	bundleTmpDir := filepath.Join(werf.GetServiceDir(), "tmp", "bundles", uuid.NewV4().String())
+	bundleTmpDir := filepath.Join(werf.GetServiceDir(), "tmp", "bundles", uuid.NewString())
 	defer os.RemoveAll(bundleTmpDir)
 
 	bundle, err := wc.CreateNewBundle(ctx, bundleTmpDir, chartVersion, &values.Options{

--- a/cmd/werf/bundle/render/render.go
+++ b/cmd/werf/bundle/render/render.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	helm_v3 "helm.sh/helm/v3/cmd/helm"
 	"helm.sh/helm/v3/pkg/action"
@@ -178,7 +178,7 @@ func runRender(ctx context.Context) error {
 			return err
 		}
 
-		bundleDir = filepath.Join(werf.GetServiceDir(), "tmp", "bundles", uuid.NewV4().String())
+		bundleDir = filepath.Join(werf.GetServiceDir(), "tmp", "bundles", uuid.NewString())
 		defer os.RemoveAll(bundleDir)
 
 		if err := bundles.Pull(ctx, fmt.Sprintf("%s:%s", repoAddress, cmdData.Tag), bundleDir, bundlesRegistryClient); err != nil {

--- a/cmd/werf/helm/secret/common/edit.go
+++ b/cmd/werf/helm/secret/common/edit.go
@@ -12,7 +12,7 @@ import (
 	"runtime"
 	"strings"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/werf/logboek"
@@ -36,7 +36,7 @@ func SecretEdit(ctx context.Context, m *secrets_manager.SecretsManager, workingD
 		return err
 	}
 
-	tmpFilePath := filepath.Join(werf.GetTmpDir(), fmt.Sprintf("werf-edit-secret-%s.yaml", uuid.NewV4().String()))
+	tmpFilePath := filepath.Join(werf.GetTmpDir(), fmt.Sprintf("werf-edit-secret-%s.yaml", uuid.NewString()))
 	defer os.RemoveAll(tmpFilePath)
 
 	if err := createTmpEditedFile(tmpFilePath, data); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/prashantv/gostub v1.1.0
 	github.com/rodaine/table v1.1.0
 	github.com/samber/lo v1.38.1
-	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1595,7 +1595,6 @@ github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiB
 github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
 github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=

--- a/pkg/context_manager/context_manager.go
+++ b/pkg/context_manager/context_manager.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 
 	"github.com/werf/logboek"
 	"github.com/werf/werf/pkg/path_matcher"
@@ -22,7 +22,7 @@ func GetTmpDir() string {
 }
 
 func GetTmpArchivePath() string {
-	return filepath.Join(GetTmpDir(), uuid.NewV4().String())
+	return filepath.Join(GetTmpDir(), uuid.NewString())
 }
 
 func GetContextAddFilesPaths(projectDir, contextDir string, contextAddFiles []string) ([]string, error) {

--- a/pkg/deploy/helm/chart_extender/chart_dependencies_loader.go
+++ b/pkg/deploy/helm/chart_extender/chart_dependencies_loader.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
@@ -126,7 +126,7 @@ func prepareDependenciesDir(ctx context.Context, metadataBytes, metadataLockByte
 				return nil
 			}
 
-			tmpDepsDir := fmt.Sprintf("%s.tmp.%s", depsDir, uuid.NewV4().String())
+			tmpDepsDir := fmt.Sprintf("%s.tmp.%s", depsDir, uuid.NewString())
 
 			if err := createChartDependenciesDir(tmpDepsDir, metadataBytes, metadataLockBytes); err != nil {
 				return err

--- a/pkg/git_repo/gitdata/git_data_manager.go
+++ b/pkg/git_repo/gitdata/git_data_manager.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 
 	"github.com/werf/lockgate"
 	"github.com/werf/werf/pkg/git_repo"
@@ -66,7 +66,7 @@ func (manager *GitDataManager) GetPatchesCacheDir() string {
 }
 
 func (manager *GitDataManager) NewTmpFile() (string, error) {
-	path := filepath.Join(manager.TmpDir, uuid.NewV4().String())
+	path := filepath.Join(manager.TmpDir, uuid.NewString())
 	if err := os.MkdirAll(filepath.Dir(path), 0o777); err != nil {
 		return "", fmt.Errorf("unable to create dir %q: %w", filepath.Dir(path), err)
 	}

--- a/pkg/ssh_agent/ssh_agent.go
+++ b/pkg/ssh_agent/ssh_agent.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/terminal"
@@ -185,7 +185,7 @@ func runSSHAgentWithKeys(ctx context.Context, keys []sshKey) (string, error) {
 }
 
 func runSSHAgent(ctx context.Context) (string, error) {
-	sockPath := filepath.Join(werf.GetTmpDir(), "werf-ssh-agent", uuid.NewV4().String())
+	sockPath := filepath.Join(werf.GetTmpDir(), "werf-ssh-agent", uuid.NewString())
 	tmpSockPath = sockPath
 
 	err := os.MkdirAll(filepath.Dir(sockPath), os.ModePerm)


### PR DESCRIPTION
Currently we are using two UUID packages:

1. `github.com/satori/go.uuid`
2. `github.com/google/uuid`

`github.com/satori/go.uuid` is no longer being actively maintained (last commit was 5 years ago [^1]). So we should just use the newer `github.com/google/uuid`.

[^1]: https://github.com/satori/go.uuid/commits/master/