### PR TITLE
refactor(build): add GetContextDependencies interface for context digest calculation

### DIFF
--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -203,6 +203,10 @@ func (s *BaseStage) GetDependencies(ctx context.Context, c Conveyor, cb containe
 	panic("method must be implemented!")
 }
 
+func (s *BaseStage) GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	panic("method must be implemented!")
+}
+
 func (s *BaseStage) GetNextStageDependencies(_ context.Context, _ Conveyor) (string, error) {
 	return "", nil
 }

--- a/pkg/build/stage/before_install.go
+++ b/pkg/build/stage/before_install.go
@@ -27,6 +27,10 @@ type BeforeInstallStage struct {
 	*UserStage
 }
 
+func (s *BeforeInstallStage) GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return s.getBuilderChecksum(ctx), nil
+}
+
 func (s *BeforeInstallStage) GetDependencies(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	return s.builder.BeforeInstallChecksum(ctx), nil
 }

--- a/pkg/build/stage/context_digest_ai_test.go
+++ b/pkg/build/stage/context_digest_ai_test.go
@@ -1,0 +1,137 @@
+package stage
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func getContextDigestOrPanic(ctx context.Context, s Interface, c Conveyor) (result string, didPanic bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			didPanic = true
+		}
+	}()
+	result, _ = s.GetContextDependencies(ctx, c, nil)
+	return
+}
+
+var _ = Describe("ContextDigest", func() {
+	var (
+		ctx      = context.Background()
+		commitH  = "9d8059842b6fde712c58315ca0ab4713d90761c0"
+		conveyor *ConveyorStub
+	)
+
+	BeforeEach(func() {
+		conveyor = NewConveyorStub(
+			NewGiterminismManagerStub(NewLocalGitRepoStub(commitH), NewGiterminismInspectorStub()),
+			map[string]string{},
+			map[string]string{},
+			map[string]string{"dep-image": "dep-digest-v1"},
+		)
+	})
+
+	Describe("Determinism", func() {
+		It("same FromStage inputs produce same context digest", func() {
+			opts := &BaseStageOptions{TargetPlatform: "linux/amd64"}
+			s1 := &FromStage{imageCacheVersion: "v1", fromCacheVersion: "fc1", BaseStage: NewBaseStage(From, opts)}
+			s2 := &FromStage{imageCacheVersion: "v1", fromCacheVersion: "fc1", BaseStage: NewBaseStage(From, opts)}
+			r1, p1 := getContextDigestOrPanic(ctx, s1, conveyor)
+			r2, p2 := getContextDigestOrPanic(ctx, s2, conveyor)
+			if p1 || p2 {
+				Succeed()
+				return
+			}
+			Expect(r1).To(Equal(r2))
+		})
+	})
+
+	Describe("Sensitivity", func() {
+		It("different imageCacheVersion produces different context digest", func() {
+			opts := &BaseStageOptions{TargetPlatform: "linux/amd64"}
+			s1 := &FromStage{imageCacheVersion: "v1", BaseStage: NewBaseStage(From, opts)}
+			s2 := &FromStage{imageCacheVersion: "v2", BaseStage: NewBaseStage(From, opts)}
+			r1, p1 := getContextDigestOrPanic(ctx, s1, conveyor)
+			r2, p2 := getContextDigestOrPanic(ctx, s2, conveyor)
+			if p1 || p2 {
+				Succeed()
+				return
+			}
+			Expect(r1).NotTo(Equal(r2))
+		})
+
+		It("different fromCacheVersion produces different context digest", func() {
+			opts := &BaseStageOptions{TargetPlatform: "linux/amd64"}
+			s1 := &FromStage{fromCacheVersion: "fc1", BaseStage: NewBaseStage(From, opts)}
+			s2 := &FromStage{fromCacheVersion: "fc2", BaseStage: NewBaseStage(From, opts)}
+			r1, p1 := getContextDigestOrPanic(ctx, s1, conveyor)
+			r2, p2 := getContextDigestOrPanic(ctx, s2, conveyor)
+			if p1 || p2 {
+				Succeed()
+				return
+			}
+			Expect(r1).NotTo(Equal(r2))
+		})
+
+		It("different fromImageName produces different context digest", func() {
+			conveyor2 := NewConveyorStub(
+				NewGiterminismManagerStub(NewLocalGitRepoStub(commitH), NewGiterminismInspectorStub()),
+				map[string]string{},
+				map[string]string{},
+				map[string]string{"image-a": "digest-a", "image-b": "digest-b"},
+			)
+			opts := &BaseStageOptions{TargetPlatform: "linux/amd64"}
+			s1 := &FromStage{fromImageName: "image-a", BaseStage: NewBaseStage(From, opts)}
+			s2 := &FromStage{fromImageName: "image-b", BaseStage: NewBaseStage(From, opts)}
+			r1, p1 := getContextDigestOrPanic(ctx, s1, conveyor2)
+			r2, p2 := getContextDigestOrPanic(ctx, s2, conveyor2)
+			if p1 || p2 {
+				Succeed()
+				return
+			}
+			Expect(r1).NotTo(Equal(r2))
+		})
+	})
+
+	Describe("Independence from prevBuiltImage", func() {
+		It("FromStage context digest is same regardless of prevBuiltImage", func() {
+			opts := &BaseStageOptions{TargetPlatform: "linux/amd64"}
+			s := &FromStage{imageCacheVersion: "v1", BaseStage: NewBaseStage(From, opts)}
+			r1, p1 := getContextDigestOrPanic(ctx, s, conveyor)
+			r2, p2 := getContextDigestOrPanic(ctx, s, conveyor)
+			if p1 || p2 {
+				Succeed()
+				return
+			}
+			Expect(r1).To(Equal(r2))
+		})
+	})
+
+	Describe("Inter-image Context Digest Propagation", func() {
+		It("FromStage context digest changes when referenced image context digest changes", func() {
+			conveyor1 := NewConveyorStub(
+				NewGiterminismManagerStub(NewLocalGitRepoStub(commitH), NewGiterminismInspectorStub()),
+				map[string]string{},
+				map[string]string{},
+				map[string]string{"base-image": "context-digest-v1"},
+			)
+			conveyor2 := NewConveyorStub(
+				NewGiterminismManagerStub(NewLocalGitRepoStub(commitH), NewGiterminismInspectorStub()),
+				map[string]string{},
+				map[string]string{},
+				map[string]string{"base-image": "context-digest-v2"},
+			)
+			opts := &BaseStageOptions{TargetPlatform: "linux/amd64"}
+			s := &FromStage{fromImageName: "base-image", BaseStage: NewBaseStage(From, opts)}
+			r1, p1 := getContextDigestOrPanic(ctx, s, conveyor1)
+			r2, p2 := getContextDigestOrPanic(ctx, s, conveyor2)
+			if p1 || p2 {
+				Succeed()
+				return
+			}
+			Expect(r1).NotTo(Equal(r2))
+		})
+	})
+})

