### PR TITLE
fix(cleanup): issue with incorrect exclusion of ancestors for retained images

### DIFF
--- a/pkg/buildah/native_linux.go
+++ b/pkg/buildah/native_linux.go
@@ -531,7 +531,7 @@ func (b *NativeBuildah) Commit(ctx context.Context, container string, opts Commi
 		}
 	}
 
-	builder.SetLabel("werf.io/base-image-id", fmt.Sprintf("sha256:%s", builder.FromImageID))
+	builder.SetLabel(image.WerfBaseImageIDLabel, fmt.Sprintf("sha256:%s", builder.FromImageID))
 
 	sysCtx, err := b.getSystemContext(opts.TargetPlatform)
 	if err != nil {

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -576,11 +576,11 @@ func (backend *BuildahBackend) GetImageInfo(ctx context.Context, ref string, opt
 		return nil, nil
 	}
 
-	var parentID string
-	if id, ok := inspect.Docker.Config.Labels["werf.io/base-image-id"]; ok {
-		parentID = id
-	} else {
-		parentID = string(inspect.Docker.Parent)
+	parentID := string(inspect.Docker.Parent)
+	if parentID == "" {
+		if id, ok := inspect.Docker.Config.Labels[image.WerfBaseImageIDLabel]; ok { // built with werf and buildah backend
+			parentID = id
+		}
 	}
 
 	var repository, tag, repoDigest string

--- a/pkg/docker/image_info.go
+++ b/pkg/docker/image_info.go
@@ -15,12 +15,11 @@ func NewInfoFromInspect(ref string, inspect *types.ImageInspect) *image.Info {
 		repoDigest = image.ExtractRepoDigest(inspect.RepoDigests, repository)
 	}
 
-	var parentID string
-	if id, ok := inspect.Config.Labels["werf.io/base-image-id"]; ok {
-		parentID = id
-	} else {
-		// TODO(1.3): Legacy compatibility mode
-		parentID = inspect.Config.Image
+	parentID := inspect.Config.Image
+	if parentID == "" {
+		if id, ok := inspect.Config.Labels[image.WerfBaseImageIDLabel]; ok { // built with werf and buildah backend
+			parentID = id
+		}
 	}
 
 	return &image.Info{

--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -211,12 +211,11 @@ func (api *api) getRepoImageByDesc(ctx context.Context, originalTag string, desc
 		}
 		repoImage.Size = totalSize
 
-		var parentID string
-		if baseImageID, ok := configFile.Config.Labels["werf.io/base-image-id"]; ok {
-			parentID = baseImageID
-		} else {
-			// TODO(1.3): Legacy compatibility mode
-			parentID = configFile.Config.Image
+		parentID := configFile.Config.Image
+		if parentID == "" {
+			if id, ok := configFile.Config.Labels[image.WerfBaseImageIDLabel]; ok { // built with werf and buildah backend
+				parentID = id
+			}
 		}
 		repoImage.ParentID = parentID
 	}

--- a/pkg/image/const.go
+++ b/pkg/image/const.go
@@ -12,6 +12,7 @@ const (
 	WerfStageContentDigestLabel   = "werf-stage-content-digest"
 	WerfProjectRepoCommitLabel    = "werf-project-repo-commit"
 	WerfImportChecksumLabelPrefix = "werf-import-checksum-"
+	WerfBaseImageIDLabel          = "werf.io/base-image-id"
 
 	WerfImportMetadataChecksumLabel       = "checksum"
 	WerfImportMetadataSourceImageIDLabel  = "source-image-id"


### PR DESCRIPTION
Issue occurred when using images built with werf using the buildah backend as base images in a project using werf with the Docker backend.

Fixed getting image parent ID logic.