### PR TITLE
feat(build): support .env format with --use-build-report

### DIFF
--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -1,13 +1,16 @@
 package build
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/werf/common-go/pkg/util"
@@ -117,9 +120,30 @@ func (report *ImagesReport) ToEnvFileData() []byte {
 	for img, record := range report.Images {
 		buf.WriteString(GenerateImageEnv(img, record.DockerImageName))
 		buf.WriteString("\n")
+
+		prefix := imageEnvPrefix(img)
+		buf.WriteString(fmt.Sprintf("%sDOCKER_IMAGE_ID=%s\n", prefix, record.DockerImageID))
+		buf.WriteString(fmt.Sprintf("%sDOCKER_IMAGE_DIGEST=%s\n", prefix, record.DockerImageDigest))
+		buf.WriteString(fmt.Sprintf("%sDOCKER_REPO=%s\n", prefix, record.DockerRepo))
+		buf.WriteString(fmt.Sprintf("%sDOCKER_TAG=%s\n", prefix, record.DockerTag))
+		buf.WriteString(fmt.Sprintf("%sWERF_IMAGE_NAME=%s\n", prefix, record.WerfImageName))
+		buf.WriteString(fmt.Sprintf("%sFINAL=%t\n", prefix, record.Final))
 	}
 
 	return buf.Bytes()
+}
+
+func imageEnvPrefix(werfImageName string) string {
+	if werfImageName == "" {
+		return "WERF_"
+	}
+
+	normalizedName := strings.ToUpper(werfImageName)
+	for _, l := range []string{"/", "-", "."} {
+		normalizedName = strings.ReplaceAll(normalizedName, l, "_")
+	}
+
+	return fmt.Sprintf("WERF_%s_", normalizedName)
 }
 
 func (report *ImagesReport) sendTelemetry(ctx context.Context) {
@@ -344,7 +368,13 @@ func LoadBuildReportFromFile(ctx context.Context, path string) (*ImagesReport, e
 	}
 	defer file.Close()
 
-	report, err := parseBuildReport(file)
+	var report *ImagesReport
+	switch filepath.Ext(path) {
+	case ".env":
+		report, err = parseEnvFileBuildReport(file)
+	default:
+		report, err = parseBuildReport(file)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse build report file %q: %w", path, err)
 	}
@@ -454,4 +484,56 @@ func (report *ImagesReport) ToImageInfoGetters(opts imagePkg.InfoGetterOptions) 
 	}
 
 	return infoGetters
+}
+
+func parseEnvFileBuildReport(reader io.Reader) (*ImagesReport, error) {
+	scanner := bufio.NewScanner(reader)
+	values := make(map[string]string)
+	lineNumber := 0
+
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("malformed env line %d: %q", lineNumber, line)
+		}
+		values[parts[0]] = parts[1]
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("unable to read env build report: %w", err)
+	}
+
+	report := NewImagesReport()
+	imagePrefixes := make(map[string]struct{})
+	for key := range values {
+		if strings.HasSuffix(key, "_DOCKER_IMAGE_NAME") {
+			prefix := strings.TrimSuffix(key, "DOCKER_IMAGE_NAME")
+			imagePrefixes[prefix] = struct{}{}
+		}
+	}
+
+	for prefix := range imagePrefixes {
+		record := ReportImageRecord{
+			WerfImageName:     values[prefix+"WERF_IMAGE_NAME"],
+			DockerImageName:   values[prefix+"DOCKER_IMAGE_NAME"],
+			DockerImageID:     values[prefix+"DOCKER_IMAGE_ID"],
+			DockerImageDigest: values[prefix+"DOCKER_IMAGE_DIGEST"],
+			DockerRepo:        values[prefix+"DOCKER_REPO"],
+			DockerTag:         values[prefix+"DOCKER_TAG"],
+		}
+
+		if finalValue, ok := values[prefix+"FINAL"]; ok {
+			record.Final = finalValue == "true"
+		}
+
+		report.Images[record.WerfImageName] = record
+	}
+
+	return report, nil
 }

