### PR TITLE
feat(build): add global staged directive

### DIFF
--- a/docs/_data/werf_yaml.yml
+++ b/docs/_data/werf_yaml.yml
@@ -28,6 +28,11 @@ sections:
               en: Common list of target platforms for all images (for example ['linux/amd64', 'linux/arm64', 'linux/arm/v8'])
               ru: Общий список целевых платформ для всех образов (например ['linux/amd64', 'linux/arm64', 'linux/arm/v8'])
             value: "[ string, ... ]"
+          - name: staged
+            value: "bool"
+            description:
+              en: "Enable layer-by-layer caching of Dockerfile instructions in container registry globally for all images"
+              ru: "Включить послойное кеширование инструкций Dockerfile в container registry глобально для всех образов"
       - name: deploy
         description:
           en: Settings for deployment

--- a/docs/pages_en/usage/build/process.md
+++ b/docs/pages_en/usage/build/process.md
@@ -125,7 +125,7 @@ If you run a build with storing images in the repository, werf will first check 
 
 By default, Dockerfile images are cached by a single image in the container registry.
 
-To enable layered caching of Dockerfile instructions in the container registry, use the `staged` directive in werf.yaml:
+To enable layered caching of Dockerfile instructions in the container registry, use the `staged` directive in werf.yaml. The directive can be set globally at the root level of werf.yaml for all images, or locally for specific images where the local setting will override the global one:
 
 ```yaml
 # werf.yaml

--- a/docs/pages_ru/usage/build/process.md
+++ b/docs/pages_ru/usage/build/process.md
@@ -123,7 +123,7 @@ werf build --repo REPO --add-custom-tag "%image%-latest"
 
 По умолчанию Dockerfile-образы кешируются одним образом в container registry. 
 
-Для включения послойного кеширования Dockerfile-инструкций в container registry необходимо использовать директиву `staged` в werf.yaml:
+Для включения послойного кеширования Dockerfile-инструкций в container registry необходимо использовать директиву `staged` в werf.yaml. Директива может быть установлена глобально на корневом уровне werf.yaml для всех образов или локально для конкретных образов, где локальная настройка переопределит глобальную:
 
 ```yaml
 # werf.yaml

--- a/pkg/config/meta_build.go
+++ b/pkg/config/meta_build.go
@@ -2,4 +2,5 @@ package config
 
 type MetaBuild struct {
 	Platform []string
+	Staged   bool
 }

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -502,6 +502,9 @@ func prepareWerfConfig(giterminismManager giterminism_manager.Interface, rawImag
 		}
 
 		for _, image := range imageList {
+			if !rawImage.isFillStaged {
+				image.Staged = meta.Build.Staged
+			}
 			images = append(images, image)
 		}
 	}
