### PR TITLE
fix(build, stapel, import): correct rsync glob handling for imports and checksums

### DIFF
--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -141,45 +141,7 @@ func (srv *RsyncServer) GetCopyCommand(ctx context.Context, importConfig *config
 		rsyncChownOption = fmt.Sprintf("--chown=%s:%s", importConfig.Owner, importConfig.Group)
 	}
 	rsyncCommand := fmt.Sprintf("RSYNC_PASSWORD='%s' %s --archive --links --inplace %s", srv.AuthPassword, stapel.RsyncBinPath(), rsyncChownOption)
-
-	if len(importConfig.IncludePaths) != 0 {
-		/**
-				Если указали include_paths — это означает, что надо копировать
-				только указанные пути. Поэтому exclude_paths в приоритете, т.к. в данном режиме
-		        exclude_paths может относится только к путям, указанным в include_paths.
-		        При этом случай, когда в include_paths указали более специальный путь, чем в exclude_paths,
-		        будет обрабатываться в пользу exclude, этот путь не скопируется.
-		*/
-		for _, p := range importConfig.ExcludePaths {
-			rsyncCommand += fmt.Sprintf(" --filter='-/ %s'", path.Join(importConfig.Add, p))
-		}
-
-		for _, p := range importConfig.IncludePaths {
-			targetPath := path.Join(importConfig.Add, p)
-
-			// Генерируем разрешающее правило для каждого элемента пути
-			for _, pathPart := range descentPath(targetPath) {
-				rsyncCommand += fmt.Sprintf(" --filter='+/ %s'", pathPart)
-			}
-
-			/**
-					На данный момент не знаем директорию или файл имел в виду пользователь,
-			        поэтому подставляем фильтры для обоих возможных случаев.
-
-					Автоматом подставляем паттерн ** для включения файлов, содержащихся в
-			        директории, которую пользователь указал в include_paths.
-			*/
-			rsyncCommand += fmt.Sprintf(" --filter='+/ %s'", targetPath)
-			rsyncCommand += fmt.Sprintf(" --filter='+/ %s'", path.Join(targetPath, "**"))
-		}
-
-		// Все что не подошло по include — исключается
-		rsyncCommand += fmt.Sprintf(" --filter='-/ %s'", path.Join(importConfig.Add, "**"))
-	} else {
-		for _, p := range importConfig.ExcludePaths {
-			rsyncCommand += fmt.Sprintf(" --filter='-/ %s'", path.Join(importConfig.Add, p))
-		}
-	}
+	rsyncCommand += PrepareRsyncFilters(importConfig.Add, importConfig.IncludePaths, importConfig.ExcludePaths)
 
 	rsyncCommand += fmt.Sprintf(" %s$IMPORT_PATH_TRAILING_SLASH_OPTIONAL %s", rsyncImportPathSpec, importConfig.To)
 	// run rsync itself
@@ -192,22 +154,177 @@ func (srv *RsyncServer) GetCopyCommand(ctx context.Context, importConfig *config
 	return command
 }
 
-func descentPath(filePath string) []string {
-	var parts []string
+func PrepareRsyncFilters(add string, includePaths, excludePaths []string) string {
+	rsyncCommand := ""
+	if len(includePaths) != 0 {
+		// First, apply exclude filters to the specified paths.
+		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, excludePaths)
+		// Then include only the paths that are listed in include_paths.
+		rsyncCommand += PrepareRsyncIncludeFiltersForGlobs(add, includePaths)
+	} else {
+		// When include_paths is empty, simply apply exclude filters.
+		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, excludePaths)
+	}
+	return rsyncCommand
+}
 
