### PR TITLE
feat(build, dockerfile, multiplatform): support automatic platform ARGs

### DIFF
--- a/pkg/build/image/dockerfile.go
+++ b/pkg/build/image/dockerfile.go
@@ -35,6 +35,7 @@ func MapDockerfileConfigToImagesSets(ctx context.Context, dockerfileImageConfig 
 
 		d, err := frontend.ParseDockerfileWithBuildkit(dockerfileID, dockerfileData, dockerfileImageConfig.Name, dockerfile.DockerfileOptions{
 			Target:               dockerfileImageConfig.Target,
+			TargetPlatform:       targetPlatform,
 			BuildArgs:            util.MapStringInterfaceToMapStringString(dockerfileImageConfig.Args),
 			AddHost:              dockerfileImageConfig.AddHost,
 			Network:              dockerfileImageConfig.Network,

--- a/pkg/container_backend/thirdparty/platformutil/platformutil.go
+++ b/pkg/container_backend/thirdparty/platformutil/platformutil.go
@@ -2,6 +2,9 @@ package platformutil
 
 import (
 	"fmt"
+
+	"github.com/containerd/containerd/platforms"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func NormalizeUserParams(platformParams []string) ([]string, error) {
@@ -11,4 +14,32 @@ func NormalizeUserParams(platformParams []string) ([]string, error) {
 	}
 
 	return Format(Dedupe(specs)), nil
+}
+
+func GetPlatformMetaArgsMap(targetPlatform string) (map[string]string, error) {
+	var bp, tp specs.Platform
+	{
+		bp = platforms.DefaultSpec()
+		if targetPlatform != "" {
+			p, err := platforms.Parse(targetPlatform)
+			if err != nil {
+				return nil, err
+			}
+
+			tp = p
+		} else {
+			tp = bp
+		}
+	}
+
+	return map[string]string{
+		"BUILDPLATFORM":  platforms.Format(bp),
+		"BUILDOS":        bp.OS,
+		"BUILDARCH":      bp.Architecture,
+		"BUILDVARIANT":   bp.Variant,
+		"TARGETPLATFORM": platforms.Format(tp),
+		"TARGETOS":       tp.OS,
+		"TARGETARCH":     tp.Architecture,
+		"TARGETVARIANT":  tp.Variant,
+	}, nil
 }

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -11,6 +11,7 @@ type DockerfileOptions struct {
 	AddHost              []string
 	Network              string
 	SSH                  string
+	TargetPlatform       string
 }
 
 func NewDockerfile(dockerfileID string, stages []*DockerfileStage, opts DockerfileOptions) *Dockerfile {


### PR DESCRIPTION
Added support for automatic platform ARGs that can be used when configuring images in the Dockerfile.

Supported ARGs:
- TARGETPLATFORM: platform of the build result. E.g., linux/amd64, linux/arm/v7, windows/amd64.
- TARGETOS: OS component of TARGETPLATFORM.
- TARGETARCH: architecture component of TARGETPLATFORM.
- TARGETVARIANT: variant component of TARGETPLATFORM.
- BUILDPLATFORM: platform of the node performing the build.
- BUILDOS: OS component of BUILDPLATFORM.
- BUILDARCH: architecture component of BUILDPLATFORM.
- BUILDVARIANT: variant component of BUILDPLATFORM.

Reference: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope

This allows the use of platform arguments in the global scope of the Dockerfile for enhanced multi-platform image building.