### PR TITLE
refactor(build): set current commit label for dependency stages

### DIFF
--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -365,15 +365,13 @@ func (s *BaseStage) PrepareImage(ctx context.Context, c Conveyor, cb container_b
 	return nil
 }
 
-func (s *BaseStage) addProjectRepoCommitLabel(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, stageImage *StageImage) map[string]string {
+func (s *BaseStage) addProjectRepoCommitLabel(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, stageImage *StageImage) {
 	addLabels := map[string]string{image.WerfProjectRepoCommitLabel: c.GiterminismManager().HeadCommit(ctx)}
 	if c.UseLegacyStapelBuilder(cb) {
 		stageImage.Builder.LegacyStapelStageBuilder().Container().ServiceCommitChangeOptions().AddLabel(addLabels)
 	} else {
 		stageImage.Builder.StapelStageBuilder().AddLabels(addLabels)
 	}
-
-	return addLabels
 }
 
 func (s *BaseStage) MutateImage(_ context.Context, _ ImageMutatorPusher, _, _ *StageImage) error {

--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -340,12 +340,7 @@ func (s *BaseStage) PrepareImage(ctx context.Context, c Conveyor, cb container_b
 	 * NOTE: Take into account when adding new base PrepareImage steps.
 	 */
 
-	addLabels := map[string]string{image.WerfProjectRepoCommitLabel: c.GiterminismManager().HeadCommit(ctx)}
-	if c.UseLegacyStapelBuilder(cb) {
-		stageImage.Builder.LegacyStapelStageBuilder().Container().ServiceCommitChangeOptions().AddLabel(addLabels)
-	} else {
-		stageImage.Builder.StapelStageBuilder().AddLabels(addLabels)
-	}
+	s.addProjectRepoCommitLabel(ctx, c, cb, stageImage)
 
 	if s.network != "" {
 		if c.UseLegacyStapelBuilder(cb) {
@@ -368,6 +363,17 @@ func (s *BaseStage) PrepareImage(ctx context.Context, c Conveyor, cb container_b
 	}
 
 	return nil
+}
+
+func (s *BaseStage) addProjectRepoCommitLabel(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, stageImage *StageImage) map[string]string {
+	addLabels := map[string]string{image.WerfProjectRepoCommitLabel: c.GiterminismManager().HeadCommit(ctx)}
+	if c.UseLegacyStapelBuilder(cb) {
+		stageImage.Builder.LegacyStapelStageBuilder().Container().ServiceCommitChangeOptions().AddLabel(addLabels)
+	} else {
+		stageImage.Builder.StapelStageBuilder().AddLabels(addLabels)
+	}
+
+	return addLabels
 }
 
 func (s *BaseStage) MutateImage(_ context.Context, _ ImageMutatorPusher, _, _ *StageImage) error {

--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -366,7 +366,12 @@ func (s *BaseStage) PrepareImage(ctx context.Context, c Conveyor, cb container_b
 }
 
 func (s *BaseStage) addProjectRepoCommitLabel(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, stageImage *StageImage) {
-	addLabels := map[string]string{image.WerfProjectRepoCommitLabel: c.GiterminismManager().HeadCommit(ctx)}
+	headCommit := c.GiterminismManager().HeadCommit(ctx)
+	if headCommit == "" {
+		return
+	}
+
+	addLabels := map[string]string{image.WerfProjectRepoCommitLabel: headCommit}
 	if c.UseLegacyStapelBuilder(cb) {
 		stageImage.Builder.LegacyStapelStageBuilder().Container().ServiceCommitChangeOptions().AddLabel(addLabels)
 	} else {

--- a/pkg/build/stage/dependencies.go
+++ b/pkg/build/stage/dependencies.go
@@ -287,6 +287,8 @@ func (s *DependenciesStage) prepareImage(ctx context.Context, c Conveyor, cr con
 }
 
 func (s *DependenciesStage) PrepareImage(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *StageImage, buildContextArchive container_backend.BuildContextArchiver) error {
+	s.addProjectRepoCommitLabel(ctx, c, cb, stageImage)
+
 	if c.UseLegacyStapelBuilder(cb) {
 		return s.prepareImageWithLegacyStapelBuilder(ctx, c, cb, prevBuiltImage, stageImage)
 	} else {

--- a/pkg/build/stage/dependencies_test.go
+++ b/pkg/build/stage/dependencies_test.go
@@ -274,6 +274,20 @@ var _ = Describe("DependenciesStage", func() {
 			Expect(stageBuilder.GetStapelStageBuilderImplementation()).NotTo(BeNil())
 			Expect(stageBuilder.GetStapelStageBuilderImplementation().Labels).To(ContainElement(fmt.Sprintf("%s=%s", image.WerfProjectRepoCommitLabel, commit)))
 		})
+
+		It("should not set empty commit label for legacy stapel builder", func(ctx SpecContext) {
+			conveyor := NewConveyorStubForDependencies(NewGiterminismManagerStub(NewLocalGitRepoStub(""), NewGiterminismInspectorStub()), nil)
+			containerBackend := NewContainerBackendStub()
+			stage := newDependenciesStage(nil, nil, DependenciesAfterSetup, &BaseStageOptions{
+				ImageName:   "example-image",
+				ProjectName: "example-project",
+			})
+
+			img, _, stageImage := newStageImage(containerBackend)
+
+			Expect(stage.PrepareImage(ctx, conveyor, containerBackend, nil, stageImage, nil)).To(Succeed())
+			Expect(img._Container._ServiceCommitChangeOptions.Labels).NotTo(HaveKey(image.WerfProjectRepoCommitLabel))
+		})
 	})
 })
 

--- a/pkg/build/stage/dependencies_test.go
+++ b/pkg/build/stage/dependencies_test.go
@@ -7,7 +7,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/werf/werf/v2/pkg/config"
+	"github.com/werf/werf/v2/pkg/container_backend"
 	"github.com/werf/werf/v2/pkg/container_backend/stage_builder"
+	"github.com/werf/werf/v2/pkg/image"
 )
 
 var _ = Describe("DependenciesStage", func() {
@@ -230,6 +232,49 @@ var _ = Describe("DependenciesStage", func() {
 				},
 			}),
 	)
+
+	Describe("setting project repo commit label", func() {
+		const commit = "9d8059842b6fde712c58315ca0ab4713d90761c0"
+
+		newStageImage := func(containerBackend *ContainerBackendStub) (*LegacyImageStub, *stage_builder.StageBuilder, *StageImage) {
+			img := NewLegacyImageStub()
+			stageBuilder := stage_builder.NewStageBuilder(containerBackend, "", img)
+
+			return img, stageBuilder, &StageImage{
+				Image:   img,
+				Builder: stageBuilder,
+			}
+		}
+
+		It("should set current commit label for legacy stapel builder", func(ctx SpecContext) {
+			conveyor := NewConveyorStubForDependencies(NewGiterminismManagerStub(NewLocalGitRepoStub(commit), NewGiterminismInspectorStub()), nil)
+			containerBackend := NewContainerBackendStub()
+			stage := newDependenciesStage(nil, nil, DependenciesAfterSetup, &BaseStageOptions{
+				ImageName:   "example-image",
+				ProjectName: "example-project",
+			})
+
+			img, _, stageImage := newStageImage(containerBackend)
+
+			Expect(stage.PrepareImage(ctx, conveyor, containerBackend, nil, stageImage, nil)).To(Succeed())
+			Expect(img._Container._ServiceCommitChangeOptions.Labels[image.WerfProjectRepoCommitLabel]).To(Equal(commit))
+		})
+
+		It("should set current commit label for stapel builder", func(ctx SpecContext) {
+			conveyor := &nonLegacyDependenciesConveyorStub{ConveyorStub: NewConveyorStubForDependencies(NewGiterminismManagerStub(NewLocalGitRepoStub(commit), NewGiterminismInspectorStub()), nil)}
+			containerBackend := NewContainerBackendStub()
+			stage := newDependenciesStage(nil, nil, DependenciesAfterSetup, &BaseStageOptions{
+				ImageName:   "example-image",
+				ProjectName: "example-project",
+			})
+
+			_, stageBuilder, stageImage := newStageImage(containerBackend)
+
+			Expect(stage.PrepareImage(ctx, conveyor, containerBackend, nil, stageImage, nil)).To(Succeed())
+			Expect(stageBuilder.GetStapelStageBuilderImplementation()).NotTo(BeNil())
+			Expect(stageBuilder.GetStapelStageBuilderImplementation().Labels).To(ContainElement(fmt.Sprintf("%s=%s", image.WerfProjectRepoCommitLabel, commit)))
+		})
+	})
 })
 
 var _ = Describe("getDependencies helper", func() {
@@ -305,4 +350,12 @@ func NewConveyorStubForDependencies(giterminismManager *GiterminismManagerStub, 
 	}
 
 	return NewConveyorStub(giterminismManager, lastStageImageNameByImageName, lastStageImageIDByImageName, lastStageImageDigestByImageName)
+}
+
+type nonLegacyDependenciesConveyorStub struct {
+	*ConveyorStub
+}
+
+func (c *nonLegacyDependenciesConveyorStub) UseLegacyStapelBuilder(container_backend.ContainerBackend) bool {
+	return false
 }

--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -95,19 +95,21 @@ func (s *FromStage) GetDependencies(_ context.Context, c Conveyor, _ container_b
 }
 
 func (s *FromStage) PrepareImage(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *StageImage, _ container_backend.BuildContextArchiver) error {
-	addLabels := map[string]string{imagePkg.WerfProjectRepoCommitLabel: c.GiterminismManager().HeadCommit(ctx)}
 	s.addProjectRepoCommitLabel(ctx, c, cb, stageImage)
 
 	// For scratch there is no builder execution, so labels added only to the builder would be lost.
 	// Merge them into the build service labels used later by MutateImage.
 	if s.fromScratch {
+		headCommit := c.GiterminismManager().HeadCommit(ctx)
+		if headCommit == "" {
+			return nil
+		}
+
 		serviceLabels := stageImage.Image.GetBuildServiceLabels()
 		if serviceLabels == nil {
 			serviceLabels = map[string]string{}
 		}
-		for key, value := range addLabels {
-			serviceLabels[key] = value
-		}
+		serviceLabels[imagePkg.WerfProjectRepoCommitLabel] = headCommit
 		stageImage.Image.SetBuildServiceLabels(serviceLabels)
 		return nil
 	}

--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -95,12 +95,7 @@ func (s *FromStage) GetDependencies(_ context.Context, c Conveyor, _ container_b
 }
 
 func (s *FromStage) PrepareImage(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *StageImage, _ container_backend.BuildContextArchiver) error {
-	addLabels := map[string]string{imagePkg.WerfProjectRepoCommitLabel: c.GiterminismManager().HeadCommit(ctx)}
-	if c.UseLegacyStapelBuilder(cb) {
-		stageImage.Builder.LegacyStapelStageBuilder().Container().ServiceCommitChangeOptions().AddLabel(addLabels)
-	} else {
-		stageImage.Builder.StapelStageBuilder().AddLabels(addLabels)
-	}
+	addLabels := s.addProjectRepoCommitLabel(ctx, c, cb, stageImage)
 
 	// For scratch there is no builder execution, so labels added only to the builder would be lost.
 	// Merge them into the build service labels used later by MutateImage.

--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -95,7 +95,8 @@ func (s *FromStage) GetDependencies(_ context.Context, c Conveyor, _ container_b
 }
 
 func (s *FromStage) PrepareImage(ctx context.Context, c Conveyor, cb container_backend.ContainerBackend, prevBuiltImage, stageImage *StageImage, _ container_backend.BuildContextArchiver) error {
-	addLabels := s.addProjectRepoCommitLabel(ctx, c, cb, stageImage)
+	addLabels := map[string]string{imagePkg.WerfProjectRepoCommitLabel: c.GiterminismManager().HeadCommit(ctx)}
+	s.addProjectRepoCommitLabel(ctx, c, cb, stageImage)
 
 	// For scratch there is no builder execution, so labels added only to the builder would be lost.
 	// Merge them into the build service labels used later by MutateImage.

--- a/pkg/build/stage/from_test.go
+++ b/pkg/build/stage/from_test.go
@@ -106,6 +106,21 @@ var _ = Describe("FromStage", func() {
 			Expect(stage.IsMutable()).To(BeFalse())
 			Expect(stage.HasPrevStage()).To(BeFalse())
 		})
+
+		It("preserves existing commit label when head commit is empty", func(ctx SpecContext) {
+			stage := GenerateFromStage(&config.StapelImageBase{From: "scratch"}, "", "", &BaseStageOptions{})
+			stageImage := NewStageImage(NewContainerBackendStub(), "", newLegacyImageForFromScratchTests("scratch-stage"))
+			stageImage.Image.SetBuildServiceLabels(map[string]string{
+				imagePkg.WerfProjectRepoCommitLabel: "valid-commit",
+			})
+
+			conveyor := NewConveyorStubForDependencies(NewGiterminismManagerStub(NewLocalGitRepoStub(""), NewGiterminismInspectorStub()), nil)
+
+			Expect(stage.PrepareImage(ctx, conveyor, NewContainerBackendStub(), nil, stageImage, nil)).To(Succeed())
+			Expect(stageImage.Image.GetBuildServiceLabels()).To(Equal(map[string]string{
+				imagePkg.WerfProjectRepoCommitLabel: "valid-commit",
+			}))
+		})
 	})
 
 	Describe("MutateImage()", func() {

--- a/pkg/build/stage/full_dockerfile.go
+++ b/pkg/build/stage/full_dockerfile.go
@@ -606,7 +606,9 @@ func (s *FullDockerfileStage) PrepareImage(ctx context.Context, c Conveyor, cb c
 
 	stageImage.Builder.DockerfileBuilder().SetBuildContextArchive(buildContextArchive)
 
-	stageImage.Builder.DockerfileBuilder().AppendLabels(fmt.Sprintf("%s=%s", image.WerfProjectRepoCommitLabel, c.GiterminismManager().HeadCommit(ctx)))
+	if headCommit := c.GiterminismManager().HeadCommit(ctx); headCommit != "" {
+		stageImage.Builder.DockerfileBuilder().AppendLabels(fmt.Sprintf("%s=%s", image.WerfProjectRepoCommitLabel, headCommit))
+	}
 
 	for _, dep := range s.dependencies {
 		depStageID := c.GetStageIDForLastImageStage(s.targetPlatform, dep.ImageName)

--- a/pkg/build/stage/full_dockerfile_test.go
+++ b/pkg/build/stage/full_dockerfile_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/werf/common-go/pkg/util"
 	"github.com/werf/werf/v2/pkg/container_backend/stage_builder"
 	"github.com/werf/werf/v2/pkg/dockerfile/frontend"
+	"github.com/werf/werf/v2/pkg/image"
 	"github.com/werf/werf/v2/pkg/logging"
 )
 
@@ -309,6 +310,26 @@ RUN echo hello
 
 			_, err := stage.GetDependencies(ctx, conveyor, containerBackend, nil, nil, nil)
 			Expect(IsErrInvalidBaseImage(err)).To(BeTrue())
+		})
+	})
+
+	When("head commit is empty", func() {
+		It("should not append project repo commit label", func(ctx SpecContext) {
+			dockerfile := []byte(`
+FROM alpine:latest
+RUN echo hello
+`)
+
+			conveyor := NewConveyorStubForDependencies(NewGiterminismManagerStub(NewLocalGitRepoStub(""), NewGiterminismInspectorStub()), nil)
+			containerBackend := NewContainerBackendStub()
+			dockerStages, dockerMetaArgs := testDockerfileToDockerStages(dockerfile)
+			stage := newTestFullDockerfileStage(dockerfile, "", nil, dockerStages, dockerMetaArgs, nil, "")
+			img := NewLegacyImageStub()
+			stageBuilder := stage_builder.NewStageBuilder(containerBackend, "", img)
+			stageImage := &StageImage{Image: img, Builder: stageBuilder}
+
+			Expect(stage.PrepareImage(ctx, conveyor, containerBackend, nil, stageImage, nil)).To(Succeed())
+			Expect(stageBuilder.GetDockerfileBuilderImplementation().BuildDockerfileOptions.Labels).NotTo(ContainElement(HavePrefix(fmt.Sprintf("%s=", image.WerfProjectRepoCommitLabel))))
 		})
 	})
 


### PR DESCRIPTION
Set the project repo commit label when building dependency stages so freshly rebuilt stages report the current head commit. Before this change dependency stages inherited the label from their base stage, which made rebuilt images log the previous stage commit even after storing a new image.