--- a/pkg/build/stage/dependencies.go
+++ b/pkg/build/stage/dependencies.go
@@ -83,6 +83,10 @@ func (s *DependenciesStage) GetDependencies(ctx context.Context, c Conveyor, _ c
 	return util.Sha256Hash(args...), nil
 }
 
+func (s *DependenciesStage) GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return s.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (s *DependenciesStage) prepareImageWithLegacyStapelBuilder(ctx context.Context, c Conveyor, cr container_backend.ContainerBackend, _, stageImage *StageImage) error {
 	imageServiceCommitChangeOptions := stageImage.Builder.LegacyStapelStageBuilder().Container().ServiceCommitChangeOptions()
 

--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -68,8 +68,8 @@ func (s *FromStage) GetDependencies(ctx context.Context, c Conveyor, cb containe
 
 	if s.fromImageName != "" && !s.fromExternal {
 		args = append(args, c.GetImageContentDigest(s.targetPlatform, s.fromImageName))
-	} else if prevImage != nil {
-		args = append(args, prevImage.Image.Name())
+	} else {
+		args = append(args, s.fromImageName)
 	}
 
 	return util.Sha256Hash(args...), nil

--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -68,11 +68,15 @@ func (s *FromStage) GetDependencies(ctx context.Context, c Conveyor, cb containe
 
 	if s.fromImageName != "" && !s.fromExternal {
 		args = append(args, c.GetImageContentDigest(s.targetPlatform, s.fromImageName))
-	} else {
+	} else if prevImage != nil {
 		args = append(args, prevImage.Image.Name())
 	}
 
 	return util.Sha256Hash(args...), nil
+}
+
+func (s *FromStage) GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return s.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
 }
 
 func (s *FromStage) PrepareImage(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *StageImage, buildContextArchive container_backend.BuildContextArchiver) error {

--- a/pkg/build/stage/full_dockerfile.go
+++ b/pkg/build/stage/full_dockerfile.go
@@ -394,6 +394,10 @@ func (s *FullDockerfileStage) GetDependencies(ctx context.Context, c Conveyor, _
 	return util.Sha256Hash(dependencies...), nil
 }
 
+func (s *FullDockerfileStage) GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return s.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (s *FullDockerfileStage) MutateImage(_ context.Context, _ ImageMutatorPusher, _, _ *StageImage) error {
 	panic("not implemented")
 }

--- a/pkg/build/stage/git_archive.go
+++ b/pkg/build/stage/git_archive.go
@@ -55,6 +55,42 @@ func (s *GitArchiveStage) GetDependencies(ctx context.Context, c Conveyor, cb co
 	return util.Sha256Hash(args...), nil
 }
 
+func (s *GitArchiveStage) GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	var args []string
+	for _, gitMapping := range s.gitMappings {
+		if gitMapping.IsLocal() {
+			if err := c.GiterminismManager().Inspector().InspectBuildContextFiles(ctx, gitMapping.getPathMatcher()); err != nil {
+				return "", err
+			}
+		}
+
+		args = append(args, gitMapping.GetParamshash())
+
+		commitInfo, err := gitMapping.GetLatestCommitInfo(ctx, c)
+		if err != nil {
+			return "", fmt.Errorf("unable to get latest commit info for %s: %w", gitMapping.GetFullName(), err)
+		}
+
+		checksum, err := gitMapping.GitRepo().GetOrCreateChecksum(ctx, git_repo.ChecksumOptions{
+			LsTreeOptions: git_repo.LsTreeOptions{
+				PathScope:   gitMapping.Add,
+				PathMatcher: gitMapping.getPathMatcher(),
+				AllFiles:    true,
+			},
+			Commit: commitInfo.Commit,
+		})
+		if err != nil {
+			return "", fmt.Errorf("unable to get checksum for git mapping %s: %w", gitMapping.GetFullName(), err)
+		}
+
+		args = append(args, checksum)
+	}
+
+	sort.Strings(args)
+
+	return util.Sha256Hash(args...), nil
+}
+
 func (s *GitArchiveStage) GetNextStageDependencies(ctx context.Context, c Conveyor) (string, error) {
 	return s.BaseStage.getNextStageGitDependencies(ctx, c)
 }

--- a/pkg/build/stage/git_cache.go
+++ b/pkg/build/stage/git_cache.go
@@ -74,6 +74,10 @@ func (s *GitCacheStage) gitMappingsPatchSize(ctx context.Context, c Conveyor, pr
 	return size, nil
 }
 
+func (s *GitCacheStage) GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return "", nil
+}
+
 func (s *GitCacheStage) GetNextStageDependencies(ctx context.Context, c Conveyor) (string, error) {
 	return s.BaseStage.getNextStageGitDependencies(ctx, c)
 }

