### PR TITLE
fix(build): show "default" in log network field when no explicit network is set

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -598,6 +598,9 @@ func (phase *BuildPhase) getLogImageNetwork(img *image.Image) string {
 			network = img.StapelImageConfig.ImageBaseConfig().Network
 		}
 	}
+	if network == "" {
+		network = "default"
+	}
 	return network
 }
 

--- a/test/e2e/build/network_test.go
+++ b/test/e2e/build/network_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Network isolation build", Label("e2e", "build", "network"), fu
 				if testOpts.ExpectNetworkValue != "" {
 					Expect(buildOut).To(ContainSubstring("network: " + testOpts.ExpectNetworkValue))
 				} else {
-					Expect(buildOut).To(ContainSubstring("network:"))
+					Expect(buildOut).To(ContainSubstring("network: default"))
 				}
 			}
 		},


### PR DESCRIPTION
When no network mode is specified via --backend-network CLI flag or werf.yaml image config, the build log shows an empty "network:" field. This is misleading because the default bridge network is still used.

Return "default" from getLogImageNetwork when the resolved value is empty, making the log output clear and consistent with the actual behavior of both Docker and Buildah backends.