### PR TITLE
feat(docker-registry): use werf user agent for requests to container registry API

### DIFF
--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/werf/logboek"
 	"github.com/werf/werf/v2/pkg/docker_registry/container_registry_extensions"
 	"github.com/werf/werf/v2/pkg/image"
+	"github.com/werf/werf/v2/pkg/werf"
 )
 
 type api struct {
@@ -508,6 +509,7 @@ func (api *api) defaultRemoteOptions(ctx context.Context) []remote.Option {
 		remote.WithContext(ctx),
 		remote.WithAuthFromKeychain(authn.DefaultKeychain),
 		remote.WithTransport(api.httpTransport),
+		remote.WithUserAgent(werf.UserAgent),
 	}
 }
 

--- a/pkg/docker_registry/common_api.go
+++ b/pkg/docker_registry/common_api.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/werf/logboek"
 	transport2 "github.com/werf/werf/v2/pkg/docker_registry/transport"
+	"github.com/werf/werf/v2/pkg/werf"
 )
 
 type apiError struct {
@@ -86,6 +87,9 @@ func newHttpTransport(skipTlsVerify bool) http.RoundTripper {
 
 		t = dt
 	}
+
+	// Add werf User-Agent header.
+	t = werf.NewUserAgentTransport(t)
 
 	// Wrap the transport with retry logic.
 	t = transport.NewRetry(t)

--- a/pkg/werf/user_agent_transport.go
+++ b/pkg/werf/user_agent_transport.go
@@ -1,0 +1,21 @@
+package werf
+
+import (
+	"fmt"
+	"net/http"
+)
+
+var UserAgent = fmt.Sprintf("werf/%s", Version)
+
+type userAgentTransport struct {
+	underlying http.RoundTripper
+}
+
+func NewUserAgentTransport(underlying http.RoundTripper) http.RoundTripper {
+	return &userAgentTransport{underlying: underlying}
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", UserAgent)
+	return t.underlying.RoundTrip(req)
+}


### PR DESCRIPTION
```
User-Agent: werf/v2.7.3
User-Agent: werf/v2.7.3 go-containerregistry/v0.19.1
```