### PR TITLE
fix: prevent growing TCP connections by using a shared HTTP transport

### DIFF
--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -30,6 +31,8 @@ import (
 type api struct {
 	InsecureRegistry      bool
 	SkipTlsVerifyRegistry bool
+
+	httpTransport http.RoundTripper
 }
 
 type apiOptions struct {
@@ -41,6 +44,7 @@ func newAPI(options apiOptions) *api {
 	return &api{
 		InsecureRegistry:      options.InsecureRegistry,
 		SkipTlsVerifyRegistry: options.SkipTlsVerifyRegistry,
+		httpTransport:         newHttpTransport(options.SkipTlsVerifyRegistry),
 	}
 }
 
@@ -501,7 +505,7 @@ func (api *api) defaultRemoteOptions(ctx context.Context) []remote.Option {
 	return []remote.Option{
 		remote.WithContext(ctx),
 		remote.WithAuthFromKeychain(authn.DefaultKeychain),
-		remote.WithTransport(getHttpTransport(api.SkipTlsVerifyRegistry)),
+		remote.WithTransport(api.httpTransport),
 	}
 }
 
@@ -600,7 +604,7 @@ func (api *api) writeToRemote(ctx context.Context, ref name.Reference, imageOrIn
 			ref, i,
 			remote.WithAuthFromKeychain(authn.DefaultKeychain),
 			remote.WithProgress(c),
-			remote.WithTransport(getHttpTransport(api.SkipTlsVerifyRegistry)),
+			remote.WithTransport(api.httpTransport),
 			remote.WithContext(ctx),
 		)
 	case v1.ImageIndex:
@@ -608,7 +612,7 @@ func (api *api) writeToRemote(ctx context.Context, ref name.Reference, imageOrIn
 			ref, i,
 			remote.WithAuthFromKeychain(authn.DefaultKeychain),
 			remote.WithProgress(c),
-			remote.WithTransport(getHttpTransport(api.SkipTlsVerifyRegistry)),
+			remote.WithTransport(api.httpTransport),
 			remote.WithContext(ctx),
 		)
 	default:

--- a/pkg/docker_registry/common_api.go
+++ b/pkg/docker_registry/common_api.go
@@ -33,7 +33,7 @@ type doRequestBasicAuth struct {
 	password string
 }
 
-func doRequest(ctx context.Context, method, url string, body io.Reader, options doRequestOptions) (*http.Response, []byte, error) {
+func doRequest(ctx context.Context, client *http.Client, method, url string, body io.Reader, options doRequestOptions) (*http.Response, []byte, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, nil, err
@@ -48,7 +48,7 @@ func doRequest(ctx context.Context, method, url string, body io.Reader, options 
 	}
 
 	logboek.Context(ctx).Debug().LogF("--> %s %s\n", method, url)
-	resp, err := getHTTPClient(options.SkipTlsVerify).Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -72,13 +72,7 @@ func doRequest(ctx context.Context, method, url string, body io.Reader, options 
 	return resp, respBody, nil
 }
 
-func getHTTPClient(skipTlsVerify bool) *http.Client {
-	return &http.Client{
-		Transport: getHttpTransport(skipTlsVerify),
-	}
-}
-
-func getHttpTransport(skipTlsVerify bool) http.RoundTripper {
+func newHttpTransport(skipTlsVerify bool) http.RoundTripper {
 	t := remote.DefaultTransport.(*http.Transport).Clone()
 
 	if skipTlsVerify {

--- a/pkg/docker_registry/docker_hub_api.go
+++ b/pkg/docker_registry/docker_hub_api.go
@@ -8,10 +8,16 @@ import (
 	"net/http"
 )
 
-type dockerHubApi struct{}
+type dockerHubApi struct {
+	httpClient *http.Client
+}
 
 func newDockerHubApi() dockerHubApi {
-	return dockerHubApi{}
+	return dockerHubApi{
+		httpClient: &http.Client{
+			Transport: newHttpTransport(false),
+		},
+	}
 }
 
 func (api *dockerHubApi) deleteRepository(ctx context.Context, account, project, token string) (*http.Response, error) {
@@ -21,7 +27,7 @@ func (api *dockerHubApi) deleteRepository(ctx context.Context, account, project,
 		project,
 	)
 
-	resp, _, err := doRequest(ctx, http.MethodDelete, url, nil, doRequestOptions{
+	resp, _, err := doRequest(ctx, api.httpClient, http.MethodDelete, url, nil, doRequestOptions{
 		Headers: map[string]string{
 			"Accept":        "application/json",
 			"Authorization": fmt.Sprintf("JWT %s", token),
@@ -40,7 +46,7 @@ func (api *dockerHubApi) deleteTag(ctx context.Context, account, project, tag, t
 		tag,
 	)
 
-	resp, _, err := doRequest(ctx, http.MethodDelete, url, nil, doRequestOptions{
+	resp, _, err := doRequest(ctx, api.httpClient, http.MethodDelete, url, nil, doRequestOptions{
 		Headers: map[string]string{
 			"Accept":        "application/json",
 			"Authorization": fmt.Sprintf("JWT %s", token),
@@ -61,7 +67,7 @@ func (api *dockerHubApi) getToken(ctx context.Context, username, password string
 		return "", nil, err
 	}
 
-	resp, respBody, err := doRequest(ctx, http.MethodPost, url, bytes.NewBuffer(body), doRequestOptions{
+	resp, respBody, err := doRequest(ctx, api.httpClient, http.MethodPost, url, bytes.NewBuffer(body), doRequestOptions{
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 		},

--- a/pkg/docker_registry/gitlab_registry.go
+++ b/pkg/docker_registry/gitlab_registry.go
@@ -143,7 +143,7 @@ func (r *gitLabRegistry) customDeleteRepoImage(endpointFormat, reference string,
 	}
 
 	scope := scopeFunc(ref)
-	tr, err := transport.New(ref.Context().Registry, auth, getHttpTransport(false), scope)
+	tr, err := transport.New(ref.Context().Registry, auth, r.api.httpTransport, scope)
 	if err != nil {
 		return err
 	}

--- a/pkg/docker_registry/harbor_api.go
+++ b/pkg/docker_registry/harbor_api.go
@@ -7,10 +7,16 @@ import (
 	"path"
 )
 
-type harborApi struct{}
+type harborApi struct {
+	httpClient *http.Client
+}
 
 func newHarborApi() harborApi {
-	return harborApi{}
+	return harborApi{
+		httpClient: &http.Client{
+			Transport: newHttpTransport(false),
+		},
+	}
 }
 
 func (api *harborApi) DeleteRepository(ctx context.Context, hostname, repository, username, password string) (*http.Response, error) {
@@ -22,7 +28,7 @@ func (api *harborApi) DeleteRepository(ctx context.Context, hostname, repository
 	u.Path = path.Join(u.Path, "repositories", repository)
 	url := u.String()
 
-	resp, _, err := doRequest(ctx, http.MethodDelete, url, nil, doRequestOptions{
+	resp, _, err := doRequest(ctx, api.httpClient, http.MethodDelete, url, nil, doRequestOptions{
 		Headers: map[string]string{
 			"Accept": "application/json",
 		},

--- a/pkg/docker_registry/quay_api.go
+++ b/pkg/docker_registry/quay_api.go
@@ -8,10 +8,16 @@ import (
 	"path"
 )
 
-type quayApi struct{}
+type quayApi struct {
+	httpClient *http.Client
+}
 
 func newQuayApi() quayApi {
-	return quayApi{}
+	return quayApi{
+		httpClient: &http.Client{
+			Transport: newHttpTransport(false),
+		},
+	}
 }
 
 func (api *quayApi) DeleteRepository(ctx context.Context, hostname, namespace, repository, token string) (*http.Response, error) {
@@ -26,7 +32,7 @@ func (api *quayApi) DeleteRepository(ctx context.Context, hostname, namespace, r
 	reqAccept := "application/json"
 	reqAuthorization := fmt.Sprintf("Bearer %s", token)
 
-	resp, _, err := doRequest(ctx, http.MethodDelete, reqUrl, nil, doRequestOptions{
+	resp, _, err := doRequest(ctx, api.httpClient, http.MethodDelete, reqUrl, nil, doRequestOptions{
 		Headers: map[string]string{
 			"Accept":        reqAccept,
 			"Authorization": reqAuthorization,


### PR DESCRIPTION
Previously, a new HTTP transport was created for each request to container registry, leading to an excessive number of open TCP connections that were not properly reused. This commit addresses the issue by introducing a shared HTTP transport that is reused for all requests, thus improving resource management and connection reuse.