### PR TITLE
fix(dev): disable signing for service commits

### DIFF
--- a/pkg/true_git/common.go
+++ b/pkg/true_git/common.go
@@ -5,7 +5,7 @@ import (
 )
 
 func getCommonGitOptions() []string {
-	return []string{"-c", "core.autocrlf=false", "-c", "gc.auto=0"}
+	return []string{"-c", "core.autocrlf=false", "-c", "gc.auto=0", "-c", "commit.gpgsign=false"}
 }
 
 func debug() bool {


### PR DESCRIPTION
Fixed an issue where GPG failed to sign the data during the commit process, resulting in the following error:

```
Error: unable to sync worktree with service branch "_werf-dev": unable to commit new changes in service branch: git commit command failed: error running command "/usr/bin/git -c core.autocrlf=false -c gc.auto=0 -c user.email=werf@werf.io -c user.name=werf commit --no-verify -m 2024-06-06 18:58:25.200251041 +0100 WEST m=+0.157575259": exit status 128
Stdout:

Stderr:
error: gpg failed to sign the data
fatal: failed to write commit object
```