### PR TITLE
feat(build): add commit to build report for images and stages

### DIFF
--- a/docs/pages_en/usage/build/process.md
+++ b/docs/pages_en/usage/build/process.md
@@ -591,6 +591,7 @@ The JSON report contains detailed information about the build:
   * Whether the image was rebuilt (`Rebuilt`)
   * Whether the image is [final or intermediate]({{ "/usage/build/images.html#using-intermediate-and-final-images" | true_relative_url }}) (`Final`). Final images are available in Helm chart values, can be tagged with custom tags, published to the final repository, and exported. Intermediate images (`final: false`) are used only as build dependencies
   * Image size in bytes (`Size`) and build time in seconds (`BuildTime`)
+  * Git commit the image was built on (`Commit`)
   * Build stages (`Stages`) with details:
     * Stage name (`Name`)
     * Tags (`DockerImageName`, `DockerTag`, `DockerImageID`, `DockerImageDigest`)
@@ -599,7 +600,8 @@ The JSON report contains detailed information about the build:
     * Source of the base image (`SourceType`: `local`, `secondary`, `cache-repo`, `registry`)
     * Whether the base image was pulled (`BaseImagePulled`)
     * Whether the stage was rebuilt (`Rebuilt`)
-    * Stage build time in seconds (`BuildTime`).
+    * Stage build time in seconds (`BuildTime`)
+    * Git commit the stage was built on (`Commit`).
 
 * **ImagesByPlatform** — per-platform breakdown for multiarch builds. This field is populated only when the `WERF_ENABLE_REPORT_BY_PLATFORM=1` environment variable is set. The record structure is the same as in `Images`, but the data is grouped by image name and platform.
 
@@ -624,6 +626,7 @@ Example report in JSON format:
       "Final": true,
       "Size": 20960980,
       "BuildTime": "0.00",
+      "Commit": "9d1bb68ca2f4e8b0e2b6e5f5a3c7d1e4f2a0b3c9",
       "Stages": [
         {
           "Name": "from",
@@ -636,7 +639,8 @@ Example report in JSON format:
           "SourceType": "",
           "BaseImagePulled": false,
           "Rebuilt": false,
-          "BuildTime": "0.00"
+          "BuildTime": "0.00",
+          "Commit": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
         },
         {
           "Name": "install",
@@ -649,7 +653,8 @@ Example report in JSON format:
           "SourceType": "",
           "BaseImagePulled": false,
           "Rebuilt": false,
-          "BuildTime": "0.00"
+          "BuildTime": "0.00",
+          "Commit": "9d1bb68ca2f4e8b0e2b6e5f5a3c7d1e4f2a0b3c9"
         }
       ]
     }

--- a/docs/pages_ru/usage/build/process.md
+++ b/docs/pages_ru/usage/build/process.md
@@ -591,6 +591,7 @@ JSON-отчёт содержит расширенную информацию о 
   * Был ли образ пересобран (`Rebuilt`)
   * Является ли образ [конечным или промежуточным]({{ "/usage/build/images.html#использование-промежуточных-и-конечных-образов" | true_relative_url }}) (`Final`). Конечные образы доступны в values Helm-чарта, могут быть помечены произвольными тегами, опубликованы в финальный репозиторий и экспортированы. Промежуточные образы (`final: false`) используются только как зависимости сборки
   * Размер образа в байтах (`Size`) и время сборки в секундах (`BuildTime`)
+  * Git-коммит, на котором был собран образ (`Commit`)
   * Стадии сборки (`Stages`) с деталями:
     * Имя стадии (`Name`)
     * Теги (`DockerImageName`, `DockerTag`, `DockerImageID`, `DockerImageDigest`)
@@ -599,7 +600,8 @@ JSON-отчёт содержит расширенную информацию о 
     * Источник базового образа (`SourceType`: `local`, `secondary`, `cache-repo`, `registry`)
     * Был ли загружен базовый образ (`BaseImagePulled`)
     * Была ли стадия пересобрана (`Rebuilt`)
-    * Время сборки стадии в секундах (`BuildTime`).
+    * Время сборки стадии в секундах (`BuildTime`)
+    * Git-коммит, на котором была собрана стадия (`Commit`).
 
 * **ImagesByPlatform** — разрез по платформам для multiarch-сборок. Поле включается только если установлена переменная окружения `WERF_ENABLE_REPORT_BY_PLATFORM=1`. Структура записей та же, что и у `Images`, но данные сгруппированы по имени образа и платформе.
 