-	part := filePath
-	for {
-		parts = append(parts, part)
-		part = path.Dir(part)
+// PrepareRsyncExcludeFiltersForGlobs builds rsync --filter rules that exclude
+// paths matching given globs under the specified base path (add).
+// It uses globToRsyncFilterPaths with finalOnly=true to generate the
+// minimal set of patterns needed to prevent rsync from descending into
+// excluded directories and files.
+//
+// For each excludeGlob in excludeGlobs, it generates rules like:
+//
+//	--filter='-/ base/excludeGlobPrefix...'
+func PrepareRsyncExcludeFiltersForGlobs(add string, excludeGlobs []string) string {
+	if len(excludeGlobs) == 0 {
+		return ""
+	}
 
-		if part == path.Dir(part) {
-			break
+	paths := map[string]struct{}{}
+	for _, p := range excludeGlobs {
+		targetPath := path.Join(add, p)
+		for _, pathPart := range globToRsyncFilterPaths(targetPath, true) {
+			paths[pathPart] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(paths))
+	for k := range paths {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b string
+	for _, p := range keys {
+		b += fmt.Sprintf(" --filter='-/ %s'", p)
+	}
+	return b
+}
+
+// PrepareRsyncIncludeFiltersForGlobs builds rsync --filter rules that include
+// only the specified includeGlobs under the given base path (add). It uses
+// globToRsyncFilterPaths with finalOnly=false to ensure that all parent
+// directories for included paths are traversable, and then adds final
+// rules for the glob itself and its recursive contents.
+//
+// For each includeGlob in includeGlobs, it generates rules like:
+//
+//	--filter='+/ base/...prefixes.../'
+//	--filter='+/ base/includeGlob'
+//	--filter='+/ base/includeGlob/**'
+//
+// At the end, it adds a catch-all exclude:
+//
+//	--filter='-/ base/**'
+func PrepareRsyncIncludeFiltersForGlobs(add string, includeGlobs []string) string {
+	if len(includeGlobs) == 0 {
+		return ""
+	}
+
+	paths := map[string]struct{}{}
+	for _, p := range includeGlobs {
+		targetPath := path.Join(add, p)
+
+		// Allow all path prefixes for this glob.
+		for _, pathPart := range globToRsyncFilterPaths(targetPath, false) {
+			paths[pathPart] = struct{}{}
+		}
+
+		// We do not know in advance whether it is a file or a directory — add both variants.
+		paths[targetPath] = struct{}{}
+		paths[path.Join(targetPath, "**")] = struct{}{}
+	}
+	keys := make([]string, 0, len(paths))
+	for k := range paths {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b string
+	for _, k := range keys {
+		b += fmt.Sprintf(" --filter='+/ %s'", k)
+	}
+	// Everything that did not match any include is excluded.
+	b += fmt.Sprintf(" --filter='-/ %s'", path.Join(add, "**"))
+	return b
+}
+
+// globToRsyncFilterPaths builds rsync filter path components for a glob.
+// Behavior:
+// - Directories (non-final segments) end with "/" unless finalOnly == true.
+// - Final segment (file or pattern) has no trailing "/".
+// - "**" expands into two branches: keep ("**") and skip (matches 0 directories).
+// - When kept and not final && !finalOnly -> adds "**/" as a directory pattern.
+// Empty or all-slash input returns nil.
+func globToRsyncFilterPaths(glob string, finalSegmentOnly bool) []string {
+	glob = strings.Trim(glob, "/")
+	if glob == "" {
+		return nil
+	}
+
+	segments := strings.Split(glob, "/")
+	lastIdx := len(segments) - 1
+
+	type void struct{}
+	set := func(m map[string]void, v string) {
+		if v != "" {
+			m[v] = void{}
 		}
 	}
 
-	sort.Sort(sort.Reverse(sort.StringSlice(parts)))
+	current := map[string]void{"": {}}
+	results := map[string]void{}
 
-	return parts
+	join := func(prefix, seg string) string {
+		if prefix == "" {
+			return seg
+		}
+		return prefix + "/" + seg
+	}
+
+	for i, seg := range segments {
+		next := map[string]void{}
+		isLast := i == lastIdx
+
+		if seg == "**" {
+			for prefix := range current {
+				// Branch: keep "**"
+				keep := join(prefix, "**")
+				set(next, keep)
+
+				// "**" as a directory (recursive) when not final and we collect dirs
+				if !isLast && !finalSegmentOnly {
+					set(results, keep+"/")
+				}
+
+				// Branch: skip "**" (0 directories matched)
+				set(next, prefix)
+
+				// Nothing added to results for skip branch (prefix stays as-is).
+			}
+		} else {
+			for prefix := range current {
+				full := join(prefix, seg)
+				set(next, full)
+
+				if isLast {
+					// Final pattern/file
+					set(results, full)
+				} else if !finalSegmentOnly {
+					// Intermediate directory
+					set(results, full+"/")
+				}
+			}
+		}
+
+		current = next
+	}
+
+	out := make([]string, 0, len(results))
+	for v := range results {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func generateSecureRandomString(length int) string {

--- a/pkg/build/import_server/rsync_server_test.go
+++ b/pkg/build/import_server/rsync_server_test.go
@@ -1,0 +1,86 @@
+package import_server
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func Test_globToRsyncFilterPaths(t *testing.T) {
+	type args struct {
+		glob             string
+		finalSegmentOnly bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "empty glob",
+			args: args{glob: "", finalSegmentOnly: false},
+			want: nil,
+		},
+		{
+			name: "simple glob (all paths)",
+			args: args{glob: "a/b/c", finalSegmentOnly: false},
+			want: []string{"a/", "a/b/", "a/b/c"},
+		},
+		{
+			name: "simple glob (only final)",
+			args: args{glob: "a/b/c", finalSegmentOnly: true},
+			want: []string{"a/b/c"},
+		},
+		{
+			name: "** recursion (all paths)",
+			args: args{glob: "a/b/**/c", finalSegmentOnly: false},
+			want: []string{"a/", "a/b/", "a/b/**/", "a/b/c", "a/b/**/c"},
+		},
+		{
+			name: "** recursion (only final)",
+			args: args{glob: "a/b/**/c", finalSegmentOnly: true},
+			want: []string{"a/b/c", "a/b/**/c"},
+		},
+		{
+			name: "mixed c* (all paths)",
+			args: args{glob: "a/b/**/c*", finalSegmentOnly: false},
+			want: []string{"a/", "a/b/", "a/b/**/", "a/b/c*", "a/b/**/c*"},
+		},
+		{
+			name: "mixed c* (only final)",
+			args: args{glob: "a/b/**/c*", finalSegmentOnly: true},
+			want: []string{"a/b/c*", "a/b/**/c*"},
+		},
+		{
+			name: "mixed c? (all paths)",
+			args: args{glob: "a/b/**/c?", finalSegmentOnly: false},
+			want: []string{"a/", "a/b/", "a/b/**/", "a/b/c?", "a/b/**/c?"},
+		},
+		{
+			name: "mixed c? (only final)",
+			args: args{glob: "a/b/**/c?", finalSegmentOnly: true},
+			want: []string{"a/b/c?", "a/b/**/c?"},
+		},
+		{
+			name: "char class (all paths)",
+			args: args{glob: "a/b/**/c[abc]", finalSegmentOnly: false},
+			want: []string{"a/", "a/b/", "a/b/**/", "a/b/c[abc]", "a/b/**/c[abc]"},
+		},
+		{
+			name: "char class (only final)",
+			args: args{glob: "a/b/**/c[abc]", finalSegmentOnly: true},
+			want: []string{"a/b/c[abc]", "a/b/**/c[abc]"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := globToRsyncFilterPaths(tt.args.glob, tt.args.finalSegmentOnly)
+			sort.Strings(got)
+			sort.Strings(tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("globDescentPath(%q, %v) = %v, want %v",
+					tt.args.glob, tt.args.finalSegmentOnly, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/build/stage/dependencies.go
+++ b/pkg/build/stage/dependencies.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/werf/common-go/pkg/util"
 	"github.com/werf/logboek"
+	"github.com/werf/werf/v2/pkg/build/import_server"
 	"github.com/werf/werf/v2/pkg/config"
 	"github.com/werf/werf/v2/pkg/container_backend"
 	"github.com/werf/werf/v2/pkg/docker"
@@ -374,53 +375,20 @@ func (s *DependenciesStage) generateImportChecksum(ctx context.Context, c Convey
 }
 
 func generateChecksumScript(from string, includePaths, excludePaths []string, resultChecksumPath string) []string {
-	findCommandParts := append([]string{}, stapel.FindBinPath(), "-H", from, "-type", "f")
-
-	var nameIncludeArgs []string
-	for _, includePath := range includePaths {
-		formattedPath := util.SafeTrimGlobsAndSlashesFromPath(includePath)
-		nameIncludeArgs = append(
-			nameIncludeArgs,
-			fmt.Sprintf("-wholename \"%s\"", path.Join(from, formattedPath)),
-			fmt.Sprintf("-wholename \"%s\"", path.Join(from, formattedPath, "**")),
-		)
-	}
-
-	if len(nameIncludeArgs) != 0 {
-		findCommandParts = append(findCommandParts, fmt.Sprintf("\\( %s \\)", strings.Join(nameIncludeArgs, " -or ")))
-	}
-
+	// Always exclude the stapel container mount root, as in the previous implementation.
 	excludePaths = append(excludePaths, stapel.CONTAINER_MOUNT_ROOT)
 
-	var nameExcludeArgs []string
-	for _, excludePath := range excludePaths {
-		formattedPath := util.SafeTrimGlobsAndSlashesFromPath(excludePath)
-		nameExcludeArgs = append(
-			nameExcludeArgs,
-			fmt.Sprintf("! -wholename \"%s\"", path.Join(from, formattedPath)),
-			fmt.Sprintf("! -wholename \"%s\"", path.Join(from, formattedPath, "**")),
-		)
-	}
+	rsyncCommand := stapel.RsyncBinPath() + " -r --dry-run"
+	rsyncCommand += import_server.PrepareRsyncFilters(from, includePaths, excludePaths)
+	rsyncCommand += " " + from
 
-	if len(nameExcludeArgs) != 0 {
-		if len(nameIncludeArgs) != 0 {
-			findCommandParts = append(findCommandParts, fmt.Sprintf("-and"))
-		}
-
-		findCommandParts = append(findCommandParts, fmt.Sprintf("\\( %s \\)", strings.Join(nameExcludeArgs, " -and ")))
-	}
-
-	findCommand := strings.Join(findCommandParts, " ")
-
-	sortCommandParts := append([]string{}, stapel.SortBinPath(), "-n")
-	sortCommand := strings.Join(sortCommandParts, " ")
-
+	// awk: leave only files (lines whose first field starts with '-') and print the path.
+	awkCommand := `awk '$1 ~ /^-/ { print "/"$NF }'`
+	sortCommand := fmt.Sprintf("%s -n", stapel.SortBinPath())
 	md5SumCommand := stapel.Md5sumBinPath()
+	cutCommand := fmt.Sprintf("%s -c 1-32", stapel.CutBinPath())
 
-	cutCommandParts := append([]string{}, stapel.CutBinPath(), "-c", "1-32")
-	cutCommand := strings.Join(cutCommandParts, " ")
-
-	commands := append([]string{}, findCommand, sortCommand, "checksum", md5SumCommand, cutCommand)
+	commands := []string{rsyncCommand, awkCommand, sortCommand, "checksum", md5SumCommand, cutCommand}
 
 	script := generateChecksumBashFunction()
 	script = append(script, fmt.Sprintf("%s > %s", strings.Join(commands, " | "), resultChecksumPath))


### PR DESCRIPTION
- Unify rsync include/exclude filter generation for import server and checksum script
- Fix glob expansion logic (**, prefixes, final patterns) to match expected rsync semantics
- Deduplicate generated rsync filters across overlapping globs
- Make checksum calculation use the same filtered file set as rsync copy