### PR TITLE
tests: Update e2e and integration tests for Kubernetes

### DIFF
--- a/.github/workflows/_test_e2e_per-k8s-version.yml
+++ b/.github/workflows/_test_e2e_per-k8s-version.yml
@@ -38,9 +38,9 @@ jobs:
       matrix:
         k8s-version:
           - major: 1
-            minor: 23
+            minor: 27
           - major: 1
-            minor: 25
+            minor: 29
     runs-on: ubuntu-latest-4-cores
     timeout-minutes: ${{ inputs.timeout }}
     steps:

--- a/.github/workflows/_test_e2e_regular.yml
+++ b/.github/workflows/_test_e2e_regular.yml
@@ -16,7 +16,7 @@ on:
         default: 1
         type: string
       k8sMinor:
-        default: 25
+        default: 29
         type: string
       coverage:
         default: false

--- a/.github/workflows/_test_integration_per-k8s-version-and-container-registry.yml
+++ b/.github/workflows/_test_integration_per-k8s-version-and-container-registry.yml
@@ -27,9 +27,9 @@ jobs:
           - ${{ inputs.linuxAmd64Runner }}
         k8s-version:
           - major: 1
-            minor: 23
+            minor: 27
           - major: 1
-            minor: 25
+            minor: 29
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:

--- a/.github/workflows/_test_integration_per-k8s-version.yml
+++ b/.github/workflows/_test_integration_per-k8s-version.yml
@@ -27,9 +27,9 @@ jobs:
           - ${{ inputs.linuxAmd64Runner }}
         k8s-version:
           - major: 1
-            minor: 23
+            minor: 27
           - major: 1
-            minor: 25
+            minor: 29
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Add configuration to run integration and e2e tests on Kubernetes 1.27 and 1.29.