### PR TITLE
fix(build, buildah, dockerfile): fix multi-stage does not work properly

### DIFF
--- a/pkg/build/image/image.go
+++ b/pkg/build/image/image.go
@@ -149,6 +149,10 @@ func ImageLogTagStyle(isArtifact bool) color.Style {
 	return logging.ImageDefaultStyle(isArtifact)
 }
 
+func (i *Image) IsBasedOnStage() bool {
+	return i.baseImageType == StageAsBaseImage
+}
+
 func (i *Image) IsFinal() bool {
 	if i.IsArtifact {
 		return false


### PR DESCRIPTION
Tagging did not account for the base Dockerfile stage, resulting in rebuilds not being triggered.

For werf.StagedDockerfileV2, the new logic should be the default. However, to avoid breaking tag reproducibility, this logic is currently enabled only for the multi-stage case. Eventually, this behavior should be the default for all versions without the extra if condition.