### PR TITLE
fix(kubectl): add klog arbitrary flags

### DIFF
--- a/cmd/werf/kubectl/kubectl.go
+++ b/cmd/werf/kubectl/kubectl.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/component-base/logs"
 	"k8s.io/kubectl/pkg/cmd"
 	"k8s.io/kubectl/pkg/cmd/plugin"
 	"k8s.io/kubectl/pkg/cmd/util"
@@ -32,6 +33,8 @@ func NewCmd(ctx context.Context) *cobra.Command {
 		ConfigFlags:   configFlags,
 		IOStreams:     genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
 	})
+
+	logs.AddFlags(kubectlCmd.PersistentFlags())
 
 	common.SetupHomeDir(&commonCmdData, kubectlCmd, common.SetupHomeDirOptions{Persistent: true})
 	common.SetupTmpDir(&commonCmdData, kubectlCmd, common.SetupTmpDirOptions{Persistent: true})

--- a/docs/_includes/reference/cli/werf_kubectl.md
+++ b/docs/_includes/reference/cli/werf_kubectl.md
@@ -49,6 +49,8 @@ werf kubectl [flags] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -76,6 +78,11 @@ werf kubectl [flags] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_alpha.md
+++ b/docs/_includes/reference/cli/werf_kubectl_alpha.md
@@ -41,6 +41,8 @@ These commands correspond to alpha features that are not enabled in Kubernetes c
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -68,6 +70,11 @@ These commands correspond to alpha features that are not enabled in Kubernetes c
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_annotate.md
+++ b/docs/_includes/reference/cli/werf_kubectl_annotate.md
@@ -129,6 +129,8 @@ werf kubectl annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KE
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -156,6 +158,11 @@ werf kubectl annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KE
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_api_resources.md
+++ b/docs/_includes/reference/cli/werf_kubectl_api_resources.md
@@ -93,6 +93,8 @@ werf kubectl api-resources [flags] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -120,6 +122,11 @@ werf kubectl api-resources [flags] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_api_versions.md
+++ b/docs/_includes/reference/cli/werf_kubectl_api_versions.md
@@ -54,6 +54,8 @@ werf kubectl api-versions
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -81,6 +83,11 @@ werf kubectl api-versions
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_apply.md
+++ b/docs/_includes/reference/cli/werf_kubectl_apply.md
@@ -153,6 +153,8 @@ werf kubectl apply (-f FILENAME | -k DIRECTORY) [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -180,6 +182,11 @@ werf kubectl apply (-f FILENAME | -k DIRECTORY) [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_apply_edit_last_applied.md
+++ b/docs/_includes/reference/cli/werf_kubectl_apply_edit_last_applied.md
@@ -103,6 +103,8 @@ werf kubectl apply edit-last-applied (RESOURCE/NAME | -f FILENAME) [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -130,6 +132,11 @@ werf kubectl apply edit-last-applied (RESOURCE/NAME | -f FILENAME) [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_apply_set_last_applied.md
+++ b/docs/_includes/reference/cli/werf_kubectl_apply_set_last_applied.md
@@ -86,6 +86,8 @@ werf kubectl apply set-last-applied -f FILENAME [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -113,6 +115,11 @@ werf kubectl apply set-last-applied -f FILENAME [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_apply_view_last_applied.md
+++ b/docs/_includes/reference/cli/werf_kubectl_apply_view_last_applied.md
@@ -80,6 +80,8 @@ werf kubectl apply view-last-applied (TYPE [NAME | -l label] | TYPE/NAME | -f FI
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -107,6 +109,11 @@ werf kubectl apply view-last-applied (TYPE [NAME | -l label] | TYPE/NAME | -f FI
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_attach.md
+++ b/docs/_includes/reference/cli/werf_kubectl_attach.md
@@ -83,6 +83,8 @@ werf kubectl attach (POD | TYPE/NAME) -c CONTAINER [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -110,6 +112,11 @@ werf kubectl attach (POD | TYPE/NAME) -c CONTAINER [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_auth.md
+++ b/docs/_includes/reference/cli/werf_kubectl_auth.md
@@ -47,6 +47,8 @@ werf kubectl auth
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -74,6 +76,11 @@ werf kubectl auth
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_auth_can_i.md
+++ b/docs/_includes/reference/cli/werf_kubectl_auth_can_i.md
@@ -99,6 +99,8 @@ werf kubectl auth can-i VERB [TYPE | TYPE/NAME | NONRESOURCEURL] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -126,6 +128,11 @@ werf kubectl auth can-i VERB [TYPE | TYPE/NAME | NONRESOURCEURL] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_auth_reconcile.md
+++ b/docs/_includes/reference/cli/werf_kubectl_auth_reconcile.md
@@ -94,6 +94,8 @@ werf kubectl auth reconcile -f FILENAME [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -121,6 +123,11 @@ werf kubectl auth reconcile -f FILENAME [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_auth_whoami.md
+++ b/docs/_includes/reference/cli/werf_kubectl_auth_whoami.md
@@ -74,6 +74,8 @@ werf kubectl auth whoami [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -101,6 +103,11 @@ werf kubectl auth whoami [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_autoscale.md
+++ b/docs/_includes/reference/cli/werf_kubectl_autoscale.md
@@ -105,6 +105,8 @@ werf kubectl autoscale (-f FILENAME | TYPE NAME | TYPE/NAME) [--min=MINPODS] --m
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -132,6 +134,11 @@ werf kubectl autoscale (-f FILENAME | TYPE NAME | TYPE/NAME) [--min=MINPODS] --m
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_certificate.md
+++ b/docs/_includes/reference/cli/werf_kubectl_certificate.md
@@ -47,6 +47,8 @@ werf kubectl certificate SUBCOMMAND
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -74,6 +76,11 @@ werf kubectl certificate SUBCOMMAND
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_certificate_approve.md
+++ b/docs/_includes/reference/cli/werf_kubectl_certificate_approve.md
@@ -84,6 +84,8 @@ werf kubectl certificate approve (-f FILENAME | NAME) [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -111,6 +113,11 @@ werf kubectl certificate approve (-f FILENAME | NAME) [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_certificate_deny.md
+++ b/docs/_includes/reference/cli/werf_kubectl_certificate_deny.md
@@ -82,6 +82,8 @@ werf kubectl certificate deny (-f FILENAME | NAME) [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -109,6 +111,11 @@ werf kubectl certificate deny (-f FILENAME | NAME) [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_cluster_info.md
+++ b/docs/_includes/reference/cli/werf_kubectl_cluster_info.md
@@ -54,6 +54,8 @@ werf kubectl cluster-info
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -81,6 +83,11 @@ werf kubectl cluster-info
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_cluster_info_dump.md
+++ b/docs/_includes/reference/cli/werf_kubectl_cluster_info_dump.md
@@ -92,6 +92,8 @@ werf kubectl cluster-info dump [flags] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -119,6 +121,11 @@ werf kubectl cluster-info dump [flags] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_completion.md
+++ b/docs/_includes/reference/cli/werf_kubectl_completion.md
@@ -107,6 +107,8 @@ werf kubectl completion SHELL
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -134,6 +136,11 @@ werf kubectl completion SHELL
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config.md
@@ -56,6 +56,8 @@ werf kubectl config SUBCOMMAND
       --kube-config-base64=''
             Kubernetes config data as base64 string (default $WERF_KUBE_CONFIG_BASE64 or            
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -83,6 +85,11 @@ werf kubectl config SUBCOMMAND
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_current_context.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_current_context.md
@@ -53,6 +53,8 @@ werf kubectl config current-context
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -80,6 +82,11 @@ werf kubectl config current-context
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_delete_cluster.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_delete_cluster.md
@@ -53,6 +53,8 @@ werf kubectl config delete-cluster NAME
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -80,6 +82,11 @@ werf kubectl config delete-cluster NAME
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_delete_context.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_delete_context.md
@@ -53,6 +53,8 @@ werf kubectl config delete-context NAME
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -80,6 +82,11 @@ werf kubectl config delete-context NAME
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_delete_user.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_delete_user.md
@@ -53,6 +53,8 @@ werf kubectl config delete-user NAME
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -80,6 +82,11 @@ werf kubectl config delete-user NAME
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_get_clusters.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_get_clusters.md
@@ -53,6 +53,8 @@ werf kubectl config get-clusters
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -80,6 +82,11 @@ werf kubectl config get-clusters
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_get_contexts.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_get_contexts.md
@@ -66,6 +66,8 @@ werf kubectl config get-contexts [(-o|--output=)name)] [options]
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -93,6 +95,11 @@ werf kubectl config get-contexts [(-o|--output=)name)] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_get_users.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_get_users.md
@@ -53,6 +53,8 @@ werf kubectl config get-users
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -80,6 +82,11 @@ werf kubectl config get-users
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_rename_context.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_rename_context.md
@@ -57,6 +57,8 @@ werf kubectl config rename-context CONTEXT_NAME NEW_NAME
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -84,6 +86,11 @@ werf kubectl config rename-context CONTEXT_NAME NEW_NAME
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_set.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_set.md
@@ -74,6 +74,8 @@ werf kubectl config set PROPERTY_NAME PROPERTY_VALUE [options]
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -101,6 +103,11 @@ werf kubectl config set PROPERTY_NAME PROPERTY_VALUE [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_set_cluster.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_set_cluster.md
@@ -79,6 +79,8 @@ werf kubectl config set-cluster NAME [--server=server] [--certificate-authority=
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -101,6 +103,11 @@ werf kubectl config set-cluster NAME [--server=server] [--certificate-authority=
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_set_context.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_set_context.md
@@ -66,6 +66,8 @@ werf kubectl config set-context [NAME | --current] [--cluster=cluster_nickname] 
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
       --password=''
@@ -89,6 +91,11 @@ werf kubectl config set-context [NAME | --current] [--cluster=cluster_nickname] 
             Bearer token for authentication to the API server
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_set_credentials.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_set_credentials.md
@@ -113,6 +113,8 @@ werf kubectl config set-credentials NAME [--client-certificate=path/to/certfile]
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -134,6 +136,11 @@ werf kubectl config set-credentials NAME [--client-certificate=path/to/certfile]
             Use specified dir to store tmp files and dirs (default $WERF_TMP_DIR or system tmp dir)
       --user=''
             The name of the kubeconfig user to use
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_unset.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_unset.md
@@ -58,6 +58,8 @@ werf kubectl config unset PROPERTY_NAME
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -85,6 +87,11 @@ werf kubectl config unset PROPERTY_NAME
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_use_context.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_use_context.md
@@ -53,6 +53,8 @@ werf kubectl config use-context CONTEXT_NAME
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -80,6 +82,11 @@ werf kubectl config use-context CONTEXT_NAME
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_config_view.md
+++ b/docs/_includes/reference/cli/werf_kubectl_config_view.md
@@ -87,6 +87,8 @@ werf kubectl config view [flags] [options]
             $WERF_KUBECONFIG_BASE64 or $KUBECONFIG_BASE64)
       --kubeconfig=''
             use a particular kubeconfig file
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -114,6 +116,11 @@ werf kubectl config view [flags] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_cordon.md
+++ b/docs/_includes/reference/cli/werf_kubectl_cordon.md
@@ -67,6 +67,8 @@ werf kubectl cordon NODE [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -94,6 +96,11 @@ werf kubectl cordon NODE [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_cp.md
+++ b/docs/_includes/reference/cli/werf_kubectl_cp.md
@@ -91,6 +91,8 @@ werf kubectl cp <file-spec-src> <file-spec-dest> [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -118,6 +120,11 @@ werf kubectl cp <file-spec-src> <file-spec-dest> [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create.md
@@ -116,6 +116,8 @@ werf kubectl create -f FILENAME [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -143,6 +145,11 @@ werf kubectl create -f FILENAME [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_clusterrole.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_clusterrole.md
@@ -116,6 +116,8 @@ werf kubectl create clusterrole NAME --verb=verb --resource=resource.group [--re
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -143,6 +145,11 @@ werf kubectl create clusterrole NAME --verb=verb --resource=resource.group [--re
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_clusterrolebinding.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_clusterrolebinding.md
@@ -100,6 +100,8 @@ werf kubectl create clusterrolebinding NAME --clusterrole=NAME [--user=username]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -125,6 +127,11 @@ werf kubectl create clusterrolebinding NAME --clusterrole=NAME [--user=username]
             Bearer token for authentication to the API server
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_configmap.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_configmap.md
@@ -120,6 +120,8 @@ werf kubectl create configmap NAME [--from-file=[key=]source] [--from-literal=ke
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -147,6 +149,11 @@ werf kubectl create configmap NAME [--from-file=[key=]source] [--from-literal=ke
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_cronjob.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_cronjob.md
@@ -100,6 +100,8 @@ werf kubectl create cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMM
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -127,6 +129,11 @@ werf kubectl create cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMM
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_deployment.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_deployment.md
@@ -106,6 +106,8 @@ werf kubectl create deployment NAME --image=image -- [COMMAND] [args...] [option
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -133,6 +135,11 @@ werf kubectl create deployment NAME --image=image -- [COMMAND] [args...] [option
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_ingress.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_ingress.md
@@ -133,6 +133,8 @@ werf kubectl create ingress NAME --rule=host/path=service:port[,tls[=secret]]  [
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -160,6 +162,11 @@ werf kubectl create ingress NAME --rule=host/path=service:port[,tls[=secret]]  [
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_job.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_job.md
@@ -101,6 +101,8 @@ werf kubectl create job NAME --image=image [--from=cronjob/name] -- [COMMAND] [a
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -128,6 +130,11 @@ werf kubectl create job NAME --image=image [--from=cronjob/name] -- [COMMAND] [a
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_namespace.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_namespace.md
@@ -91,6 +91,8 @@ werf kubectl create namespace NAME [--dry-run=server|client|none] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -118,6 +120,11 @@ werf kubectl create namespace NAME [--dry-run=server|client|none] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_poddisruptionbudget.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_poddisruptionbudget.md
@@ -103,6 +103,8 @@ werf kubectl create poddisruptionbudget NAME --selector=SELECTOR --min-available
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -130,6 +132,11 @@ werf kubectl create poddisruptionbudget NAME --selector=SELECTOR --min-available
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_priorityclass.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_priorityclass.md
@@ -107,6 +107,8 @@ werf kubectl create priorityclass NAME --value=VALUE --global-default=BOOL [--dr
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -134,6 +136,11 @@ werf kubectl create priorityclass NAME --value=VALUE --global-default=BOOL [--dr
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_quota.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_quota.md
@@ -99,6 +99,8 @@ werf kubectl create quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -126,6 +128,11 @@ werf kubectl create quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_role.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_role.md
@@ -106,6 +106,8 @@ werf kubectl create role NAME --verb=verb --resource=resource.group/subresource 
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -133,6 +135,11 @@ werf kubectl create role NAME --verb=verb --resource=resource.group/subresource 
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_rolebinding.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_rolebinding.md
@@ -105,6 +105,8 @@ werf kubectl create rolebinding NAME --clusterrole=NAME|--role=NAME [--user=user
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -130,6 +132,11 @@ werf kubectl create rolebinding NAME --clusterrole=NAME|--role=NAME [--user=user
             Bearer token for authentication to the API server
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_secret.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_secret.md
@@ -47,6 +47,8 @@ werf kubectl create secret (docker-registry | generic | tls)
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -74,6 +76,11 @@ werf kubectl create secret (docker-registry | generic | tls)
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_secret_docker_registry.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_secret_docker_registry.md
@@ -119,6 +119,8 @@ werf kubectl create secret docker-registry NAME --docker-username=user --docker-
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -146,6 +148,11 @@ werf kubectl create secret docker-registry NAME --docker-username=user --docker-
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_secret_generic.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_secret_generic.md
@@ -122,6 +122,8 @@ werf kubectl create secret generic NAME [--type=string] [--from-file=[key=]sourc
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -149,6 +151,11 @@ werf kubectl create secret generic NAME [--type=string] [--from-file=[key=]sourc
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_secret_tls.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_secret_tls.md
@@ -99,6 +99,8 @@ werf kubectl create secret tls NAME --cert=path/to/cert/file --key=path/to/key/f
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -126,6 +128,11 @@ werf kubectl create secret tls NAME --cert=path/to/cert/file --key=path/to/key/f
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_service.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_service.md
@@ -47,6 +47,8 @@ werf kubectl create service
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -74,6 +76,11 @@ werf kubectl create service
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_service_clusterip.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_service_clusterip.md
@@ -98,6 +98,8 @@ werf kubectl create service clusterip NAME [--tcp=<port>:<targetPort>] [--dry-ru
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -125,6 +127,11 @@ werf kubectl create service clusterip NAME [--tcp=<port>:<targetPort>] [--dry-ru
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_service_externalname.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_service_externalname.md
@@ -97,6 +97,8 @@ werf kubectl create service externalname NAME --external-name external.name [--d
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -124,6 +126,11 @@ werf kubectl create service externalname NAME --external-name external.name [--d
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_service_loadbalancer.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_service_loadbalancer.md
@@ -93,6 +93,8 @@ werf kubectl create service loadbalancer NAME [--tcp=port:targetPort] [--dry-run
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -120,6 +122,11 @@ werf kubectl create service loadbalancer NAME [--tcp=port:targetPort] [--dry-run
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_service_nodeport.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_service_nodeport.md
@@ -95,6 +95,8 @@ werf kubectl create service nodeport NAME [--tcp=port:targetPort] [--dry-run=ser
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -122,6 +124,11 @@ werf kubectl create service nodeport NAME [--tcp=port:targetPort] [--dry-run=ser
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_serviceaccount.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_serviceaccount.md
@@ -91,6 +91,8 @@ werf kubectl create serviceaccount NAME [--dry-run=server|client|none] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -118,6 +120,11 @@ werf kubectl create serviceaccount NAME [--dry-run=server|client|none] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_create_token.md
+++ b/docs/_includes/reference/cli/werf_kubectl_create_token.md
@@ -103,6 +103,8 @@ werf kubectl create token SERVICE_ACCOUNT_NAME [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -130,6 +132,11 @@ werf kubectl create token SERVICE_ACCOUNT_NAME [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_debug.md
+++ b/docs/_includes/reference/cli/werf_kubectl_debug.md
@@ -129,6 +129,8 @@ werf kubectl debug (POD | TYPE[[.VERSION].GROUP]/NAME) [ -- COMMAND [args...] ] 
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -154,6 +156,11 @@ werf kubectl debug (POD | TYPE[[.VERSION].GROUP]/NAME) [ -- COMMAND [args...] ] 
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_delete.md
+++ b/docs/_includes/reference/cli/werf_kubectl_delete.md
@@ -141,6 +141,8 @@ werf kubectl delete ([-f FILENAME] | [-k DIRECTORY] | TYPE [(NAME | -l label | -
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -168,6 +170,11 @@ werf kubectl delete ([-f FILENAME] | [-k DIRECTORY] | TYPE [(NAME | -l label | -
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_describe.md
+++ b/docs/_includes/reference/cli/werf_kubectl_describe.md
@@ -98,6 +98,8 @@ werf kubectl describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME) 
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -125,6 +127,11 @@ werf kubectl describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME) 
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_diff.md
+++ b/docs/_includes/reference/cli/werf_kubectl_diff.md
@@ -101,6 +101,8 @@ werf kubectl diff -f FILENAME [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -128,6 +130,11 @@ werf kubectl diff -f FILENAME [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_drain.md
+++ b/docs/_includes/reference/cli/werf_kubectl_drain.md
@@ -101,6 +101,8 @@ werf kubectl drain NODE [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -128,6 +130,11 @@ werf kubectl drain NODE [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_edit.md
+++ b/docs/_includes/reference/cli/werf_kubectl_edit.md
@@ -123,6 +123,8 @@ werf kubectl edit (RESOURCE/NAME | -f FILENAME) [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -150,6 +152,11 @@ werf kubectl edit (RESOURCE/NAME | -f FILENAME) [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_events.md
+++ b/docs/_includes/reference/cli/werf_kubectl_events.md
@@ -101,6 +101,8 @@ werf kubectl events [(-o|--output=)json|yaml|name|go-template|go-template-file|t
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -128,6 +130,11 @@ werf kubectl events [(-o|--output=)json|yaml|name|go-template|go-template-file|t
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_exec.md
+++ b/docs/_includes/reference/cli/werf_kubectl_exec.md
@@ -94,6 +94,8 @@ werf kubectl exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...] 
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -121,6 +123,11 @@ werf kubectl exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...] 
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_explain.md
+++ b/docs/_includes/reference/cli/werf_kubectl_explain.md
@@ -87,6 +87,8 @@ werf kubectl explain TYPE [--recursive=FALSE|TRUE] [--api-version=api-version-gr
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -114,6 +116,11 @@ werf kubectl explain TYPE [--recursive=FALSE|TRUE] [--api-version=api-version-gr
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_expose.md
+++ b/docs/_includes/reference/cli/werf_kubectl_expose.md
@@ -152,6 +152,8 @@ werf kubectl expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP|
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -179,6 +181,11 @@ werf kubectl expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP|
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_get.md
+++ b/docs/_includes/reference/cli/werf_kubectl_get.md
@@ -168,6 +168,8 @@ werf kubectl get [(-o|--output=)json|yaml|name|go-template|go-template-file|temp
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -195,6 +197,11 @@ werf kubectl get [(-o|--output=)json|yaml|name|go-template|go-template-file|temp
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_kustomize.md
+++ b/docs/_includes/reference/cli/werf_kubectl_kustomize.md
@@ -90,6 +90,8 @@ werf kubectl kustomize DIR [flags] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -117,6 +119,11 @@ werf kubectl kustomize DIR [flags] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_label.md
+++ b/docs/_includes/reference/cli/werf_kubectl_label.md
@@ -126,6 +126,8 @@ werf kubectl label [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -153,6 +155,11 @@ werf kubectl label [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_logs.md
+++ b/docs/_includes/reference/cli/werf_kubectl_logs.md
@@ -131,6 +131,8 @@ werf kubectl logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -158,6 +160,11 @@ werf kubectl logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_options.md
+++ b/docs/_includes/reference/cli/werf_kubectl_options.md
@@ -54,6 +54,8 @@ werf kubectl options
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -81,6 +83,11 @@ werf kubectl options
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_patch.md
+++ b/docs/_includes/reference/cli/werf_kubectl_patch.md
@@ -112,6 +112,8 @@ werf kubectl patch (-f FILENAME | TYPE NAME) [-p PATCH|--patch-file FILE] [optio
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -139,6 +141,11 @@ werf kubectl patch (-f FILENAME | TYPE NAME) [-p PATCH|--patch-file FILE] [optio
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_plugin.md
+++ b/docs/_includes/reference/cli/werf_kubectl_plugin.md
@@ -51,6 +51,8 @@ werf kubectl plugin [flags]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -78,6 +80,11 @@ werf kubectl plugin [flags]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_plugin_list.md
+++ b/docs/_includes/reference/cli/werf_kubectl_plugin_list.md
@@ -66,6 +66,8 @@ werf kubectl plugin list [flags] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -93,6 +95,11 @@ werf kubectl plugin list [flags] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_port_forward.md
+++ b/docs/_includes/reference/cli/werf_kubectl_port_forward.md
@@ -88,6 +88,8 @@ werf kubectl port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCA
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -115,6 +117,11 @@ werf kubectl port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCA
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_proxy.md
+++ b/docs/_includes/reference/cli/werf_kubectl_proxy.md
@@ -109,6 +109,8 @@ werf kubectl proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -136,6 +138,11 @@ werf kubectl proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_replace.md
+++ b/docs/_includes/reference/cli/werf_kubectl_replace.md
@@ -131,6 +131,8 @@ werf kubectl replace -f FILENAME [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -158,6 +160,11 @@ werf kubectl replace -f FILENAME [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_rollout.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout.md
@@ -68,6 +68,8 @@ werf kubectl rollout SUBCOMMAND
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -95,6 +97,11 @@ werf kubectl rollout SUBCOMMAND
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_history.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_history.md
@@ -87,6 +87,8 @@ werf kubectl rollout history (TYPE NAME | TYPE/NAME) [flags] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -114,6 +116,11 @@ werf kubectl rollout history (TYPE NAME | TYPE/NAME) [flags] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_pause.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_pause.md
@@ -88,6 +88,8 @@ werf kubectl rollout pause RESOURCE [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -115,6 +117,11 @@ werf kubectl rollout pause RESOURCE [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_restart.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_restart.md
@@ -95,6 +95,8 @@ werf kubectl rollout restart RESOURCE [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -122,6 +124,11 @@ werf kubectl rollout restart RESOURCE [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_resume.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_resume.md
@@ -86,6 +86,8 @@ werf kubectl rollout resume RESOURCE [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -113,6 +115,11 @@ werf kubectl rollout resume RESOURCE [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_status.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_status.md
@@ -79,6 +79,8 @@ werf kubectl rollout status (TYPE NAME | TYPE/NAME) [flags] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -106,6 +108,11 @@ werf kubectl rollout status (TYPE NAME | TYPE/NAME) [flags] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_rollout_undo.md
+++ b/docs/_includes/reference/cli/werf_kubectl_rollout_undo.md
@@ -94,6 +94,8 @@ werf kubectl rollout undo (TYPE NAME | TYPE/NAME) [flags] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -121,6 +123,11 @@ werf kubectl rollout undo (TYPE NAME | TYPE/NAME) [flags] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_run.md
+++ b/docs/_includes/reference/cli/werf_kubectl_run.md
@@ -153,6 +153,8 @@ werf kubectl run NAME --image=image [--env="key=value"] [--port=port] [--dry-run
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -180,6 +182,11 @@ werf kubectl run NAME --image=image [--env="key=value"] [--port=port] [--dry-run
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_scale.md
+++ b/docs/_includes/reference/cli/werf_kubectl_scale.md
@@ -115,6 +115,8 @@ werf kubectl scale [--resource-version=version] [--current-replicas=count] --rep
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -142,6 +144,11 @@ werf kubectl scale [--resource-version=version] [--current-replicas=count] --rep
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_set.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set.md
@@ -49,6 +49,8 @@ werf kubectl set SUBCOMMAND
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -76,6 +78,11 @@ werf kubectl set SUBCOMMAND
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_set_env.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_env.md
@@ -154,6 +154,8 @@ werf kubectl set env RESOURCE/NAME KEY_1=VAL_1 ... KEY_N=VAL_N [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -181,6 +183,11 @@ werf kubectl set env RESOURCE/NAME KEY_1=VAL_1 ... KEY_N=VAL_N [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_set_image.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_image.md
@@ -110,6 +110,8 @@ werf kubectl set image (-f FILENAME | TYPE NAME) CONTAINER_NAME_1=CONTAINER_IMAG
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -137,6 +139,11 @@ werf kubectl set image (-f FILENAME | TYPE NAME) CONTAINER_NAME_1=CONTAINER_IMAG
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_set_resources.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_resources.md
@@ -116,6 +116,8 @@ werf kubectl set resources (-f FILENAME | TYPE NAME)  ([--limits=LIMITS & --requ
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -143,6 +145,11 @@ werf kubectl set resources (-f FILENAME | TYPE NAME)  ([--limits=LIMITS & --requ
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_set_selector.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_selector.md
@@ -94,6 +94,8 @@ werf kubectl set selector (-f FILENAME | TYPE NAME) EXPRESSIONS [--resource-vers
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -121,6 +123,11 @@ werf kubectl set selector (-f FILENAME | TYPE NAME) EXPRESSIONS [--resource-vers
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_set_serviceaccount.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_serviceaccount.md
@@ -99,6 +99,8 @@ werf kubectl set serviceaccount (-f FILENAME | TYPE NAME) SERVICE_ACCOUNT [optio
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -126,6 +128,11 @@ werf kubectl set serviceaccount (-f FILENAME | TYPE NAME) SERVICE_ACCOUNT [optio
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_set_subject.md
+++ b/docs/_includes/reference/cli/werf_kubectl_set_subject.md
@@ -104,6 +104,8 @@ werf kubectl set subject (-f FILENAME | TYPE NAME) [--user=username] [--group=gr
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -129,6 +131,11 @@ werf kubectl set subject (-f FILENAME | TYPE NAME) [--user=username] [--group=gr
             Bearer token for authentication to the API server
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_taint.md
+++ b/docs/_includes/reference/cli/werf_kubectl_taint.md
@@ -116,6 +116,8 @@ werf kubectl taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EF
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -143,6 +145,11 @@ werf kubectl taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EF
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_top.md
+++ b/docs/_includes/reference/cli/werf_kubectl_top.md
@@ -51,6 +51,8 @@ werf kubectl top
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -78,6 +80,11 @@ werf kubectl top
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_top_node.md
+++ b/docs/_includes/reference/cli/werf_kubectl_top_node.md
@@ -77,6 +77,8 @@ werf kubectl top node [NAME | -l label] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -104,6 +106,11 @@ werf kubectl top node [NAME | -l label] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_top_pod.md
+++ b/docs/_includes/reference/cli/werf_kubectl_top_pod.md
@@ -94,6 +94,8 @@ werf kubectl top pod [NAME | -l label] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -121,6 +123,11 @@ werf kubectl top pod [NAME | -l label] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_uncordon.md
+++ b/docs/_includes/reference/cli/werf_kubectl_uncordon.md
@@ -67,6 +67,8 @@ werf kubectl uncordon NODE [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -94,6 +96,11 @@ werf kubectl uncordon NODE [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_version.md
+++ b/docs/_includes/reference/cli/werf_kubectl_version.md
@@ -63,6 +63,8 @@ werf kubectl version [flags] [options]
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -90,6 +92,11 @@ werf kubectl version [flags] [options]
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/docs/_includes/reference/cli/werf_kubectl_wait.md
+++ b/docs/_includes/reference/cli/werf_kubectl_wait.md
@@ -121,6 +121,8 @@ werf kubectl wait ([-f FILENAME] | resource.group/resource.name | resource.group
       --kubeconfig=''
             Path to the kubeconfig file to use for CLI requests (default $WERF_KUBE_CONFIG, or      
             $WERF_KUBECONFIG, or $KUBECONFIG). Ignored if kubeconfig passed as base64.
+      --log-flush-frequency=5s
+            Maximum number of seconds between log flushes
       --match-server-version=false
             Require server version to match client version
   -n, --namespace=''
@@ -148,6 +150,11 @@ werf kubectl wait ([-f FILENAME] | resource.group/resource.name | resource.group
             The name of the kubeconfig user to use
       --username=''
             Username for basic authentication to the API server
+  -v, --v=0
+            number for the log level verbosity
+      --vmodule=
+            comma-separated list of pattern=N settings for file-filtered logging (only works for    
+            the default text log format)
       --warnings-as-errors=false
             Treat warnings received from the server as errors and exit with a non-zero exit code
 ```

--- a/go.mod
+++ b/go.mod
@@ -128,6 +128,7 @@ require (
 	github.com/aws/smithy-go v1.22.0 // indirect
 	github.com/aymanbagabas/go-udiff v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bugsnag/bugsnag-go v2.2.0+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect


### PR DESCRIPTION
`cmd.NewDefaultKubectlCommandWithArgs()` does not inject log arbitrary flags required by args like in the `werf kubectl get nodes -v=10`.

I had a look on  how `kubectl` is originally run and found `logs.AddFlags(kubectlCmd.PersistentFlags())` call here - https://github.com/kubernetes/component-base/blob/55c45bc78189d14353588befc15715b156914ce7/cli/run.go#L85C1-L118C1

Fix bug #6319