### PR TITLE
chore(deploy): route werf.io docs to ru cluster

### DIFF
--- a/docs/.helm/templates/20-ingress.yaml
+++ b/docs/.helm/templates/20-ingress.yaml
@@ -45,8 +45,10 @@ spec:
       - www.{{ $host }}
 {{- else }}
       - {{ $ruHost }}
+      - {{ $host }}
+      - www.{{ $host }}
 {{- end }}
-    secretName: tls-{{ $host }}
+    secretName: tls-werf-io
   rules:
 {{- if eq $targetCluster "eu" }}
   - host: {{ $host }}
@@ -68,6 +70,23 @@ spec:
               name: http
 {{- else }}
   - host: {{ $ruHost }}
+    http:
+      paths:
+      - path: /docs/{{ $versionURLNormalized }}/
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ $.Chart.Name }}-{{ $versionDNSNormalized }}
+            port:
+              name: http
+      - path: /documentation/{{ $versionURLNormalized }}/
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ $.Chart.Name }}-{{ $versionDNSNormalized }}
+            port:
+              name: http
+  - host: {{ $host }}
     http:
       paths:
       - path: /docs/{{ $versionURLNormalized }}/
@@ -107,7 +126,7 @@ spec:
   - hosts:
       - {{ $host }}
 {{- if eq $.Values.werf.env "production" }}
-    secretName: tls-{{ $host }}
+    secretName: tls-werf-io
 {{- else }}
     secretName: {{ pluck $.Values.werf.env $.Values.ingressSecretName | first | default $.Values.ingressSecretName._default }}
 {{- end }}
@@ -155,7 +174,7 @@ spec:
       - ru-{{ $host }}
 {{- end }}
 {{- if eq $.Values.werf.env "production" }}
-    secretName: tls-{{ $host }}
+    secretName: tls-werf-io
 {{- else }}
     secretName: {{ pluck $.Values.werf.env $.Values.ingressSecretName | first | default $.Values.ingressSecretName._default }}
 {{- end }}

--- a/docs/.helm/templates/20-ingress.yaml
+++ b/docs/.helm/templates/20-ingress.yaml
@@ -21,7 +21,6 @@
 {{- if hasPrefix "review" $.Values.werf.env }}
 {{- $host = printf "%s.%s" $.Values.werf.env (pluck "dev" $.Values.host | first | default $.Values.host._default ) | lower }}
 {{- end }}
-{{- $targetCluster := include "targetCluster" $ }}
 {{- $ruHost := printf "ru.%s" $host }}
 {{- if eq $.Values.werf.env "production" }}
 ---
@@ -40,35 +39,11 @@ spec:
   ingressClassName: {{ include "ingressClassName" $ }}
   tls:
   - hosts:
-{{- if eq $targetCluster "eu" }}
-      - {{ $host }}
-      - www.{{ $host }}
-{{- else }}
       - {{ $ruHost }}
       - {{ $host }}
       - www.{{ $host }}
-{{- end }}
     secretName: tls-werf-io
   rules:
-{{- if eq $targetCluster "eu" }}
-  - host: {{ $host }}
-    http:
-      paths:
-      - path: /docs/{{ $versionURLNormalized }}/
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: {{ $.Chart.Name }}-{{ $versionDNSNormalized }}
-            port:
-              name: http
-      - path: /documentation/{{ $versionURLNormalized }}/
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: {{ $.Chart.Name }}-{{ $versionDNSNormalized }}
-            port:
-              name: http
-{{- else }}
   - host: {{ $ruHost }}
     http:
       paths:
@@ -103,7 +78,6 @@ spec:
             name: {{ $.Chart.Name }}-{{ $versionDNSNormalized }}
             port:
               name: http
-{{- end }}
 {{- else }}
 
 ---


### PR DESCRIPTION
Route production docs ingress for the RU cluster through werf.io and www.werf.io in addition to ru.werf.io. Use the shared tls-werf-io wildcard secret instead of per-host production TLS secrets so both clusters rely on the same pre-provisioned certificate.