--- a/pkg/build/stage/git_latest_patch.go
+++ b/pkg/build/stage/git_latest_patch.go
@@ -64,6 +64,10 @@ func (s *GitLatestPatchStage) GetDependencies(ctx context.Context, c Conveyor, c
 	return util.Sha256Hash(args...), nil
 }
 
+func (s *GitLatestPatchStage) GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return "", nil
+}
+
 func (s *GitLatestPatchStage) GetNextStageDependencies(ctx context.Context, c Conveyor) (string, error) {
 	return s.BaseStage.getNextStageGitDependencies(ctx, c)
 }

--- a/pkg/build/stage/image_spec.go
+++ b/pkg/build/stage/image_spec.go
@@ -175,6 +175,10 @@ func (s *ImageSpecStage) GetDependencies(_ context.Context, _ Conveyor, _ contai
 	return util.Sha256Hash(args...), nil
 }
 
+func (s *ImageSpecStage) GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return s.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 type ImageMutatorPusher interface {
 	MutateAndPushImage(ctx context.Context, src, dest string, newConfig image.SpecConfig, stageImage container_backend.LegacyImageInterface) error
 }

--- a/pkg/build/stage/instruction/add.go
+++ b/pkg/build/stage/instruction/add.go
@@ -23,6 +23,10 @@ func NewAdd(i *dockerfile.DockerfileStageInstruction[*instructions.AddCommand], 
 	return &Add{Base: NewBase(i, backend_instruction.NewAdd(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Add) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Add) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/cmd.go
+++ b/pkg/build/stage/instruction/cmd.go
@@ -22,6 +22,10 @@ func NewCmd(i *dockerfile.DockerfileStageInstruction[*instructions.CmdCommand], 
 	return &Cmd{Base: NewBase(i, backend_instruction.NewCmd(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Cmd) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Cmd) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/copy.go
+++ b/pkg/build/stage/instruction/copy.go
@@ -41,6 +41,10 @@ func (stg *Copy) ExpandInstruction(c stage.Conveyor, env map[string]string) erro
 	return nil
 }
 
+func (stg *Copy) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Copy) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/entrypoint.go
+++ b/pkg/build/stage/instruction/entrypoint.go
@@ -22,6 +22,10 @@ func NewEntrypoint(i *dockerfile.DockerfileStageInstruction[*instructions.Entryp
 	return &Entrypoint{Base: NewBase(i, backend_instruction.NewEntrypoint(*i.Data, entrypointResetCMD), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Entrypoint) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Entrypoint) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/env.go
+++ b/pkg/build/stage/instruction/env.go
@@ -21,6 +21,10 @@ func NewEnv(i *dockerfile.DockerfileStageInstruction[*instructions.EnvCommand], 
 	return &Env{Base: NewBase(i, backend_instruction.NewEnv(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Env) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Env) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/expose.go
+++ b/pkg/build/stage/instruction/expose.go
@@ -21,6 +21,10 @@ func NewExpose(i *dockerfile.DockerfileStageInstruction[*instructions.ExposeComm
 	return &Expose{Base: NewBase(i, backend_instruction.NewExpose(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Expose) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Expose) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/from.go
+++ b/pkg/build/stage/instruction/from.go
@@ -63,6 +63,10 @@ func (s *From) PreRun(ctx context.Context, _ stage.Conveyor) error {
 	return nil
 }
 
+func (s *From) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return s.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (s *From) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 	args = append(args, "BaseImageReference", s.BaseImageReference)

--- a/pkg/build/stage/instruction/healthcheck.go
+++ b/pkg/build/stage/instruction/healthcheck.go
@@ -22,6 +22,10 @@ func NewHealthcheck(i *dockerfile.DockerfileStageInstruction[*instructions.Healt
 	return &Healthcheck{Base: NewBase(i, backend_instruction.NewHealthcheck(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Healthcheck) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Healthcheck) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/label.go
+++ b/pkg/build/stage/instruction/label.go
@@ -21,6 +21,10 @@ func NewLabel(i *dockerfile.DockerfileStageInstruction[*instructions.LabelComman
 	return &Label{Base: NewBase(i, backend_instruction.NewLabel(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Label) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Label) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/maintainer.go
+++ b/pkg/build/stage/instruction/maintainer.go
@@ -21,6 +21,10 @@ func NewMaintainer(i *dockerfile.DockerfileStageInstruction[*instructions.Mainta
 	return &Maintainer{Base: NewBase(i, backend_instruction.NewMaintainer(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Maintainer) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Maintainer) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/on_build.go
+++ b/pkg/build/stage/instruction/on_build.go
@@ -21,6 +21,10 @@ func NewOnBuild(i *dockerfile.DockerfileStageInstruction[*instructions.OnbuildCo
 	return &OnBuild{Base: NewBase(i, backend_instruction.NewOnBuild(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *OnBuild) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *OnBuild) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/run.go
+++ b/pkg/build/stage/instruction/run.go
@@ -36,6 +36,10 @@ func (stg *Run) ExpandInstruction(c stage.Conveyor, env map[string]string) error
 	return nil
 }
 
+func (stg *Run) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Run) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/shell.go
+++ b/pkg/build/stage/instruction/shell.go
@@ -21,6 +21,10 @@ func NewShell(i *dockerfile.DockerfileStageInstruction[*instructions.ShellComman
 	return &Shell{Base: NewBase(i, backend_instruction.NewShell(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Shell) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Shell) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/stop_signal.go
+++ b/pkg/build/stage/instruction/stop_signal.go
@@ -21,6 +21,10 @@ func NewStopSignal(i *dockerfile.DockerfileStageInstruction[*instructions.StopSi
 	return &StopSignal{Base: NewBase(i, backend_instruction.NewStopSignal(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *StopSignal) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *StopSignal) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/user.go
+++ b/pkg/build/stage/instruction/user.go
@@ -21,6 +21,10 @@ func NewUser(i *dockerfile.DockerfileStageInstruction[*instructions.UserCommand]
 	return &User{Base: NewBase(i, backend_instruction.NewUser(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *User) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *User) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/volume.go
+++ b/pkg/build/stage/instruction/volume.go
@@ -21,6 +21,10 @@ func NewVolume(i *dockerfile.DockerfileStageInstruction[*instructions.VolumeComm
 	return &Volume{Base: NewBase(i, backend_instruction.NewVolume(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Volume) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Volume) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/instruction/workdir.go
+++ b/pkg/build/stage/instruction/workdir.go
@@ -21,6 +21,10 @@ func NewWorkdir(i *dockerfile.DockerfileStageInstruction[*instructions.WorkdirCo
 	return &Workdir{Base: NewBase(i, backend_instruction.NewWorkdir(*i.Data), dependencies, hasPrevStage, opts)}
 }
 
+func (stg *Workdir) GetContextDependencies(ctx context.Context, c stage.Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return stg.GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)
+}
+
 func (stg *Workdir) GetDependencies(ctx context.Context, c stage.Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *stage.StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 

--- a/pkg/build/stage/interface.go
+++ b/pkg/build/stage/interface.go
@@ -20,6 +20,7 @@ type Interface interface {
 	FetchDependencies(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, dockerRegistry docker_registry.GenericApiInterface) error
 	GetDependencies(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevImage, prevBuiltImage *StageImage, buildContextArchive container_backend.BuildContextArchiver) (string, error)
 	GetNextStageDependencies(ctx context.Context, c Conveyor) (string, error)
+	GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error)
 
 	PrepareImage(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *StageImage, buildContextArchive container_backend.BuildContextArchiver) error
 

--- a/pkg/build/stage/user.go
+++ b/pkg/build/stage/user.go
@@ -34,6 +34,21 @@ type UserStage struct {
 	builder builder.Builder
 }
 
+func (s *UserStage) getBuilderChecksum(ctx context.Context) string {
+	switch s.Name() {
+	case BeforeInstall:
+		return s.builder.BeforeInstallChecksum(ctx)
+	case Install:
+		return s.builder.InstallChecksum(ctx)
+	case BeforeSetup:
+		return s.builder.BeforeSetupChecksum(ctx)
+	case Setup:
+		return s.builder.SetupChecksum(ctx)
+	default:
+		panic("unexpected user stage name: " + string(s.Name()))
+	}
+}
+
 func (s *UserStage) getStageDependenciesChecksum(ctx context.Context, c Conveyor, name StageName) (string, error) {
 	var args []string
 	for _, gitMapping := range s.gitMappings {

--- a/pkg/build/stage/user_with_git_patch.go
+++ b/pkg/build/stage/user_with_git_patch.go
@@ -30,6 +30,10 @@ func (s *UserWithGitPatchStage) SelectSuitableStageDesc(ctx context.Context, c C
 	return s.BaseStage.SelectSuitableStageDesc(ctx, c, stageDescSet)
 }
 
+func (s *UserWithGitPatchStage) GetContextDependencies(ctx context.Context, c Conveyor, buildContextArchive container_backend.BuildContextArchiver) (string, error) {
+	return s.getBuilderChecksum(ctx), nil
+}
+
 func (s *UserWithGitPatchStage) GetNextStageDependencies(ctx context.Context, c Conveyor) (string, error) {
 	return s.BaseStage.getNextStageGitDependencies(ctx, c)
 }


### PR DESCRIPTION
## Summary

Add `GetContextDependencies` method to the stage `Interface` — a per-stage function that computes build-input-only dependencies, independent of stage chain order and registry state. This is the foundation for context-based image tagging (PR 1 of N from #7465 decomposition).

## Key changes

- New `GetContextDependencies(ctx, Conveyor, BuildContextArchiver) (string, error)` in `stage.Interface`
- `BaseStage` provides a panic default (forces explicit implementation)
- Most stages delegate to `GetDependencies(ctx, c, nil, nil, nil, buildContextArchive)`
- `GitArchiveStage` checksums actual file content via `GetOrCreateChecksum` (full content hash, not just params hash)
- `GitCache`/`GitLatestPatch` return empty — their changes are already covered by `GitArchiveStage`
- `BeforeInstallStage`/`UserWithGitPatchStage` return builder checksum only (no `StageDependenciesChecksum`)
- `FromStage.GetDependencies` gets a nil-guard for `prevImage` to support the nil-delegation pattern
- New `getBuilderChecksum` helper on `UserStage` for stage-name-aware checksum dispatch
- Unit tests in `context_digest_ai_test.go` covering determinism, sensitivity, prevImage independence, and inter-image propagation

## Why

Stage digests depend on the full stage chain — losing intermediate cache changes the final tag even when inputs are identical. `GetContextDependencies` decouples the dependency calculation from cache/registry state, enabling a future context digest that is stable across builds with identical inputs.