### PR TITLE
Revert "fix(build, stapel, git): prevent patch creation error when a submodule commit no longer exists in the remote"

### DIFF
--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -289,16 +289,6 @@ ScanImages:
 				logboek.Context(ctx).Info().LogF("Skipping stage %s: commit %s is not an ancestor of %s in repo %s\n", stageDesc.Info.Name, commitToCheckAncestry, currentCommit, gitMapping.GitRepo().String())
 				continue ScanImages
 			}
-
-			areSubmodulesValid, err := gitMapping.GitRepo().AreSubmoduleCommitsValid(ctx, commitToCheckAncestry)
-			if err != nil {
-				return nil, fmt.Errorf("error checking submodule commits validity for commit %s: %w", commitToCheckAncestry, err)
-			}
-
-			if !areSubmodulesValid {
-				logboek.Context(ctx).Info().LogF("Skipping stage %s: submodule commits are not valid (failed to fetch one or more submodule commits) for commit %s in repo %s\n", stageDesc.Info.Name, commitToCheckAncestry, gitMapping.GitRepo().String())
-				continue ScanImages
-			}
 		}
 
 		logboek.Context(ctx).Info().LogF("Using stage %s (ancestor)\n", stageDesc.Info.Name)

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -437,18 +437,6 @@ func (repo *Base) createArchive(ctx context.Context, repoPath, gitDir, repoID, w
 	}
 }
 
-func (repo *Base) AreSubmoduleCommitsValid(ctx context.Context, commit string) (bool, error) {
-	if _, err := repo.initRepoHandleBackedByWorkTree(ctx, commit); err != nil {
-		if strings.Contains(err.Error(), "Direct fetching of that commit failed") {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	return true, nil
-}
-
 func (repo *Base) isCommitExists(ctx context.Context, repoPath, gitDir, commit string) (bool, error) {
 	repository, err := repo.PlainOpen(repoPath)
 	if err != nil {

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -65,7 +65,6 @@ type GitRepo interface {
 	IsCommitTreeEntryDirectory(ctx context.Context, commit, relPath string) (bool, error)
 	IsCommitTreeEntryExist(ctx context.Context, commit, relPath string) (bool, error)
 	IsEmpty(ctx context.Context) (bool, error)
-	AreSubmoduleCommitsValid(ctx context.Context, commit string) (bool, error)
 	LatestBranchCommit(ctx context.Context, branch string) (string, error)
 	ListCommitFilesWithGlob(ctx context.Context, commit, dir, glob string) ([]string, error)
 	ReadCommitFile(ctx context.Context, commit, path string) ([]byte, error)


### PR DESCRIPTION
This reverts commit 3ad251e6