### PR TITLE
feat(build, bundle): add sha256

### DIFF
--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -457,7 +457,7 @@ func (report *ImagesReport) ToImageInfoGetters(opts imagePkg.InfoGetterOptions) 
 			continue
 		}
 
-		infoGetters = append(infoGetters, imagePkg.NewInfoGetter(record.WerfImageName, record.DockerImageName, opts))
+		infoGetters = append(infoGetters, imagePkg.NewInfoGetter(record.WerfImageName, record.DockerImageName, record.DockerImageDigest, opts))
 	}
 
 	return infoGetters

--- a/pkg/container_backend/utils.go
+++ b/pkg/container_backend/utils.go
@@ -37,6 +37,9 @@ func LogImageInfo(ctx context.Context, img LegacyImageInterface, prevStageImageS
 	LogImageName(ctx, img.Name())
 
 	logboek.Context(ctx).Default().LogFDetails(logImageInfoFormat, "id", stringid.TruncateID(img.GetStageDesc().Info.ID))
+
+	logboek.Context(ctx).Default().LogFDetails(logImageInfoFormat, "sha256", (strings.TrimPrefix(img.GetStageDesc().Info.GetDigest(), "sha256:")))
+
 	logboek.Context(ctx).Default().LogFDetails(logImageInfoFormat, "created", img.GetStageDesc().Info.GetCreatedAt())
 
 	if prevStageImageSize == 0 {

--- a/pkg/deploy/helm/chart_extender/helpers/service_values.go
+++ b/pkg/deploy/helm/chart_extender/helpers/service_values.go
@@ -45,6 +45,7 @@ func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGe
 		"repo":    repo,
 		"image":   map[string]interface{}{},
 		"tag":     map[string]interface{}{},
+		"sha256":  map[string]interface{}{},
 		"commit": map[string]interface{}{
 			"hash": opts.CommitHash,
 			"date": map[string]interface{}{
@@ -69,18 +70,21 @@ func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGe
 	if opts.IsStub {
 		stubTag := "TAG"
 		stubImage := fmt.Sprintf("%s:%s", repo, stubTag)
+		stubSha256 := "SHA256"
 
 		werfInfo["is_stub"] = true
 		werfInfo["stub_image"] = stubImage
 		for _, name := range opts.StubImageNameList {
 			werfInfo["image"].(map[string]interface{})[name] = stubImage
 			werfInfo["tag"].(map[string]interface{})[name] = stubTag
+			werfInfo["sha256"].(map[string]interface{})[name] = stubSha256
 		}
 	}
 
 	for _, imageInfoGetter := range imageInfoGetters {
 		tag := imageInfoGetter.GetTag()
 		image := imageInfoGetter.GetName()
+		digest := imageInfoGetter.GetDigest()
 
 		if imageInfoGetter.IsNameless() {
 			werfInfo["is_nameless_image"] = true
@@ -88,6 +92,7 @@ func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGe
 		} else {
 			werfInfo["image"].(map[string]interface{})[imageInfoGetter.GetWerfImageName()] = image
 			werfInfo["tag"].(map[string]interface{})[imageInfoGetter.GetWerfImageName()] = tag
+			werfInfo["sha256"].(map[string]interface{})[imageInfoGetter.GetWerfImageName()] = digest
 		}
 	}
 

--- a/pkg/deploy/helm_for_werf_helm/chart_extender_for_werf_helm/helpers_for_werf_helm/service_values.go
+++ b/pkg/deploy/helm_for_werf_helm/chart_extender_for_werf_helm/helpers_for_werf_helm/service_values.go
@@ -73,6 +73,7 @@ func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGe
 		"repo":    repo,
 		"image":   map[string]interface{}{},
 		"tag":     map[string]interface{}{},
+		"sha256":  map[string]interface{}{},
 		"commit": map[string]interface{}{
 			"hash": opts.CommitHash,
 			"date": map[string]interface{}{
@@ -96,6 +97,7 @@ func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGe
 
 	if opts.IsStub {
 		stubTag := "TAG"
+		stubSha256 := "SHA256"
 		stubImage := fmt.Sprintf("%s:%s", repo, stubTag)
 
 		werfInfo["is_stub"] = true
@@ -103,12 +105,14 @@ func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGe
 		for _, name := range opts.StubImageNameList {
 			werfInfo["image"].(map[string]interface{})[name] = stubImage
 			werfInfo["tag"].(map[string]interface{})[name] = stubTag
+			werfInfo["sha256"].(map[string]interface{})[name] = stubSha256
 		}
 	}
 
 	for _, imageInfoGetter := range imageInfoGetters {
 		tag := imageInfoGetter.GetTag()
 		image := imageInfoGetter.GetName()
+		digest := imageInfoGetter.GetDigest()
 
 		if imageInfoGetter.IsNameless() {
 			werfInfo["is_nameless_image"] = true
@@ -116,6 +120,7 @@ func GetServiceValues(ctx context.Context, projectName, repo string, imageInfoGe
 		} else {
 			werfInfo["image"].(map[string]interface{})[imageInfoGetter.GetWerfImageName()] = image
 			werfInfo["tag"].(map[string]interface{})[imageInfoGetter.GetWerfImageName()] = tag
+			werfInfo["sha256"].(map[string]interface{})[imageInfoGetter.GetWerfImageName()] = digest
 		}
 	}
 

--- a/pkg/image/info_getter.go
+++ b/pkg/image/info_getter.go
@@ -11,6 +11,7 @@ type InfoGetter struct {
 	WerfImageName string
 	Repo          string
 	Tag           string
+	Digest        string
 
 	InfoGetterOptions
 }
@@ -20,13 +21,14 @@ type InfoGetterOptions struct {
 	OnlyFinal     bool
 }
 
-func NewInfoGetter(imageName, ref string, opts InfoGetterOptions) *InfoGetter {
+func NewInfoGetter(imageName, ref, digest string, opts InfoGetterOptions) *InfoGetter {
 	repo, tag := ParseRepositoryAndTag(ref)
 
 	return &InfoGetter{
 		WerfImageName:     imageName,
 		Repo:              repo,
 		Tag:               tag,
+		Digest:            digest,
 		InfoGetterOptions: opts,
 	}
 }
@@ -48,4 +50,8 @@ func (d *InfoGetter) GetTag() string {
 		return d.CustomTagFunc(d.WerfImageName, d.Tag)
 	}
 	return d.Tag
+}
+
+func (d *InfoGetter) GetDigest() string {
+	return d.Digest
 }

--- a/pkg/image/info_getter_test.go
+++ b/pkg/image/info_getter_test.go
@@ -10,7 +10,7 @@ import (
 var _ = Describe("InfoGetter", func() {
 	DescribeTable("TestInfoGetter",
 		func(data TestInfoGetter) {
-			getter := NewInfoGetter(data.ImageName, data.Ref, data.Opts)
+			getter := NewInfoGetter(data.ImageName, data.Ref, data.Digest, data.Opts)
 
 			Expect(getter.IsNameless()).To(Equal(data.ExpectIsNameless))
 			Expect(getter.GetWerfImageName()).To(Equal(data.ExpectWerfImageName))
@@ -22,6 +22,7 @@ var _ = Describe("InfoGetter", func() {
 			TestInfoGetter{
 				ImageName:           "",
 				Ref:                 "myregistry.domain.com/group/project:abcd",
+				Digest:              "sha256:abcd1234",
 				Opts:                InfoGetterOptions{},
 				ExpectIsNameless:    true,
 				ExpectWerfImageName: "",
@@ -33,6 +34,7 @@ var _ = Describe("InfoGetter", func() {
 			TestInfoGetter{
 				ImageName:           "backend",
 				Ref:                 "myregistry.domain.com/group/project:abcd",
+				Digest:              "sha256:abcd1234",
 				Opts:                InfoGetterOptions{},
 				ExpectIsNameless:    false,
 				ExpectWerfImageName: "backend",
@@ -44,6 +46,7 @@ var _ = Describe("InfoGetter", func() {
 			TestInfoGetter{
 				ImageName: "backend",
 				Ref:       "myregistry.domain.com/group/project:abcd",
+				Digest:    "sha256:abcd1234",
 				Opts: InfoGetterOptions{
 					CustomTagFunc: func(werfImageName, tag string) string {
 						return fmt.Sprintf("%s-%s", werfImageName, tag)
@@ -60,6 +63,7 @@ var _ = Describe("InfoGetter", func() {
 type TestInfoGetter struct {
 	ImageName string
 	Ref       string
+	Digest    string
 	Opts      InfoGetterOptions
 
 	ExpectIsNameless    bool

--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -223,10 +223,10 @@ func (m *StorageManager) GetServiceValuesRepo() string {
 func (m *StorageManager) GetImageInfoGetter(imageName string, stageDesc *image.StageDesc, opts image.InfoGetterOptions) *image.InfoGetter {
 	if m.FinalStagesStorage != nil {
 		finalImageName := m.FinalStagesStorage.ConstructStageImageName(m.ProjectName, stageDesc.StageID.Digest, stageDesc.StageID.CreationTs)
-		return image.NewInfoGetter(imageName, finalImageName, opts)
+		return image.NewInfoGetter(imageName, finalImageName, stageDesc.Info.GetDigest(), opts)
 	}
 
-	return image.NewInfoGetter(imageName, stageDesc.Info.Name, opts)
+	return image.NewInfoGetter(imageName, stageDesc.Info.Name, stageDesc.Info.GetDigest(), opts)
 }
 
 func (m *StorageManager) InitCache(ctx context.Context) error {


### PR DESCRIPTION
Add sha256 to helm and build report. 
Allow to pin image by sha256 hash string 

werf render 
```yaml
werf:
  commit:
    date:
      human: 2026-03-07 16:56:48 +0400 +0400
      unix: 1772888208
    hash: 863e215488e6b8dffa9709aa2990ee6ea2cb0691
  image:
    config_reloader: repo.test.local/victoria-metrics:c4e255bbb1e34497f27c30f3241a8b45c05ea7f226f3392f84844d1e-1765788637782
    vmagent: repo.test.local/victoria-metrics:8a64c26884bfe9f7e878360d20e68b620e5058111b22c63b2c5fc651-1765466949732
  name: victoria-metrics
  repo: repo.test.local/victoria-metrics
  sha256:
    config_reloader: sha256:c99b3ccd04332fab0cd2383ea05bcfe9b982ed6fad692143b97560294182b2ec
    vmagent: sha256:b8c68a5c2b9985ffff665a6c5357a8629e810761f0cf21e71eb17c0469a3063a
  tag:
    config_reloader: c4e255bbb1e34497f27c30f3241a8b45c05ea7f226f3392f84844d1e-1765788637782
    vmagent: 8a64c26884bfe9f7e878360d20e68b620e5058111b22c63b2c5fc651-1765466949732
 ```

build report output
```
┌ 🛳️  (1/2) image vmagent [linux/amd64]
│ Use previously built image for vmagent/dockerfile
│      name:                                                                                                                 ↵
│ repo.test.local/victoria-metrics:8a64c26884bfe9f7e878360d20e68b620e5058111b22c63b2c5fc651-1765466949732
│        id: 22b91ea1319d
│    sha256: b8c68a5c2b9985ffff665a6c5357a8629e810761f0cf21e71eb17c0469a3063a
│   created: 2025-12-01 15:04:03 +0400 +04
│      size: 13.8 MiB
│    commit: 941e44ca4c814ce8e433a7b6edb272a51cddac37
│  platform: linux/amd64
│   network: 
└ 🛳️  (1/2) image vmagent [linux/amd64] (0.01 seconds)

┌ 🛳️  (2/2) image config_reloader [linux/amd64]
│ Use previously built image for config_reloader/dockerfile
│      name:                                                                                                                 ↵
│ repo.test.local/victoria-metrics:c4e255bbb1e34497f27c30f3241a8b45c05ea7f226f3392f84844d1e-1765788637782
│        id: 2013c0b58f8e
│    sha256: c99b3ccd04332fab0cd2383ea05bcfe9b982ed6fad692143b97560294182b2ec
│   created: 2025-12-06 18:58:48 +0400 +04
│      size: 18.5 MiB
│    commit: f5a43431f48c511179700eb48d932a1b1b2af7c6
│  platform: linux/amd64
│   network: 
└ 🛳️  (2/2) image config_reloader [linux/amd64] (0.01 seconds)
```