### PR TITLE
fix(build): eliminate redundant registry tag listing in post-build metadata publication

### DIFF
--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -560,20 +560,6 @@ func (storage *RepoStagesStorage) ShouldFetchImage(ctx context.Context, img cont
 func (storage *RepoStagesStorage) PutImageMetadata(ctx context.Context, projectName, imageNameOrManagedImageName, commit, stageID string) error {
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.PutImageMetadata %s %s %s %s\n", projectName, imageNameOrManagedImageName, commit, stageID)
 
-	tagName := makeRepoImageMetadataTagName(imageNameOrManagedImageName, commit, stageID)
-	tags, err := storage.Tags(ctx, storage.RepoAddress)
-	if err != nil {
-		return fmt.Errorf("unable to get repo %s tags: %w", storage.RepoAddress, err)
-	}
-
-	for _, tag := range tags {
-		if tag == tagName {
-			logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.PutImageMetadata tag %s already exists, skipping push\n", tagName)
-
-			return nil
-		}
-	}
-
 	fullImageName := makeRepoImageMetadataName(storage.RepoAddress, imageNameOrManagedImageName, commit, stageID)
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.PutImageMetadata full image name: %s\n", fullImageName)
 


### PR DESCRIPTION
## Summary

Remove a redundant full tag listing from `PutImageMetadata` that caused hundreds of uncached HTTP requests during the post-build metadata publication phase, adding minutes of idle time for projects with many images.

## Key changes

- `pkg/storage/repo_stages_storage.go`: Remove the `Tags()` + linear-scan existence check inside `PutImageMetadata`. The method now directly pushes the metadata tag, matching the pattern used by `AddManagedImage`.

## Why

After building all images, werf publishes git metadata for each one by calling `PutImageMetadata` per image. Each call fetched the **full tag list** from the container registry (`GET /v2/<repo>/tags/list`) without caching to check whether the tag already exists. For a project with ~1268 images this produced ~1268 uncached list-tags HTTP requests during the `AfterImages` phase — a major contributor to an observed ~8-minute gap between the build summary and the final output.

The caller (`publishImageGitMetadata`) already checks existence via `IsImageMetadataExist` with a cached tag list before calling `PutImageMetadata`, making the internal check redundant. `AddManagedImage` already follows this pattern — it performs a direct push without an internal existence check, relying on the caller (`addManagedImage`) which checks via `IsManagedImageExist` with cache.

## Review focus / risks

- `PutImageMetadata` no longer has a self-contained idempotency guard. All current callers check existence before calling. The push itself is idempotent at the registry level (metadata tag overwrites are safe), so a redundant push is harmless — just an extra HTTP request.