### PR TITLE
chore(docs): add backticks to --keep-list

### DIFF
--- a/docs/pages_en/usage/cleanup/cr_cleanup.md
+++ b/docs/pages_en/usage/cleanup/cr_cleanup.md
@@ -267,7 +267,7 @@ You can extract tags from the output of the `werf cleanup` command as follows:
   werf cleanup --repo registry.mydomain.com/app --dry-run | grep -a -o -P '\x1b\[31m\K[^\x1b]+' > keep-list.txt
   ```
 
-Then, use this list with the --keep-list option to ensure only the specified tags are preserved during cleanup:
+Then, use this list with the `--keep-list` option to ensure only the specified tags are preserved during cleanup:
 
 ```bash
 werf cleanup --repo registry.mydomain.com/app --keep-list=keep-list.txt


### PR DESCRIPTION
Adding backticks to the `--keep-list` param mentioned in the documentation to render it properly.