### PR TITLE
fix(build): allow usage of non-final images for specific commands

### DIFF
--- a/cmd/werf/build/main.go
+++ b/cmd/werf/build/main.go
@@ -210,7 +210,7 @@ func run(ctx context.Context, containerBackend container_backend.ContainerBacken
 		return fmt.Errorf("unable to load werf config: %w", err)
 	}
 
-	imagesToProcess, err := config.NewImagesToProcess(werfConfig, imageNameListFromArgs, true, false)
+	imagesToProcess, err := config.NewImagesToProcess(werfConfig, imageNameListFromArgs, false, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/werf/compose/main.go
+++ b/cmd/werf/compose/main.go
@@ -473,7 +473,7 @@ func run(ctx context.Context, containerBackend container_backend.ContainerBacken
 		imageNameList = imageNameListFromComposeConfig
 	}
 
-	imagesToProcess, err := config.NewImagesToProcess(werfConfig, imageNameList, true, *commonCmdData.WithoutImages)
+	imagesToProcess, err := config.NewImagesToProcess(werfConfig, imageNameList, false, *commonCmdData.WithoutImages)
 	if err != nil {
 		return err
 	}

--- a/cmd/werf/config/graph/graph.go
+++ b/cmd/werf/config/graph/graph.go
@@ -97,7 +97,7 @@ func NewCmd(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			imagesToProcess, err := config.NewImagesToProcess(werfConfig, args, true, false)
+			imagesToProcess, err := config.NewImagesToProcess(werfConfig, args, false, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/werf/kube_run/kube_run.go
+++ b/cmd/werf/kube_run/kube_run.go
@@ -363,11 +363,11 @@ func run(ctx context.Context, pod, secret, namespace string, werfConfig *config.
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
 	imageName := cmdData.ImageName
-	if imageName == "" && len(werfConfig.Images(true)) == 1 {
-		imageName = werfConfig.Images(true)[0].GetName()
+	if imageName == "" && len(werfConfig.Images(false)) == 1 {
+		imageName = werfConfig.Images(false)[0].GetName()
 	}
 
-	imagesToProcess, err := config.NewImagesToProcess(werfConfig, []string{imageName}, true, false)
+	imagesToProcess, err := config.NewImagesToProcess(werfConfig, []string{imageName}, false, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -357,11 +357,11 @@ func run(ctx context.Context, containerBackend container_backend.ContainerBacken
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
 	imageName := cmdData.ImageName
-	if imageName == "" && len(werfConfig.Images(true)) == 1 {
-		imageName = werfConfig.Images(true)[0].GetName()
+	if imageName == "" && len(werfConfig.Images(false)) == 1 {
+		imageName = werfConfig.Images(false)[0].GetName()
 	}
 
-	imagesToProcess, err := config.NewImagesToProcess(werfConfig, []string{imageName}, true, false)
+	imagesToProcess, err := config.NewImagesToProcess(werfConfig, []string{imageName}, false, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -174,7 +174,7 @@ func run(ctx context.Context, imageName string) error {
 		imageName = werfConfig.Images(true)[0].GetName()
 	}
 
-	imagesToProcess, err := config.NewImagesToProcess(werfConfig, []string{imageName}, true, false)
+	imagesToProcess, err := config.NewImagesToProcess(werfConfig, []string{imageName}, false, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Enabled non-final images for `build`, `run`, `kube-run`, and `compose` commands.