### PR TITLE
fix: avoid checksum errors in service worktree when core.untrackedCache is enabled

### DIFF
--- a/pkg/true_git/common.go
+++ b/pkg/true_git/common.go
@@ -5,7 +5,7 @@ import (
 )
 
 func getCommonGitOptions() []string {
-	return []string{"-c", "core.autocrlf=false", "-c", "gc.auto=0", "-c", "commit.gpgsign=false"}
+	return []string{"-c", "core.autocrlf=false", "-c", "gc.auto=0", "-c", "commit.gpgsign=false", "-c", "core.untrackedCache=false", "-c", "core.splitIndex=false"}
 }
 
 func debug() bool {


### PR DESCRIPTION
If the user has `untrackedCache=true` in their global or repo config, the service worktree created by werf ends up using a Git index format unsupported by go-git (see https://github.com/go-git/go-git/issues/180). This leads to errors like:

```
Error: unable to read werf giterminism config: unable to get submodule "name" status: invalid checksum
```

To prevent this, we now explicitly disable both `untrackedCache` and `splitIndex` via `-c` options when creating the service worktree. This ensures compatibility with go-git's index parser and avoids checksum-related failures.