### PR TITLE
fix(build, stapel): fix service git apply patch failed

### DIFF
--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -231,11 +231,12 @@ func (gm *GitMapping) applyPatchCommand(patchFile *ContainerFileDescriptor, arch
 	))
 
 	gitCommand := fmt.Sprintf(
-		"%s %s apply --ignore-whitespace --whitespace=nowarn --directory=\"%s\" --unsafe-paths %s",
+		"%s %s apply --ignore-whitespace --whitespace=nowarn --directory=\"%s\" --unsafe-paths %s %s",
 		stapel.OptionalSudoCommand(gm.Owner, gm.Group),
 		stapel.GitBinPath(),
 		applyPatchDirectory,
 		patchFile.ContainerFilePath,
+		fmt.Sprintf("|| exit %d", container_backend.ErrPatchApplyCode),
 	)
 
 	commands = append(commands, strings.TrimLeft(gitCommand, " "))

--- a/pkg/container_backend/errors.go
+++ b/pkg/container_backend/errors.go
@@ -15,13 +15,15 @@ var (
 	ErrPruneIsAlreadyRunning        = errors.New("a prune operation is already running")
 )
 
-var ErrPatchApply = errors.New(`werf cannot apply the patch to the current source code because the files being added were modified by user commands in earlier stages.
+var ErrPatchApply = errors.New(`cannot update source code added by git directive because the files being patched were modified by user commands in earlier stages (install, beforeSetup or setup)
 
-- If these files should NOT be changed, update the instructions for the preceding stages with user commands.
+Possible solutions:
 
-- If these files SHOULD be changed, declare this dependency using the stageDependencies directive, and these files will be updated before running user commands.
+  - If these files should not be changed, update the commands that modify them.
 
-- If these files are NOT required, exclude them using the git.[*].includePaths / excludePaths directives.`)
+  - If these files should be changed, declare them explicitly using the stageDependencies.<install|beforeSetup|setup> directive. This ensures the files are updated before running user commands.
+
+  - If these files are not needed, exclude them using the includePaths or excludePaths options under the git directive.`)
 
 const (
 	ErrPatchApplyCode = 42

--- a/pkg/container_backend/errors.go
+++ b/pkg/container_backend/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/containers/storage/types"
+	"github.com/docker/cli/cli"
 )
 
 var (
@@ -13,3 +14,34 @@ var (
 	ErrImageUsedByContainer         = types.ErrImageUsedByContainer
 	ErrPruneIsAlreadyRunning        = errors.New("a prune operation is already running")
 )
+
+var (
+	ErrPatchApply = errors.New(`werf cannot apply the patch to the current source code because the files being added were modified by user commands in earlier stages.
+
+- If these files should NOT be changed, update the instructions for the preceding stages with user commands.
+
+- If these files SHOULD be changed, declare this dependency using the stageDependencies directive, and these files will be updated before running user commands.
+
+- If these files are NOT required, exclude them using the git.[*].includePaths / excludePaths directives.`)
+)
+
+const (
+	ErrPatchApplyCode = 42
+)
+
+var errByCode = map[int]error{
+	ErrPatchApplyCode: ErrPatchApply,
+}
+
+func CliErrorByCode(err error) error {
+	if err == nil {
+		return nil
+	}
+	var statusError cli.StatusError
+	if errors.As(err, &statusError) {
+		if e, ok := errByCode[statusError.StatusCode]; ok {
+			return e
+		}
+	}
+	return err
+}

--- a/pkg/container_backend/errors.go
+++ b/pkg/container_backend/errors.go
@@ -15,15 +15,13 @@ var (
 	ErrPruneIsAlreadyRunning        = errors.New("a prune operation is already running")
 )
 
-var (
-	ErrPatchApply = errors.New(`werf cannot apply the patch to the current source code because the files being added were modified by user commands in earlier stages.
+var ErrPatchApply = errors.New(`werf cannot apply the patch to the current source code because the files being added were modified by user commands in earlier stages.
 
 - If these files should NOT be changed, update the instructions for the preceding stages with user commands.
 
 - If these files SHOULD be changed, declare this dependency using the stageDependencies directive, and these files will be updated before running user commands.
 
 - If these files are NOT required, exclude them using the git.[*].includePaths / excludePaths directives.`)
-)
 
 const (
 	ErrPatchApplyCode = 42

--- a/pkg/container_backend/legacy_stage_image_container.go
+++ b/pkg/container_backend/legacy_stage_image_container.go
@@ -288,7 +288,7 @@ func (c *LegacyStageImageContainer) run(ctx context.Context) error {
 	err = docker.CliRun_LiveOutput(ctx, runArgs...)
 	UnregisterRunningContainer(c.name)
 	if err != nil {
-		return fmt.Errorf("container run failed: %w", err)
+		return fmt.Errorf("container run failed: %w", CliErrorByCode(err))
 	}
 	return nil
 }

--- a/pkg/stapel/stapel.go
+++ b/pkg/stapel/stapel.go
@@ -3,7 +3,6 @@ package stapel
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -226,5 +225,5 @@ func CreateScript(path string, commands []string) error {
 	scriptLines = append(scriptLines, commands...)
 	scriptData := []byte(strings.Join(scriptLines, "\n") + "\n")
 
-	return ioutil.WriteFile(path, scriptData, os.FileMode(0o667))
+	return os.WriteFile(path, scriptData, os.FileMode(0o667))
 }


### PR DESCRIPTION
```
│ ┌ Building stage a/setup
│ │ a/setup  error: patch failed: /my_file:1
│ │ a/setup  error: /my_file: patch does not apply
│ ├ Info
│ └ Building stage a/setup (0.40 seconds) FAILED
└ 🛳️  (1/1) image a [linux/amd64] (0.53 seconds) FAILED

Running time 1.01 seconds
Error: phase build on image a stage setup handler failed: failed to build image for stage setup with digest c0f00bbf9c2743ed26e5c4dbcc515ec3c00b1358f687cf0bdceeb266: error building stage setup: container run failed: Status: , Code: 1
```

=>

```
│ ┌ Building stage a/setup
│ │ a/setup  error: patch failed: /my_file:1
│ │ a/setup  error: /my_file: patch does not apply
│ ├ Info
│ └ Building stage a/setup (0.30 seconds) FAILED
└ 🛳️  (1/1) image a [linux/amd64] (0.40 seconds) FAILED

Running time 0.83 seconds
Error: phase build on image a stage setup handler failed: failed to build image for stage setup with digest c0f00bbf9c2743ed26e5c4dbcc515ec3c00b1358f687cf0bdceeb266: error building stage setup: container run failed: cannot update source code added by git directive because the files being added were modified by user commands in earlier stages (install, beforeSetup or setup)

Possible solutions:

  - If these files should not be changed, update the commands that modify them.

  - If these files should be changed, declare them explicitly using the stageDependencies.<install|beforeSetup|setup> directive. This ensures the files are updated before running user commands.

  - If these files are not needed, exclude them using the includePaths or excludePaths options under the git directive.
```