### PR TITLE
fix(cleanup): panic related to corrupted images in the final repo

### DIFF
--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -311,6 +311,7 @@ func (m *StorageManager) GetFinalStageDescriptionList(ctx context.Context) ([]*i
 
 		if stageDesc == nil {
 			logboek.Context(ctx).Warn().LogF("Ignoring stage %s: cannot get stage description from %s\n", stageID.String(), m.FinalStagesStorage.String())
+			return nil
 		}
 
 		mutex.Lock()


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x31c9217]
goroutine 1 [running]:
github.com/werf/werf/pkg/cleaning/stage_manager.(*Manager).InitFinalStages(0xc0011ce5a0, {0x4a176a8?, 0xc0012be360?}, {0x4a48428?, 0xc000cca0b0?})
	/git/pkg/cleaning/stage_manager/manager.go:88 +0x97
github.com/werf/werf/pkg/cleaning.(*cleanupManager).init.func2()
	/git/pkg/cleaning/cleanup.go:90 +0x2d
github.com/werf/logboek/internal/stream.(*LogProcess).DoError(0xc000da3d80, 0xc00002d3e0)
	/go/pkg/mod/github.com/werf/logboek@v0.6.1/internal/stream/process_types.go:195 +0xd5
github.com/werf/werf/pkg/cleaning.(*cleanupManager).init(0xc0011ce5a0, {0x4a176a8?, 0xc0012be360})
	/git/pkg/cleaning/cleanup.go:89 +0x1c6
```