### PR TITLE
fix(compose): show docker compose config error instead of bare exit code

### DIFF
--- a/cmd/werf/compose/main.go
+++ b/cmd/werf/compose/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
-	"github.com/werf/common-go/pkg/graceful"
 	"github.com/werf/logboek"
 	"github.com/werf/werf/v2/cmd/werf/common"
 	"github.com/werf/werf/v2/pkg/build"
@@ -112,7 +111,7 @@ func extractImageNamesFromComposeConfig(ctx context.Context, customConfigPathLis
 
 	err := cmd.Run()
 	if err != nil {
-		graceful.Terminate(ctx, err, werfExec.ExitCode(err))
+		werfExec.TerminateIfCanceled(ctx)
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {
 			return nil, fmt.Errorf("error running command %q: %w\n\nStdout:\n%s\nStderr:\n%s", cmd, err, stdout.String(), stderr.String())


### PR DESCRIPTION
## Summary

When `docker compose config --no-interpolate` fails during `werf compose up`, the user only sees `Error: exit status 125` with no explanation. This PR fixes the error to include the actual stdout/stderr from the failed command.

## Key changes

- `cmd/werf/compose/main.go`: replace `graceful.Terminate(ctx, err, werfExec.ExitCode(err))` with `werfExec.TerminateIfCanceled(ctx)` in `extractImageNamesFromComposeConfig`
- Remove unused `"github.com/werf/common-go/pkg/graceful"` import

## Why

`graceful.Terminate` killed the process immediately before the detailed error message (containing captured stdout/stderr from `docker compose config`) could be constructed and returned. The user saw only a bare exit code with no way to diagnose the root cause. Now the error propagates normally through the standard error path, matching the pattern used by the main docker compose invocation at line 557.

## Review focus / risks

- The only behavioral change is that `docker compose config` failures no longer call `graceful.Terminate` — they return a descriptive error instead. Context cancellation is still handled via `TerminateIfCanceled`.
- No risk to other code paths: this was the only `graceful.Terminate` call outside of `main.go` and `run.go` (both of which are correct top-level termination points).