### PR TITLE
refactor(docs): actualise cr cli param help message

### DIFF
--- a/cmd/werf/root/root.go
+++ b/cmd/werf/root/root.go
@@ -144,7 +144,7 @@ func dockerComposeCmd(ctx context.Context) *cobra.Command {
 func crCmd(ctx context.Context) *cobra.Command {
 	cmd := common.SetCommandContext(ctx, &cobra.Command{
 		Use:   "cr",
-		Short: "Work with container registry: authenticate, list and remove images, etc.",
+		Short: "Authenticate with container registry.",
 	})
 	cmd.AddCommand(
 		cr_login.NewCmd(ctx),

--- a/docs/_includes/reference/cli/werf_cr.md
+++ b/docs/_includes/reference/cli/werf_cr.md
@@ -3,5 +3,5 @@
 {% else %}
 {% assign header = "###" %}
 {% endif %}
-Work with container registry: authenticate, list and remove images, etc.
+Authenticate with container registry.
 

--- a/docs/_includes/reference/cli/werf_cr.short.md
+++ b/docs/_includes/reference/cli/werf_cr.short.md
@@ -1,1 +1,1 @@
-work with container registry: authenticate, list and remove images, etc.
+authenticate with container registry.


### PR DESCRIPTION
Hi there,

I started working with Werf and noticed that the werf cr --help message does not accurately reflect the available actions; currently, only “login” and “logout” are supported. This pull request updates the help message to align with the actual functionality.

Regards,
Ilya