### PR TITLE
fix(build): panic: assignment to entry in nil map

### DIFF
--- a/pkg/build/stage/image_spec.go
+++ b/pkg/build/stage/image_spec.go
@@ -63,8 +63,11 @@ func (s *ImageSpecStage) PrepareImage(ctx context.Context, _ Conveyor, _ contain
 		newConfig.Env = modifyEnv(ctx, imageInfo.Env, s.imageSpec.RemoveEnv, s.imageSpec.Env)
 		newConfig.Volumes = modifyVolumes(ctx, imageInfo.Volumes, s.imageSpec.RemoveVolumes, s.imageSpec.Volumes)
 
-		for _, expose := range s.imageSpec.Expose {
-			newConfig.ExposedPorts[expose] = struct{}{}
+		if s.imageSpec.Expose != nil {
+			newConfig.ExposedPorts = make(map[string]struct{}, len(s.imageSpec.Expose))
+			for _, expose := range s.imageSpec.Expose {
+				newConfig.ExposedPorts[expose] = struct{}{}
+			}
 		}
 
 		if s.imageSpec.Healthcheck != nil {


### PR DESCRIPTION
panic: assignment to entry in nil map

goroutine 13229 [running]:
github.com/werf/werf/v2/pkg/build/stage.(*ImageSpecStage).PrepareImage(0xc000e99660, {0x4ead678, 0xc003309980}, {0x10?, 0x2c?}, {0x30?, 0x30?}, 0xc001d454c0?, 0xc0072c25a0, {0x0, ...})
	/git/pkg/build/stage/image_spec.go:67 +0x6d5