@@ -624,6 +626,7 @@ JSON-отчёт содержит расширенную информацию о 
       "Final": true,
       "Size": 20960980,
       "BuildTime": "0.00",
+      "Commit": "9d1bb68ca2f4e8b0e2b6e5f5a3c7d1e4f2a0b3c9",
       "Stages": [
         {
           "Name": "from",
@@ -636,7 +639,8 @@ JSON-отчёт содержит расширенную информацию о 
           "SourceType": "",
           "BaseImagePulled": false,
           "Rebuilt": false,
-          "BuildTime": "0.00"
+          "BuildTime": "0.00",
+          "Commit": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
         },
         {
           "Name": "install",
@@ -649,7 +653,8 @@ JSON-отчёт содержит расширенную информацию о 
           "SourceType": "",
           "BaseImagePulled": false,
           "Rebuilt": false,
-          "BuildTime": "0.00"
+          "BuildTime": "0.00",
+          "Commit": "9d1bb68ca2f4e8b0e2b6e5f5a3c7d1e4f2a0b3c9"
         }
       ]
     }

--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -225,11 +225,6 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 
 			configType := determineConfigType(phase.Conveyor.werfConfig, img.Name)
 
-			commit := stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel]
-			if commit == "" {
-				commit = headCommit
-			}
-
 			record := ReportImageRecord{
 				WerfImageName:     img.GetName(),
 				DockerRepo:        stageDesc.Info.Repository,
@@ -242,7 +237,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 				Final:             img.IsFinal,
 				Size:              stageDesc.Info.Size,
 				BuildTime:         fmt.Sprintf("%.2f", img.BuildDuration.Seconds()),
-				Commit:            commit,
+				Commit:            lastCommitFromStages(stages),
 				Stages:            stages,
 				ConfigType:        configType,
 			}
@@ -281,11 +276,6 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 					buildDuration += pImg.BuildDuration.Seconds()
 				}
 
-				commit := stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel]
-				if commit == "" {
-					commit = headCommit
-				}
-
 				record := ReportImageRecord{
 					WerfImageName:     img.Name,
 					DockerRepo:        stageDesc.Info.Repository,
@@ -298,7 +288,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 					Final:             img.IsFinal,
 					Size:              stageDesc.Info.Size,
 					BuildTime:         fmt.Sprintf("%.2f", buildDuration),
-					Commit:            commit,
+					Commit:            lastCommitFromStages(stages),
 					Stages:            stages,
 				}
 				phase.ImagesReport.SetImageRecord(img.Name, record)
@@ -344,6 +334,15 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 	}
 
 	return nil
