### PR TITLE
fix(build): fix no such image error

### DIFF
--- a/pkg/container_backend/legacy_stage_image.go
+++ b/pkg/container_backend/legacy_stage_image.go
@@ -66,7 +66,7 @@ func (i *LegacyStageImage) GetID() string {
 	if i.buildImage != nil {
 		return i.buildImage.Name()
 	} else {
-		return i.legacyBaseImage.GetStageDesc().Info.ID
+		return i.legacyBaseImage.GetStageDesc().Info.Name
 	}
 }
 


### PR DESCRIPTION
```
│ ┌ Building stage common/relocate-artifact/from
│ │ common/relocate-artifact/from  docker: Error response from daemon: No such image: sha256:8c6ead2bd8a90a3969dc9fd39513bcf332ca130d44ac9791b7536e78440198f1. │ │ common/relocate-artifact/from  See 'docker run --help'.
 ...
Error: phase build on image common/relocate-artifact stage from handler failed: failed to build image for stage from with digest 999f9fefd1e9ad7092be30c38711c041bb8c922125e32b1fe74bd64c: error building stage from: unable to remove container (original error container run failed: Status: , Code: 125): unable to remove container werf.build.awnree2bxr: Error response from daemon: No such container: werf.build.awnree2bxr
```


