### PR TITLE
fix(logging): use yellow color for warnings to distinguish them from errors

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 
+	"github.com/gookit/color"
 	"github.com/sirupsen/logrus"
 
 	"github.com/werf/logboek"
@@ -19,6 +20,7 @@ func WithLogger(ctx context.Context) context.Context {
 // NewLogger returns new logger for any (foreground or background) mode.
 func NewLogger() types.LoggerInterface {
 	logger := logboek.DefaultLogger()
+	logger.Warn().SetStyle(color.New(color.Yellow))
 
 	captureOutputFromAnotherLoggers(logger.OutStream())
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1c8aabfc-9eea-4e6d-a97d-2870f1ff35ef)
![image](https://github.com/user-attachments/assets/b8264d80-cdf5-4c24-9fc0-3151a027986f)
