### PR TITLE
docs(usage): Remove Kubernetes guides' CI/CD section links

### DIFF
--- a/docs/.helm/templates/_rewrites.tpl
+++ b/docs/.helm/templates/_rewrites.tpl
@@ -78,10 +78,6 @@ rewrite ^/publications_ru\.html$                                                
 rewrite ^/how_it_works\.html                                                                      /#how-it-works                                         redirect;
 rewrite ^/introduction\.html$                                                                     /#how-it-works                                         redirect;
 
-rewrite ^/guides/(?<lang>[^/]+)/400_ci_cd_workflow/030_gitlab_ci_cd/010_workflows\.html           /guides/$lang/400_ci_cd_workflow/030_gitlab_ci_cd.html redirect;
-rewrite ^/guides/(?<lang>[^/]+)/400_ci_cd_workflow/030_gitlab_ci_cd/020_docker_executor\.html     /guides/$lang/400_ci_cd_workflow/030_gitlab_ci_cd.html redirect;
-rewrite ^/guides/(?<lang>[^/]+)/400_ci_cd_workflow/030_gitlab_ci_cd/030_kubernetes_executor\.html /guides/$lang/400_ci_cd_workflow/030_gitlab_ci_cd.html redirect;
-
 ############################################
 # v1.1/v1.2 redirects for moved or deleted urls
 ############################################

--- a/docs/pages_en/usage/integration_with_ci_cd_systems.md
+++ b/docs/pages_en/usage/integration_with_ci_cd_systems.md
@@ -39,11 +39,8 @@ Deploy to Production:
     name: production
 ```
 
-> The complete `.gitlab-ci.yml` file for ready-to-use workflows, as well as the details of using werf with Shell, Docker, and Kubernetes executors, can be found in the corresponding guides:
->
-> - [Ready-to-use workflows](/guides/nodejs/400_ci_cd_workflow/030_gitlab_ci_cd/010_workflows.html);
-> - [Docker executor](/guides/nodejs/400_ci_cd_workflow/030_gitlab_ci_cd/020_docker_executor.html);
-> - [Kubernetes executor](/guides/nodejs/400_ci_cd_workflow/030_gitlab_ci_cd/030_kubernetes_executor.html).
+> You can find the complete `.gitlab-ci.yml` file for ready-to-use workflows, as well as the details of using werf with Shell, Docker, and Kubernetes executors, 
+> in the [Getting started](https://werf.io/getting_started/?usage=ci&ci=gitlabCiCd) configurator by selecting _CI/CD_ as your usage scenario and _GitLab CI/CD_ as your CI/CD system, and choosing the CI runner type you need.
 
 ## GitHub Actions
 
@@ -84,4 +81,5 @@ converge:
 ```
 {% endraw %}
 
-> The complete set of configurations (`.github/workflows/*.yml`) for the ready-to-use workflows can be found [in the corresponding section](/guides/nodejs/400_ci_cd_workflow/040_github_actions.html) of the manual.
+> You can find the complete set of configurations (`.github/workflows/*.yml`) for the ready-to-use workflows in the [Getting started](https://werf.io/getting_started/?usage=ci&ci=githubActions) configurator
+> by selecting _CI/CD_ as your usage scenario and _GitHub Actions_ as your CI/CD system.

--- a/docs/pages_ru/usage/integration_with_ci_cd_systems.md
+++ b/docs/pages_ru/usage/integration_with_ci_cd_systems.md
@@ -39,11 +39,8 @@ Deploy to Production:
     name: production
 ```
 
-> Полный `.gitlab-ci.yml` для готовых рабочих процессов, а также особенности использования werf c Shell, Docker и Kubernetes executors можно найти в соответствующих статьях руководства:
->
-> - [Готовые рабочие процессы](/guides/nodejs/400_ci_cd_workflow/030_gitlab_ci_cd/010_workflows.html);
-> - [Docker executor](/guides/nodejs/400_ci_cd_workflow/030_gitlab_ci_cd/020_docker_executor.html);
-> - [Kubernetes executor](/guides/nodejs/400_ci_cd_workflow/030_gitlab_ci_cd/030_kubernetes_executor.html).
+> Полный `.gitlab-ci.yml` для готовых рабочих процессов, а также особенности использования werf c Shell, Docker и Kubernetes executors можно найти в конфигураторе «[Быстрый старт](https://werf.io/getting_started/?usage=ci&ci=gitlabCiCd)»,
+> указав в нём _CI/CD_ как сценарий использования и _GitLab CI/CD_ как CI/CD-систему, а затем выбрав интересующий вас тип CI-раннера.
 
 ## GitHub Actions
 
@@ -83,4 +80,5 @@ converge:
 ```
 {% endraw %}
 
-> Полный набор конфигураций (`.github/workflows/*.yml`) для готовых рабочих процессов можно найти [в соответствующей статье руководства](/guides/nodejs/400_ci_cd_workflow/040_github_actions.html).
+> Полный набор конфигураций (`.github/workflows/*.yml`) для готовых рабочих процессов можно найти в конфигураторе «[Быстрый старт](https://werf.io/getting_started/?usage=ci&ci=githubActions)»,
+> выбрав в нём _CI/CD_ как сценарий использования и _GitHub Actions_ — как CI/CD-систему.


### PR DESCRIPTION
Following our recent removal of the outdated CI/CD section in the Kubernetes guides ([#795](https://github.com/werf/website/pull/795)), I removed the related links from the [usage documentation](https://werf.io/docs/latest/usage/integration_with_ci_cd_systems.html).