### PR TITLE
fix(build): drop redundant tags list in PutImageMetadata

### DIFF
--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -560,20 +560,6 @@ func (storage *RepoStagesStorage) ShouldFetchImage(ctx context.Context, img cont
 func (storage *RepoStagesStorage) PutImageMetadata(ctx context.Context, projectName, imageNameOrManagedImageName, commit, stageID string) error {
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.PutImageMetadata %s %s %s %s\n", projectName, imageNameOrManagedImageName, commit, stageID)
 
-	tagName := makeRepoImageMetadataTagName(imageNameOrManagedImageName, commit, stageID)
-	tags, err := storage.Tags(ctx, storage.RepoAddress)
-	if err != nil {
-		return fmt.Errorf("unable to get repo %s tags: %w", storage.RepoAddress, err)
-	}
-
-	for _, tag := range tags {
-		if tag == tagName {
-			logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.PutImageMetadata tag %s already exists, skipping push\n", tagName)
-
-			return nil
-		}
-	}
-
 	fullImageName := makeRepoImageMetadataName(storage.RepoAddress, imageNameOrManagedImageName, commit, stageID)
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.PutImageMetadata full image name: %s\n", fullImageName)
 


### PR DESCRIPTION
## Summary

Remove a redundant full-tags-list HTTP call from `PutImageMetadata` that was executed once per image during the post-build `AfterImages` phase, causing multi-minute delays for projects with many images.

## Key changes

- `pkg/storage/repo_stages_storage.go`: Remove the `Tags()` + linear-scan existence check inside `PutImageMetadata`. The caller (`publishImageGitMetadata`) already performs this check via `IsImageMetadataExist` with a cached tags list before calling `PutImageMetadata`, making the internal listing redundant. This aligns `PutImageMetadata` with the pattern already used by `AddManagedImage`.

## Why

For projects with ~1268 images, `PutImageMetadata` was called ~1268 times during `AfterImages`. Each call performed an uncached `GET /v2/<repo>/tags/list` request to the registry. With thousands of tags in the repo, each request was expensive and none of the results were cached (unlike `IsImageMetadataExist` which uses `WithCache()`). This produced an ~8-minute "dark gap" between the build summary and the WARNINGS/Running time output.

## Review focus / risks

- `PutImageMetadata` no longer has a self-contained idempotency guard. All current callers check existence before calling, but any future caller must also check first or accept a redundant push. The push itself is still idempotent at the registry level (tag overwrites are safe for metadata tags).