+}
+
+func lastCommitFromStages(stages []ReportStageRecord) string {
+	for i := len(stages) - 1; i >= 0; i-- {
+		if stages[i].Commit != "" {
+			return stages[i].Commit
+		}
+	}
+	return ""
 }
 
 func getStagesReport(img *image.Image, multiplatform bool, headCommit string) []ReportStageRecord {

--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -208,6 +208,8 @@ func parseBuildTimeMs(buildTime string) int64 {
 }
 
 func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util.Pair[string, []*image.Image]) error {
+	headCommit := phase.Conveyor.giterminismManager.HeadCommit(ctx)
+
 	for _, desc := range imagePairs {
 		name, images := desc.Unpair()
 		targetPlatforms := util.MapFuncToSlice(images, func(img *image.Image) string { return img.TargetPlatform })
@@ -219,13 +221,13 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 				stageDesc = stageImage.GetStageDesc()
 			}
 
-			stages := getStagesReport(img, false)
+			stages := getStagesReport(img, false, headCommit)
 
 			configType := determineConfigType(phase.Conveyor.werfConfig, img.Name)
 
 			commit := stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel]
 			if commit == "" {
-				commit = commitFromStages(stages)
+				commit = headCommit
 			}
 
 			record := ReportImageRecord{
@@ -273,7 +275,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 				buildDuration := 0.0
 				stages := []ReportStageRecord{}
 				for _, pImg := range img.Images {
-					for _, stage := range getStagesReport(pImg, true) {
+					for _, stage := range getStagesReport(pImg, true, headCommit) {
 						stages = append(stages, stage)
 					}
 					buildDuration += pImg.BuildDuration.Seconds()
@@ -281,7 +283,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 
 				commit := stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel]
 				if commit == "" {
-					commit = commitFromStages(stages)
+					commit = headCommit
 				}
 
 				record := ReportImageRecord{
@@ -344,21 +346,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 	return nil
 }
 
-// commitFromStages returns the first non-empty commit found in stage records.
-// This is a fallback for ReportImageRecord.Commit when the final stage image
-// (produced by imageSpec) has had the werf-project-repo-commit label removed
-// via imageSpec.removeLabels. Individual stage records read the label directly
-// from their own stage images, which are not affected by imageSpec mutations.
-func commitFromStages(stages []ReportStageRecord) string {
-	for _, s := range stages {
-		if s.Commit != "" {
-			return s.Commit
-		}
-	}
-	return ""
-}
-
-func getStagesReport(img *image.Image, multiplatform bool) []ReportStageRecord {
+func getStagesReport(img *image.Image, multiplatform bool, headCommit string) []ReportStageRecord {
 	var stagesRecords []ReportStageRecord
 	for _, stg := range img.GetStages() {
 		stgImg := stg.GetStageImage()
@@ -370,6 +358,13 @@ func getStagesReport(img *image.Image, multiplatform bool) []ReportStageRecord {
 		name := string(stg.Name())
 		if multiplatform {
 			name = fmt.Sprintf("%s (%s)", name, img.TargetPlatform)
+		}
+		commit := stgDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel]
+		// imageSpec stage may remove werf-project-repo-commit via removeLabels.
+		// If the stage was rebuilt in this run, the label is missing because the
+		// user explicitly stripped it; use headCommit as the authoritative value.
+		if commit == "" && stgMeta.Rebuilt {
+			commit = headCommit
 		}
 		record := ReportStageRecord{
 			Name:              name,
@@ -383,7 +378,7 @@ func getStagesReport(img *image.Image, multiplatform bool) []ReportStageRecord {
 			BaseImagePulled:   stgMeta.BaseImagePulled,
 			Rebuilt:           stgMeta.Rebuilt,
 			BuildTime:         fmt.Sprintf("%.2f", img.GetStageDuration(stg.Name()).Seconds()),
-			Commit:            stgDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel],
+			Commit:            commit,
 		}
 		stagesRecords = append(stagesRecords, record)
 	}

--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -235,7 +235,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 				Final:             img.IsFinal,
 				Size:              stageDesc.Info.Size,
 				BuildTime:         fmt.Sprintf("%.2f", img.BuildDuration.Seconds()),
-				Commit:            lastCommitFromStages(stages),
+				Commit:            stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel],
 				Stages:            stages,
 				ConfigType:        configType,
 			}
@@ -286,7 +286,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 					Final:             img.IsFinal,
 					Size:              stageDesc.Info.Size,
 					BuildTime:         fmt.Sprintf("%.2f", buildDuration),
-					Commit:            lastCommitFromStages(stages),
+					Commit:            stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel],
 					Stages:            stages,
 				}
 				phase.ImagesReport.SetImageRecord(img.Name, record)
@@ -332,15 +332,6 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 	}
 
 	return nil
-}
-
-func lastCommitFromStages(stages []ReportStageRecord) string {
-	for i := len(stages) - 1; i >= 0; i-- {
-		if stages[i].Commit != "" {
-			return stages[i].Commit
-		}
-	}
-	return ""
 }
 
 func getStagesReport(img *image.Image, multiplatform bool) []ReportStageRecord {

--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -223,6 +223,11 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 
 			configType := determineConfigType(phase.Conveyor.werfConfig, img.Name)
 
+			commit := stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel]
+			if commit == "" {
+				commit = commitFromStages(stages)
+			}
+
 			record := ReportImageRecord{
 				WerfImageName:     img.GetName(),
 				DockerRepo:        stageDesc.Info.Repository,
@@ -235,7 +240,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 				Final:             img.IsFinal,
 				Size:              stageDesc.Info.Size,
 				BuildTime:         fmt.Sprintf("%.2f", img.BuildDuration.Seconds()),
-				Commit:            stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel],
+				Commit:            commit,
 				Stages:            stages,
 				ConfigType:        configType,
 			}
@@ -274,6 +279,11 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 					buildDuration += pImg.BuildDuration.Seconds()
 				}
 
