### PR TITLE
fix(build): use cached tag existence check in PutImageMetadata

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -510,7 +510,7 @@ func (phase *BuildPhase) publishImageGitMetadata(ctx context.Context, imageName 
 		}
 
 		if !exist {
-			if err := stagesStorage.PutImageMetadata(ctx, phase.Conveyor.ProjectName(), imageName, commit, stageID.String()); err != nil {
+			if err := stagesStorage.PutImageMetadata(ctx, phase.Conveyor.ProjectName(), imageName, commit, stageID.String(), storage.WithCache()); err != nil {
 				return fmt.Errorf("unable to put image %s metadata by commit %s and stage ID %s: %w", imageName, commit, stageID.String(), err)
 			}
 		}

--- a/pkg/storage/local_stages_storage.go
+++ b/pkg/storage/local_stages_storage.go
@@ -236,7 +236,7 @@ func (storage *LocalStagesStorage) GetManagedImages(ctx context.Context, project
 	return []string{}, nil
 }
 
-func (storage *LocalStagesStorage) PutImageMetadata(ctx context.Context, projectName, imageNameOrManagedImageName, commit, stageID string) error {
+func (storage *LocalStagesStorage) PutImageMetadata(ctx context.Context, projectName, imageNameOrManagedImageName, commit, stageID string, opts ...Option) error {
 	return nil
 }
 

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -557,29 +557,25 @@ func (storage *RepoStagesStorage) ShouldFetchImage(ctx context.Context, img cont
 	return true, nil
 }
 
-func (storage *RepoStagesStorage) PutImageMetadata(ctx context.Context, projectName, imageNameOrManagedImageName, commit, stageID string) error {
+func (storage *RepoStagesStorage) PutImageMetadata(ctx context.Context, projectName, imageNameOrManagedImageName, commit, stageID string, opts ...Option) error {
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.PutImageMetadata %s %s %s %s\n", projectName, imageNameOrManagedImageName, commit, stageID)
 
-	tagName := makeRepoImageMetadataTagName(imageNameOrManagedImageName, commit, stageID)
-	tags, err := storage.Tags(ctx, storage.RepoAddress)
-	if err != nil {
-		return fmt.Errorf("unable to get repo %s tags: %w", storage.RepoAddress, err)
-	}
-
-	for _, tag := range tags {
-		if tag == tagName {
-			logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.PutImageMetadata tag %s already exists, skipping push\n", tagName)
-
-			return nil
-		}
-	}
-
 	fullImageName := makeRepoImageMetadataName(storage.RepoAddress, imageNameOrManagedImageName, commit, stageID)
+
+	o := makeOptions(opts...)
+	exist, err := storage.DockerRegistry.IsTagExist(ctx, fullImageName, o.dockerRegistryOptions...)
+	if err != nil {
+		return fmt.Errorf("unable to check existence of image metadata %s: %w", fullImageName, err)
+	}
+	if exist {
+		logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.PutImageMetadata tag already exists, skipping push\n")
+		return nil
+	}
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.PutImageMetadata full image name: %s\n", fullImageName)
 
-	opts := &docker_registry.PushImageOptions{Labels: map[string]string{image.WerfLabel: projectName}}
+	pushOpts := &docker_registry.PushImageOptions{Labels: map[string]string{image.WerfLabel: projectName}}
 
-	if err := storage.DockerRegistry.PushImage(ctx, fullImageName, opts); err != nil {
+	if err := storage.DockerRegistry.PushImage(ctx, fullImageName, pushOpts); err != nil {
 		if docker_registry.IsStatusForbiddenErr(err) {
 			logboek.Context(ctx).Warn().LogF("WARNING: Failed to push meta tag image %s\n", fullImageName)
 

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -89,7 +89,7 @@ type StagesStorage interface {
 	// GetManagedImages returns the list of managedImageName.
 	GetManagedImages(ctx context.Context, projectName string, opts ...Option) ([]string, error)
 
-	PutImageMetadata(ctx context.Context, projectName, imageNameOrManagedImageName, commit, stageID string) error
+	PutImageMetadata(ctx context.Context, projectName, imageNameOrManagedImageName, commit, stageID string, opts ...Option) error
 	RmImageMetadata(ctx context.Context, projectName, imageNameOrManagedImageNameOrImageMetadataID, commit, stageID string) error
 	IsImageMetadataExist(ctx context.Context, projectName, imageNameOrManagedImageName, commit, stageID string, opts ...Option) (bool, error)
 	GetAllAndGroupImageMetadataByImageName(ctx context.Context, projectName string, imageNameOrManagedImageList []string, opts ...Option) (map[string]map[string][]string, map[string]map[string][]string, error)


### PR DESCRIPTION
## Summary

Replace the uncached `Tags()` + linear-scan pattern in `PutImageMetadata` with `IsTagExist()` accepting `storage.WithCache()`, matching the pattern used by `IsManagedImageExist` and `IsImageMetadataExist`.

## Key changes

- `pkg/storage/stages_storage.go`: Add `opts ...Option` to `PutImageMetadata` interface method.
- `pkg/storage/repo_stages_storage.go`: Replace `Tags()` + scan with `IsTagExist()` that forwards `dockerRegistryOptions` from opts, matching `IsManagedImageExist` / `IsImageMetadataExist`.
- `pkg/storage/local_stages_storage.go`: Add `opts ...Option` to no-op implementation.
- `pkg/build/build_phase.go`: Pass `storage.WithCache()` to `PutImageMetadata` call in `publishImageGitMetadata`.

## Why

`PutImageMetadata` was called per-image (~1268 times) during the `AfterImages` phase. Each call performed an uncached `GET /v2/<repo>/tags/list`, while the adjacent `IsImageMetadataExist` call already used cached tags via `storage.WithCache()`. This inconsistency caused ~1268 redundant full tag listings, contributing to an ~8-minute post-build delay.

## Review focus / risks

- Interface change: `PutImageMetadata` now accepts `opts ...Option`. All existing callers pass `storage.WithCache()`. New callers without the option get uncached behavior (same as before).
- `IsTagExist` under `DockerRegistryWithCache` still uses the `cachedTagsMap` populated by `Tags()` — the cache is shared with `IsImageMetadataExist`.