### PR TITLE
fix(build, buildah, staged): fix panic in run instruction

### DIFF
--- a/pkg/buildah/native_linux.go
+++ b/pkg/buildah/native_linux.go
@@ -461,6 +461,7 @@ func (b *NativeBuildah) RunCommand(ctx context.Context, container string, comman
 	}
 
 	runOpts := buildah.RunOptions{
+		Logger:           logrus.StandardLogger(),
 		Env:              opts.Envs,
 		ContextDir:       contextDir,
 		AddCapabilities:  opts.AddCapabilities,


### PR DESCRIPTION
Due to we don't set logger in run options a panic occurs when running this code
https://github.com/werf/3p-buildah/blob/5b80b7b735de074279ceabad77697d1fe54fafab/run_linux.go#L350-L354
It can't take a global logger since it uses pointer to logger from options struct, so we need to set it in the run options.