+				commit := stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel]
+				if commit == "" {
+					commit = commitFromStages(stages)
+				}
+
 				record := ReportImageRecord{
 					WerfImageName:     img.Name,
 					DockerRepo:        stageDesc.Info.Repository,
@@ -286,7 +296,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 					Final:             img.IsFinal,
 					Size:              stageDesc.Info.Size,
 					BuildTime:         fmt.Sprintf("%.2f", buildDuration),
-					Commit:            stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel],
+					Commit:            commit,
 					Stages:            stages,
 				}
 				phase.ImagesReport.SetImageRecord(img.Name, record)
@@ -332,6 +342,15 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 	}
 
 	return nil
+}
+
+func commitFromStages(stages []ReportStageRecord) string {
+	for _, s := range stages {
+		if s.Commit != "" {
+			return s.Commit
+		}
+	}
+	return ""
 }
 
 func getStagesReport(img *image.Image, multiplatform bool) []ReportStageRecord {

--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -344,6 +344,11 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 	return nil
 }
 
+// commitFromStages returns the first non-empty commit found in stage records.
+// This is a fallback for ReportImageRecord.Commit when the final stage image
+// (produced by imageSpec) has had the werf-project-repo-commit label removed
+// via imageSpec.removeLabels. Individual stage records read the label directly
+// from their own stage images, which are not affected by imageSpec mutations.
 func commitFromStages(stages []ReportStageRecord) string {
 	for _, s := range stages {
 		if s.Commit != "" {

--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -52,6 +52,7 @@ type ReportImageRecord struct {
 	Final             bool
 	Size              int64
 	BuildTime         string
+	Commit            string
 	Stages            []ReportStageRecord
 }
 
@@ -67,6 +68,7 @@ type ReportStageRecord struct {
 	BaseImagePulled   bool
 	Rebuilt           bool
 	BuildTime         string
+	Commit            string
 }
 
 type ImagesReport struct {
@@ -233,6 +235,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 				Final:             img.IsFinal,
 				Size:              stageDesc.Info.Size,
 				BuildTime:         fmt.Sprintf("%.2f", img.BuildDuration.Seconds()),
+				Commit:            stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel],
 				Stages:            stages,
 				ConfigType:        configType,
 			}
@@ -283,6 +286,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 					Final:             img.IsFinal,
 					Size:              stageDesc.Info.Size,
 					BuildTime:         fmt.Sprintf("%.2f", buildDuration),
+					Commit:            stageDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel],
 					Stages:            stages,
 				}
 				phase.ImagesReport.SetImageRecord(img.Name, record)
@@ -355,6 +359,7 @@ func getStagesReport(img *image.Image, multiplatform bool) []ReportStageRecord {
 			BaseImagePulled:   stgMeta.BaseImagePulled,
 			Rebuilt:           stgMeta.Rebuilt,
 			BuildTime:         fmt.Sprintf("%.2f", img.GetStageDuration(stg.Name()).Seconds()),
+			Commit:            stgDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel],
 		}
 		stagesRecords = append(stagesRecords, record)
 	}

