### PR TITLE
fix(host-cleanup): remove invalid entries from git cache

### DIFF
--- a/pkg/git_repo/gitdata/gc.go
+++ b/pkg/git_repo/gitdata/gc.go
@@ -151,9 +151,9 @@ func RunGC(ctx context.Context, allowedVolumeUsagePercentage, allowedVolumeUsage
 	{
 		cacheVersionRoot := filepath.Join(werf.GetLocalCacheDir(), "git_repos", git_repo.GitReposCacheVersion)
 
-		entries, err := GetExistingGitRepos(cacheVersionRoot)
+		entries, err := GetGitReposAndRemoveInvalid(ctx, cacheVersionRoot)
 		if err != nil {
-			return fmt.Errorf("error getting existing git repos from %q: %w", cacheVersionRoot, err)
+			return fmt.Errorf("unable to process git repos from %q: %w", cacheVersionRoot, err)
 		}
 
 		for _, entry := range entries {
@@ -164,9 +164,9 @@ func RunGC(ctx context.Context, allowedVolumeUsagePercentage, allowedVolumeUsage
 	{
 		cacheVersionRoot := filepath.Join(werf.GetLocalCacheDir(), "git_worktrees", git_repo.GitWorktreesCacheVersion)
 
-		entries, err := GetExistingGitWorktrees(cacheVersionRoot)
+		entries, err := GetGitWorktreesAndRemoveInvalid(ctx, cacheVersionRoot)
 		if err != nil {
-			return fmt.Errorf("error getting existing git repos from %q: %w", cacheVersionRoot, err)
+			return fmt.Errorf("unable to process git worktrees from %q: %w", cacheVersionRoot, err)
 		}
 
 		for _, entry := range entries {
@@ -177,9 +177,9 @@ func RunGC(ctx context.Context, allowedVolumeUsagePercentage, allowedVolumeUsage
 	{
 		cacheVersionRoot := filepath.Join(werf.GetLocalCacheDir(), "git_archives", GitArchivesCacheVersion)
 
-		entries, err := GetExistingGitArchives(cacheVersionRoot)
+		entries, err := GetGitArchivesAndRemoveInvalid(ctx, cacheVersionRoot)
 		if err != nil {
-			return fmt.Errorf("error getting existing git repos from %q: %w", cacheVersionRoot, err)
+			return fmt.Errorf("unable to process git archives from %q: %w", cacheVersionRoot, err)
 		}
 
 		for _, entry := range entries {
@@ -190,9 +190,9 @@ func RunGC(ctx context.Context, allowedVolumeUsagePercentage, allowedVolumeUsage
 	{
 		cacheVersionRoot := filepath.Join(werf.GetLocalCacheDir(), "git_patches", GitPatchesCacheVersion)
 
-		entries, err := GetExistingGitPatches(cacheVersionRoot)
+		entries, err := GetGitPatchesAndRemoveInvalid(ctx, cacheVersionRoot)
 		if err != nil {
-			return fmt.Errorf("error getting existing git repos from %q: %w", cacheVersionRoot, err)
+			return fmt.Errorf("unable to process git patches from %q: %w", cacheVersionRoot, err)
 		}
 
 		for _, entry := range entries {

--- a/pkg/git_repo/gitdata/git_repo.go
+++ b/pkg/git_repo/gitdata/git_repo.go
@@ -1,12 +1,14 @@
 package gitdata
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/werf/logboek"
 	"github.com/werf/werf/v2/pkg/util/timestamps"
 	"github.com/werf/werf/v2/pkg/volumeutils"
 )
@@ -34,27 +36,47 @@ func (entry *GitRepoDesc) GetCacheBasePath() string {
 	return entry.CacheBasePath
 }
 
-func GetExistingGitRepos(cacheVersionRoot string) ([]*GitRepoDesc, error) {
+// GetGitReposAndRemoveInvalid scans the given cacheVersionRoot directory and returns
+// a list of GitRepoDesc for each valid git repository found. It removes invalid
+// entries and handles errors appropriately.
+//
+// The directory structure expected is as follows:
+// ├── c447df0d5918decb5d832cb4324e3e2cbe0670eb3fe9301f795be831a9175f47
+// │   └── ... (repository files)
+// └── ... (other repositories)
+func GetGitReposAndRemoveInvalid(ctx context.Context, cacheVersionRoot string) ([]*GitRepoDesc, error) {
 	var res []*GitRepoDesc
 
-	if _, err := os.Stat(cacheVersionRoot); os.IsNotExist(err) {
-		return nil, nil
-	} else if err != nil {
+	// Check if cacheVersionRoot exists and is a directory
+	fileStat, err := os.Stat(cacheVersionRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("error accessing dir %q: %w", cacheVersionRoot, err)
 	}
+	if !fileStat.IsDir() {
+		logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: not a directory\n", cacheVersionRoot)
+		if err := os.RemoveAll(cacheVersionRoot); err != nil {
+			return nil, fmt.Errorf("unable to remove %q: %w", cacheVersionRoot, err)
+		}
+		return nil, nil
+	}
 
-	files, err := ioutil.ReadDir(cacheVersionRoot)
+	repoDirs, err := ioutil.ReadDir(cacheVersionRoot)
 	if err != nil {
 		return nil, fmt.Errorf("error reading dir %q: %w", cacheVersionRoot, err)
 	}
 
-	for _, finfo := range files {
-		repoPath := filepath.Join(cacheVersionRoot, finfo.Name())
+	for _, repoDirInfo := range repoDirs {
+		repoPath := filepath.Join(cacheVersionRoot, repoDirInfo.Name())
 
-		if !finfo.IsDir() {
+		if !repoDirInfo.IsDir() {
+			logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: not a directory\n", repoPath)
 			if err := os.RemoveAll(repoPath); err != nil {
 				return nil, fmt.Errorf("unable to remove %q: %w", repoPath, err)
 			}
+			continue
 		}
 
 		size, err := volumeutils.DirSizeBytes(repoPath)
@@ -65,7 +87,11 @@ func GetExistingGitRepos(cacheVersionRoot string) ([]*GitRepoDesc, error) {
 		lastAccessAtPath := filepath.Join(repoPath, "last_access_at")
 		lastAccessAt, err := timestamps.ReadTimestampFile(lastAccessAtPath)
 		if err != nil {
-			return nil, fmt.Errorf("error reading last access timestamp file %q: %w", lastAccessAtPath, err)
+			logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: error reading last access timestamp file %q: %v\n", repoPath, lastAccessAtPath, err)
+			if err := os.RemoveAll(repoPath); err != nil {
+				return nil, fmt.Errorf("unable to remove %q: %w", repoPath, err)
+			}
+			continue
 		}
 
 		res = append(res, &GitRepoDesc{

--- a/pkg/git_repo/gitdata/git_worktree.go
+++ b/pkg/git_repo/gitdata/git_worktree.go
@@ -1,12 +1,14 @@
 package gitdata
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/werf/logboek"
 	"github.com/werf/werf/v2/pkg/util/timestamps"
 	"github.com/werf/werf/v2/pkg/volumeutils"
 )
@@ -34,43 +36,67 @@ func (entry *GitWorktreeDesc) GetCacheBasePath() string {
 	return entry.CacheBasePath
 }
 
-func GetExistingGitWorktrees(cacheVersionRoot string) ([]*GitWorktreeDesc, error) {
+// GetGitWorktreesAndRemoveInvalid scans the given cacheVersionRoot directory and returns
+// a list of GitWorktreeDesc for each valid git worktree found. It removes invalid
+// entries and handles errors appropriately.
+//
+// The directory structure expected is as follows:
+// ├── 9/
+// │   ├── local/
+// │   │   ├── <worktree_hash>/
+// │   │   │   └── ... (repository files)
+// │   │   └── ... (other worktrees)
+// │   ├── remote/
+// │   │   ├── <worktree_hash>/
+// │   │   │   └── ... (repository files)
+// │   │   └── ... (other worktrees)
+// └── ... (other cache versions)
+func GetGitWorktreesAndRemoveInvalid(ctx context.Context, cacheVersionRoot string) ([]*GitWorktreeDesc, error) {
 	var res []*GitWorktreeDesc
 
-	for _, dir := range []string{filepath.Join(cacheVersionRoot, "local"), filepath.Join(cacheVersionRoot, "remote")} {
+	for _, subdir := range []string{"local", "remote"} {
+		dir := filepath.Join(cacheVersionRoot, subdir)
+
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
 			continue
 		} else if err != nil {
 			return nil, fmt.Errorf("error accessing dir %q: %w", dir, err)
 		}
 
-		files, err := ioutil.ReadDir(dir)
+		worktreeDirs, err := ioutil.ReadDir(dir)
 		if err != nil {
 			return nil, fmt.Errorf("error reading dir %q: %w", dir, err)
 		}
 
-		for _, finfo := range files {
-			worktreePath := filepath.Join(dir, finfo.Name())
+		for _, worktreeDirInfo := range worktreeDirs {
+			worktreeDir := filepath.Join(dir, worktreeDirInfo.Name())
 
-			if !finfo.IsDir() {
-				if err := os.RemoveAll(worktreePath); err != nil {
-					return nil, fmt.Errorf("unable to remove %q: %w", worktreePath, err)
+			if !worktreeDirInfo.IsDir() {
+				logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: not a directory\n", worktreeDir)
+				if err := os.RemoveAll(worktreeDir); err != nil {
+					return nil, fmt.Errorf("unable to remove %q: %w", worktreeDir, err)
 				}
+				continue
 			}
 
-			size, err := volumeutils.DirSizeBytes(worktreePath)
+			size, err := volumeutils.DirSizeBytes(worktreeDir)
 			if err != nil {
-				return nil, fmt.Errorf("error getting dir %q size: %w", worktreePath, err)
+				return nil, fmt.Errorf("error getting dir %q size: %w", worktreeDir, err)
 			}
 
-			lastAccessAtPath := filepath.Join(worktreePath, "last_access_at")
+			lastAccessAtPath := filepath.Join(worktreeDir, "last_access_at")
 			lastAccessAt, err := timestamps.ReadTimestampFile(lastAccessAtPath)
 			if err != nil {
-				return nil, fmt.Errorf("error reading last access timestamp file %q: %w", lastAccessAtPath, err)
+				logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: unable to read last access timestamp file %q: %s\n", worktreeDir, lastAccessAtPath, err)
+				if err := os.RemoveAll(worktreeDir); err != nil {
+					return nil, fmt.Errorf("unable to remove %q: %w", worktreeDir, err)
+				}
+
+				continue
 			}
 
 			res = append(res, &GitWorktreeDesc{
-				Path:          worktreePath,
+				Path:          worktreeDir,
 				Size:          size,
 				LastAccessAt:  lastAccessAt,
 				CacheBasePath: dir,


### PR DESCRIPTION
E.g.:
```
Version: v1.2.317

┌ Running GC for tmp data
└ Running GC for tmp data (0.00 seconds)

┌ Running GC for git data
│ ┌ Git data storage check
│ │ Werf local cache dir: /home/user/.werf/local_cache
│ │ Volume usage: 876 GB / 926 GB
│ │ Allowed percentage level exceeded: 94.53% > 70.00% — HIGH VOLUME USAGE
│ │ Target percentage level after cleanup: 70.00% - 5.00% (margin) = 65.00%
│ │ Needed to free: 274 GB
│ └ Git data storage check
└ Running GC for git data (0.30 seconds) FAILED

Running time 0.30 seconds
Error: git repo GC failed: error getting existing git repos from "/home/user/.werf/local_cache/git_patches/6": error unmarshalling json from "/home/user/.werf/local_cache/git_patches/6/99ded8ecb2d5b367b3ba1f28a1631e124bf129229f4e99b63a977ff4ec4bb2e8/94/94fb8623fb405d780b6bb30a5ca06f5e11a7720f2022290633c94ebd1cd935fd.meta.json": unexpected end of JSON input

```