### PR TITLE
docs(bundles): fix custom tag usage example

### DIFF
--- a/docs/pages_en/usage/distribute/bundles.md
+++ b/docs/pages_en/usage/distribute/bundles.md
@@ -102,7 +102,7 @@ To use custom image tags for bundles, you need to set the naming template using 
 Example usage:
 
 ```shell
-werf bundle publish --repo example.org/bundles/mybundle --tag "%image%-my-custom-tag"
+werf bundle publish --repo example.org/bundles/mybundle --use-custom-tag "%image%-my-custom-tag"
 ```
 
 You can read more about custom tags in the [documentation]({{ "/usage/build/process.html#adding-custom-tags" | true_relative_url }}).

--- a/docs/pages_ru/usage/distribute/bundles.md
+++ b/docs/pages_ru/usage/distribute/bundles.md
@@ -101,7 +101,7 @@ werf bundle publish --repo example.org/bundles/bundle2
 
 Пример использования:
 ```shell
-werf bundle publish --repo example.org/bundles/mybundle --tag "%image%-my-custom-tag"
+werf bundle publish --repo example.org/bundles/mybundle --use-custom-tag "%image%-my-custom-tag"
 ```
 
 Подробнее про кастомные теги можно прочитать в [документации]({{ "/usage/build/process.html#добавление-произвольных-тегов" | true_relative_url }}).


### PR DESCRIPTION
There was a typo in the documentation: 
one mentioned option -`-use-custom-tag` but  snippet had example with `--tag` 