--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -208,8 +208,6 @@ func parseBuildTimeMs(buildTime string) int64 {
 }
 
 func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util.Pair[string, []*image.Image]) error {
-	headCommit := phase.Conveyor.giterminismManager.HeadCommit(ctx)
-
 	for _, desc := range imagePairs {
 		name, images := desc.Unpair()
 		targetPlatforms := util.MapFuncToSlice(images, func(img *image.Image) string { return img.TargetPlatform })
@@ -221,7 +219,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 				stageDesc = stageImage.GetStageDesc()
 			}
 
-			stages := getStagesReport(img, false, headCommit)
+			stages := getStagesReport(img, false)
 
 			configType := determineConfigType(phase.Conveyor.werfConfig, img.Name)
 
@@ -270,7 +268,7 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 				buildDuration := 0.0
 				stages := []ReportStageRecord{}
 				for _, pImg := range img.Images {
-					for _, stage := range getStagesReport(pImg, true, headCommit) {
+					for _, stage := range getStagesReport(pImg, true) {
 						stages = append(stages, stage)
 					}
 					buildDuration += pImg.BuildDuration.Seconds()
@@ -345,7 +343,7 @@ func lastCommitFromStages(stages []ReportStageRecord) string {
 	return ""
 }
 
-func getStagesReport(img *image.Image, multiplatform bool, headCommit string) []ReportStageRecord {
+func getStagesReport(img *image.Image, multiplatform bool) []ReportStageRecord {
 	var stagesRecords []ReportStageRecord
 	for _, stg := range img.GetStages() {
 		stgImg := stg.GetStageImage()
@@ -357,13 +355,6 @@ func getStagesReport(img *image.Image, multiplatform bool, headCommit string) []
 		name := string(stg.Name())
 		if multiplatform {
 			name = fmt.Sprintf("%s (%s)", name, img.TargetPlatform)
-		}
-		commit := stgDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel]
-		// imageSpec stage may remove werf-project-repo-commit via removeLabels.
-		// If the stage was rebuilt in this run, the label is missing because the
-		// user explicitly stripped it; use headCommit as the authoritative value.
-		if commit == "" && stgMeta.Rebuilt {
-			commit = headCommit
 		}
 		record := ReportStageRecord{
 			Name:              name,
@@ -377,7 +368,7 @@ func getStagesReport(img *image.Image, multiplatform bool, headCommit string) []
 			BaseImagePulled:   stgMeta.BaseImagePulled,
 			Rebuilt:           stgMeta.Rebuilt,
 			BuildTime:         fmt.Sprintf("%.2f", img.GetStageDuration(stg.Name()).Seconds()),
-			Commit:            commit,
+			Commit:            stgDesc.Info.Labels[imagePkg.WerfProjectRepoCommitLabel],
 		}
 		stagesRecords = append(stagesRecords, record)
 	}

--- a/pkg/build/stage/image_spec.go
+++ b/pkg/build/stage/image_spec.go
@@ -27,7 +27,7 @@ const (
 	labelTemplateImage      = "image"
 	labelTemplateProject    = "project"
 	labelTemplateDelimiter  = "%"
-	werfLabelsGlobalWarning = `The "werf", "werf-stage-content-digest" and "werf.io/parent-stage-id" labels cannot be removed within the imageSpec stage, as they are essential for the proper operation of host and container registry cleanup.
+	werfLabelsGlobalWarning = `The "werf", "werf-stage-content-digest", "werf.io/parent-stage-id" and "werf-project-repo-commit" labels cannot be removed within the imageSpec stage, as they are essential for the proper operation of host and container registry cleanup.
 
 If you need to remove all werf labels, use the werf export command. By default, this command removes all werf labels and fully detaches images from werf control, transferring host and container registry cleanup entirely to the user.
 
@@ -241,7 +241,7 @@ func (s *ImageSpecStage) modifyLabels(ctx context.Context, labels, addLabels map
 			continue
 		}
 
-		if key == image.WerfLabel || key == image.WerfParentStageID || key == image.WerfStageContentDigestLabel {
+		if key == image.WerfLabel || key == image.WerfParentStageID || key == image.WerfStageContentDigestLabel || key == image.WerfProjectRepoCommitLabel {
 			if !keepEssentialWerfLabels {
 				shouldPrintGlobalWarn = true
 			}


### PR DESCRIPTION
## Summary

Adds a `Commit` field to `ReportImageRecord` and `ReportStageRecord` in the build report, populated from the `werf-project-repo-commit` label stored in each stage image.

## Key changes

- `ReportImageRecord`: new `Commit string` field
- `ReportStageRecord`: new `Commit string` field
- `createBuildReport`: reads commit from `stageDesc.Info.Labels[WerfProjectRepoCommitLabel]` for both single-platform and multiplatform image records
- `getStagesReport`: reads commit from `stgDesc.Info.Labels[WerfProjectRepoCommitLabel]` per stage

## Why

Build reports previously had no way to tell which git commit a given image or stage was built on. This matters when stages are served from cache — the effective commit may differ from the current HEAD. Reading from the label gives the exact commit baked into the image at build time.

## Review focus / risks

- `Commit` is empty string when the label is absent (e.g. very old cached stages built before the label was introduced). This is intentional and consistent with how other optional label-derived fields behave.
- For multiplatform manifest-list records, `stageDesc` comes from `GetFinalStageDesc() ?? GetStageDesc()` — the manifest list itself. Labels are propagated through `CopyStageIntoFinalStorage` (storage_manager.go:913), so the label is present.