### PR TITLE
feat(telemetry): add telemetry fields for build metrics

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/werf/werf/v2/pkg/build/image"
 	"github.com/werf/werf/v2/pkg/build/stage"
 	"github.com/werf/werf/v2/pkg/build/stage/instruction"
+	"github.com/werf/werf/v2/pkg/config"
 	"github.com/werf/werf/v2/pkg/container_backend"
 	backend_instruction "github.com/werf/werf/v2/pkg/container_backend/instruction"
 	"github.com/werf/werf/v2/pkg/docker_registry"
@@ -74,6 +76,7 @@ func NewBuildPhase(c *Conveyor, opts BuildPhaseOptions) *BuildPhase {
 		BasePhase:         BasePhase{c},
 		BuildPhaseOptions: opts,
 		ImagesReport:      NewImagesReport(),
+		buildMetadata:     newBuildMetadata(),
 	}
 }
 
@@ -85,6 +88,23 @@ type BuildPhase struct {
 	ImagesReport   *ImagesReport
 
 	buildContextArchive container_backend.BuildContextArchiver
+	buildMetadata       *BuildMetadata
+}
+
+type BuildMetadata struct {
+	configTypes      map[string]bool
+	totalStages      int
+	cachedStages     int
+	buildStartTime   time.Time
+	totalBuildTimeMs int64
+	imagesCount      int
+}
+
+func newBuildMetadata() *BuildMetadata {
+	return &BuildMetadata{
+		configTypes:    make(map[string]bool),
+		buildStartTime: time.Now(),
+	}
 }
 
 func GenerateImageEnv(werfImageName, imageName string) string {
@@ -108,11 +128,35 @@ func (phase *BuildPhase) Name() string {
 }
 
 func (phase *BuildPhase) BeforeImages(ctx context.Context) error {
+	phase.buildMetadata.buildStartTime = time.Now()
+
 	if err := phase.Conveyor.StorageManager.InitCache(ctx); err != nil {
 		return fmt.Errorf("unable to init storage manager cache: %w", err)
 	}
 
 	imagesPairs := phase.Conveyor.imagesTree.GetImagesByName(false)
+	phase.buildMetadata.imagesCount = len(imagesPairs)
+
+	for _, pair := range imagesPairs {
+		_, images := pair.Unpair()
+		for _, img := range images {
+			configImage := phase.Conveyor.werfConfig.GetImage(img.Name)
+			if configImage != nil {
+				if configImage.IsStapel() {
+					phase.buildMetadata.configTypes["stapel"] = true
+				} else {
+					if dockerfileImg, ok := configImage.(*config.ImageFromDockerfile); ok {
+						if dockerfileImg.Staged {
+							phase.buildMetadata.configTypes["staged_dockerfile"] = true
+						} else {
+							phase.buildMetadata.configTypes["dockerfile"] = true
+						}
+					}
+				}
+			}
+		}
+	}
+
 	telemetry.GetTelemetryWerfIO().BuildStarted(ctx, len(imagesPairs))
 
 	return nil
@@ -194,9 +238,15 @@ func (phase *BuildPhase) AfterImages(ctx context.Context) error {
 		return err
 	}
 
-	telemetry.GetTelemetryWerfIO().BuildFinished(ctx, true)
+	if err := phase.createReport(ctx, imagesPairs); err != nil {
+		telemetry.GetTelemetryWerfIO().BuildFinished(ctx, false)
+		return err
+	}
 
-	return phase.createReport(ctx, imagesPairs)
+	telemetry.GetTelemetryWerfIO().BuildFinished(ctx, true)
+	phase.sendBuildMetadata(ctx)
+
+	return nil
 }
 
 func (phase *BuildPhase) targetPlatforms(ctx context.Context, forcedTargetPlatforms, commonTargetPlatforms []string, name string, images []*image.Image) ([]string, error) {
@@ -240,6 +290,43 @@ AssertAllTargetPlatformsPresent:
 	}
 
 	return targetPlatforms, nil
+}
+
+func (phase *BuildPhase) sendBuildMetadata(ctx context.Context) {
+	totalStages, cachedStages, totalBuildTimeMs := phase.ImagesReport.CollectStageStats()
+
+	phase.buildMetadata.totalStages = totalStages
+	phase.buildMetadata.cachedStages = cachedStages
+	phase.buildMetadata.totalBuildTimeMs = totalBuildTimeMs
+
+	backend := "docker"
+	if phase.Conveyor.ContainerBackend.HasStapelBuildSupport() {
+		backend = "buildah"
+	}
+
+	configTypes := make([]string, 0, len(phase.buildMetadata.configTypes))
+	for configType := range phase.buildMetadata.configTypes {
+		configTypes = append(configTypes, configType)
+	}
+	sort.Strings(configTypes)
+
+	var avgBuildTimeMs int64
+	if phase.buildMetadata.imagesCount > 0 {
+		avgBuildTimeMs = phase.buildMetadata.totalBuildTimeMs / int64(phase.buildMetadata.imagesCount)
+	}
+
+	fullBuildTimeMs := time.Since(phase.buildMetadata.buildStartTime).Milliseconds()
+
+	telemetry.GetTelemetryWerfIO().BuildMetadata(
+		ctx,
+		backend,
+		configTypes,
+		os.Getenv("WERF_CONTAINERIZED") == "yes",
+		phase.buildMetadata.totalStages,
+		phase.buildMetadata.cachedStages,
+		avgBuildTimeMs,
+		fullBuildTimeMs,
+	)
 }
 
 func (phase *BuildPhase) publishFinalImage(ctx context.Context, name string, img *image.Image, finalStagesStorage storage.StagesStorage) error {
@@ -682,8 +769,9 @@ func (phase *BuildPhase) onImageStage(ctx context.Context, img *image.Image, stg
 		var fetchInfo fetchBaseImageForStageInfo
 		if stg.IsBuildable() {
 			info, err := phase.fetchBaseImageForStage(ctx, img, stg)
+			err = container_backend.SanitizeError(err)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to prepare base image for stage %s: %w", stg.LogDetailedName(), err)
 			}
 			fetchInfo = info
 		} else {

--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -129,6 +129,8 @@ func (report *ImagesReport) sendTelemetry(ctx context.Context) {
 				stage.Name,
 				durationMs,
 				fromCache,
+				stage.SourceType,
+				stage.BaseImagePulled,
 			)
 		}
 
@@ -140,6 +142,38 @@ func (report *ImagesReport) sendTelemetry(ctx context.Context) {
 			record.Rebuilt,
 		)
 	}
