### PR TITLE
fix(build): stages copy panic

### DIFF
--- a/pkg/build/stages/archive_storage.go
+++ b/pkg/build/stages/archive_storage.go
@@ -68,7 +68,10 @@ func (s *ArchiveStorage) copyAllFromRemote(ctx context.Context, fromRemote *Remo
 
 			stageDesc, err := fromRemote.StorageManager.StagesStorage.GetStageDesc(ctx, opts.ProjectName, stageId)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to get description of stage %s: %w", stageId, err)
+			}
+			if stageDesc == nil {
+				return fmt.Errorf("description of stage %s not found", stageId)
 			}
 
 			stageRef := stageDesc.Info.Name

--- a/pkg/build/stages/remote_storage.go
+++ b/pkg/build/stages/remote_storage.go
@@ -72,7 +72,7 @@ func (s *RemoteStorage) copyCurrentBuildStagesFromRemote(ctx context.Context, fr
 
 			reference, err := ref.ParseReference(infoGetter.Tag)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to parse reference %q: %w", infoGetter.Tag, err)
 			}
 
 			reference.Repo = s.RegistryAddress.Repo
@@ -100,12 +100,15 @@ func (s *RemoteStorage) copyAllFromRemote(ctx context.Context, fromRemote *Remot
 
 		stageDesc, err := fromRemote.StorageManager.StagesStorage.GetStageDesc(ctx, opts.ProjectName, stageId)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to get description of stage %s: %w", stageId, err)
+		}
+		if stageDesc == nil {
+			return fmt.Errorf("description of stage %s not found", stageId)
 		}
 
 		reference, err := ref.ParseReference(stageId.Digest)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to parse stage %q reference: %w", stageId, err)
 		}
 
 		reference.Repo = s.RegistryAddress.Repo
@@ -132,7 +135,7 @@ func (s *RemoteStorage) copyFromArchive(ctx context.Context, fromArchive *Archiv
 
 		reference, err := ref.ParseReference(stageId)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to parse stage %q reference: %w", stageId, err)
 		}
 
 		reference.Repo = s.RegistryAddress.Repo

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -302,7 +302,7 @@ func (storage *RepoStagesStorage) GetStageDesc(ctx context.Context, projectName 
 
 	imgInfo, err := storage.DockerRegistry.GetRepoImage(ctx, stageImageName)
 	if docker_registry.IsImageNotFoundError(err) {
-		return nil, nil
+		return nil, ErrImageNotFound
 	}
 	if docker_registry.IsBrokenImageError(err) {
 		return nil, ErrBrokenImage

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -18,7 +18,10 @@ const (
 	NamelessImageRecordTag          = "__nameless__"
 )
 
-var ErrBrokenImage = errors.New("broken image")
+var (
+	ErrBrokenImage   = errors.New("broken image")
+	ErrImageNotFound = errors.New("image not found")
+)
 
 func IsErrBrokenImage(err error) bool {
 	return err != nil && strings.HasSuffix(err.Error(), ErrBrokenImage.Error())


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Enhanced error handling in archive and remote storage by wrapping errors with descriptive messages and adding nil checks for stage descriptions.</li>
<li>Introduced a new error variable ErrImageNotFound in stages_storage.go and updated repo_stages_storage.go to return it instead of nil for image not found cases.</li>
<li>Improved error messages for reference parsing failures in remote_storage.go with wrapped errors.</li>
</ul></div>