### PR TITLE
Work around null pointer exception on reports for multi-platform images

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -486,9 +486,8 @@ func (phase *BuildPhase) createReport(ctx context.Context) error {
 		}
 
 		if _, isLocal := phase.Conveyor.StorageManager.GetStagesStorage().(*storage.LocalStagesStorage); !isLocal {
-			if len(targetPlatforms) > 1 {
-				img := phase.Conveyor.imagesTree.GetMultiplatformImage(name)
-
+			img := phase.Conveyor.imagesTree.GetMultiplatformImage(name)
+			if len(targetPlatforms) > 1 && img != nil {
 				isRebuilt := false
 				for _, pImg := range img.Images {
 					isRebuilt = (isRebuilt || pImg.GetRebuilt())


### PR DESCRIPTION
Tries to fix: https://github.com/werf/werf/issues/6315

Although it does not address the root cause (unknown to me atm) this at least prevents a secondary function (like reporting) to break the primary functionality of building images