### PR TITLE
fix: propagate --docker-config to image pulling in bundle copy

### DIFF
--- a/cmd/werf/bundle/copy/copy.go
+++ b/cmd/werf/bundle/copy/copy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/werf/nelm/pkg/export/helm/werf/helmopts"
 	"github.com/werf/werf/v2/cmd/werf/common"
 	"github.com/werf/werf/v2/pkg/deploy/bundles"
+	"github.com/werf/werf/v2/pkg/docker"
 	"github.com/werf/werf/v2/pkg/docker_registry"
 	"github.com/werf/werf/v2/pkg/ref"
 	"github.com/werf/werf/v2/pkg/tmp_manager"
@@ -82,6 +83,10 @@ func runCopy(ctx context.Context) error {
 	})
 	if err != nil {
 		return fmt.Errorf("component init error: %w", err)
+	}
+
+	if err := docker.InitDockerConfig(docker.InitOptions{DockerConfigDir: *commonCmdData.DockerConfig}); err != nil {
+		return fmt.Errorf("unable to init docker config: %w", err)
 	}
 
 	defer func() {


### PR DESCRIPTION
## Summary

Fixes #6755

When running `werf bundle copy --docker-config=<dir>`, the custom docker config is used for pulling the bundle chart itself but **not** for pulling the associated images. This results in a `DENIED: Permission denied` error when pulling images from a registry that requires the custom credentials.

## Root Cause

The `bundle copy` command initializes the docker registry via `InitCommonComponents` with `InitDockerRegistry: true`, which calls `DockerRegistryInit` → `docker_registry.Init`. However, it does **not** call `docker.InitDockerConfig()`, so the `DOCKER_CONFIG` environment variable is never set.

The image pulling code in `PullImageArchive` uses `authn.DefaultKeychain` from `go-containerregistry`, which reads from `$DOCKER_CONFIG` to locate credentials. Without the env var set, it falls back to `~/.docker/config.json` and cannot find the custom credentials.

Other commands (like `werf build`) call `InitProcessContainerBackend`, which calls `docker.Init()` → `docker.InitDockerConfig()`, so they work correctly. But `bundle copy` skips this step since it doesn't need a full container backend.

## Fix

Call `docker.InitDockerConfig()` with the configured docker config directory in `runCopy()` after `InitCommonComponents`. This sets the `DOCKER_CONFIG` environment variable so that `authn.DefaultKeychain` can find the credentials for image pulling.

## Files Changed

- `cmd/werf/bundle/copy/copy.go` — Add `docker.InitDockerConfig()` call with the `--docker-config` value