### PR TITLE
test(build): eliminate race between context timeout and goroutine startup in tests

### DIFF
--- a/pkg/util/parallel/parallel_test.go
+++ b/pkg/util/parallel/parallel_test.go
@@ -32,6 +32,9 @@ var _ = DescribeTable("parallel task",
 		output := newSpyOutput(numberOfTasks)
 		ctx = logboek.NewContext(ctx, logboek.NewLogger(output, output))
 
+		// tmp_manager requires werf init
+		Expect(werf.Init(GinkgoT().TempDir(), "")).To(Succeed())
+
 		// Force GC to get timers more predictable for being able to rely on them
 		runtime.GC()
 
@@ -40,9 +43,6 @@ var _ = DescribeTable("parallel task",
 			ctx, cancel = context.WithTimeout(ctx, parallelExecutionLimit)
 			defer cancel()
 		}
-
-		// tmp_manager requires werf init
-		Expect(werf.Init(GinkgoT().TempDir(), "")).To(Succeed())
 
 		err := parallel.DoTasks(ctx, numberOfTasks, options, spyTask.Callback)
 
@@ -198,7 +198,7 @@ var _ = DescribeTable("parallel task",
 	),
 	Entry(
 		"should cancel execution via context for all workers",
-		time.Second,
+		3*time.Second,
 		4,
 		parallel.DoTasksOptions{
 			MaxNumberOfWorkers: 2,
@@ -261,7 +261,7 @@ var _ = DescribeTable("parallel task",
 	),
 	Entry(
 		"should cancel execution of second task per single worker if 1-st task is canceled",
-		time.Second,
+		3*time.Second,
 		2,
 		parallel.DoTasksOptions{
 			MaxNumberOfWorkers: 1,


### PR DESCRIPTION
- Move werf.Init before the timeout context creation so initialization
  overhead doesn't eat into the timeout window.
- Move runtime.GC() immediately before WithTimeout so GC doesn't
  interfere with timer reliability.
- Increase timeout from 1s to 3s for the two DeadlineExceeded tests to
  give goroutines ample time to be scheduled in slow CI environments.