### PR TITLE
refactor(cleanup): add detailed error for invalid regex in config

### DIFF
--- a/pkg/config/raw_meta_cleanup.go
+++ b/pkg/config/raw_meta_cleanup.go
@@ -175,7 +175,7 @@ func (c *rawMetaCleanupKeepPolicyReferences) processRegexpString(name, configVal
 	expr := fmt.Sprintf("^%s$", value)
 	regex, err := regexp.Compile(expr)
 	if err != nil {
-		return nil, newDetailedConfigError(fmt.Sprintf("invalid value %q for `%s: string|REGEX`!", configValue, name), c, c.rawMetaCleanup.rawMeta.doc)
+		return nil, newDetailedConfigError(fmt.Sprintf("invalid value %q for %q: %s", configValue, name, err.Error()), c, c.rawMetaCleanup.rawMeta.doc)
 	}
 
 	return regex, nil


### PR DESCRIPTION
```
Error: invalid value "/(?!main$|release-).*/" for `branch`: error parsing regexp: invalid or unsupported Perl syntax: `(?!`

    branch: /(?!main$|release-).*/

/private/var/folders/58/893r9slj6lsc19mrn19vjp180000gn/T/werf-config-render-4202248949

     1  project: echoserver
     2  configVersion: 1
     3  cleanup:
     4    keepPolicies:
     5      - references:
     6          branch: "/(?!main$|release-).*/"
     7  build:
     8    imageSpec:
     9      config:
    10        labels: 
    11          OLOLO: x
    12 
```