### PR TITLE
refactor(test): set predefined host port for registry container

### DIFF
--- a/test/e2e/compose/complex_test.go
+++ b/test/e2e/compose/complex_test.go
@@ -18,6 +18,7 @@ type simpleTestOptions struct {
 	ExtraArgs        []string
 	State            string
 	StateDescription string
+	Repo             string
 }
 
 var _ = Describe("Complex compose", Label("e2e", "compose", "complex"), func() {
@@ -25,7 +26,7 @@ var _ = Describe("Complex compose", Label("e2e", "compose", "complex"), func() {
 		func(opts simpleTestOptions) {
 			By(fmt.Sprintf("%s: starting", opts.State))
 			{
-				repoDirname := "repo0"
+				repoDirname := opts.Repo
 				fixtureRelPath := fmt.Sprintf("simple/%s", opts.State)
 
 				By(fmt.Sprintf("%s: preparing test repo", opts.State))
@@ -53,6 +54,7 @@ var _ = Describe("Complex compose", Label("e2e", "compose", "complex"), func() {
 			ExtraArgs:        []string{},
 			State:            "state0",
 			StateDescription: "running compose up with no options",
+			Repo:             "repo0",
 		}),
 		Entry("with multiple compose files", simpleTestOptions{
 			ExtraArgs: []string{
@@ -61,6 +63,7 @@ var _ = Describe("Complex compose", Label("e2e", "compose", "complex"), func() {
 			},
 			State:            "state1",
 			StateDescription: "running compose up with multiple compose files and args",
+			Repo:             "repo1",
 		}),
 	)
 })

--- a/test/e2e/compose/complex_test.go
+++ b/test/e2e/compose/complex_test.go
@@ -18,7 +18,6 @@ type simpleTestOptions struct {
 	ExtraArgs        []string
 	State            string
 	StateDescription string
-	Repo             string
 }
 
 var _ = Describe("Complex compose", Label("e2e", "compose", "complex"), func() {
@@ -26,7 +25,7 @@ var _ = Describe("Complex compose", Label("e2e", "compose", "complex"), func() {
 		func(opts simpleTestOptions) {
 			By(fmt.Sprintf("%s: starting", opts.State))
 			{
-				repoDirname := opts.Repo
+				repoDirname := "repo0"
 				fixtureRelPath := fmt.Sprintf("simple/%s", opts.State)
 
 				By(fmt.Sprintf("%s: preparing test repo", opts.State))
@@ -54,7 +53,6 @@ var _ = Describe("Complex compose", Label("e2e", "compose", "complex"), func() {
 			ExtraArgs:        []string{},
 			State:            "state0",
 			StateDescription: "running compose up with no options",
-			Repo:             "repo0",
 		}),
 		Entry("with multiple compose files", simpleTestOptions{
 			ExtraArgs: []string{
@@ -63,7 +61,6 @@ var _ = Describe("Complex compose", Label("e2e", "compose", "complex"), func() {
 			},
 			State:            "state1",
 			StateDescription: "running compose up with multiple compose files and args",
-			Repo:             "repo1",
 		}),
 	)
 })

--- a/test/pkg/utils/docker/docker_registry.go
+++ b/test/pkg/utils/docker/docker_registry.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	. "github.com/onsi/gomega"
@@ -13,14 +14,17 @@ func LocalDockerRegistryRun() (string, string, string) {
 	containerName := fmt.Sprintf("werf_test_docker_registry-%s", utils.GetRandomString(10))
 	imageName := "registry:2"
 
+	port, err := getFreeEphemeralPort()
+	Ω(err).ShouldNot(HaveOccurred())
+
 	dockerCliRunArgs := []string{
 		"-d",
-		"-p", ":5000",
+		"-p", fmt.Sprintf("%d:5000", port),
 		"-e", "REGISTRY_STORAGE_DELETE_ENABLED=true",
 		"--name", containerName,
 		imageName,
 	}
-	err := CliRun(dockerCliRunArgs...)
+	err = CliRun(dockerCliRunArgs...)
 	Ω(err).ShouldNot(HaveOccurred(), "docker run "+strings.Join(dockerCliRunArgs, " "))
 
 	inspect := ContainerInspect(containerName)
@@ -28,10 +32,21 @@ func LocalDockerRegistryRun() (string, string, string) {
 	Ω(inspect.NetworkSettings.IPAddress).ShouldNot(BeEmpty())
 	registryInternalAddress := fmt.Sprintf("%s:%d", inspect.NetworkSettings.IPAddress, 5000)
 
-	registryLocalAddress := fmt.Sprintf("localhost:%s", ContainerHostPort(containerName, "5000/tcp"))
+	registryLocalAddress := fmt.Sprintf("localhost:%d", port)
 	registryWithScheme := fmt.Sprintf("http://%s", registryLocalAddress)
 
 	utils.WaitTillHostReadyToRespond(registryWithScheme, utils.DefaultWaitTillHostReadyToRespondMaxAttempts)
 
 	return registryLocalAddress, registryInternalAddress, containerName
+}
+
+// Listen on a random port using TCP protocol on localhost and return the free ephemeral port number.
+func getFreeEphemeralPort() (int, error) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+	return port, nil
 }


### PR DESCRIPTION
This is fixing the issue with empty host port from docker inspect of registry container both on Mac and Linux