@@ -571,6 +574,9 @@ func splitByMetaAndRawImages(docs []*doc) (*Meta, []*rawStapelImage, []*rawImage
 			resultMeta = rawMeta.toMeta()
 		case isImageFromDockerfileDoc(raw):
 			imageFromDockerfile := &rawImageFromDockerfile{doc: doc}
+			if isStagedDoc(raw) {
+				imageFromDockerfile.isFillStaged = true
+			}
 			err := yaml.UnmarshalStrict(doc.Content, &imageFromDockerfile)
 			if err != nil {
 				return nil, nil, nil, newYamlUnmarshalError(err, doc)
@@ -611,6 +617,14 @@ func isImageDoc(h map[string]interface{}) bool {
 
 func isImageFromDockerfileDoc(h map[string]interface{}) bool {
 	if _, ok := h["dockerfile"]; ok {
+		return true
+	}
+
+	return false
+}
+
+func isStagedDoc(h map[string]interface{}) bool {
+	if _, ok := h["staged"]; ok {
 		return true
 	}
 

--- a/pkg/config/raw_image_from_dockerfile.go
+++ b/pkg/config/raw_image_from_dockerfile.go
@@ -24,7 +24,8 @@ type rawImageFromDockerfile struct {
 	Platform        []string               `yaml:"platform,omitempty"`
 	RawSecrets      []*rawSecret           `yaml:"secrets,omitempty"`
 
-	doc *doc `yaml:"-"` // parent
+	doc          *doc `yaml:"-"` // parent
+	isFillStaged bool `yaml:"-"` // indicates whether 'staged' field is explicitly set in the image section
 
 	UnsupportedAttributes map[string]interface{} `yaml:",inline"`
 }

--- a/pkg/config/raw_meta_build.go
+++ b/pkg/config/raw_meta_build.go
@@ -2,8 +2,8 @@ package config
 
 type rawMetaBuild struct {
 	Platform []string `yaml:"platform,omitempty"`
-
-	rawMeta *rawMeta
+	Staged   bool     `yaml:"staged,omitempty"`
+	rawMeta  *rawMeta
 
 	UnsupportedAttributes map[string]interface{} `yaml:",inline"`
 }
@@ -31,5 +31,6 @@ func (c *rawMetaBuild) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (c *rawMetaBuild) toMetaBuild() MetaBuild {
 	metaBuild := MetaBuild{}
 	metaBuild.Platform = c.Platform
+	metaBuild.Staged = c.Staged
 	return metaBuild
 }


### PR DESCRIPTION
> **What this PR does / why we need it**:
>
> feat #5974
>
> **Special notes for your reviewer**:
>
> **If applicable**:
>
> * [x] this PR contains documentation
> * [x] this PR has been tested for backwards compatibility
>
> I have thoroughly tested it locally. Please take a review at this pr.
>
> ## How to Test This Modification Locally
>
> 1. Init demo
>
>    ```
>    Initialize the demo project on the local machine:
>    
>    git clone https://github.com/werf/examples
>    cp -rf examples/local-dev example
>    cd example
>    git init
>    ```
>
> 2. Edit a `werf.yaml`
>
> ```yaml
> project: demo-app
> configVersion: 1
> build:
>   staged: true
> 
> ---
> image: backend
> dockerfile: backend.Dockerfile
> 
> ---
> image: frontend
> dockerfile: frontend.Dockerfile
> ```
>
> 3. Git commit
>
> ```yaml
> git add .
> git commit -m-
> ```
>
> 4. Execute `./werf build` 
>
>    1 )  global staged: true
>
> ```shell
> # export WERF_BUILDAH_MODE=auto
> # ./werf build --config=/data/github/werf-test/example/werf.yaml --git-work-tree=/data/github/werf-test/example --dir /data/github/werf-test/example
> Version: dev
> Using werf config render file: /tmp/werf-config-render-4207574424
> 
> ┌ Concurrent build plan (no more than 5 images at the same time)
> │ Set #0:
> │ - 🛳️  image backend
> │ - 🛳️  image frontend
> └ Concurrent build plan (no more than 5 images at the same time)
> 
> ┌ 🛳️  image backend
> │ Use previously built image for backend/WORKDIR1
> │      name: demo-app:d88993b2ee3becce15901f091e8ec589f593bb426b789fc8e4741501-1737645062974
> │        id: 
> │   created: 2025-01-23 23:11:02.807444403 +0800 CST
> │      size: 0 B
> │ 
> │ Use previously built image for backend/COPY2
> │      name: demo-app:a7f9630789fbe2e925c01280fe1814e1f3c3706f3b9573765db9a7dd-1737645066695
> │        id: 
> │   created: 2025-01-23 23:11:06.528447806 +0800 CST
> │      size: 0 B
> │ 
> │ Use previously built image for backend/RUN3
> │      name: demo-app:ee62d0cd231cc67ccbe21775459157a20cf4c583c6e61bfa04202da4-1737645076463
> │        id: 
> │   created: 2025-01-23 23:11:14.7496714 +0800 CST
> │      size: 0 B
> │ 
> │ Use previously built image for backend/COPY4
> │      name: demo-app:1be05468947a1e5bb004f297a44d1443e3f78a19b09166e14a596c3b-1737645080071
> │        id: 
> │   created: 2025-01-23 23:11:19.89776069 +0800 CST
> │      size: 0 B
> └ 🛳️  image backend (0.30 seconds)
> 
> ┌ 🛳️  image frontend
> │ Use previously built image for frontend/WORKDIR1
> │      name: demo-app:5de1daa80b91a938519be6f7ec4082875575f617730b5f87f006a09d-1737645425274
> │        id: 
> │   created: 2025-01-23 23:17:05.124517775 +0800 CST
> │      size: 0 B
> └ 🛳️  image frontend (0.04 seconds)
> 
> ┌ Build summary
> │ Set #0:
> │ - 🛳️  image frontend (0.04 seconds)
> │ - 🛳️  image backend (0.30 seconds)
> └ Build summary
> 
> Running time 0.53 seconds
> ```
>
>    2)  global staged: false or none global staged
>
> ```
> # ./werf build --config=/data/github/werf-test/example/werf.yaml --git-work-tree=/data/github/werf-test/example --dir /data/github/werf-test/example
> Version: dev
> Using werf config render file: /tmp/werf-config-render-381878679
> 
> ┌ Concurrent build plan (no more than 5 images at the same time)
> │ Set #0:
> │ - 🛳️  image backend
> │ - 🛳️  image frontend
> └ Concurrent build plan (no more than 5 images at the same time)
> 
> ┌ 🛳️  image backend
> │ Use previously built image for backend/dockerfile
> │      name: demo-app:c6052aca675d5d57c1afc25539f81c1c09f3f6c794ccd8b5c9da4b82-1737645750471
> │        id: 
> │   created: 2025-01-23 23:22:30.271641731 +0800 CST
> │      size: 0 B
> └ 🛳️  image backend (0.06 seconds)
> 
> ┌ 🛳️  image frontend
> │ Use previously built image for frontend/dockerfile
> │      name: demo-app:d0277257030903b476c8379294f196b798547b14b7b0860efd51f869-1737645051660
> │        id: 
> │   created: 2025-01-23 23:10:51.618450507 +0800 CST
> │      size: 0 B
> └ 🛳️  image frontend (0.06 seconds)
> 
> ┌ Build summary
> │ Set #0:
> │ - 🛳️  image backend (0.06 seconds)
> │ - 🛳️  image frontend (0.06 seconds)
> └ Build summary
> 
> Running time 0.33 seconds
> 
> ```
>
>    3 )  local staged: false and global staged: false
>
> ```
> project: demo-app
> configVersion: 1
> build:
>   staged: false
> 
> ---
> image: backend
> dockerfile: backend.Dockerfile
> staged: true
> 
> ---
> image: frontend
> dockerfile: frontend.Dockerfile
> ```

> ```shell
> # ./werf build --config=/data/github/werf-test/example/werf.yaml --git-work-tree=/data/github/werf-test/example --dir /data/github/werf-test/example
> Version: dev
> Using werf config render file: /tmp/werf-config-render-1025467448
> 
> ┌ Concurrent build plan (no more than 5 images at the same time)
> │ Set #0:
> │ - 🛳️  image backend
> │ - 🛳️  image frontend
> └ Concurrent build plan (no more than 5 images at the same time)
> 
> ┌ 🛳️  image backend
> │ Use previously built image for backend/WORKDIR1
> │      name: demo-app:d88993b2ee3becce15901f091e8ec589f593bb426b789fc8e4741501-1737645062974
> │        id: 
> │   created: 2025-01-23 23:11:02.807444403 +0800 CST
> │      size: 0 B
> │ 
> │ Use previously built image for backend/COPY2
> │      name: demo-app:a7f9630789fbe2e925c01280fe1814e1f3c3706f3b9573765db9a7dd-1737645066695
> │        id: 
> │   created: 2025-01-23 23:11:06.528447806 +0800 CST
> │      size: 0 B
> │ 
> │ Use previously built image for backend/RUN3
> │      name: demo-app:ee62d0cd231cc67ccbe21775459157a20cf4c583c6e61bfa04202da4-1737645076463
> │        id: 
> │   created: 2025-01-23 23:11:14.7496714 +0800 CST
> │      size: 0 B
> │ 
> │ Use previously built image for backend/COPY4
> │      name: demo-app:1be05468947a1e5bb004f297a44d1443e3f78a19b09166e14a596c3b-1737645080071
> │        id: 
> │   created: 2025-01-23 23:11:19.89776069 +0800 CST
> │      size: 0 B
> └ 🛳️  image backend (0.32 seconds)
> 
> ┌ 🛳️  image frontend
> │ Use previously built image for frontend/dockerfile
> │      name: demo-app:d0277257030903b476c8379294f196b798547b14b7b0860efd51f869-1737645051660
> │        id: 
> │   created: 2025-01-23 23:10:51.618450507 +0800 CST
> │      size: 0 B
> └ 🛳️  image frontend (0.05 seconds)
> 
> ┌ Build summary
> │ Set #0:
> │ - 🛳️  image frontend (0.05 seconds)
> │ - 🛳️  image backend (0.32 seconds)
> └ Build summary
> 
> Running time 0.63 seconds
> 
> ```

```

```

