### PR TITLE
fix(build, docker, dockerfile): fix panic expected stage "dockerfile" content digest label to be set!

### DIFF
--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -209,6 +209,9 @@ func CliBuild_LiveOutputWithCustomIn(ctx context.Context, rc io.ReadCloser, args
 
 	if useBuildx {
 		buildOpts.EnableBuildx = true
+
+		// TODO: --provenance=false is a workaround for index manifests that we cannot handle properly with current code base (fix in v3).
+		args = append([]string{"--provenance=false"}, args...)
 	} else {
 		var err error
 		args, err = checkForUnsupportedOptions(ctx, args...)

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -231,11 +231,6 @@ func CliBuild_LiveOutputWithCustomIn(ctx context.Context, rc io.ReadCloser, args
 	})
 }
 
-func CliBuild_LiveOutput(ctx context.Context, args ...string) error {
-	buildOpts := BuildOptions{EnableBuildx: useBuildx}
-	return doCliBuild(cli(ctx), buildOpts, args...)
-}
-
 func checkForUnsupportedOptions(ctx context.Context, args ...string) ([]string, error) {
 	borderIndex := 0
 	for i := 0; i < len(args); i++ {


### PR DESCRIPTION
Disable provenance to avoid creating an index manifest (result of Buildx build), which is not handled correctly with the current code.

```
panic: expected stage "dockerfile" content digest label to be set!

goroutine 1 [running]:
github.com/werf/werf/v2/pkg/build.(*BuildPhase).calculateStage(0x14000cf0a00, {0x104100598, 0x14000b12090}, 0x14000371680, {0x10412ad20, 0x1400095f800})
	/git/pkg/build/build_phase.go:985 +0xb68
github.com/werf/werf/v2/pkg/build.(*BuildPhase).onImageStage(0x14000cf0a00, {0x104100598, 0x14000b12090}, 0x14000371680, {0x10412ad20, 0x1400095f800})
	/git/pkg/build/build_phase.go:744 +0xf8
```