### PR TITLE
fix: label/annotation separator options behaviour 

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -419,8 +419,6 @@ Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separ
 Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g. $WERF_ADD_ANNOTATION_1=annoName1=annoValue1, $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)`, DefaultPairSeparator))
 }
 
-const DefaultAnnoAndLabelPairSeparator = "\n"
-
 func SetupAddAnnotationSeparator(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.AddAnnotationSeparator = new(string)
 

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -414,9 +414,9 @@ func SetupNamespace(cmdData *CmdData, cmd *cobra.Command, projectConfigParsed bo
 
 func SetupAddAnnotations(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.AddAnnotations = new([]string)
-	cmd.Flags().StringArrayVarP(cmdData.AddAnnotations, "add-annotation", "", []string{}, `Add annotation to deploying resources (can specify multiple).
-Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
-Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g. $WERF_ADD_ANNOTATION_1=annoName1=annoValue1, $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)`)
+	cmd.Flags().StringArrayVarP(cmdData.AddAnnotations, "add-annotation", "", []string{}, fmt.Sprintf(`Add annotation to deploying resources (can specify multiple).
+Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is %q, but it can be customized using the --add-annotation-separator flag.
+Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g. $WERF_ADD_ANNOTATION_1=annoName1=annoValue1, $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)`, DefaultPairSeparator))
 }
 
 const DefaultAnnoAndLabelPairSeparator = "\n"
@@ -424,30 +424,30 @@ const DefaultAnnoAndLabelPairSeparator = "\n"
 func SetupAddAnnotationSeparator(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.AddAnnotationSeparator = new(string)
 
-	defaultValue := DefaultAnnoAndLabelPairSeparator
+	defaultValue := DefaultPairSeparator
 	if os.Getenv("WERF_ADD_ANNOTATION_SEPARATOR") != "" {
 		defaultValue = os.Getenv("WERF_ADD_ANNOTATION_SEPARATOR")
 	}
 
-	cmd.Flags().StringVarP(cmdData.AddAnnotationSeparator, "add-annotation-separator", "", defaultValue, `Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")`)
+	cmd.Flags().StringVarP(cmdData.AddAnnotationSeparator, "add-annotation-separator", "", defaultValue, fmt.Sprintf(`Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or %q)`, DefaultPairSeparator))
 }
 
 func SetupAddLabels(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.AddLabels = new([]string)
-	cmd.Flags().StringArrayVarP(cmdData.AddLabels, "add-label", "", []string{}, `Add label to deploying resources (can specify multiple).
-Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default separator is a newline ("\n"), but it can be customized using the --add-label-separator flag.
-Also, can be specified with $WERF_ADD_LABEL_* (e.g. $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)`)
+	cmd.Flags().StringArrayVarP(cmdData.AddLabels, "add-label", "", []string{}, fmt.Sprintf(`Add label to deploying resources (can specify multiple).
+Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default separator is %q, but it can be customized using the --add-label-separator flag.
+Also, can be specified with $WERF_ADD_LABEL_* (e.g. $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)`, DefaultPairSeparator))
 }
 
 func SetupAddLabelSeparator(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.AddLabelSeparator = new(string)
 
-	defaultValue := DefaultAnnoAndLabelPairSeparator
+	defaultValue := DefaultPairSeparator
 	if os.Getenv("WERF_ADD_LABEL_SEPARATOR") != "" {
 		defaultValue = os.Getenv("WERF_ADD_LABEL_SEPARATOR")
 	}
 
-	cmd.Flags().StringVarP(cmdData.AddLabelSeparator, "add-label-separator", "", defaultValue, `Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")`)
+	cmd.Flags().StringVarP(cmdData.AddLabelSeparator, "add-label-separator", "", defaultValue, fmt.Sprintf(`Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or %q)`, DefaultPairSeparator))
 }
 
 func SetupKubeContext(cmdData *CmdData, cmd *cobra.Command) {

--- a/cmd/werf/common/deploy_params.go
+++ b/cmd/werf/common/deploy_params.go
@@ -13,7 +13,7 @@ const (
 )
 
 func GetUserExtraAnnotations(cmdData *CmdData) (map[string]string, error) {
-	result, err := InputArrayToKeyValueMap(GetAddAnnotations(cmdData), ",", DefaultKeyValueSeparator)
+	result, err := InputArrayToKeyValueMap(GetAddAnnotations(cmdData), *cmdData.AddAnnotationSeparator, DefaultKeyValueSeparator)
 	if err != nil {
 		return nil, fmt.Errorf("unsupported --add-annotation value: %w", err)
 	}
@@ -22,7 +22,7 @@ func GetUserExtraAnnotations(cmdData *CmdData) (map[string]string, error) {
 }
 
 func GetUserExtraLabels(cmdData *CmdData) (map[string]string, error) {
-	result, err := InputArrayToKeyValueMap(GetAddLabels(cmdData), ",", DefaultKeyValueSeparator)
+	result, err := InputArrayToKeyValueMap(GetAddLabels(cmdData), *cmdData.AddLabelSeparator, DefaultKeyValueSeparator)
 	if err != nil {
 		return nil, fmt.Errorf("unsupported --add-label value: %w", err)
 	}

--- a/cmd/werf/export/export.go
+++ b/cmd/werf/export/export.go
@@ -128,16 +128,16 @@ func NewExportCmd(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&tagTemplateList, "tag", "", []string{}, `Set a tag template (can specify multiple).
 It is necessary to use image name shortcut %image% or %image_slug% if multiple images are exported (e.g. REPO:TAG-%image% or REPO-%image%:TAG)`)
 
-	cmd.Flags().StringArrayVarP(&addLabelArray, "add-label", "", []string{}, `Add label to exported images (can specify multiple).
-Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default separator is a newline ("\n"), but it can be customized using the --add-label-separator flag.
-Also, can be specified with $WERF_EXPORT_ADD_LABEL_* (e.g. $WERF_EXPORT_ADD_LABEL_1=labelName1=labelValue1, $WERF_EXPORT_ADD_LABEL_2=labelName2=labelValue2)`)
+	cmd.Flags().StringArrayVarP(&addLabelArray, "add-label", "", []string{}, fmt.Sprintf(`Add label to exported images (can specify multiple).
+Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default separator is a newline %q, but it can be customized using the --add-label-separator flag.
+Also, can be specified with $WERF_EXPORT_ADD_LABEL_* (e.g. $WERF_EXPORT_ADD_LABEL_1=labelName1=labelValue1, $WERF_EXPORT_ADD_LABEL_2=labelName2=labelValue2)`, common.DefaultPairSeparator))
 
-	defaultValue := common.DefaultAnnoAndLabelPairSeparator
+	defaultValue := common.DefaultPairSeparator
 	if os.Getenv("WERF_EXPORT_ADD_LABEL_SEPARATOR") != "" {
 		defaultValue = os.Getenv("WERF_EXPORT_ADD_LABEL_SEPARATOR")
 	}
 
-	cmd.Flags().StringVarP(&addLabelSeparator, "add-label-separator", "", defaultValue, `Separator for --add-label values (default $WERF_EXPORT_ADD_LABEL_SEPARATOR or "\n")`)
+	cmd.Flags().StringVarP(&addLabelSeparator, "add-label-separator", "", defaultValue, fmt.Sprintf(`Separator for --add-label values (default $WERF_EXPORT_ADD_LABEL_SEPARATOR or %q)`, common.DefaultPairSeparator))
 
 	commonCmdData.SetupSkipImageSpecStage(cmd)
 

--- a/docs/_includes/reference/cli/werf_bundle_apply.md
+++ b/docs/_includes/reference/cli/werf_bundle_apply.md
@@ -18,21 +18,20 @@ werf bundle apply [options]
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
       --atomic=false
             Enable auto rollback of the failed release to the previous deployed release version     
             when current deploy process have failed ($WERF_ATOMIC by default)

--- a/docs/_includes/reference/cli/werf_bundle_publish.md
+++ b/docs/_includes/reference/cli/werf_bundle_publish.md
@@ -19,12 +19,12 @@ werf bundle publish [IMAGE_NAME...] [options]
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-custom-tag=[]
             Set tag alias for the content-based tag.
             The alias may contain the following shortcuts:
@@ -37,12 +37,11 @@ werf bundle publish [IMAGE_NAME...] [options]
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
       --allowed-backend-storage-volume-usage=70
             Set allowed percentage of backend (Docker or Buildah) storage volume usage which will   
             cause cleanup of least recently used local backend images (default 70% or               

--- a/docs/_includes/reference/cli/werf_bundle_render.md
+++ b/docs/_includes/reference/cli/werf_bundle_render.md
@@ -29,21 +29,20 @@ werf bundle render [options]
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
   -b, --bundle-dir=""
             Get extracted bundle from directory instead of registry (default $WERF_BUNDLE_DIR)
       --container-registry-mirror=[]

--- a/docs/_includes/reference/cli/werf_converge.md
+++ b/docs/_includes/reference/cli/werf_converge.md
@@ -42,12 +42,12 @@ werf converge --repo registry.mydomain.com/web --env production
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-custom-tag=[]
             Set tag alias for the content-based tag.
             The alias may contain the following shortcuts:
@@ -60,12 +60,11 @@ werf converge --repo registry.mydomain.com/web --env production
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
       --allowed-backend-storage-volume-usage=70
             Set allowed percentage of backend (Docker or Buildah) storage volume usage which will   
             cause cleanup of least recently used local backend images (default 70% or               

--- a/docs/_includes/reference/cli/werf_export.md
+++ b/docs/_includes/reference/cli/werf_export.md
@@ -38,13 +38,13 @@ werf export [IMAGE_NAME...] [options]
       --add-label=[]
             Add label to exported images (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
+            separator is a newline ",", but it can be customized using the --add-label-separator    
             flag.
             Also, can be specified with $WERF_EXPORT_ADD_LABEL_* (e.g.                              
             $WERF_EXPORT_ADD_LABEL_1=labelName1=labelValue1,                                        
             $WERF_EXPORT_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_EXPORT_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_EXPORT_ADD_LABEL_SEPARATOR or ",")
       --cache-repo=[]
             Specify one or multiple cache repos with images that will be used as a cache. Cache     
             will be populated when pushing newly built images into the primary repo and when        

--- a/docs/_includes/reference/cli/werf_helm_install.md
+++ b/docs/_includes/reference/cli/werf_helm_install.md
@@ -61,21 +61,20 @@ werf helm install [NAME] [CHART] [flags] [options]
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
       --atomic=false
             if set, the installation process deletes the installation on failure. The --wait flag   
             will be set automatically if --atomic is used

--- a/docs/_includes/reference/cli/werf_helm_lint.md
+++ b/docs/_includes/reference/cli/werf_helm_lint.md
@@ -19,21 +19,20 @@ werf helm lint PATH [flags] [options]
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
       --env=""
             Use specified environment (default $WERF_ENV)
       --ignore-secret-key=false

--- a/docs/_includes/reference/cli/werf_helm_template.md
+++ b/docs/_includes/reference/cli/werf_helm_template.md
@@ -23,21 +23,20 @@ werf helm template [NAME] [CHART] [flags] [options]
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
   -a, --api-versions=[]
             Kubernetes api versions used for Capabilities.APIVersions
       --atomic=false

--- a/docs/_includes/reference/cli/werf_helm_upgrade.md
+++ b/docs/_includes/reference/cli/werf_helm_upgrade.md
@@ -31,21 +31,20 @@ werf helm upgrade [RELEASE] [CHART] [flags] [options]
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
       --atomic=false
             if set, upgrade process rolls back changes made in case of failed upgrade. The --wait   
             flag will be set automatically if --atomic is used

--- a/docs/_includes/reference/cli/werf_kube_run.md
+++ b/docs/_includes/reference/cli/werf_kube_run.md
@@ -31,21 +31,20 @@ werf kube-run [options] [IMAGE_NAME] [-- COMMAND ARG...]
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
       --auto-pull-secret=true
             Automatically create docker config secret in the namespace and plug it via pod`s        
             imagePullSecrets for private registry access (default $WERF_AUTO_PULL_SECRET or true if 

--- a/docs/_includes/reference/cli/werf_plan.md
+++ b/docs/_includes/reference/cli/werf_plan.md
@@ -40,12 +40,12 @@ werf plan --repo registry.mydomain.com/web --env production
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-custom-tag=[]
             Set tag alias for the content-based tag.
             The alias may contain the following shortcuts:
@@ -58,12 +58,11 @@ werf plan --repo registry.mydomain.com/web --env production
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
       --allowed-backend-storage-volume-usage=70
             Set allowed percentage of backend (Docker or Buildah) storage volume usage which will   
             cause cleanup of least recently used local backend images (default 70% or               

--- a/docs/_includes/reference/cli/werf_render.md
+++ b/docs/_includes/reference/cli/werf_render.md
@@ -29,21 +29,20 @@ werf render [IMAGE_NAME...] [options]
       --add-annotation=[]
             Add annotation to deploying resources (can specify multiple).
             Format: annoName=annoValue[<separator>annoName=annoValue ...]. The default separator is 
-            a newline ("\n"), but it can be customized using the --add-annotation-separator flag.
+            ",", but it can be customized using the --add-annotation-separator flag.
             Also, can be specified with $WERF_ADD_ANNOTATION_* (e.g.                                
             $WERF_ADD_ANNOTATION_1=annoName1=annoValue1,                                            
             $WERF_ADD_ANNOTATION_2=annoName2=annoValue2)
-      --add-annotation-separator="\n"
-            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or "\n")
+      --add-annotation-separator=","
+            Separator for --add-annotation values (default $WERF_ADD_ANNOTATION_SEPARATOR or ",")
       --add-label=[]
             Add label to deploying resources (can specify multiple).
             Format: labelName=labelValue[<separator>labelName=labelValue ...]. The default          
-            separator is a newline ("\n"), but it can be customized using the --add-label-separator 
-            flag.
+            separator is ",", but it can be customized using the --add-label-separator flag.
             Also, can be specified with $WERF_ADD_LABEL_* (e.g.                                     
             $WERF_ADD_LABEL_1=labelName1=labelValue1, $WERF_ADD_LABEL_2=labelName2=labelValue2)
-      --add-label-separator="\n"
-            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or "\n")
+      --add-label-separator=","
+            Separator for --add-label values (default $WERF_ADD_LABEL_SEPARATOR or ",")
       --build-report-path=""
             Change build report path and format (by default $WERF_BUILD_REPORT_PATH or              
             ".werf-build-report.json" if not set). Extension must be either .json for JSON format   


### PR DESCRIPTION
Previously, the separator option only worked in the `werf export` command and the default was `\n`.
In other commands, separator options had no effect, and the default separator was `,`.

This PR unifies the behavior: `,` is now used as the default separator across all commands, and the separator options are respected consistently. Backward compatibility is broken only for `werf export`, but the behavior is now consistent and predictable.