### PR TITLE
chore(dev): add mandatory inline diff and error handling for review skills

### DIFF
--- a/.agents/skills/review-multi/SKILL.md
+++ b/.agents/skills/review-multi/SKILL.md
@@ -29,16 +29,18 @@ Orchestrate a multi-role review. Two roles run in parallel, then the third consu
 
 1. **DoD first.** Ask user for numbered acceptance criteria. Block until received. Nothing proceeds without DoD. Record the criteria — they will be passed inline to every sub-skill.
 2. **Get branch name:** `git rev-parse --abbrev-ref HEAD` → `$BRANCH`. Create safe directory name: `$SAFE_BRANCH=$(echo "$BRANCH" | sed 's|/|-|g')`. Create directory `reviews/$SAFE_BRANCH/`.
-3. **Save diff to file:** `git --no-pager diff main...HEAD > reviews/$SAFE_BRANCH/pr_diff.txt` — read via `read_file` with `start_line`/`end_line`. Avoids terminal truncation.
+3. **Save diff to file:** `git --no-pager diff origin/main...HEAD > reviews/$SAFE_BRANCH/pr_diff.txt`. Avoids terminal truncation.
 4. **Diff analysis:** Identify modified files, change types (feature/fix/refactor/docs), patterns, concerns.
 5. **Deep analysis:** Read changed files and their consumers. Examine key functions and their callers in the codebase.
-6. **Read diff for sub-skills:** Use `read_file(path="reviews/$SAFE_BRANCH/pr_diff.txt")` to get the full diff content. It will be passed inline to every sub-skill.
-7. **Phase 1a — Technical Reviewer (parallel).** Activate **review-tech**. Provide: the full diff content inline, the DoD criteria inline, analysis.
+6. **Read diff for sub-skills (MANDATORY):** Use `read_file(path="reviews/$SAFE_BRANCH/pr_diff.txt")` to get the full diff content.
+   - If read_file returns the full text → include the COMPLETE diff inline in every spawn_agent message.
+   - If read_file returns an outline/truncation (file too large) → output `ERROR: Diff too large for review-multi workflow.` and STOP. Do NOT split, summarize, or pass a file path.
+7. **Phase 1a — Technical Reviewer (parallel).** Activate **review-tech**. Provide: the COMPLETE diff content inline (NOT a file path or summary), the DoD criteria inline, analysis.
    → **Output of Phase 1a:** best practices table + DoD tech checklist + issues found.
-8. **Phase 1b — Product Reviewer (parallel with 1a).** Activate **review-product**. Provide: the full diff content inline, the DoD criteria inline, analysis.
+8. **Phase 1b — Product Reviewer (parallel with 1a).** Activate **review-product**. Provide: the COMPLETE diff content inline (NOT a file path or summary), the DoD criteria inline, analysis.
    → **Output of Phase 1b:** DoD product checklist + product impact assessment + gaps.
    → **Wait for BOTH Phase 1a and Phase 1b to complete before proceeding.**
-9. **Phase 2 — Risk Analyst.** Activate **review-risk**. Provide: the full diff content inline, the DoD criteria inline, analysis, AND full outputs from Phase 1a + Phase 1b.
+9. **Phase 2 — Risk Analyst.** Activate **review-risk**. Provide: the COMPLETE diff content inline (NOT a file path or summary), the DoD criteria inline, analysis, AND full outputs from Phase 1a + Phase 1b.
    → **Output of Phase 2:** risk analysis table with numbered rows.
 10. **Phase 3 — Final report.** Assemble combined report (format below). Save to `reviews/$SAFE_BRANCH/REPORT.md`.
 

--- a/.agents/skills/review-product/SKILL.md
+++ b/.agents/skills/review-product/SKILL.md
@@ -22,7 +22,8 @@ description: Product review for changes. Assesses DoD alignment, user impact, co
 3. Be concrete — no vague statements.
 4. NEVER sugarcoat. Deliver honest, fact-based critiques.
 5. First message opens with the full role declaration above.
-6. The full diff is provided to you inline. Do NOT run `git diff` yourself.
+6. **MANDATORY:** The full diff is provided to you inline. Do NOT read it from a file or run `git diff` yourself.
+   - If NO diff content is present in the instructions → output `ERROR: No diff provided. Cannot perform review.` and STOP immediately.
 
 Assess whether code changes fulfill product requirements from a user and product perspective.
 

--- a/.agents/skills/review-risk/SKILL.md
+++ b/.agents/skills/review-risk/SKILL.md
@@ -22,7 +22,8 @@ description: Risk analysis for changes. Identifies technical, security, UX, and 
 3. Be realistic about probability and severity — do not inflate.
 4. NEVER sugarcoat. Base risks only on evidence.
 5. First message opens with the full role declaration above.
-6. The full diff is provided to you inline. Do NOT run `git diff` yourself.
+6. **MANDATORY:** The full diff is provided to you inline. Do NOT read it from a file or run `git diff` yourself.
+   - If NO diff content is present in the instructions → output `ERROR: No diff provided. Cannot perform review.` and STOP immediately.
 
 Identify and assess risks based on the technical review, product review, and the actual diff. The output is a single table. No prose summary.
 

--- a/.agents/skills/review-tech/SKILL.md
+++ b/.agents/skills/review-tech/SKILL.md
@@ -22,7 +22,8 @@ description: Technical code review for changes. Evaluates Go, werf, Docker, Cont
 3. Be concrete — no vague generalizations.
 4. NEVER sugarcoat. Deliver honest, fact-based critiques.
 5. First message opens with the full role declaration above.
-6. The full diff is provided to you inline. Do NOT run `git diff` yourself.
+6. **MANDATORY:** The full diff is provided to you inline. Do NOT read it from a file or run `git diff` yourself.
+   - If NO diff content is present in the instructions → output `ERROR: No diff provided. Cannot perform review.` and STOP immediately.
 
 Review code changes for quality, architecture, and best practices.
 


### PR DESCRIPTION
Update all four review skill definitions (multi, tech, product, risk) to require the complete diff content inline rather than allowing file paths or self-run git diff. The multi-skill now errors out when the diff is too large instead of truncating or summarizing. Each sub-skill includes a guard that stops immediately if no diff is provided. This ensures reliable, complete diff input across all reviews.