### PR TITLE
fix(deploy): hide traces from `--log-debug` output by default

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -1523,10 +1523,14 @@ func ProcessLogOptions(cmdData *CmdData) error {
 }
 
 func GetNelmLogLevel(cmdData *CmdData) string {
+	if util.GetBoolEnvironmentDefaultFalse("WERF_NELM_TRACE") {
+		return action.TraceLogLevel
+	}
+
 	var logLevel string
 	switch {
 	case *cmdData.LogDebug:
-		logLevel = action.TraceLogLevel
+		logLevel = action.DebugLogLevel
 	case *cmdData.LogQuiet:
 		logLevel = action.ErrorLogLevel
 	default:


### PR DESCRIPTION
Traces can be shown now with `export WERF_NELM_TRACE=1`

Fixes #6880