### PR TITLE
feat(werf): add application version param support

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -1201,6 +1201,14 @@ func GetHelmChartDir(werfConfigPath string, werfConfig *config.WerfConfig, giter
 	return helmChartDir, nil
 }
 
+func GetHelmChartConfigAppVersion(werfConfig *config.WerfConfig) string {
+	if werfConfig.Meta.Deploy.HelmChartConfig.AppVersion != nil {
+		return *werfConfig.Meta.Deploy.HelmChartConfig.AppVersion
+	}
+
+	return ""
+}
+
 func GetNamespace(cmdData *CmdData) string {
 	if *cmdData.Namespace == "" {
 		return "default"

--- a/pkg/config/meta_deploy.go
+++ b/pkg/config/meta_deploy.go
@@ -1,9 +1,14 @@
 package config
 
 type MetaDeploy struct {
+	HelmChartConfig MetaDeployHelmChartConfig
 	HelmChartDir    *string
 	HelmRelease     *string
 	HelmReleaseSlug *bool
 	Namespace       *string
 	NamespaceSlug   *bool
+}
+
+type MetaDeployHelmChartConfig struct {
+	AppVersion *string
 }

--- a/pkg/deploy/helm/chart_extender/helpers/chart_metadata_autosetter.go
+++ b/pkg/deploy/helm/chart_extender/helpers/chart_metadata_autosetter.go
@@ -3,9 +3,10 @@ package helpers
 import "github.com/werf/3p-helm/pkg/chart"
 
 type GetHelmChartMetadataOptions struct {
-	OverrideName   string
-	DefaultName    string
-	DefaultVersion string
+	OverrideAppVersion string
+	OverrideName       string
+	DefaultName        string
+	DefaultVersion     string
 }
 
 func AutosetChartMetadata(metadataIn *chart.Metadata, opts GetHelmChartMetadataOptions) *chart.Metadata {
@@ -22,6 +23,10 @@ func AutosetChartMetadata(metadataIn *chart.Metadata, opts GetHelmChartMetadataO
 		metadata.Name = opts.OverrideName
 	} else if metadata.Name == "" {
 		metadata.Name = opts.DefaultName
+	}
+
+	if opts.OverrideAppVersion != "" {
+		metadata.AppVersion = opts.OverrideAppVersion
 	}
 
 	if metadata.Version == "" {

--- a/pkg/deploy/helm/chart_extender/werf_chart.go
+++ b/pkg/deploy/helm/chart_extender/werf_chart.go
@@ -24,6 +24,7 @@ import (
 	"github.com/werf/3p-helm/pkg/registry"
 	"github.com/werf/logboek"
 	"github.com/werf/nelm/pkg/secrets_manager"
+	"github.com/werf/werf/v2/cmd/werf/common"
 	"github.com/werf/werf/v2/pkg/config"
 	"github.com/werf/werf/v2/pkg/deploy/helm"
 	"github.com/werf/werf/v2/pkg/deploy/helm/chart_extender/helpers"
@@ -131,6 +132,7 @@ func (wc *WerfChart) ChartLoaded(files []*chart.ChartExtenderBufferedFile) error
 	var opts helpers.GetHelmChartMetadataOptions
 	if wc.werfConfig != nil {
 		opts.DefaultName = wc.werfConfig.Meta.Project
+		opts.OverrideAppVersion = common.GetHelmChartConfigAppVersion(wc.werfConfig)
 	}
 	opts.DefaultVersion = "1.0.0"
 	wc.HelmChart.Metadata = helpers.AutosetChartMetadata(wc.HelmChart.Metadata, opts)


### PR DESCRIPTION
Implements #6390

The current implementation scope:

* Add `applicationVersion` global param support to `werf.yml`
* Add `applicationVersionFile` global param support to `werf.yml` 
* Plain/text, JSON, YAML files can be used as `applicationVersionFile` params
* Giterminism is enforced for `applicationVersionFile` param
* Giterminism dev mode is supported for `applicationVersionFile` param
* Handle corner case when both `applicationVersion` and `applicationVersionFile` params are set
* `applicationVersion` value is available in nelm templates by using `$.Values.werf.applicationVersion` variable

## Inline set application version by `applicationVersion` param
`werf.yaml` file content:
```
project: demo-app
configVersion: 1
applicationVersion: v0.0.1

---
image: backend
dockerfile: backend.Dockerfile

---
image: frontend
dockerfile: frontend.Dockerfile

```
##  Set application version by external JSON file
`werf.yaml` file content:
```
project: demo-app
configVersion: 1
applicationVersionFile: ./version.json

---
image: backend
dockerfile: backend.Dockerfile

---
image: frontend
dockerfile: frontend.Dockerfile

```
`./version.json` file content:
```
{
    "version": "v0.0.1"
}
```
##  Set application version by external YAML file
`werf.yaml` file content:
```
project: demo-app
configVersion: 1
applicationVersionFile: ./version.yaml

---
image: backend
dockerfile: backend.Dockerfile

---
image: frontend
dockerfile: frontend.Dockerfile

```
`./version.yaml` file content:
```
version: v0.0.1
```
##  Set application version by external plain/text file
`werf.yaml` file content:
```
project: demo-app
configVersion: 1
applicationVersionFile: ./version

---
image: backend
dockerfile: backend.Dockerfile

---
image: frontend
dockerfile: frontend.Dockerfile

```
`./version` file content:
```
v0.0.1
```