### PR TITLE
fix(build): non-local synchronization server requires --repo be set

### DIFF
--- a/cmd/werf/common/synchronization.go
+++ b/cmd/werf/common/synchronization.go
@@ -100,6 +100,9 @@ func GetSynchronization(ctx context.Context, cmdData *CmdData, projectName strin
 		ServerAddress: *cmdData.Synchronization,
 		StagesStorage: stagesStorage,
 	}
+	if params.ServerAddress != "" && !protocolIsLocal(params.ServerAddress) && protocolIsLocal(params.StagesStorage.Address()) {
+		return nil, fmt.Errorf("--synchronization (or WERF_SYNCHRONIZATION) is set to %q but --repo (or WERF_REPO) is not specified: --repo is required when using a non-local synchronization server", params.ServerAddress)
+	}
 
 	if params.ServerAddress == "" {
 		return initDefault(ctx, params)


### PR DESCRIPTION
When --synchronization (or WERF_SYNCHRONIZATION) is set to a non-local value (http://, https://, kubernetes://) without --repo (or WERF_REPO), werf panics with "not implemented" in
LocalStagesStorage.GetClientIDRecords.

Add an early validation in GetSynchronization that returns a clear error when non-local synchronization is configured but no remote repo is specified.