--- a/pkg/build/build_report_ai_test.go
+++ b/pkg/build/build_report_ai_test.go
@@ -1,0 +1,142 @@
+//go:build ai_tests
+// +build ai_tests
+
+package build
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAI_EnvBuildReport_RoundTripNamedImages(t *testing.T) {
+	report := NewImagesReport()
+	report.SetImageRecord("frontend", newTestReportImageRecord("frontend", true))
+	report.SetImageRecord("backend", newTestReportImageRecord("backend", true))
+
+	envData := report.ToEnvFileData()
+	parsed, err := parseEnvFileBuildReport(bytes.NewReader(envData))
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	require.Len(t, parsed.Images, 2)
+
+	frontendRecord, ok := parsed.Images["frontend"]
+	require.True(t, ok)
+	assertReportImageRecordEqual(t, report.Images["frontend"], frontendRecord)
+
+	backendRecord, ok := parsed.Images["backend"]
+	require.True(t, ok)
+	assertReportImageRecordEqual(t, report.Images["backend"], backendRecord)
+}
+
+func TestAI_EnvBuildReport_RoundTripUnnamedImage(t *testing.T) {
+	report := NewImagesReport()
+	report.SetImageRecord("", newTestReportImageRecord("", true))
+
+	envData := report.ToEnvFileData()
+	assert.Contains(t, string(envData), "WERF_DOCKER_IMAGE_NAME=")
+
+	parsed, err := parseEnvFileBuildReport(bytes.NewReader(envData))
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	require.Len(t, parsed.Images, 1)
+
+	unnamedRecord, ok := parsed.Images[""]
+	require.True(t, ok)
+	assertReportImageRecordEqual(t, report.Images[""], unnamedRecord)
+}
+
+func TestAI_EnvBuildReport_PreservesFinalField(t *testing.T) {
+	report := NewImagesReport()
+	report.SetImageRecord("frontend", newTestReportImageRecord("frontend", true))
+	report.SetImageRecord("backend", newTestReportImageRecord("backend", false))
+
+	envData := report.ToEnvFileData()
+	parsed, err := parseEnvFileBuildReport(bytes.NewReader(envData))
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	require.Len(t, parsed.Images, 2)
+
+	assert.Equal(t, true, parsed.Images["frontend"].Final)
+	assert.Equal(t, false, parsed.Images["backend"].Final)
+}
+
+func TestAI_EnvBuildReport_LoadBuildReportFromFile_EnvExtension(t *testing.T) {
+	report := NewImagesReport()
+	report.SetImageRecord("frontend", newTestReportImageRecord("frontend", true))
+
+	envData := report.ToEnvFileData()
+	reportPath := filepath.Join(t.TempDir(), "report.env")
+	require.NoError(t, os.WriteFile(reportPath, envData, 0o644))
+
+	loadedReport, err := LoadBuildReportFromFile(context.Background(), reportPath)
+	require.NoError(t, err)
+	require.NotNil(t, loadedReport)
+}
+
+func TestAI_EnvBuildReport_LoadBuildReportFromFile_JSONExtension(t *testing.T) {
+	report := NewImagesReport()
+	report.SetImageRecord("frontend", newTestReportImageRecord("frontend", true))
+
+	jsonData, err := report.ToJsonData()
+	require.NoError(t, err)
+
+	reportPath := filepath.Join(t.TempDir(), "report.json")
+	require.NoError(t, os.WriteFile(reportPath, jsonData, 0o644))
+
+	loadedReport, err := LoadBuildReportFromFile(context.Background(), reportPath)
+	require.NoError(t, err)
+	require.NotNil(t, loadedReport)
+}
+
+func TestAI_EnvBuildReport_ValidateParsedEnv(t *testing.T) {
+	report := NewImagesReport()
+	report.SetImageRecord("frontend", newTestReportImageRecord("frontend", true))
+
+	envData := report.ToEnvFileData()
+	parsed, err := parseEnvFileBuildReport(bytes.NewReader(envData))
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	require.NoError(t, validateBuildReport(context.Background(), "test.env", parsed))
+}
+
+func newTestReportImageRecord(werfImageName string, final bool) ReportImageRecord {
+	suffix := werfImageName
+	if suffix == "" {
+		suffix = "unnamed"
+	}
+
+	return ReportImageRecord{
+		WerfImageName:     werfImageName,
+		DockerRepo:        "registry.example.com/" + suffix,
+		DockerTag:         "v1",
+		DockerImageID:     "sha256:id-" + suffix,
+		DockerImageDigest: "sha256:digest-" + suffix,
+		DockerImageName:   "registry.example.com/" + suffix + ":v1",
+		Final:             final,
+	}
+}
+
+func assertReportImageRecordEqual(t *testing.T, expected, actual ReportImageRecord) {
+	t.Helper()
+
+	assert.Equal(t, expected.WerfImageName, actual.WerfImageName)
+	assert.Equal(t, expected.ConfigType, actual.ConfigType)
+	assert.Equal(t, expected.DockerRepo, actual.DockerRepo)
+	assert.Equal(t, expected.DockerTag, actual.DockerTag)
+	assert.Equal(t, expected.DockerImageID, actual.DockerImageID)
+	assert.Equal(t, expected.DockerImageDigest, actual.DockerImageDigest)
+	assert.Equal(t, expected.DockerImageName, actual.DockerImageName)
+	assert.Equal(t, expected.TargetPlatform, actual.TargetPlatform)
+	assert.Equal(t, expected.Rebuilt, actual.Rebuilt)
+	assert.Equal(t, expected.Final, actual.Final)
+	assert.Equal(t, expected.Size, actual.Size)
+	assert.Equal(t, expected.BuildTime, actual.BuildTime)
+	assert.Equal(t, expected.Stages, actual.Stages)
+}


### PR DESCRIPTION
Extend .env build report generation (ToEnvFileData) with additional fields (DockerImageID, DockerImageDigest, DockerRepo, DockerTag, WerfImageName, Final) and add a parser (parseEnvFileBuildReport) to read them back into ImagesReport. LoadBuildReportFromFile now detects .env extension and routes to the appropriate parser, enabling 'werf export --use-build-report --build-report-path=report.env'.