+}
+
+func (report *ImagesReport) CollectStageStats() (totalStages, cachedStages int, totalBuildTimeMs int64) {
+	report.mux.Lock()
+	defer report.mux.Unlock()
+
+	if len(report.Images) > 0 {
+		for _, record := range report.Images {
+			for _, stage := range record.Stages {
+				totalStages++
+				if !stage.Rebuilt {
+					cachedStages++
+				}
+			}
+			totalBuildTimeMs += parseBuildTimeMs(record.BuildTime)
+		}
+		return totalStages, cachedStages, totalBuildTimeMs
+	}
+
+	for _, platformRecords := range report.ImagesByPlatform {
+		for _, record := range platformRecords {
+			for _, stage := range record.Stages {
+				totalStages++
+				if !stage.Rebuilt {
+					cachedStages++
+				}
+			}
+			totalBuildTimeMs += parseBuildTimeMs(record.BuildTime)
+		}
+	}
+
+	return totalStages, cachedStages, totalBuildTimeMs
 }
 
 func parseBuildTimeMs(buildTime string) int64 {
@@ -156,10 +190,22 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 		targetPlatforms := util.MapFuncToSlice(images, func(img *image.Image) string { return img.TargetPlatform })
 
 		for _, img := range images {
-			stageImage := img.GetLastNonEmptyStage().GetStageImage().Image
-			stageDesc := stageImage.GetFinalStageDesc()
+			lastStage := img.GetLastNonEmptyStage()
+			if lastStage == nil {
+				continue
+			}
+
+			stageImage := lastStage.GetStageImage()
+			if stageImage == nil || stageImage.Image == nil {
+				continue
+			}
+
+			stageDesc := stageImage.Image.GetFinalStageDesc()
 			if stageDesc == nil {
-				stageDesc = stageImage.GetStageDesc()
+				stageDesc = stageImage.Image.GetStageDesc()
+			}
+			if stageDesc == nil {
+				continue
 			}
 
 			stages := getStagesReport(img, false)

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -400,7 +401,64 @@ func (c *Conveyor) SkipImageSpecStage() bool {
 func (c *Conveyor) SetShouldAddManagedImagesRecords() {
 	c.GetServiceRWMutex("ShouldAddManagedImagesRecords").Lock()
 	defer c.GetServiceRWMutex("ShouldAddManagedImagesRecords").Unlock()
+
 	c.shouldAddManagedImagesRecords = true
+}
+
+func (c *Conveyor) sendBuildErrorTelemetry(ctx context.Context, err error) {
+	if err == nil {
+		return
+	}
+
+	errorType := classifyBuildError(err)
+	telemetry.GetTelemetryWerfIO().BuildError(ctx, errorType, exitCodeFromError(err))
+}
+
+func classifyBuildError(err error) string {
+	switch {
+	case errors.Is(err, stage.ErrInvalidBaseImage):
+		return "invalid_base_image"
+	case errors.Is(err, stage.ErrNothingToImport):
+		return "nothing_to_import"
+	case errors.Is(err, container_backend.ErrPatchApply):
+		return "git_patch_apply_failed"
+	case storage.IsErrBrokenImage(err):
+		return "broken_image"
+	case errors.Is(err, lock_manager.ErrNoSyncServerFound):
+		return "no_sync_server"
+	}
+
+	exitCode := exitCodeFromError(err)
+	if exitCode != 0 {
+		return "build_run_failed"
+	}
+
+	return "build_failed"
+}
+
+func exitCodeFromError(err error) int {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "exit code") && !strings.Contains(msg, "exit status") {
+		return 0
+	}
+
+	parts := strings.Split(msg, "exit")
+	for _, part := range parts[1:] {
+		var code int
+		if _, parseErr := fmt.Sscanf(part, " code %d", &code); parseErr == nil {
+			return code
+		}
+		if _, parseErr := fmt.Sscanf(part, " status %d", &code); parseErr == nil {
+			return code
+		}
+	}
+
+	return 0
 }
 
 func (c *Conveyor) ShouldAddManagedImagesRecords() bool {
@@ -733,6 +791,14 @@ func (c *Conveyor) doDetermineStages(ctx context.Context) error {
 }
 
 func (c *Conveyor) runPhases(ctx context.Context, phases []Phase, logImages bool) error {
+	var buildFinishedSent bool
+
+	defer func() {
+		if !buildFinishedSent {
+			telemetry.GetTelemetryWerfIO().BuildFinished(ctx, false)
+		}
+	}()
+
 	for _, phase := range phases {
 		logProcess := logboek.Context(ctx).Debug().LogProcess("Phase %s -- BeforeImages()", phase.Name())
 		logProcess.Start()
@@ -744,7 +810,14 @@ func (c *Conveyor) runPhases(ctx context.Context, phases []Phase, logImages bool
 	}
 
 	if err := c.doImages(ctx, phases, logImages); err != nil {
-		telemetry.GetTelemetryWerfIO().BuildFinished(ctx, false)
+		for _, phase := range phases {
+			if buildPhase, ok := phase.(*BuildPhase); ok {
+				imagesPairs := buildPhase.Conveyor.imagesTree.GetImagesByName(false)
+				_ = buildPhase.createReport(ctx, imagesPairs)
+				buildPhase.sendBuildMetadata(ctx)
+			}
+		}
+		c.sendBuildErrorTelemetry(ctx, err)
 		return fmt.Errorf("unable to process images: %w", err)
 	}
 
@@ -761,6 +834,7 @@ func (c *Conveyor) runPhases(ctx context.Context, phases []Phase, logImages bool
 		}
 	}
 
+	buildFinishedSent = true
 	return nil
 }
 

--- a/pkg/telemetry/event.go
+++ b/pkg/telemetry/event.go
@@ -12,6 +12,8 @@ const (
 	BuildFinishedEvent      EventType = "BuildFinished"
 	ImageBuildFinishedEvent EventType = "ImageBuildFinished"
 	StageBuildFinishedEvent EventType = "StageBuildFinished"
+	BuildErrorEvent         EventType = "BuildError"
+	BuildMetadataEvent      EventType = "BuildMetadata"
 )
 
 type Event interface {
@@ -105,19 +107,61 @@ func NewImageBuildFinished(image string, durationMs int64, rebuilt bool) *ImageB
 func (*ImageBuildFinished) GetType() EventType { return ImageBuildFinishedEvent }
 
 type StageBuildFinished struct {
-	Image      string `json:"image"`
-	Stage      string `json:"stage"`
-	DurationMs int64  `json:"durationMs"`
-	FromCache  bool   `json:"fromCache"`
+	Image           string `json:"image"`
+	Stage           string `json:"stage"`
+	DurationMs      int64  `json:"durationMs"`
+	FromCache       bool   `json:"fromCache"`
+	SourceType      string `json:"sourceType,omitempty"`
+	BaseImagePulled bool   `json:"baseImagePulled"`
 }
 
-func NewStageBuildFinished(image, stage string, durationMs int64, fromCache bool) *StageBuildFinished {
+func NewStageBuildFinished(image, stage string, durationMs int64, fromCache bool, sourceType string, baseImagePulled bool) *StageBuildFinished {
 	return &StageBuildFinished{
-		Image:      image,
-		Stage:      stage,
-		DurationMs: durationMs,
-		FromCache:  fromCache,
+		Image:           image,
+		Stage:           stage,
+		DurationMs:      durationMs,
+		FromCache:       fromCache,
+		SourceType:      sourceType,
+		BaseImagePulled: baseImagePulled,
 	}
 }
 
 func (*StageBuildFinished) GetType() EventType { return StageBuildFinishedEvent }
+
+type BuildError struct {
+	ErrorType string `json:"errorType"`
+	ExitCode  int    `json:"exitCode,omitempty"`
+}
+
+func NewBuildError(errorType string, exitCode int) *BuildError {
+	return &BuildError{
+		ErrorType: errorType,
+		ExitCode:  exitCode,
+	}
+}
+
+func (*BuildError) GetType() EventType { return BuildErrorEvent }
+
+type BuildMetadata struct {
+	Backend              string   `json:"backend"`
+	ConfigTypes          []string `json:"configTypes"`
+	Containerized        bool     `json:"containerized"`
+	TotalStagesCount     int      `json:"totalStagesCount"`
+	CachedStagesCount    int      `json:"cachedStagesCount"`
+	AvgBuildTimeMs       int64    `json:"avgBuildTimeMs"`
+	WallClockBuildTimeMs int64    `json:"wallClockBuildTimeMs"`
+}
+
+func NewBuildMetadata(backend string, configTypes []string, containerized bool, totalStages, cachedStages int, avgBuildTimeMs, wallClockBuildTimeMs int64) *BuildMetadata {
+	return &BuildMetadata{
+		Backend:              backend,
+		ConfigTypes:          configTypes,
+		Containerized:        containerized,
+		TotalStagesCount:     totalStages,
+		CachedStagesCount:    cachedStages,
+		AvgBuildTimeMs:       avgBuildTimeMs,
+		WallClockBuildTimeMs: wallClockBuildTimeMs,
+	}
+}
+
+func (*BuildMetadata) GetType() EventType { return BuildMetadataEvent }

--- a/pkg/telemetry/no_telemetrywerfio.go
+++ b/pkg/telemetry/no_telemetrywerfio.go
@@ -4,14 +4,18 @@ import "context"
 
 type NoTelemetryWerfIO struct{}
 
-func (t *NoTelemetryWerfIO) CommandStarted(context.Context)                                  {}
-func (t *NoTelemetryWerfIO) SetUserID(context.Context, string)                               {}
-func (t *NoTelemetryWerfIO) SetProjectID(context.Context, string)                            {}
-func (t *NoTelemetryWerfIO) SetCommand(context.Context, string)                              {}
-func (t *NoTelemetryWerfIO) CommandExited(context.Context, int)                              {}
-func (t *NoTelemetryWerfIO) SetCommandOptions(context.Context, []CommandOption)              {}
-func (t *NoTelemetryWerfIO) UnshallowFailed(context.Context, error)                          {}
-func (t *NoTelemetryWerfIO) BuildStarted(context.Context, int)                               {}
-func (t *NoTelemetryWerfIO) BuildFinished(context.Context, bool)                             {}
-func (t *NoTelemetryWerfIO) ImageBuildFinished(context.Context, string, int64, bool)         {}
-func (t *NoTelemetryWerfIO) StageBuildFinished(context.Context, string, string, int64, bool) {}
+func (t *NoTelemetryWerfIO) CommandStarted(context.Context)                          {}
+func (t *NoTelemetryWerfIO) SetUserID(context.Context, string)                       {}
+func (t *NoTelemetryWerfIO) SetProjectID(context.Context, string)                    {}
+func (t *NoTelemetryWerfIO) SetCommand(context.Context, string)                      {}
+func (t *NoTelemetryWerfIO) CommandExited(context.Context, int)                      {}
+func (t *NoTelemetryWerfIO) SetCommandOptions(context.Context, []CommandOption)      {}
+func (t *NoTelemetryWerfIO) UnshallowFailed(context.Context, error)                  {}
+func (t *NoTelemetryWerfIO) BuildStarted(context.Context, int)                       {}
+func (t *NoTelemetryWerfIO) BuildFinished(context.Context, bool)                     {}
+func (t *NoTelemetryWerfIO) ImageBuildFinished(context.Context, string, int64, bool) {}
+func (t *NoTelemetryWerfIO) StageBuildFinished(context.Context, string, string, int64, bool, string, bool) {
+}
+func (t *NoTelemetryWerfIO) BuildError(context.Context, string, int) {}
+func (t *NoTelemetryWerfIO) BuildMetadata(context.Context, string, []string, bool, int, int, int64, int64) {
+}

--- a/pkg/telemetry/telemetrywerfio.go
+++ b/pkg/telemetry/telemetrywerfio.go
@@ -38,7 +38,9 @@ type TelemetryWerfIOInterface interface {
 	BuildStarted(ctx context.Context, imagesCount int)
 	BuildFinished(ctx context.Context, success bool)
 	ImageBuildFinished(ctx context.Context, image string, durationMs int64, rebuilt bool)
-	StageBuildFinished(ctx context.Context, image, stage string, durationMs int64, fromCache bool)
+	StageBuildFinished(ctx context.Context, image, stage string, durationMs int64, fromCache bool, sourceType string, baseImagePulled bool)
+	BuildError(ctx context.Context, errorType string, exitCode int)
+	BuildMetadata(ctx context.Context, backend string, configTypes []string, containerized bool, totalStages, cachedStages int, avgBuildTimeMs, wallClockBuildTimeMs int64)
 }
 
 type TelemetryWerfIO struct {
@@ -160,8 +162,16 @@ func (t *TelemetryWerfIO) ImageBuildFinished(ctx context.Context, image string, 
 	t.sendEvent(ctx, NewImageBuildFinished(image, durationMs, rebuilt))
 }
 
-func (t *TelemetryWerfIO) StageBuildFinished(ctx context.Context, image, stage string, durationMs int64, fromCache bool) {
-	t.sendEvent(ctx, NewStageBuildFinished(image, stage, durationMs, fromCache))
+func (t *TelemetryWerfIO) StageBuildFinished(ctx context.Context, image, stage string, durationMs int64, fromCache bool, sourceType string, baseImagePulled bool) {
+	t.sendEvent(ctx, NewStageBuildFinished(image, stage, durationMs, fromCache, sourceType, baseImagePulled))
+}
+
+func (t *TelemetryWerfIO) BuildError(ctx context.Context, errorType string, exitCode int) {
+	t.sendEvent(ctx, NewBuildError(errorType, exitCode))
+}
+
+func (t *TelemetryWerfIO) BuildMetadata(ctx context.Context, backend string, configTypes []string, containerized bool, totalStages, cachedStages int, avgBuildTimeMs, wallClockBuildTimeMs int64) {
+	t.sendEvent(ctx, NewBuildMetadata(backend, configTypes, containerized, totalStages, cachedStages, avgBuildTimeMs, wallClockBuildTimeMs))
 }
 
 func (t *TelemetryWerfIO) getAttributes() map[string]interface{} {


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added BuildMetadata struct and related functionality to track build statistics including config types, stage counts, build times, and backend usage for telemetry purposes.</li>
<li>Implemented telemetry collection for successful builds by populating and sending build metadata after image processing, including details like total stages, cached stages, and average build times.</li>
<li>Introduced error telemetry for failed builds, classifying errors into categories such as platform mismatch, authentication errors, and network issues, and sending error details via telemetry.</li>
<li>Enhanced error handling with improved error messages and ensured telemetry is dispatched on build failures or interruptions using defer mechanisms.</li>
<li>Extended telemetry package with new BuildError and BuildMetadata event types, including structs, constructors, and interface implementations.</li>
</ul></div>