### PR TITLE
fix: init docker config in InitCommonComponents when docker registry is requested

### DIFF
--- a/cmd/werf/bundle/copy/copy.go
+++ b/cmd/werf/bundle/copy/copy.go
@@ -12,7 +12,6 @@ import (
 	"github.com/werf/nelm/pkg/export/helm/werf/helmopts"
 	"github.com/werf/werf/v2/cmd/werf/common"
 	"github.com/werf/werf/v2/pkg/deploy/bundles"
-	"github.com/werf/werf/v2/pkg/docker"
 	"github.com/werf/werf/v2/pkg/docker_registry"
 	"github.com/werf/werf/v2/pkg/ref"
 	"github.com/werf/werf/v2/pkg/tmp_manager"
@@ -83,10 +82,6 @@ func runCopy(ctx context.Context) error {
 	})
 	if err != nil {
 		return fmt.Errorf("component init error: %w", err)
-	}
-
-	if err := docker.InitDockerConfig(docker.InitOptions{DockerConfigDir: *commonCmdData.DockerConfig}); err != nil {
-		return fmt.Errorf("unable to init docker config: %w", err)
 	}
 
 	defer func() {

--- a/cmd/werf/common/components_manager.go
+++ b/cmd/werf/common/components_manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/werf/logboek"
 	"github.com/werf/werf/v2/pkg/buildah"
 	"github.com/werf/werf/v2/pkg/container_backend"
+	"github.com/werf/werf/v2/pkg/docker"
 	"github.com/werf/werf/v2/pkg/git_repo"
 	"github.com/werf/werf/v2/pkg/git_repo/gitdata"
 	"github.com/werf/werf/v2/pkg/image"
@@ -80,6 +81,14 @@ func InitCommonComponents(ctx context.Context, opts InitCommonComponentsOptions)
 		}
 		resolvedBuildahMode = *buildahMode
 		cmanager.buildahMode = resolvedBuildahMode
+	}
+
+	// Set DOCKER_CONFIG early so that authn.DefaultKeychain (used by go-containerregistry)
+	// picks up custom credentials even when the full container backend is not initialized.
+	if opts.InitDockerRegistry || opts.InitProcessContainerBackend {
+		if err := docker.InitDockerConfig(docker.InitOptions{DockerConfigDir: *opts.Cmd.DockerConfig}); err != nil {
+			return nil, ctx, fmt.Errorf("init docker config: %w", err)
+		}
 	}
 
 	if opts.InitProcessContainerBackend && resolvedBuildahMode == buildah.ModeDisabled {

--- a/cmd/werf/common/container_backend.go
+++ b/cmd/werf/common/container_backend.go
@@ -136,11 +136,6 @@ func InitProcessContainerBackend(ctx context.Context, cmdData *CmdData, registry
 			return nil, ctx, fmt.Errorf("unable to get buildah client: %w", err)
 		}
 
-		err = docker.InitDockerConfig(docker.InitOptions{DockerConfigDir: *cmdData.DockerConfig})
-		if err != nil {
-			return nil, ctx, fmt.Errorf("unable to set docker config for buildah client: %w", err)
-		}
-
 		return wrapContainerBackend(container_backend.NewBuildahBackend(b, container_backend.BuildahBackendOptions{TmpDir: filepath.Join(werf.GetServiceDir(), "tmp", "buildah")})), ctx, nil
 	}
 


### PR DESCRIPTION
## Summary

Systemic follow-up to #7448. Centralizes `docker.InitDockerConfig` in `InitCommonComponents` as the single source of truth for `DOCKER_CONFIG` initialization.

## Problem

`docker.InitDockerConfig` was called in multiple places:
- Buildah branch of `InitProcessContainerBackend` (`container_backend.go`)
- Docker branch via `InitProcessDocker` → `docker.Init` → `docker.InitDockerConfig`
- Per-command band-aid in `bundle copy` (added by #7448)

Any command using `InitDockerRegistry` without `InitProcessContainerBackend` didn't get `DOCKER_CONFIG` set, breaking `authn.DefaultKeychain` credential lookup.

## Fix

- Call `docker.InitDockerConfig` once in `InitCommonComponents` when either `InitDockerRegistry` or `InitProcessContainerBackend` is requested — early, before any registry interaction.
- Remove the duplicate call from `InitProcessContainerBackend` buildah branch.
- Remove the per-command band-aid from `bundle copy`.

`InitDockerConfig` is idempotent (just `os.Setenv` + global var), so the docker path (`InitProcessDocker` → `docker.Init`) calling it again is harmless.

## Files Changed

- `cmd/werf/common/components_manager.go` — Add centralized `docker.InitDockerConfig` call
- `cmd/werf/common/container_backend.go` — Remove duplicate from buildah branch
- `cmd/werf/bundle/copy/copy.go` — Remove per-command band-aid from #7448