### PR TITLE
docs: update the werf installation link

### DIFF
--- a/.github/workflows/release_release-please.yml
+++ b/.github/workflows/release_release-please.yml
@@ -32,7 +32,7 @@ jobs:
           release-notes-footer: |
             ## Installation
 
-            To install `werf` we strongly recommend following [these instructions](https://werf.io/installation.html).
+            To install `werf` we strongly recommend following [these instructions](https://werf.io/getting_started/).
 
             Alternatively, you can download `werf` binaries from here:
             * [Linux amd64](https://tuf.werf.io/targets/releases/{{> version }}/linux-amd64/bin/werf) ([PGP signature](https://tuf.werf.io/targets/signatures/{{> version }}/linux-amd64/bin/werf.sig))

--- a/README.md
+++ b/README.md
@@ -23,13 +23,9 @@ What makes werf special:
 - **Gluing common technologies**: Git, Buildah, Helm, Kubernetes, and your CI system of choice.
 - **Production-ready**: werf has been used in production since 2017; thousands of projects rely on it to build & deploy various apps.
 
-## Quickstart
-
-The [quickstart guide](https://werf.io/docs/quickstart.html) shows how to set up the deployment of an example application (a cool voting app in our case) using werf.
-
 ## Installation
 
-The [installation guide](https://werf.io/installation.html) helps set up and use werf both locally and in your CI system.
+The [Getting Started guide](https://werf.io/getting_started/) helps set up and use werf both locally and in your CI system.
 
 ## Documentation
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -11,7 +11,7 @@ ___
 
 Run `jekyll serve` with --watch option to test changes in "real time". Requires to run werf compose in werf/website to access documentation in browser.
 
-- Install [werf](http://werf.io/installation.html).
+- Install [werf](http://werf.io/getting_started/).
 - Install [task](https://taskfile.dev/installation/).
 - Run:
   ```shell
@@ -29,7 +29,7 @@ Run `jekyll serve` with --watch option to test changes in "real time". Requires 
 
 Run `jekyll serve` with --watch option to test changes in "real time". Use scripts/styles/images from werf.io site.
 
-- Install [werf](http://werf.io/installation.html). 
+- Install [werf](http://werf.io/getting_started/). 
 - Install [task](https://taskfile.dev/installation/)
 - Run (add `--follow --docker-compose-command-options="-d"` if necessary):
   ```shell


### PR DESCRIPTION
We provide actual instructions for installing werf in the [Getting Started guide](https://werf.io/getting_started/). This PR updates all old links leading to the non-existing `/installation.html` page. Additionally, we removed the Quickstart guide a while ago.