### PR TITLE
fix(cache): allow application/vnd.cncf.helm.chart.content.v1.tar+gzip media type.

### DIFF
--- a/pkg/deploy/bundles/registry/cache.go
+++ b/pkg/deploy/bundles/registry/cache.go
@@ -120,7 +120,7 @@ func (cache *Cache) FetchReference(ref *Reference) (*CacheRefSummary, error) {
 			var contentLayer *ocispec.Descriptor
 			for _, layer := range manifest.Layers {
 				layer := layer
-				if layer.MediaType == HelmChartContentLayerMediaType {
+				if layer.MediaType == HelmChartContentLayerMediaType || layer.MediaType == HelmChartContentLayerFullMediaType {
 					contentLayer = &layer
 				}
 			}

--- a/pkg/deploy/bundles/registry/constants.go
+++ b/pkg/deploy/bundles/registry/constants.go
@@ -22,6 +22,9 @@ const (
 
 	// HelmChartContentLayerMediaType is the reserved media type for Helm chart package content
 	HelmChartContentLayerMediaType = "application/tar+gzip"
+
+	// HelmChartContentLayerFullMediaType is the reserved media type for Helm chart package content, full variant
+	HelmChartContentLayerFullMediaType = "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
 )
 
 // KnownMediaTypes returns a list of layer mediaTypes that the Helm client knows about
@@ -29,5 +32,6 @@ func KnownMediaTypes() []string {
 	return []string{
 		HelmChartConfigMediaType,
 		HelmChartContentLayerMediaType,
+		HelmChartContentLayerFullMediaType,
 	}
 }


### PR DESCRIPTION
This fix allow "application/vnd.cncf.helm.chart.content.v1.tar+gzip" MIME type to `KnownMediaTypes` method and resolves situation, when some other instruments fetch bundle chart from registry and push chart artifact to another registry. This case in some banks, where dev registry is separated from prod registry.