### PR TITLE
feat(cleanup): delete rejected stages and linked custom tags during cleanup/purge

### DIFF
--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -883,15 +883,22 @@ func deleteImageMetadata(ctx context.Context, projectName string, storageManager
 }
 
 func (m *cleanupManager) cleanupRejectedStages(ctx context.Context) error {
-	customTagsByStageID := m.stageManager.GetCustomTagsMetadata()
+	protectedStageIDs := map[string]bool{}
+	for stageDesc := range m.stageManager.GetProtectedStageDescSet().Iter() {
+		protectedStageIDs[stageDesc.StageID.String()] = true
+	}
 
-	handledStageIDs, err := cleanupRejectedStages(ctx, m.StorageManager, customTagsByStageID, m.DryRun)
+	deletedStageIDs, err := cleanupRejectedStages(ctx, m.StorageManager, m.stageManager.GetCustomTagsMetadata(), protectedStageIDs, m.DryRun)
 	if err != nil {
 		return err
 	}
 
+	if m.DryRun {
+		return nil
+	}
+
 	forgottenStageDescSet := image.NewStageDescSet()
-	for _, stageIDStr := range handledStageIDs {
+	for _, stageIDStr := range deletedStageIDs {
 		m.stageManager.ForgetCustomTagsByStageID(stageIDStr)
 		if stageDesc := m.stageManager.GetStageDescByStageID(stageIDStr); stageDesc != nil {
 			forgottenStageDescSet.Add(stageDesc)
@@ -904,11 +911,7 @@ func (m *cleanupManager) cleanupRejectedStages(ctx context.Context) error {
 	return nil
 }
 
-// cleanupRejectedStages deletes every rejected stage tag in the registry together with the custom
-// tags that point to it. Broken/corrupted rejected tags are handled inside DeleteRejectedStage via
-// the dummy-image overwrite fallback. Returns the string forms of stage IDs whose linked custom
-// tags were processed so callers can forget them from their stage manager state.
-func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, customTagsByStageID map[string][]string, dryRun bool) ([]string, error) {
+func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, customTagsByStageID map[string][]string, protectedStageIDs map[string]bool, dryRun bool) ([]string, error) {
 	rejectedStageIDs, err := storageManager.GetStagesStorage().GetRejectedStageIDs(ctx, storage.WithCache())
 	if err != nil {
 		return nil, fmt.Errorf("unable to get rejected stage ids: %w", err)
@@ -918,12 +921,27 @@ func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageMa
 		return nil, nil
 	}
 
-	var customTagsToDelete []string
-	handledStageIDs := make([]string, 0, len(rejectedStageIDs))
+	stageIDsToDelete := make([]image.StageID, 0, len(rejectedStageIDs))
+	var skippedProtected []image.StageID
 	for _, stageID := range rejectedStageIDs {
-		stageIDStr := stageID.String()
-		handledStageIDs = append(handledStageIDs, stageIDStr)
-		if tags, ok := customTagsByStageID[stageIDStr]; ok {
+		if protectedStageIDs[stageID.String()] {
+			skippedProtected = append(skippedProtected, stageID)
+			continue
+		}
+		stageIDsToDelete = append(stageIDsToDelete, stageID)
+	}
+
+	for _, stageID := range skippedProtected {
+		logboek.Context(ctx).Warn().LogF("WARNING: Rejected marker found for protected stage %s (in use by Kubernetes or kept by a policy); leaving the marker and its parent stage untouched\n", stageID.String())
+	}
+
+	if len(stageIDsToDelete) == 0 {
+		return nil, nil
+	}
+
+	var customTagsToDelete []string
+	for _, stageID := range stageIDsToDelete {
+		if tags, ok := customTagsByStageID[stageID.String()]; ok {
 			customTagsToDelete = append(customTagsToDelete, tags...)
 		}
 	}
@@ -936,22 +954,29 @@ func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageMa
 		}
 	}
 
-	if err := logboek.Context(ctx).Default().LogProcess("Deleting rejected stages tags (%d)", len(rejectedStageIDs)).DoError(func() error {
-		return deleteRejectedStages(ctx, storageManager, rejectedStageIDs, dryRun)
+	var deletedStageIDs []string
+	if err := logboek.Context(ctx).Default().LogProcess("Deleting rejected stages tags (%d)", len(stageIDsToDelete)).DoError(func() error {
+		deleted, err := deleteRejectedStages(ctx, storageManager, stageIDsToDelete, dryRun)
+		deletedStageIDs = deleted
+		return err
 	}); err != nil {
 		return nil, err
 	}
 
-	return handledStageIDs, nil
+	return deletedStageIDs, nil
 }
 
-func deleteRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, stageIDs []image.StageID, dryRun bool) error {
+func deleteRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, stageIDs []image.StageID, dryRun bool) ([]string, error) {
 	if dryRun {
+		deleted := make([]string, 0, len(stageIDs))
 		for _, stageID := range stageIDs {
-			logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s-rejected\n", stageID.String())
+			stageIDStr := stageID.String()
+			logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s\n", stageIDStr)
+			logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s-rejected\n", stageIDStr)
+			deleted = append(deleted, stageIDStr)
 		}
 		logboek.Context(ctx).LogOptionalLn()
-		return nil
+		return deleted, nil
 	}
 
 	deleteStageOptions := manager.ForEachDeleteStageOptions{
@@ -960,17 +985,29 @@ func deleteRejectedStages(ctx context.Context, storageManager manager.StorageMan
 		},
 	}
 
-	return storageManager.ForEachDeleteRejectedStage(ctx, deleteStageOptions, stageIDs, func(ctx context.Context, stageID image.StageID, err error) error {
+	var (
+		mu      sync.Mutex
+		deleted []string
+	)
+	if err := storageManager.ForEachDeleteRejectedStage(ctx, deleteStageOptions, stageIDs, func(ctx context.Context, stageID image.StageID, err error) error {
+		stageIDStr := stageID.String()
 		if err != nil {
 			if err := handleDeletionError(err); err != nil {
 				return err
 			}
-			logboek.Context(ctx).Warn().LogF("WARNING: Rejected stage %s deletion failed: %s\n", stageID.String(), err)
+			logboek.Context(ctx).Warn().LogF("WARNING: Rejected stage %s deletion failed: %s\n", stageIDStr, err)
 			return nil
 		}
-		logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s-rejected\n", stageID.String())
+		logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s\n", stageIDStr)
+		logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s-rejected\n", stageIDStr)
+		mu.Lock()
+		deleted = append(deleted, stageIDStr)
+		mu.Unlock()
 		return nil
-	})
+	}); err != nil {
+		return nil, err
+	}
+	return deleted, nil
 }
 
 func (m *cleanupManager) cleanupUnusedStages(ctx context.Context) error {

--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -883,12 +883,7 @@ func deleteImageMetadata(ctx context.Context, projectName string, storageManager
 }
 
 func (m *cleanupManager) cleanupRejectedStages(ctx context.Context) error {
-	protectedStageIDs := map[string]bool{}
-	for stageDesc := range m.stageManager.GetProtectedStageDescSet().Iter() {
-		protectedStageIDs[stageDesc.StageID.String()] = true
-	}
-
-	deletedStageIDs, err := cleanupRejectedStages(ctx, m.StorageManager, m.stageManager.GetCustomTagsMetadata(), protectedStageIDs, m.DryRun)
+	deletedStageIDs, err := cleanupRejectedStages(ctx, m.StorageManager, m.stageManager.GetCustomTagsMetadata(), m.DryRun)
 	if err != nil {
 		return err
 	}
@@ -911,7 +906,13 @@ func (m *cleanupManager) cleanupRejectedStages(ctx context.Context) error {
 	return nil
 }
 
-func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, customTagsByStageID map[string][]string, protectedStageIDs map[string]bool, dryRun bool) ([]string, error) {
+// cleanupRejectedStages unconditionally deletes every rejected stage tag found in the registry
+// together with the custom tags pointing to it. A rejected marker means the underlying stage is
+// broken/invalid by construction (RejectStage is called only after build-time detection of a
+// corrupted stage), so the cleanup must purge it regardless of any protection policy. Returns the
+// stage IDs whose deletion was confirmed by the registry so callers can drop them from in-memory
+// state.
+func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, customTagsByStageID map[string][]string, dryRun bool) ([]string, error) {
 	rejectedStageIDs, err := storageManager.GetStagesStorage().GetRejectedStageIDs(ctx, storage.WithCache())
 	if err != nil {
 		return nil, fmt.Errorf("unable to get rejected stage ids: %w", err)
@@ -921,26 +922,8 @@ func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageMa
 		return nil, nil
 	}
 
-	stageIDsToDelete := make([]image.StageID, 0, len(rejectedStageIDs))
-	var skippedProtected []image.StageID
-	for _, stageID := range rejectedStageIDs {
-		if protectedStageIDs[stageID.String()] {
-			skippedProtected = append(skippedProtected, stageID)
-			continue
-		}
-		stageIDsToDelete = append(stageIDsToDelete, stageID)
-	}
-
-	for _, stageID := range skippedProtected {
-		logboek.Context(ctx).Warn().LogF("WARNING: Rejected marker found for protected stage %s (in use by Kubernetes or kept by a policy); leaving the marker and its parent stage untouched\n", stageID.String())
-	}
-
-	if len(stageIDsToDelete) == 0 {
-		return nil, nil
-	}
-
 	var customTagsToDelete []string
-	for _, stageID := range stageIDsToDelete {
+	for _, stageID := range rejectedStageIDs {
 		if tags, ok := customTagsByStageID[stageID.String()]; ok {
 			customTagsToDelete = append(customTagsToDelete, tags...)
 		}
@@ -955,8 +938,8 @@ func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageMa
 	}
 
 	var deletedStageIDs []string
-	if err := logboek.Context(ctx).Default().LogProcess("Deleting rejected stages tags (%d)", len(stageIDsToDelete)).DoError(func() error {
-		deleted, err := deleteRejectedStages(ctx, storageManager, stageIDsToDelete, dryRun)
+	if err := logboek.Context(ctx).Default().LogProcess("Deleting rejected stages tags (%d)", len(rejectedStageIDs)).DoError(func() error {
+		deleted, err := deleteRejectedStages(ctx, storageManager, rejectedStageIDs, dryRun)
 		deletedStageIDs = deleted
 		return err
 	}); err != nil {

--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -890,8 +890,15 @@ func (m *cleanupManager) cleanupRejectedStages(ctx context.Context) error {
 		return err
 	}
 
+	forgottenStageDescSet := image.NewStageDescSet()
 	for _, stageIDStr := range handledStageIDs {
 		m.stageManager.ForgetCustomTagsByStageID(stageIDStr)
+		if stageDesc := m.stageManager.GetStageDescByStageID(stageIDStr); stageDesc != nil {
+			forgottenStageDescSet.Add(stageDesc)
+		}
+	}
+	if !forgottenStageDescSet.IsEmpty() {
+		m.stageManager.ForgetDeletedStageDescSet(forgottenStageDescSet)
 	}
 
 	return nil

--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -211,6 +211,12 @@ func (m *cleanupManager) run(ctx context.Context) error {
 
 	m.markWhitelistStagesAsProtected()
 
+	if err := logboek.Context(ctx).LogProcess("Cleanup rejected stages").DoError(func() error {
+		return m.cleanupRejectedStages(ctx)
+	}); err != nil {
+		return err
+	}
+
 	if err := logboek.Context(ctx).LogProcess("Cleanup unused stages").DoError(func() error {
 		return m.cleanupUnusedStages(ctx)
 	}); err != nil {
@@ -872,6 +878,90 @@ func deleteImageMetadata(ctx context.Context, projectName string, storageManager
 		logboek.Context(ctx).Info().LogFDetails("  stageID: %s\n", stageID)
 		logboek.Context(ctx).Info().LogFDetails("  commit: %s\n", commit)
 
+		return nil
+	})
+}
+
+func (m *cleanupManager) cleanupRejectedStages(ctx context.Context) error {
+	customTagsByStageID := m.stageManager.GetCustomTagsMetadata()
+
+	handledStageIDs, err := cleanupRejectedStages(ctx, m.StorageManager, customTagsByStageID, m.DryRun)
+	if err != nil {
+		return err
+	}
+
+	for _, stageIDStr := range handledStageIDs {
+		m.stageManager.ForgetCustomTagsByStageID(stageIDStr)
+	}
+
+	return nil
+}
+
+// cleanupRejectedStages deletes every rejected stage tag in the registry together with the custom
+// tags that point to it. Broken/corrupted rejected tags are handled inside DeleteRejectedStage via
+// the dummy-image overwrite fallback. Returns the string forms of stage IDs whose linked custom
+// tags were processed so callers can forget them from their stage manager state.
+func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, customTagsByStageID map[string][]string, dryRun bool) ([]string, error) {
+	rejectedStageIDs, err := storageManager.GetStagesStorage().GetRejectedStageIDs(ctx, storage.WithCache())
+	if err != nil {
+		return nil, fmt.Errorf("unable to get rejected stage ids: %w", err)
+	}
+
+	if len(rejectedStageIDs) == 0 {
+		return nil, nil
+	}
+
+	var customTagsToDelete []string
+	handledStageIDs := make([]string, 0, len(rejectedStageIDs))
+	for _, stageID := range rejectedStageIDs {
+		stageIDStr := stageID.String()
+		handledStageIDs = append(handledStageIDs, stageIDStr)
+		if tags, ok := customTagsByStageID[stageIDStr]; ok {
+			customTagsToDelete = append(customTagsToDelete, tags...)
+		}
+	}
+
+	if len(customTagsToDelete) != 0 {
+		if err := logboek.Context(ctx).Default().LogProcess("Deleting custom tags linked to rejected stages (%d)", len(customTagsToDelete)).DoError(func() error {
+			return deleteCustomTags(ctx, storageManager, customTagsToDelete, dryRun)
+		}); err != nil {
+			return nil, fmt.Errorf("unable to delete custom tags linked to rejected stages: %w", err)
+		}
+	}
+
+	if err := logboek.Context(ctx).Default().LogProcess("Deleting rejected stages tags (%d)", len(rejectedStageIDs)).DoError(func() error {
+		return deleteRejectedStages(ctx, storageManager, rejectedStageIDs, dryRun)
+	}); err != nil {
+		return nil, err
+	}
+
+	return handledStageIDs, nil
+}
+
+func deleteRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, stageIDs []image.StageID, dryRun bool) error {
+	if dryRun {
+		for _, stageID := range stageIDs {
+			logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s-rejected\n", stageID.String())
+		}
+		logboek.Context(ctx).LogOptionalLn()
+		return nil
+	}
+
+	deleteStageOptions := manager.ForEachDeleteStageOptions{
+		DeleteImageOptions: storage.DeleteImageOptions{
+			RmiForce: false,
+		},
+	}
+
+	return storageManager.ForEachDeleteRejectedStage(ctx, deleteStageOptions, stageIDs, func(ctx context.Context, stageID image.StageID, err error) error {
+		if err != nil {
+			if err := handleDeletionError(err); err != nil {
+				return err
+			}
+			logboek.Context(ctx).Warn().LogF("WARNING: Rejected stage %s deletion failed: %s\n", stageID.String(), err)
+			return nil
+		}
+		logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s-rejected\n", stageID.String())
 		return nil
 	})
 }

--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -933,7 +933,7 @@ func deleteRejectedStagesWithLinkedTags(ctx context.Context, storageManager mana
 
 	var deletedStageIDs []string
 	if err := logboek.Context(ctx).Default().LogProcess("Deleting rejected stages tags (%d)", len(rejectedStageIDs)).DoError(func() error {
-		deleted, err := deleteRejectedStageList(ctx, storageManager, rejectedStageIDs, dryRun)
+		deleted, err := deleteRejectedStages(ctx, storageManager, rejectedStageIDs, dryRun)
 		deletedStageIDs = deleted
 		return err
 	}); err != nil {
@@ -943,7 +943,7 @@ func deleteRejectedStagesWithLinkedTags(ctx context.Context, storageManager mana
 	return deletedStageIDs, nil
 }
 
-func deleteRejectedStageList(ctx context.Context, storageManager manager.StorageManagerInterface, stageIDs []image.StageID, dryRun bool) ([]string, error) {
+func deleteRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, stageIDs []image.StageID, dryRun bool) ([]string, error) {
 	if dryRun {
 		deleted := make([]string, 0, len(stageIDs))
 		for _, stageID := range stageIDs {

--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -916,38 +916,15 @@ func deleteRejectedStagesWithLinkedTags(ctx context.Context, storageManager mana
 		return nil, nil
 	}
 
-	var customTagsToDelete []string
-	for _, stageID := range rejectedStageIDs {
-		if tags, ok := customTagsByStageID[stageID.String()]; ok {
-			customTagsToDelete = append(customTagsToDelete, tags...)
-		}
-	}
-
-	if len(customTagsToDelete) != 0 {
-		if err := logboek.Context(ctx).Default().LogProcess("Deleting custom tags linked to rejected stages (%d)", len(customTagsToDelete)).DoError(func() error {
-			return deleteCustomTags(ctx, storageManager, customTagsToDelete, dryRun)
-		}); err != nil {
-			return nil, fmt.Errorf("unable to delete custom tags linked to rejected stages: %w", err)
-		}
-	}
-
-	var deletedStageIDs []string
-	if err := logboek.Context(ctx).Default().LogProcess("Deleting rejected stages tags (%d)", len(rejectedStageIDs)).DoError(func() error {
-		deleted, err := deleteRejectedStages(ctx, storageManager, rejectedStageIDs, dryRun)
-		deletedStageIDs = deleted
-		return err
-	}); err != nil {
-		return nil, err
-	}
-
-	return deletedStageIDs, nil
-}
-
-func deleteRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, stageIDs []image.StageID, dryRun bool) ([]string, error) {
 	if dryRun {
-		deleted := make([]string, 0, len(stageIDs))
-		for _, stageID := range stageIDs {
+		deleted := make([]string, 0, len(rejectedStageIDs))
+		for _, stageID := range rejectedStageIDs {
 			stageIDStr := stageID.String()
+			if customTags, ok := customTagsByStageID[stageIDStr]; ok {
+				if err := deleteCustomTags(ctx, storageManager, customTags, dryRun); err != nil {
+					return nil, err
+				}
+			}
 			logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s\n", stageIDStr)
 			logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s-rejected\n", stageIDStr)
 			deleted = append(deleted, stageIDStr)
@@ -966,7 +943,7 @@ func deleteRejectedStages(ctx context.Context, storageManager manager.StorageMan
 		mu      sync.Mutex
 		deleted []string
 	)
-	if err := storageManager.ForEachDeleteRejectedStage(ctx, deleteStageOptions, stageIDs, func(ctx context.Context, stageID image.StageID, err error) error {
+	if err := storageManager.ForEachDeleteRejectedStage(ctx, deleteStageOptions, rejectedStageIDs, func(ctx context.Context, stageID image.StageID, err error) error {
 		stageIDStr := stageID.String()
 		if err != nil {
 			if err := handleDeletionError(err); err != nil {
@@ -975,6 +952,13 @@ func deleteRejectedStages(ctx context.Context, storageManager manager.StorageMan
 			logboek.Context(ctx).Warn().LogF("WARNING: Rejected stage %s deletion failed: %s\n", stageIDStr, err)
 			return nil
 		}
+
+		if customTags, ok := customTagsByStageID[stageIDStr]; ok && len(customTags) != 0 {
+			if err := deleteCustomTags(ctx, storageManager, customTags, false); err != nil {
+				return fmt.Errorf("unable to delete custom tags for rejected stage %s: %w", stageIDStr, err)
+			}
+		}
+
 		logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s\n", stageIDStr)
 		logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s-rejected\n", stageIDStr)
 		mu.Lock()

--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -907,7 +907,8 @@ func (m *cleanupManager) deleteRejectedStagesWithLinkedTags(ctx context.Context)
 }
 
 func deleteRejectedStagesWithLinkedTags(ctx context.Context, storageManager manager.StorageManagerInterface, customTagsByStageID map[string][]string, dryRun bool) ([]string, error) {
-	rejectedStageIDs, err := storageManager.GetStagesStorage().GetRejectedStageIDs(ctx, storage.WithCache())
+	stagesStorage := storageManager.GetStagesStorage()
+	rejectedStageIDs, err := stagesStorage.GetRejectedStageIDs(ctx, storage.WithCache())
 	if err != nil {
 		return nil, fmt.Errorf("unable to get rejected stage ids: %w", err)
 	}
@@ -920,12 +921,10 @@ func deleteRejectedStagesWithLinkedTags(ctx context.Context, storageManager mana
 		deleted := make([]string, 0, len(rejectedStageIDs))
 		for _, stageID := range rejectedStageIDs {
 			stageIDStr := stageID.String()
-			if customTags, ok := customTagsByStageID[stageIDStr]; ok {
-				if err := deleteCustomTags(ctx, storageManager, customTags, dryRun); err != nil {
-					return nil, err
-				}
-			}
 			logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s\n", stageIDStr)
+			for _, customTag := range customTagsByStageID[stageIDStr] {
+				logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s\n", customTag)
+			}
 			logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s-rejected\n", stageIDStr)
 			deleted = append(deleted, stageIDStr)
 		}
@@ -933,34 +932,48 @@ func deleteRejectedStagesWithLinkedTags(ctx context.Context, storageManager mana
 		return deleted, nil
 	}
 
-	deleteStageOptions := manager.ForEachDeleteStageOptions{
-		DeleteImageOptions: storage.DeleteImageOptions{
-			RmiForce: false,
-		},
-	}
+	deleteImageOptions := storage.DeleteImageOptions{RmiForce: false}
 
 	var (
 		mu      sync.Mutex
 		deleted []string
 	)
-	if err := storageManager.ForEachDeleteRejectedStage(ctx, deleteStageOptions, rejectedStageIDs, func(ctx context.Context, stageID image.StageID, err error) error {
+	if err := storageManager.ForEachDeleteRejectedStage(ctx, rejectedStageIDs, func(ctx context.Context, stageID image.StageID) error {
 		stageIDStr := stageID.String()
-		if err != nil {
+
+		// 1. Stage image — broken-image fallback applies here (corrupt manifest may block delete).
+		if err := stagesStorage.DeleteRejectedStageImage(ctx, stageID, deleteImageOptions); err != nil {
 			if err := handleDeletionError(err); err != nil {
 				return err
 			}
-			logboek.Context(ctx).Warn().LogF("WARNING: Rejected stage %s deletion failed: %s\n", stageIDStr, err)
+			logboek.Context(ctx).Warn().LogF("WARNING: Rejected stage image %s deletion failed: %s; marker kept for retry\n", stageIDStr, err)
 			return nil
 		}
+		logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s\n", stageIDStr)
 
-		if customTags, ok := customTagsByStageID[stageIDStr]; ok && len(customTags) != 0 {
-			if err := deleteCustomTags(ctx, storageManager, customTags, false); err != nil {
-				return fmt.Errorf("unable to delete custom tags for rejected stage %s: %w", stageIDStr, err)
+		// 2. Linked custom tags — sequential (avoids parallel-of-parallel registry pressure).
+		// Fail-fast: leave marker untouched on any failure so the next cleanup retries.
+		for _, customTag := range customTagsByStageID[stageIDStr] {
+			if err := stagesStorage.DeleteStageCustomTag(ctx, customTag); err != nil {
+				if err := handleDeletionError(err); err != nil {
+					return err
+				}
+				logboek.Context(ctx).Warn().LogF("WARNING: Custom tag %s linked to rejected stage %s deletion failed: %s; marker kept for retry\n", customTag, stageIDStr, err)
+				return nil
 			}
+			logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s\n", customTag)
 		}
 
-		logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s\n", stageIDStr)
+		// 3. Rejected marker — only after stage image and all linked custom tags are gone.
+		if err := stagesStorage.DeleteRejectedStageRecord(ctx, stageID, deleteImageOptions); err != nil {
+			if err := handleDeletionError(err); err != nil {
+				return err
+			}
+			logboek.Context(ctx).Warn().LogF("WARNING: Rejected stage marker %s-rejected deletion failed: %s\n", stageIDStr, err)
+			return nil
+		}
 		logboek.Context(ctx).Default().LogFWithCustomStyle(deletedStyle, "  tag: %s-rejected\n", stageIDStr)
+
 		mu.Lock()
 		deleted = append(deleted, stageIDStr)
 		mu.Unlock()

--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -938,7 +938,7 @@ func deleteRejectedStagesWithLinkedTags(ctx context.Context, storageManager mana
 		mu      sync.Mutex
 		deleted []string
 	)
-	if err := storageManager.ForEachDeleteRejectedStage(ctx, rejectedStageIDs, func(ctx context.Context, stageID image.StageID) error {
+	if err := storageManager.ForEachRejectedStage(ctx, rejectedStageIDs, func(ctx context.Context, stageID image.StageID) error {
 		stageIDStr := stageID.String()
 
 		// 1. Stage image — broken-image fallback applies here (corrupt manifest may block delete).

--- a/pkg/cleaning/cleanup.go
+++ b/pkg/cleaning/cleanup.go
@@ -212,7 +212,7 @@ func (m *cleanupManager) run(ctx context.Context) error {
 	m.markWhitelistStagesAsProtected()
 
 	if err := logboek.Context(ctx).LogProcess("Cleanup rejected stages").DoError(func() error {
-		return m.cleanupRejectedStages(ctx)
+		return m.deleteRejectedStagesWithLinkedTags(ctx)
 	}); err != nil {
 		return err
 	}
@@ -882,8 +882,8 @@ func deleteImageMetadata(ctx context.Context, projectName string, storageManager
 	})
 }
 
-func (m *cleanupManager) cleanupRejectedStages(ctx context.Context) error {
-	deletedStageIDs, err := cleanupRejectedStages(ctx, m.StorageManager, m.stageManager.GetCustomTagsMetadata(), m.DryRun)
+func (m *cleanupManager) deleteRejectedStagesWithLinkedTags(ctx context.Context) error {
+	deletedStageIDs, err := deleteRejectedStagesWithLinkedTags(ctx, m.StorageManager, m.stageManager.GetCustomTagsMetadata(), m.DryRun)
 	if err != nil {
 		return err
 	}
@@ -906,13 +906,7 @@ func (m *cleanupManager) cleanupRejectedStages(ctx context.Context) error {
 	return nil
 }
 
-// cleanupRejectedStages unconditionally deletes every rejected stage tag found in the registry
-// together with the custom tags pointing to it. A rejected marker means the underlying stage is
-// broken/invalid by construction (RejectStage is called only after build-time detection of a
-// corrupted stage), so the cleanup must purge it regardless of any protection policy. Returns the
-// stage IDs whose deletion was confirmed by the registry so callers can drop them from in-memory
-// state.
-func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, customTagsByStageID map[string][]string, dryRun bool) ([]string, error) {
+func deleteRejectedStagesWithLinkedTags(ctx context.Context, storageManager manager.StorageManagerInterface, customTagsByStageID map[string][]string, dryRun bool) ([]string, error) {
 	rejectedStageIDs, err := storageManager.GetStagesStorage().GetRejectedStageIDs(ctx, storage.WithCache())
 	if err != nil {
 		return nil, fmt.Errorf("unable to get rejected stage ids: %w", err)
@@ -939,7 +933,7 @@ func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageMa
 
 	var deletedStageIDs []string
 	if err := logboek.Context(ctx).Default().LogProcess("Deleting rejected stages tags (%d)", len(rejectedStageIDs)).DoError(func() error {
-		deleted, err := deleteRejectedStages(ctx, storageManager, rejectedStageIDs, dryRun)
+		deleted, err := deleteRejectedStageList(ctx, storageManager, rejectedStageIDs, dryRun)
 		deletedStageIDs = deleted
 		return err
 	}); err != nil {
@@ -949,7 +943,7 @@ func cleanupRejectedStages(ctx context.Context, storageManager manager.StorageMa
 	return deletedStageIDs, nil
 }
 
-func deleteRejectedStages(ctx context.Context, storageManager manager.StorageManagerInterface, stageIDs []image.StageID, dryRun bool) ([]string, error) {
+func deleteRejectedStageList(ctx context.Context, storageManager manager.StorageManagerInterface, stageIDs []image.StageID, dryRun bool) ([]string, error) {
 	if dryRun {
 		deleted := make([]string, 0, len(stageIDs))
 		for _, stageID := range stageIDs {

--- a/pkg/cleaning/cleanup_ai_test.go
+++ b/pkg/cleaning/cleanup_ai_test.go
@@ -78,9 +78,9 @@ func (f *fakeStorageManager) ForEachDeleteStageCustomTag(ctx context.Context, id
 func TestAI_cleanupRejectedStages_NoRejected(t *testing.T) {
 	sm := newFakeStorageManager()
 
-	handled, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	deleted, err := cleanupRejectedStages(context.Background(), sm, nil, nil, false)
 	require.NoError(t, err)
-	assert.Empty(t, handled)
+	assert.Empty(t, deleted)
 	assert.Empty(t, sm.deletedRejected)
 	assert.Empty(t, sm.deletedCustomTags)
 }
@@ -98,10 +98,10 @@ func TestAI_cleanupRejectedStages_DeletesLinkedCustomTags(t *testing.T) {
 		otherStageID.String(): {"unrelated"},
 	}
 
-	handled, err := cleanupRejectedStages(context.Background(), sm, customTagsByStageID, false)
+	deleted, err := cleanupRejectedStages(context.Background(), sm, customTagsByStageID, nil, false)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{stageID.String()}, handled)
+	assert.Equal(t, []string{stageID.String()}, deleted)
 	assert.Equal(t, []image.StageID{*stageID}, sm.deletedRejected)
 	assert.ElementsMatch(t, []string{"v1.0.0", "latest"}, sm.deletedCustomTags, "must delete linked custom tags, untouched 'unrelated'")
 }
@@ -113,9 +113,9 @@ func TestAI_cleanupRejectedStages_DryRun(t *testing.T) {
 	sm := newFakeStorageManager()
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
 
-	handled, err := cleanupRejectedStages(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, true)
+	deleted, err := cleanupRejectedStages(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, nil, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{stageID.String()}, handled)
+	assert.Equal(t, []string{stageID.String()}, deleted)
 	assert.Empty(t, sm.deletedRejected, "dry run must not touch registry")
 	assert.Empty(t, sm.deletedCustomTags, "dry run must not delete custom tags")
 }
@@ -124,7 +124,7 @@ func TestAI_cleanupRejectedStages_PropagatesGetError(t *testing.T) {
 	sm := newFakeStorageManager()
 	sm.stages.rejectedErr = errors.New("registry down")
 
-	_, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	_, err := cleanupRejectedStages(context.Background(), sm, nil, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to get rejected stage ids")
 }
@@ -137,9 +137,9 @@ func TestAI_cleanupRejectedStages_DeletionErrorSwallowed(t *testing.T) {
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
 	sm.deleteRejectedErrs[stageID.String()] = errors.New("temporary network glitch")
 
-	handled, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	deleted, err := cleanupRejectedStages(context.Background(), sm, nil, nil, false)
 	require.NoError(t, err, "non-fatal deletion errors must be logged but not fail cleanup")
-	assert.Equal(t, []string{stageID.String()}, handled)
+	assert.Empty(t, deleted, "failed deletions must not appear in the returned 'successfully deleted' list")
 }
 
 func TestAI_cleanupRejectedStages_FatalDeletionErrorPropagates(t *testing.T) {
@@ -150,7 +150,44 @@ func TestAI_cleanupRejectedStages_FatalDeletionErrorPropagates(t *testing.T) {
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
 	sm.deleteRejectedErrs[stageID.String()] = errors.New("UNAUTHORIZED")
 
-	_, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	_, err := cleanupRejectedStages(context.Background(), sm, nil, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "UNAUTHORIZED")
+}
+
+func TestAI_cleanupRejectedStages_SkipsProtectedStages(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	protectedID := image.NewStageID(digest, 1700000000)
+	freeID := image.NewStageID(digest, 1700000001)
+
+	sm := newFakeStorageManager()
+	sm.stages.rejectedStageIDs = []image.StageID{*protectedID, *freeID}
+
+	customTagsByStageID := map[string][]string{
+		protectedID.String(): {"deployed-tag"},
+		freeID.String():      {"orphan-tag"},
+	}
+	protected := map[string]bool{protectedID.String(): true}
+
+	deleted, err := cleanupRejectedStages(context.Background(), sm, customTagsByStageID, protected, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{freeID.String()}, deleted, "protected stage must not be reported as deleted")
+	assert.Equal(t, []image.StageID{*freeID}, sm.deletedRejected, "protected stage must not be deleted from registry")
+	assert.Equal(t, []string{"orphan-tag"}, sm.deletedCustomTags, "custom tag of protected stage must NOT be deleted")
+}
+
+func TestAI_cleanupRejectedStages_AllProtectedNoop(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	stageID := image.NewStageID(digest, 1700000000)
+
+	sm := newFakeStorageManager()
+	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
+	protected := map[string]bool{stageID.String(): true}
+
+	deleted, err := cleanupRejectedStages(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, protected, false)
+	require.NoError(t, err)
+	assert.Empty(t, deleted)
+	assert.Empty(t, sm.deletedRejected, "registry must not be touched when every rejected stage is protected")
+	assert.Empty(t, sm.deletedCustomTags, "linked custom tags must NOT be deleted when their parent is protected")
 }

--- a/pkg/cleaning/cleanup_ai_test.go
+++ b/pkg/cleaning/cleanup_ai_test.go
@@ -78,7 +78,7 @@ func (f *fakeStorageManager) ForEachDeleteStageCustomTag(ctx context.Context, id
 func TestAI_cleanupRejectedStages_NoRejected(t *testing.T) {
 	sm := newFakeStorageManager()
 
-	deleted, err := cleanupRejectedStages(context.Background(), sm, nil, nil, false)
+	deleted, err := cleanupRejectedStages(context.Background(), sm, nil, false)
 	require.NoError(t, err)
 	assert.Empty(t, deleted)
 	assert.Empty(t, sm.deletedRejected)
@@ -98,7 +98,7 @@ func TestAI_cleanupRejectedStages_DeletesLinkedCustomTags(t *testing.T) {
 		otherStageID.String(): {"unrelated"},
 	}
 
-	deleted, err := cleanupRejectedStages(context.Background(), sm, customTagsByStageID, nil, false)
+	deleted, err := cleanupRejectedStages(context.Background(), sm, customTagsByStageID, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{stageID.String()}, deleted)
@@ -113,7 +113,7 @@ func TestAI_cleanupRejectedStages_DryRun(t *testing.T) {
 	sm := newFakeStorageManager()
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
 
-	deleted, err := cleanupRejectedStages(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, nil, true)
+	deleted, err := cleanupRejectedStages(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{stageID.String()}, deleted)
 	assert.Empty(t, sm.deletedRejected, "dry run must not touch registry")
@@ -124,7 +124,7 @@ func TestAI_cleanupRejectedStages_PropagatesGetError(t *testing.T) {
 	sm := newFakeStorageManager()
 	sm.stages.rejectedErr = errors.New("registry down")
 
-	_, err := cleanupRejectedStages(context.Background(), sm, nil, nil, false)
+	_, err := cleanupRejectedStages(context.Background(), sm, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to get rejected stage ids")
 }
@@ -137,7 +137,7 @@ func TestAI_cleanupRejectedStages_DeletionErrorSwallowed(t *testing.T) {
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
 	sm.deleteRejectedErrs[stageID.String()] = errors.New("temporary network glitch")
 
-	deleted, err := cleanupRejectedStages(context.Background(), sm, nil, nil, false)
+	deleted, err := cleanupRejectedStages(context.Background(), sm, nil, false)
 	require.NoError(t, err, "non-fatal deletion errors must be logged but not fail cleanup")
 	assert.Empty(t, deleted, "failed deletions must not appear in the returned 'successfully deleted' list")
 }
@@ -150,44 +150,7 @@ func TestAI_cleanupRejectedStages_FatalDeletionErrorPropagates(t *testing.T) {
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
 	sm.deleteRejectedErrs[stageID.String()] = errors.New("UNAUTHORIZED")
 
-	_, err := cleanupRejectedStages(context.Background(), sm, nil, nil, false)
+	_, err := cleanupRejectedStages(context.Background(), sm, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "UNAUTHORIZED")
-}
-
-func TestAI_cleanupRejectedStages_SkipsProtectedStages(t *testing.T) {
-	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-	protectedID := image.NewStageID(digest, 1700000000)
-	freeID := image.NewStageID(digest, 1700000001)
-
-	sm := newFakeStorageManager()
-	sm.stages.rejectedStageIDs = []image.StageID{*protectedID, *freeID}
-
-	customTagsByStageID := map[string][]string{
-		protectedID.String(): {"deployed-tag"},
-		freeID.String():      {"orphan-tag"},
-	}
-	protected := map[string]bool{protectedID.String(): true}
-
-	deleted, err := cleanupRejectedStages(context.Background(), sm, customTagsByStageID, protected, false)
-	require.NoError(t, err)
-
-	assert.Equal(t, []string{freeID.String()}, deleted, "protected stage must not be reported as deleted")
-	assert.Equal(t, []image.StageID{*freeID}, sm.deletedRejected, "protected stage must not be deleted from registry")
-	assert.Equal(t, []string{"orphan-tag"}, sm.deletedCustomTags, "custom tag of protected stage must NOT be deleted")
-}
-
-func TestAI_cleanupRejectedStages_AllProtectedNoop(t *testing.T) {
-	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-	stageID := image.NewStageID(digest, 1700000000)
-
-	sm := newFakeStorageManager()
-	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
-	protected := map[string]bool{stageID.String(): true}
-
-	deleted, err := cleanupRejectedStages(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, protected, false)
-	require.NoError(t, err)
-	assert.Empty(t, deleted)
-	assert.Empty(t, sm.deletedRejected, "registry must not be touched when every rejected stage is protected")
-	assert.Empty(t, sm.deletedCustomTags, "linked custom tags must NOT be deleted when their parent is protected")
 }

--- a/pkg/cleaning/cleanup_ai_test.go
+++ b/pkg/cleaning/cleanup_ai_test.go
@@ -78,7 +78,7 @@ func (f *fakeStorageManager) ForEachDeleteStageCustomTag(ctx context.Context, id
 func TestAI_cleanupRejectedStages_NoRejected(t *testing.T) {
 	sm := newFakeStorageManager()
 
-	deleted, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	deleted, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, nil, false)
 	require.NoError(t, err)
 	assert.Empty(t, deleted)
 	assert.Empty(t, sm.deletedRejected)
@@ -98,7 +98,7 @@ func TestAI_cleanupRejectedStages_DeletesLinkedCustomTags(t *testing.T) {
 		otherStageID.String(): {"unrelated"},
 	}
 
-	deleted, err := cleanupRejectedStages(context.Background(), sm, customTagsByStageID, false)
+	deleted, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, customTagsByStageID, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{stageID.String()}, deleted)
@@ -113,7 +113,7 @@ func TestAI_cleanupRejectedStages_DryRun(t *testing.T) {
 	sm := newFakeStorageManager()
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
 
-	deleted, err := cleanupRejectedStages(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, true)
+	deleted, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{stageID.String()}, deleted)
 	assert.Empty(t, sm.deletedRejected, "dry run must not touch registry")
@@ -124,7 +124,7 @@ func TestAI_cleanupRejectedStages_PropagatesGetError(t *testing.T) {
 	sm := newFakeStorageManager()
 	sm.stages.rejectedErr = errors.New("registry down")
 
-	_, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	_, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to get rejected stage ids")
 }
@@ -137,7 +137,7 @@ func TestAI_cleanupRejectedStages_DeletionErrorSwallowed(t *testing.T) {
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
 	sm.deleteRejectedErrs[stageID.String()] = errors.New("temporary network glitch")
 
-	deleted, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	deleted, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, nil, false)
 	require.NoError(t, err, "non-fatal deletion errors must be logged but not fail cleanup")
 	assert.Empty(t, deleted, "failed deletions must not appear in the returned 'successfully deleted' list")
 }
@@ -150,7 +150,7 @@ func TestAI_cleanupRejectedStages_FatalDeletionErrorPropagates(t *testing.T) {
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
 	sm.deleteRejectedErrs[stageID.String()] = errors.New("UNAUTHORIZED")
 
-	_, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	_, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "UNAUTHORIZED")
 }

--- a/pkg/cleaning/cleanup_ai_test.go
+++ b/pkg/cleaning/cleanup_ai_test.go
@@ -1,0 +1,156 @@
+package cleaning
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/werf/werf/v2/pkg/image"
+	"github.com/werf/werf/v2/pkg/storage"
+	"github.com/werf/werf/v2/pkg/storage/manager"
+)
+
+type fakePrimaryStagesStorage struct {
+	storage.PrimaryStagesStorage
+
+	rejectedStageIDs []image.StageID
+	rejectedErr      error
+}
+
+func (f *fakePrimaryStagesStorage) GetRejectedStageIDs(_ context.Context, _ ...storage.Option) ([]image.StageID, error) {
+	return f.rejectedStageIDs, f.rejectedErr
+}
+
+type fakeStorageManager struct {
+	manager.StorageManagerInterface
+
+	stages *fakePrimaryStagesStorage
+
+	mu                  sync.Mutex
+	deletedRejected     []image.StageID
+	deleteRejectedErrs  map[string]error
+	deletedCustomTags   []string
+	deleteCustomTagErrs map[string]error
+}
+
+func newFakeStorageManager() *fakeStorageManager {
+	return &fakeStorageManager{
+		stages:              &fakePrimaryStagesStorage{},
+		deleteRejectedErrs:  map[string]error{},
+		deleteCustomTagErrs: map[string]error{},
+	}
+}
+
+func (f *fakeStorageManager) GetStagesStorage() storage.PrimaryStagesStorage {
+	return f.stages
+}
+
+func (f *fakeStorageManager) ForEachDeleteRejectedStage(ctx context.Context, _ manager.ForEachDeleteStageOptions, stageIDs []image.StageID, cb func(ctx context.Context, stageID image.StageID, err error) error) error {
+	for _, id := range stageIDs {
+		f.mu.Lock()
+		f.deletedRejected = append(f.deletedRejected, id)
+		err := f.deleteRejectedErrs[id.String()]
+		f.mu.Unlock()
+		if cbErr := cb(ctx, id, err); cbErr != nil {
+			return cbErr
+		}
+	}
+	return nil
+}
+
+func (f *fakeStorageManager) ForEachDeleteStageCustomTag(ctx context.Context, ids []string, cb func(ctx context.Context, tag string, err error) error) error {
+	for _, id := range ids {
+		f.mu.Lock()
+		f.deletedCustomTags = append(f.deletedCustomTags, id)
+		err := f.deleteCustomTagErrs[id]
+		f.mu.Unlock()
+		if cbErr := cb(ctx, id, err); cbErr != nil {
+			return cbErr
+		}
+	}
+	return nil
+}
+
+func TestAI_cleanupRejectedStages_NoRejected(t *testing.T) {
+	sm := newFakeStorageManager()
+
+	handled, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	require.NoError(t, err)
+	assert.Empty(t, handled)
+	assert.Empty(t, sm.deletedRejected)
+	assert.Empty(t, sm.deletedCustomTags)
+}
+
+func TestAI_cleanupRejectedStages_DeletesLinkedCustomTags(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	stageID := image.NewStageID(digest, 1700000000)
+	otherStageID := image.NewStageID(digest, 1700000999)
+
+	sm := newFakeStorageManager()
+	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
+
+	customTagsByStageID := map[string][]string{
+		stageID.String():      {"v1.0.0", "latest"},
+		otherStageID.String(): {"unrelated"},
+	}
+
+	handled, err := cleanupRejectedStages(context.Background(), sm, customTagsByStageID, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{stageID.String()}, handled)
+	assert.Equal(t, []image.StageID{*stageID}, sm.deletedRejected)
+	assert.ElementsMatch(t, []string{"v1.0.0", "latest"}, sm.deletedCustomTags, "must delete linked custom tags, untouched 'unrelated'")
+}
+
+func TestAI_cleanupRejectedStages_DryRun(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	stageID := image.NewStageID(digest, 1700000000)
+
+	sm := newFakeStorageManager()
+	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
+
+	handled, err := cleanupRejectedStages(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{stageID.String()}, handled)
+	assert.Empty(t, sm.deletedRejected, "dry run must not touch registry")
+	assert.Empty(t, sm.deletedCustomTags, "dry run must not delete custom tags")
+}
+
+func TestAI_cleanupRejectedStages_PropagatesGetError(t *testing.T) {
+	sm := newFakeStorageManager()
+	sm.stages.rejectedErr = errors.New("registry down")
+
+	_, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to get rejected stage ids")
+}
+
+func TestAI_cleanupRejectedStages_DeletionErrorSwallowed(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	stageID := image.NewStageID(digest, 1700000000)
+
+	sm := newFakeStorageManager()
+	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
+	sm.deleteRejectedErrs[stageID.String()] = errors.New("temporary network glitch")
+
+	handled, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	require.NoError(t, err, "non-fatal deletion errors must be logged but not fail cleanup")
+	assert.Equal(t, []string{stageID.String()}, handled)
+}
+
+func TestAI_cleanupRejectedStages_FatalDeletionErrorPropagates(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	stageID := image.NewStageID(digest, 1700000000)
+
+	sm := newFakeStorageManager()
+	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
+	sm.deleteRejectedErrs[stageID.String()] = errors.New("UNAUTHORIZED")
+
+	_, err := cleanupRejectedStages(context.Background(), sm, nil, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UNAUTHORIZED")
+}

--- a/pkg/cleaning/cleanup_ai_test.go
+++ b/pkg/cleaning/cleanup_ai_test.go
@@ -76,7 +76,7 @@ func (f *fakeStorageManager) GetStagesStorage() storage.PrimaryStagesStorage {
 	return f.stages
 }
 
-func (f *fakeStorageManager) ForEachDeleteRejectedStage(ctx context.Context, stageIDs []image.StageID, cb func(ctx context.Context, stageID image.StageID) error) error {
+func (f *fakeStorageManager) ForEachRejectedStage(ctx context.Context, stageIDs []image.StageID, cb func(ctx context.Context, stageID image.StageID) error) error {
 	for _, id := range stageIDs {
 		if err := cb(ctx, id); err != nil {
 			return err

--- a/pkg/cleaning/cleanup_ai_test.go
+++ b/pkg/cleaning/cleanup_ai_test.go
@@ -17,31 +17,58 @@ import (
 type fakePrimaryStagesStorage struct {
 	storage.PrimaryStagesStorage
 
+	mu sync.Mutex
+
 	rejectedStageIDs []image.StageID
 	rejectedErr      error
+
+	deleteImageErrs  map[string]error
+	deleteRecordErrs map[string]error
+	deleteTagErrs    map[string]error
+
+	deletedImages  []image.StageID
+	deletedRecords []image.StageID
+	deletedTags    []string
 }
 
 func (f *fakePrimaryStagesStorage) GetRejectedStageIDs(_ context.Context, _ ...storage.Option) ([]image.StageID, error) {
 	return f.rejectedStageIDs, f.rejectedErr
 }
 
+func (f *fakePrimaryStagesStorage) DeleteRejectedStageImage(_ context.Context, stageID image.StageID, _ storage.DeleteImageOptions) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletedImages = append(f.deletedImages, stageID)
+	return f.deleteImageErrs[stageID.String()]
+}
+
+func (f *fakePrimaryStagesStorage) DeleteRejectedStageRecord(_ context.Context, stageID image.StageID, _ storage.DeleteImageOptions) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletedRecords = append(f.deletedRecords, stageID)
+	return f.deleteRecordErrs[stageID.String()]
+}
+
+func (f *fakePrimaryStagesStorage) DeleteStageCustomTag(_ context.Context, tag string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletedTags = append(f.deletedTags, tag)
+	return f.deleteTagErrs[tag]
+}
+
 type fakeStorageManager struct {
 	manager.StorageManagerInterface
 
 	stages *fakePrimaryStagesStorage
-
-	mu                  sync.Mutex
-	deletedRejected     []image.StageID
-	deleteRejectedErrs  map[string]error
-	deletedCustomTags   []string
-	deleteCustomTagErrs map[string]error
 }
 
 func newFakeStorageManager() *fakeStorageManager {
 	return &fakeStorageManager{
-		stages:              &fakePrimaryStagesStorage{},
-		deleteRejectedErrs:  map[string]error{},
-		deleteCustomTagErrs: map[string]error{},
+		stages: &fakePrimaryStagesStorage{
+			deleteImageErrs:  map[string]error{},
+			deleteRecordErrs: map[string]error{},
+			deleteTagErrs:    map[string]error{},
+		},
 	}
 }
 
@@ -49,43 +76,27 @@ func (f *fakeStorageManager) GetStagesStorage() storage.PrimaryStagesStorage {
 	return f.stages
 }
 
-func (f *fakeStorageManager) ForEachDeleteRejectedStage(ctx context.Context, _ manager.ForEachDeleteStageOptions, stageIDs []image.StageID, cb func(ctx context.Context, stageID image.StageID, err error) error) error {
+func (f *fakeStorageManager) ForEachDeleteRejectedStage(ctx context.Context, stageIDs []image.StageID, cb func(ctx context.Context, stageID image.StageID) error) error {
 	for _, id := range stageIDs {
-		f.mu.Lock()
-		f.deletedRejected = append(f.deletedRejected, id)
-		err := f.deleteRejectedErrs[id.String()]
-		f.mu.Unlock()
-		if cbErr := cb(ctx, id, err); cbErr != nil {
-			return cbErr
+		if err := cb(ctx, id); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func (f *fakeStorageManager) ForEachDeleteStageCustomTag(ctx context.Context, ids []string, cb func(ctx context.Context, tag string, err error) error) error {
-	for _, id := range ids {
-		f.mu.Lock()
-		f.deletedCustomTags = append(f.deletedCustomTags, id)
-		err := f.deleteCustomTagErrs[id]
-		f.mu.Unlock()
-		if cbErr := cb(ctx, id, err); cbErr != nil {
-			return cbErr
-		}
-	}
-	return nil
-}
-
-func TestAI_cleanupRejectedStages_NoRejected(t *testing.T) {
+func TestAI_deleteRejectedStagesWithLinkedTags_NoRejected(t *testing.T) {
 	sm := newFakeStorageManager()
 
 	deleted, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, nil, false)
 	require.NoError(t, err)
 	assert.Empty(t, deleted)
-	assert.Empty(t, sm.deletedRejected)
-	assert.Empty(t, sm.deletedCustomTags)
+	assert.Empty(t, sm.stages.deletedImages)
+	assert.Empty(t, sm.stages.deletedTags)
+	assert.Empty(t, sm.stages.deletedRecords)
 }
 
-func TestAI_cleanupRejectedStages_DeletesLinkedCustomTags(t *testing.T) {
+func TestAI_deleteRejectedStagesWithLinkedTags_OrderStageThenTagsThenMarker(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	stageID := image.NewStageID(digest, 1700000000)
 	otherStageID := image.NewStageID(digest, 1700000999)
@@ -102,11 +113,12 @@ func TestAI_cleanupRejectedStages_DeletesLinkedCustomTags(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{stageID.String()}, deleted)
-	assert.Equal(t, []image.StageID{*stageID}, sm.deletedRejected)
-	assert.ElementsMatch(t, []string{"v1.0.0", "latest"}, sm.deletedCustomTags, "must delete linked custom tags, untouched 'unrelated'")
+	assert.Equal(t, []image.StageID{*stageID}, sm.stages.deletedImages, "stage image deleted first")
+	assert.Equal(t, []string{"v1.0.0", "latest"}, sm.stages.deletedTags, "linked custom tags deleted next, in given order")
+	assert.Equal(t, []image.StageID{*stageID}, sm.stages.deletedRecords, "marker deleted last")
 }
 
-func TestAI_cleanupRejectedStages_DryRun(t *testing.T) {
+func TestAI_deleteRejectedStagesWithLinkedTags_DryRun(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	stageID := image.NewStageID(digest, 1700000000)
 
@@ -116,11 +128,12 @@ func TestAI_cleanupRejectedStages_DryRun(t *testing.T) {
 	deleted, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{stageID.String()}, deleted)
-	assert.Empty(t, sm.deletedRejected, "dry run must not touch registry")
-	assert.Empty(t, sm.deletedCustomTags, "dry run must not delete custom tags")
+	assert.Empty(t, sm.stages.deletedImages, "dry run must not touch registry")
+	assert.Empty(t, sm.stages.deletedTags, "dry run must not touch registry")
+	assert.Empty(t, sm.stages.deletedRecords, "dry run must not touch registry")
 }
 
-func TestAI_cleanupRejectedStages_PropagatesGetError(t *testing.T) {
+func TestAI_deleteRejectedStagesWithLinkedTags_PropagatesGetError(t *testing.T) {
 	sm := newFakeStorageManager()
 	sm.stages.rejectedErr = errors.New("registry down")
 
@@ -129,28 +142,65 @@ func TestAI_cleanupRejectedStages_PropagatesGetError(t *testing.T) {
 	assert.Contains(t, err.Error(), "unable to get rejected stage ids")
 }
 
-func TestAI_cleanupRejectedStages_DeletionErrorSwallowed(t *testing.T) {
+func TestAI_deleteRejectedStagesWithLinkedTags_StageImageNonFatalFailureKeepsMarker(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	stageID := image.NewStageID(digest, 1700000000)
 
 	sm := newFakeStorageManager()
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
-	sm.deleteRejectedErrs[stageID.String()] = errors.New("temporary network glitch")
+	sm.stages.deleteImageErrs[stageID.String()] = errors.New("temporary network glitch")
 
-	deleted, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, nil, false)
-	require.NoError(t, err, "non-fatal deletion errors must be logged but not fail cleanup")
-	assert.Empty(t, deleted, "failed deletions must not appear in the returned 'successfully deleted' list")
+	deleted, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0"}}, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, deleted, "stage image deletion failed: stage not reported deleted, retry on next cleanup")
+	assert.Equal(t, []image.StageID{*stageID}, sm.stages.deletedImages, "attempt was made")
+	assert.Empty(t, sm.stages.deletedTags, "custom tags must NOT be touched when stage image delete failed")
+	assert.Empty(t, sm.stages.deletedRecords, "marker must remain so retry picks up this stage")
 }
 
-func TestAI_cleanupRejectedStages_FatalDeletionErrorPropagates(t *testing.T) {
+func TestAI_deleteRejectedStagesWithLinkedTags_StageImageFatalFailurePropagates(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	stageID := image.NewStageID(digest, 1700000000)
 
 	sm := newFakeStorageManager()
 	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
-	sm.deleteRejectedErrs[stageID.String()] = errors.New("UNAUTHORIZED")
+	sm.stages.deleteImageErrs[stageID.String()] = errors.New("UNAUTHORIZED")
 
 	_, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "UNAUTHORIZED")
+}
+
+func TestAI_deleteRejectedStagesWithLinkedTags_CustomTagFailureKeepsMarker(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	stageID := image.NewStageID(digest, 1700000000)
+
+	sm := newFakeStorageManager()
+	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
+	sm.stages.deleteTagErrs["v1.0.0"] = errors.New("temporary network glitch")
+
+	deleted, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, map[string][]string{stageID.String(): {"v1.0.0", "latest"}}, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, deleted, "stage with failed custom tag must NOT be reported deleted")
+	assert.Equal(t, []image.StageID{*stageID}, sm.stages.deletedImages, "stage image already deleted")
+	assert.Equal(t, []string{"v1.0.0"}, sm.stages.deletedTags, "fail-fast on first custom tag failure; 'latest' not attempted")
+	assert.Empty(t, sm.stages.deletedRecords, "marker MUST remain so next cleanup retries linked tags")
+}
+
+func TestAI_deleteRejectedStagesWithLinkedTags_MarkerFailureExcludesFromDeleted(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	stageID := image.NewStageID(digest, 1700000000)
+
+	sm := newFakeStorageManager()
+	sm.stages.rejectedStageIDs = []image.StageID{*stageID}
+	sm.stages.deleteRecordErrs[stageID.String()] = errors.New("temporary network glitch")
+
+	deleted, err := deleteRejectedStagesWithLinkedTags(context.Background(), sm, nil, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, deleted, "marker deletion failed: stage not in deleted list")
+	assert.Equal(t, []image.StageID{*stageID}, sm.stages.deletedImages)
+	assert.Equal(t, []image.StageID{*stageID}, sm.stages.deletedRecords, "attempt was made")
 }

--- a/pkg/cleaning/purge.go
+++ b/pkg/cleaning/purge.go
@@ -177,7 +177,7 @@ func (m *purgeManager) purgeRejectedStages(ctx context.Context) error {
 		return fmt.Errorf("unable to get custom tags metadata: %w", err)
 	}
 
-	if _, err := cleanupRejectedStages(ctx, m.StorageManager, customTagsByStageID, m.DryRun); err != nil {
+	if _, err := deleteRejectedStagesWithLinkedTags(ctx, m.StorageManager, customTagsByStageID, m.DryRun); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cleaning/purge.go
+++ b/pkg/cleaning/purge.go
@@ -2,6 +2,7 @@ package cleaning
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/werf/logboek"
 	"github.com/werf/werf/v2/pkg/cleaning/stage_manager"
@@ -67,6 +68,12 @@ func (m *purgeManager) run(ctx context.Context) error {
 	}
 
 	if err := m.deleteCustomTags(ctx); err != nil {
+		return err
+	}
+
+	if err := logboek.Context(ctx).Default().LogProcess("Deleting rejected stages").DoError(func() error {
+		return m.purgeRejectedStages(ctx)
+	}); err != nil {
 		return err
 	}
 
@@ -161,5 +168,17 @@ func deleteCustomTags(ctx context.Context, storageManager manager.StorageManager
 		return err
 	}
 
+	return nil
+}
+
+func (m *purgeManager) purgeRejectedStages(ctx context.Context) error {
+	customTagsByStageID, err := stage_manager.GetCustomTagsMetadata(ctx, m.StorageManager)
+	if err != nil {
+		return fmt.Errorf("unable to get custom tags metadata: %w", err)
+	}
+
+	if _, err := cleanupRejectedStages(ctx, m.StorageManager, customTagsByStageID, m.DryRun); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/cleaning/purge.go
+++ b/pkg/cleaning/purge.go
@@ -177,7 +177,7 @@ func (m *purgeManager) purgeRejectedStages(ctx context.Context) error {
 		return fmt.Errorf("unable to get custom tags metadata: %w", err)
 	}
 
-	if _, err := cleanupRejectedStages(ctx, m.StorageManager, customTagsByStageID, m.DryRun); err != nil {
+	if _, err := cleanupRejectedStages(ctx, m.StorageManager, customTagsByStageID, nil, m.DryRun); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cleaning/purge.go
+++ b/pkg/cleaning/purge.go
@@ -177,7 +177,7 @@ func (m *purgeManager) purgeRejectedStages(ctx context.Context) error {
 		return fmt.Errorf("unable to get custom tags metadata: %w", err)
 	}
 
-	if _, err := cleanupRejectedStages(ctx, m.StorageManager, customTagsByStageID, nil, m.DryRun); err != nil {
+	if _, err := cleanupRejectedStages(ctx, m.StorageManager, customTagsByStageID, m.DryRun); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/storage/local_stages_storage.go
+++ b/pkg/storage/local_stages_storage.go
@@ -197,6 +197,14 @@ func (storage *LocalStagesStorage) RejectStage(_ context.Context, _, _ string, _
 	return nil
 }
 
+func (storage *LocalStagesStorage) GetRejectedStageIDs(_ context.Context, _ ...Option) ([]image.StageID, error) {
+	return nil, nil
+}
+
+func (storage *LocalStagesStorage) DeleteRejectedStage(_ context.Context, _ image.StageID, _ DeleteImageOptions) error {
+	return nil
+}
+
 func (storage *LocalStagesStorage) ConstructStageImageName(projectName, digest string, creationTs int64) string {
 	if creationTs == 0 {
 		return fmt.Sprintf(LocalStage_ImageFormat, projectName, digest)

--- a/pkg/storage/local_stages_storage.go
+++ b/pkg/storage/local_stages_storage.go
@@ -201,7 +201,11 @@ func (storage *LocalStagesStorage) GetRejectedStageIDs(_ context.Context, _ ...O
 	return nil, nil
 }
 
-func (storage *LocalStagesStorage) DeleteRejectedStage(_ context.Context, _ image.StageID, _ DeleteImageOptions) error {
+func (storage *LocalStagesStorage) DeleteRejectedStageImage(_ context.Context, _ image.StageID, _ DeleteImageOptions) error {
+	return nil
+}
+
+func (storage *LocalStagesStorage) DeleteRejectedStageRecord(_ context.Context, _ image.StageID, _ DeleteImageOptions) error {
 	return nil
 }
 

--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -79,7 +79,7 @@ type StorageManagerInterface interface {
 
 	ForEachDeleteStage(ctx context.Context, options ForEachDeleteStageOptions, stageDescSet image.StageDescSet, f func(ctx context.Context, stageDesc *image.StageDesc, err error) error) error
 	ForEachDeleteFinalStage(ctx context.Context, options ForEachDeleteStageOptions, stageDescSet image.StageDescSet, f func(ctx context.Context, stageDesc *image.StageDesc, err error) error) error
-	ForEachDeleteRejectedStage(ctx context.Context, stageIDs []image.StageID, f func(ctx context.Context, stageID image.StageID) error) error
+	ForEachRejectedStage(ctx context.Context, stageIDs []image.StageID, f func(ctx context.Context, stageID image.StageID) error) error
 	ForEachRmImageMetadata(ctx context.Context, projectName, imageNameOrID string, stageIDCommitList map[string][]string, f func(ctx context.Context, commit, stageID string, err error) error) error
 	ForEachRmManagedImage(ctx context.Context, projectName string, managedImages []string, f func(ctx context.Context, managedImage string, err error) error) error
 	ForEachGetImportMetadata(ctx context.Context, projectName string, ids []string, f func(ctx context.Context, metadataID string, metadata *storage.ImportMetadata, err error) error) error
@@ -1061,7 +1061,7 @@ func (m *StorageManager) ForEachRmImportMetadata(ctx context.Context, projectNam
 	})
 }
 
-func (m *StorageManager) ForEachDeleteRejectedStage(ctx context.Context, stageIDs []image.StageID, f func(ctx context.Context, stageID image.StageID) error) error {
+func (m *StorageManager) ForEachRejectedStage(ctx context.Context, stageIDs []image.StageID, f func(ctx context.Context, stageID image.StageID) error) error {
 	ids := append([]image.StageID(nil), stageIDs...)
 	return parallel.DoTasks(ctx, len(ids), parallel.DoTasksOptions{
 		MaxNumberOfWorkers:         m.MaxNumberOfWorkers(),

--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -79,6 +79,7 @@ type StorageManagerInterface interface {
 
 	ForEachDeleteStage(ctx context.Context, options ForEachDeleteStageOptions, stageDescSet image.StageDescSet, f func(ctx context.Context, stageDesc *image.StageDesc, err error) error) error
 	ForEachDeleteFinalStage(ctx context.Context, options ForEachDeleteStageOptions, stageDescSet image.StageDescSet, f func(ctx context.Context, stageDesc *image.StageDesc, err error) error) error
+	ForEachDeleteRejectedStage(ctx context.Context, options ForEachDeleteStageOptions, stageIDs []image.StageID, f func(ctx context.Context, stageID image.StageID, err error) error) error
 	ForEachRmImageMetadata(ctx context.Context, projectName, imageNameOrID string, stageIDCommitList map[string][]string, f func(ctx context.Context, commit, stageID string, err error) error) error
 	ForEachRmManagedImage(ctx context.Context, projectName string, managedImages []string, f func(ctx context.Context, managedImage string, err error) error) error
 	ForEachGetImportMetadata(ctx context.Context, projectName string, ids []string, f func(ctx context.Context, metadataID string, metadata *storage.ImportMetadata, err error) error) error
@@ -1057,6 +1058,18 @@ func (m *StorageManager) ForEachRmImportMetadata(ctx context.Context, projectNam
 		id := ids[taskId]
 		err := m.StagesStorage.RmImportMetadata(ctx, projectName, id)
 		return f(ctx, id, err)
+	})
+}
+
+func (m *StorageManager) ForEachDeleteRejectedStage(ctx context.Context, options ForEachDeleteStageOptions, stageIDs []image.StageID, f func(ctx context.Context, stageID image.StageID, err error) error) error {
+	ids := append([]image.StageID(nil), stageIDs...)
+	return parallel.DoTasks(ctx, len(ids), parallel.DoTasksOptions{
+		MaxNumberOfWorkers:         m.MaxNumberOfWorkers(),
+		InitDockerCLIForEachWorker: true,
+	}, func(ctx context.Context, taskId int) error {
+		stageID := ids[taskId]
+		err := m.StagesStorage.DeleteRejectedStage(ctx, stageID, options.DeleteImageOptions)
+		return f(ctx, stageID, err)
 	})
 }
 

--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -79,7 +79,7 @@ type StorageManagerInterface interface {
 
 	ForEachDeleteStage(ctx context.Context, options ForEachDeleteStageOptions, stageDescSet image.StageDescSet, f func(ctx context.Context, stageDesc *image.StageDesc, err error) error) error
 	ForEachDeleteFinalStage(ctx context.Context, options ForEachDeleteStageOptions, stageDescSet image.StageDescSet, f func(ctx context.Context, stageDesc *image.StageDesc, err error) error) error
-	ForEachDeleteRejectedStage(ctx context.Context, options ForEachDeleteStageOptions, stageIDs []image.StageID, f func(ctx context.Context, stageID image.StageID, err error) error) error
+	ForEachDeleteRejectedStage(ctx context.Context, stageIDs []image.StageID, f func(ctx context.Context, stageID image.StageID) error) error
 	ForEachRmImageMetadata(ctx context.Context, projectName, imageNameOrID string, stageIDCommitList map[string][]string, f func(ctx context.Context, commit, stageID string, err error) error) error
 	ForEachRmManagedImage(ctx context.Context, projectName string, managedImages []string, f func(ctx context.Context, managedImage string, err error) error) error
 	ForEachGetImportMetadata(ctx context.Context, projectName string, ids []string, f func(ctx context.Context, metadataID string, metadata *storage.ImportMetadata, err error) error) error
@@ -1061,15 +1061,13 @@ func (m *StorageManager) ForEachRmImportMetadata(ctx context.Context, projectNam
 	})
 }
 
-func (m *StorageManager) ForEachDeleteRejectedStage(ctx context.Context, options ForEachDeleteStageOptions, stageIDs []image.StageID, f func(ctx context.Context, stageID image.StageID, err error) error) error {
+func (m *StorageManager) ForEachDeleteRejectedStage(ctx context.Context, stageIDs []image.StageID, f func(ctx context.Context, stageID image.StageID) error) error {
 	ids := append([]image.StageID(nil), stageIDs...)
 	return parallel.DoTasks(ctx, len(ids), parallel.DoTasksOptions{
 		MaxNumberOfWorkers:         m.MaxNumberOfWorkers(),
 		InitDockerCLIForEachWorker: true,
 	}, func(ctx context.Context, taskId int) error {
-		stageID := ids[taskId]
-		err := m.StagesStorage.DeleteRejectedStage(ctx, stageID, options.DeleteImageOptions)
-		return f(ctx, stageID, err)
+		return f(ctx, ids[taskId])
 	})
 }
 

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -177,7 +177,7 @@ func mutateExportStageConfig(mutateConfigFunc func(config v1.Config) (v1.Config,
 }
 
 func (storage *RepoStagesStorage) DeleteStage(ctx context.Context, stageDesc *image.StageDesc, _ DeleteImageOptions) error {
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, stageDesc.Info, stageDesc.Info.Name); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, stageDesc.Info); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", stageDesc.Info.Name, err)
 	}
 
@@ -489,7 +489,7 @@ func (storage *RepoStagesStorage) deleteStageCustomTagMetadata(ctx context.Conte
 		panic("unexpected condition")
 	}
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -580,7 +580,7 @@ func (storage *RepoStagesStorage) RmManagedImage(ctx context.Context, projectNam
 		return nil
 	}
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -687,7 +687,7 @@ func (storage *RepoStagesStorage) RmImageMetadata(ctx context.Context, projectNa
 	}
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.RmImageMetadata full image name: %s\n", img.Tag)
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, img, img.Name); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, img); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", img.Tag, err)
 	}
 
@@ -825,7 +825,7 @@ func (storage *RepoStagesStorage) RmImportMetadata(ctx context.Context, _, id st
 		return nil
 	}
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, img, fullImageName); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, img); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", img.Tag, err)
 	}
 

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -180,11 +180,6 @@ func (storage *RepoStagesStorage) DeleteStage(ctx context.Context, stageDesc *im
 	if err := storage.DockerRegistry.DeleteRepoImage(ctx, stageDesc.Info); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", stageDesc.Info.Name, err)
 	}
-
-	if err := storage.deleteRejectedImageRecord(ctx, stageDesc.StageID.Digest, stageDesc.StageID.CreationTs); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -268,6 +268,17 @@ func (storage *RepoStagesStorage) GetRejectedStageIDs(ctx context.Context, opts 
 }
 
 func (storage *RepoStagesStorage) DeleteRejectedStage(ctx context.Context, stageID image.StageID, _ DeleteImageOptions) error {
+	stageName := storage.ConstructStageImageName("", stageID.Digest, stageID.CreationTs)
+	stageImgInfo, err := storage.DockerRegistry.TryGetRepoImage(ctx, stageName)
+	if err != nil {
+		return fmt.Errorf("unable to get stage image info %q: %w", stageName, err)
+	}
+	if stageImgInfo != nil {
+		if err := storage.deleteRepoImageWithBrokenFallback(ctx, stageImgInfo, stageName); err != nil {
+			return fmt.Errorf("unable to remove rejected stage image %q: %w", stageName, err)
+		}
+	}
+
 	return storage.deleteRejectedImageRecord(ctx, stageID.Digest, stageID.CreationTs)
 }
 

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -176,22 +176,99 @@ func mutateExportStageConfig(mutateConfigFunc func(config v1.Config) (v1.Config,
 }
 
 func (storage *RepoStagesStorage) DeleteStage(ctx context.Context, stageDesc *image.StageDesc, _ DeleteImageOptions) error {
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, stageDesc.Info); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, stageDesc.Info, stageDesc.Info.Name); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", stageDesc.Info.Name, err)
 	}
 
-	rejectedImageName := makeRepoRejectedStageImageRecord(storage.RepoAddress, stageDesc.StageID.Digest, stageDesc.StageID.CreationTs)
-	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.DeleteStage full image name: %s\n", rejectedImageName)
-
-	if rejectedImgInfo, err := storage.DockerRegistry.TryGetRepoImage(ctx, rejectedImageName); err != nil {
-		return fmt.Errorf("unable to get rejected image record %q: %w", rejectedImageName, err)
-	} else if rejectedImgInfo != nil {
-		if err := storage.DockerRegistry.DeleteRepoImage(ctx, rejectedImgInfo); err != nil {
-			return fmt.Errorf("unable to remove rejected image record %q: %w", rejectedImageName, err)
-		}
+	if err := storage.deleteRejectedImageRecord(ctx, stageDesc.StageID.Digest, stageDesc.StageID.CreationTs); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func (storage *RepoStagesStorage) deleteRejectedImageRecord(ctx context.Context, digest string, creationTs int64) error {
+	rejectedImageName := makeRepoRejectedStageImageRecord(storage.RepoAddress, digest, creationTs)
+	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.deleteRejectedImageRecord full image name: %s\n", rejectedImageName)
+
+	rejectedImgInfo, err := storage.DockerRegistry.TryGetRepoImage(ctx, rejectedImageName)
+	if err != nil {
+		return fmt.Errorf("unable to get rejected image record %q: %w", rejectedImageName, err)
+	}
+	if rejectedImgInfo == nil {
+		return nil
+	}
+
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, rejectedImgInfo, rejectedImageName); err != nil {
+		return fmt.Errorf("unable to remove rejected image record %q: %w", rejectedImageName, err)
+	}
+	return nil
+}
+
+// deleteRepoImageWithBrokenFallback deletes a repo image. If the registry rejects the call with a
+// broken-image error (corrupt manifest/blob), the tag is overwritten with a manifest-only dummy
+// image via PushImage and the deletion is retried so cleanup can finish.
+func (storage *RepoStagesStorage) deleteRepoImageWithBrokenFallback(ctx context.Context, imgInfo *image.Info, fullImageName string) error {
+	err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo)
+	if err == nil {
+		return nil
+	}
+	if !docker_registry.IsBrokenImageError(err) {
+		return err
+	}
+
+	logboek.Context(ctx).Warn().LogF("WARNING: Image %q is broken (%s); overwriting with dummy image before retrying delete\n", fullImageName, err)
+
+	if pushErr := storage.DockerRegistry.PushImage(ctx, fullImageName, &docker_registry.PushImageOptions{}); pushErr != nil {
+		return fmt.Errorf("unable to overwrite broken image %q with dummy: %w (original delete error: %s)", fullImageName, pushErr, err)
+	}
+
+	freshInfo, getErr := storage.DockerRegistry.TryGetRepoImage(ctx, fullImageName)
+	if getErr != nil {
+		return fmt.Errorf("unable to refresh image info %q after dummy overwrite: %w (original delete error: %s)", fullImageName, getErr, err)
+	}
+	if freshInfo == nil {
+		logboek.Context(ctx).Debug().LogF("-- deleteRepoImageWithBrokenFallback: image %q vanished after dummy push, treating as deleted\n", fullImageName)
+		return nil
+	}
+
+	if retryErr := storage.DockerRegistry.DeleteRepoImage(ctx, freshInfo); retryErr != nil {
+		return fmt.Errorf("unable to delete image %q after dummy overwrite: %w (original delete error: %s)", fullImageName, retryErr, err)
+	}
+	return nil
+}
+
+func (storage *RepoStagesStorage) GetRejectedStageIDs(ctx context.Context, opts ...Option) ([]image.StageID, error) {
+	o := makeOptions(opts...)
+	tags, err := storage.Tags(ctx, storage.RepoAddress, o.dockerRegistryOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch tags for repo %q: %w", storage.RepoAddress, err)
+	}
+
+	var res []image.StageID
+	for _, tag := range tags {
+		if !strings.HasSuffix(tag, RepoRejectedStageImageRecord_ImageTagSuffix) {
+			continue
+		}
+
+		realTag := strings.TrimSuffix(tag, RepoRejectedStageImageRecord_ImageTagSuffix)
+		digest, creationTs, err := getDigestAndCreationTsFromRepoStageImageTag(realTag)
+		if err != nil {
+			if isUnexpectedTagFormatError(err) {
+				logboek.Context(ctx).Info().LogF("Unexpected rejected tag %q format: %s\n", tag, err)
+				continue
+			}
+			return nil, fmt.Errorf("unable to parse rejected stage tag %q: %w", tag, err)
+		}
+
+		res = append(res, *image.NewStageID(digest, creationTs))
+	}
+
+	return res, nil
+}
+
+func (storage *RepoStagesStorage) DeleteRejectedStage(ctx context.Context, stageID image.StageID, _ DeleteImageOptions) error {
+	return storage.deleteRejectedImageRecord(ctx, stageID.Digest, stageID.CreationTs)
 }
 
 func makeRepoRejectedStageImageRecord(repoAddress, digest string, creationTs int64) string {

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -195,7 +195,7 @@ func (storage *RepoStagesStorage) deleteRejectedImageRecord(ctx context.Context,
 		return nil
 	}
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, rejectedImgInfo, rejectedImageName); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, rejectedImgInfo); err != nil {
 		return fmt.Errorf("unable to remove rejected image record %q: %w", rejectedImageName, err)
 	}
 	return nil
@@ -451,7 +451,7 @@ func (storage *RepoStagesStorage) DeleteStageCustomTag(ctx context.Context, tag 
 		return nil
 	}
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -176,7 +177,7 @@ func mutateExportStageConfig(mutateConfigFunc func(config v1.Config) (v1.Config,
 }
 
 func (storage *RepoStagesStorage) DeleteStage(ctx context.Context, stageDesc *image.StageDesc, _ DeleteImageOptions) error {
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, stageDesc.Info, stageDesc.Info.Name); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, stageDesc.Info); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", stageDesc.Info.Name, err)
 	}
 
@@ -205,38 +206,84 @@ func (storage *RepoStagesStorage) deleteRejectedImageRecord(ctx context.Context,
 	return nil
 }
 
+// Tunable knobs for the broken-image fallback. Exposed as package vars (not consts) so tests can
+// reduce wait time without faking the clock.
+var (
+	brokenFallbackRefreshAttempts = 5
+	brokenFallbackRefreshDelay    = 500 * time.Millisecond
+)
+
 // deleteRepoImageWithBrokenFallback deletes a repo image. If the registry rejects the call with a
 // broken-image error (corrupt manifest/blob), the tag is overwritten with a manifest-only dummy
 // image via PushImage and the deletion is retried so cleanup can finish.
+//
+// This fallback is intentionally restricted to the rejected-stage cleanup path: rejected markers
+// (and the underlying rejected stage tag) are being permanently removed, so overwriting a corrupt
+// manifest with a dummy is safe. Other werf-managed records (custom-tag metadata, managed-image
+// records, image metadata, import metadata) must NOT use this helper, as a dummy-but-undeleted tag
+// would leave parseable-but-empty metadata that confuses downstream readers.
 func (storage *RepoStagesStorage) deleteRepoImageWithBrokenFallback(ctx context.Context, imgInfo *image.Info, fullImageName string) error {
-	err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo)
-	if err == nil {
+	origErr := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo)
+	if origErr == nil {
 		return nil
 	}
-	if !docker_registry.IsBrokenImageError(err) {
-		return err
+	if !docker_registry.IsBrokenImageError(origErr) {
+		return origErr
 	}
 
-	logboek.Context(ctx).Warn().LogF("WARNING: Image %q is broken (%s); overwriting with dummy image before retrying delete\n", fullImageName, err)
+	logboek.Context(ctx).Warn().LogF("WARNING: Image %q is broken (%s); overwriting with dummy image before retrying delete\n", fullImageName, origErr)
 
 	if pushErr := storage.DockerRegistry.PushImage(ctx, fullImageName, &docker_registry.PushImageOptions{}); pushErr != nil {
-		return fmt.Errorf("unable to overwrite broken image %q with dummy: %w (original delete error: %s)", fullImageName, pushErr, err)
+		return fmt.Errorf("unable to overwrite broken image %q with dummy: %w (original delete error: %s)", fullImageName, pushErr, origErr)
 	}
 
-	freshInfo, getErr := storage.DockerRegistry.TryGetRepoImage(ctx, fullImageName)
-	if getErr != nil {
-		return fmt.Errorf("unable to refresh image info %q after dummy overwrite: %w (original delete error: %s)", fullImageName, getErr, err)
+	freshInfo, err := storage.refreshImageInfoAfterDummyPush(ctx, fullImageName)
+	if err != nil {
+		return fmt.Errorf("unable to refresh image info %q after dummy overwrite: %w (original delete error: %s)", fullImageName, err, origErr)
 	}
 	if freshInfo == nil {
-		logboek.Context(ctx).Debug().LogF("-- deleteRepoImageWithBrokenFallback: image %q vanished after dummy push, treating as deleted\n", fullImageName)
-		return nil
+		return fmt.Errorf("image %q not found in registry after dummy overwrite within %d attempts; refusing to treat as deleted (original delete error: %s)", fullImageName, brokenFallbackRefreshAttempts, origErr)
 	}
 
 	if retryErr := storage.DockerRegistry.DeleteRepoImage(ctx, freshInfo); retryErr != nil {
-		return fmt.Errorf("unable to delete image %q after dummy overwrite: %w (original delete error: %s)", fullImageName, retryErr, err)
+		return fmt.Errorf("unable to delete image %q after dummy overwrite: %w (original delete error: %s)", fullImageName, retryErr, origErr)
 	}
 	return nil
 }
+
+// refreshImageInfoAfterDummyPush polls the registry for the freshly pushed dummy image. Some
+// registries (GCR/ACR/ECR) exhibit read-after-write lag where the just-pushed tag is briefly
+// invisible. Returning a nil-but-no-error result without retry would let callers treat a delayed
+// push as a successful delete, leaving a real dummy tag behind.
+func (storage *RepoStagesStorage) refreshImageInfoAfterDummyPush(ctx context.Context, fullImageName string) (*image.Info, error) {
+	var lastInfo *image.Info
+	for attempt := 1; attempt <= brokenFallbackRefreshAttempts; attempt++ {
+		info, err := storage.DockerRegistry.TryGetRepoImage(ctx, fullImageName)
+		if err != nil {
+			return nil, err
+		}
+		if info != nil {
+			return info, nil
+		}
+		lastInfo = info
+		if attempt == brokenFallbackRefreshAttempts {
+			break
+		}
+		logboek.Context(ctx).Debug().LogF("-- refreshImageInfoAfterDummyPush: %q not visible yet (attempt %d/%d), retrying after %s\n", fullImageName, attempt, brokenFallbackRefreshAttempts, brokenFallbackRefreshDelay)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(brokenFallbackRefreshDelay):
+		}
+	}
+	return lastInfo, nil
+}
+
+// rejectedStageTagRegexp matches exactly the format produced by RejectStage:
+// <56-char lowercase-hex sha3-224 digest>-<positive int creation ts>-rejected. Tightening the
+// parse to this exact shape avoids accidentally deleting user-created tags that happen to end
+// with "-rejected".
+var rejectedStageTagRegexp = regexp.MustCompile(`^([0-9a-f]{56})-([0-9]+)-rejected$`)
 
 func (storage *RepoStagesStorage) GetRejectedStageIDs(ctx context.Context, opts ...Option) ([]image.StageID, error) {
 	o := makeOptions(opts...)
@@ -247,21 +294,21 @@ func (storage *RepoStagesStorage) GetRejectedStageIDs(ctx context.Context, opts 
 
 	var res []image.StageID
 	for _, tag := range tags {
-		if !strings.HasSuffix(tag, RepoRejectedStageImageRecord_ImageTagSuffix) {
+		match := rejectedStageTagRegexp.FindStringSubmatch(tag)
+		if match == nil {
+			if strings.HasSuffix(tag, RepoRejectedStageImageRecord_ImageTagSuffix) {
+				logboek.Context(ctx).Info().LogF("Skipping tag %q: does not match werf rejected-stage format\n", tag)
+			}
 			continue
 		}
 
-		realTag := strings.TrimSuffix(tag, RepoRejectedStageImageRecord_ImageTagSuffix)
-		digest, creationTs, err := getDigestAndCreationTsFromRepoStageImageTag(realTag)
+		creationTs, err := image.ParseCreationTs(match[2])
 		if err != nil {
-			if isUnexpectedTagFormatError(err) {
-				logboek.Context(ctx).Info().LogF("Unexpected rejected tag %q format: %s\n", tag, err)
-				continue
-			}
-			return nil, fmt.Errorf("unable to parse rejected stage tag %q: %w", tag, err)
+			logboek.Context(ctx).Info().LogF("Skipping rejected tag %q: cannot parse creation timestamp %q: %s\n", tag, match[2], err)
+			continue
 		}
 
-		res = append(res, *image.NewStageID(digest, creationTs))
+		res = append(res, *image.NewStageID(match[1], creationTs))
 	}
 
 	return res, nil
@@ -449,7 +496,7 @@ func (storage *RepoStagesStorage) DeleteStageCustomTag(ctx context.Context, tag 
 		return nil
 	}
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -482,7 +529,7 @@ func (storage *RepoStagesStorage) deleteStageCustomTagMetadata(ctx context.Conte
 		panic("unexpected condition")
 	}
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -573,7 +620,7 @@ func (storage *RepoStagesStorage) RmManagedImage(ctx context.Context, projectNam
 		return nil
 	}
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -680,7 +727,7 @@ func (storage *RepoStagesStorage) RmImageMetadata(ctx context.Context, projectNa
 	}
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.RmImageMetadata full image name: %s\n", img.Tag)
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, img, img.Name); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, img); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", img.Tag, err)
 	}
 
@@ -818,7 +865,7 @@ func (storage *RepoStagesStorage) RmImportMetadata(ctx context.Context, _, id st
 		return nil
 	}
 
-	if err := storage.deleteRepoImageWithBrokenFallback(ctx, img, fullImageName); err != nil {
+	if err := storage.DockerRegistry.DeleteRepoImage(ctx, img); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", img.Tag, err)
 	}
 

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -449,7 +449,7 @@ func (storage *RepoStagesStorage) DeleteStageCustomTag(ctx context.Context, tag 
 		return nil
 	}
 
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -482,7 +482,7 @@ func (storage *RepoStagesStorage) deleteStageCustomTagMetadata(ctx context.Conte
 		panic("unexpected condition")
 	}
 
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -573,7 +573,7 @@ func (storage *RepoStagesStorage) RmManagedImage(ctx context.Context, projectNam
 		return nil
 	}
 
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -680,7 +680,7 @@ func (storage *RepoStagesStorage) RmImageMetadata(ctx context.Context, projectNa
 	}
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.RmImageMetadata full image name: %s\n", img.Tag)
 
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, img); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, img, img.Name); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", img.Tag, err)
 	}
 
@@ -818,7 +818,7 @@ func (storage *RepoStagesStorage) RmImportMetadata(ctx context.Context, _, id st
 		return nil
 	}
 
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, img); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, img, fullImageName); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", img.Tag, err)
 	}
 

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -177,7 +177,7 @@ func mutateExportStageConfig(mutateConfigFunc func(config v1.Config) (v1.Config,
 }
 
 func (storage *RepoStagesStorage) DeleteStage(ctx context.Context, stageDesc *image.StageDesc, _ DeleteImageOptions) error {
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, stageDesc.Info); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, stageDesc.Info, stageDesc.Info.Name); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", stageDesc.Info.Name, err)
 	}
 
@@ -206,22 +206,9 @@ func (storage *RepoStagesStorage) deleteRejectedImageRecord(ctx context.Context,
 	return nil
 }
 
-// Tunable knobs for the broken-image fallback. Exposed as package vars (not consts) so tests can
-// reduce wait time without faking the clock.
-var (
-	brokenFallbackRefreshAttempts = 5
-	brokenFallbackRefreshDelay    = 500 * time.Millisecond
-)
-
 // deleteRepoImageWithBrokenFallback deletes a repo image. If the registry rejects the call with a
 // broken-image error (corrupt manifest/blob), the tag is overwritten with a manifest-only dummy
 // image via PushImage and the deletion is retried so cleanup can finish.
-//
-// This fallback is intentionally restricted to the rejected-stage cleanup path: rejected markers
-// (and the underlying rejected stage tag) are being permanently removed, so overwriting a corrupt
-// manifest with a dummy is safe. Other werf-managed records (custom-tag metadata, managed-image
-// records, image metadata, import metadata) must NOT use this helper, as a dummy-but-undeleted tag
-// would leave parseable-but-empty metadata that confuses downstream readers.
 func (storage *RepoStagesStorage) deleteRepoImageWithBrokenFallback(ctx context.Context, imgInfo *image.Info, fullImageName string) error {
 	origErr := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo)
 	if origErr == nil {
@@ -237,46 +224,19 @@ func (storage *RepoStagesStorage) deleteRepoImageWithBrokenFallback(ctx context.
 		return fmt.Errorf("unable to overwrite broken image %q with dummy: %w (original delete error: %s)", fullImageName, pushErr, origErr)
 	}
 
-	freshInfo, err := storage.refreshImageInfoAfterDummyPush(ctx, fullImageName)
-	if err != nil {
-		return fmt.Errorf("unable to refresh image info %q after dummy overwrite: %w (original delete error: %s)", fullImageName, err, origErr)
+	freshInfo, getErr := storage.DockerRegistry.TryGetRepoImage(ctx, fullImageName)
+	if getErr != nil {
+		return fmt.Errorf("unable to refresh image info %q after dummy overwrite: %w (original delete error: %s)", fullImageName, getErr, origErr)
 	}
 	if freshInfo == nil {
-		return fmt.Errorf("image %q not found in registry after dummy overwrite within %d attempts; refusing to treat as deleted (original delete error: %s)", fullImageName, brokenFallbackRefreshAttempts, origErr)
+		logboek.Context(ctx).Debug().LogF("-- deleteRepoImageWithBrokenFallback: image %q vanished after dummy push, treating as deleted\n", fullImageName)
+		return nil
 	}
 
 	if retryErr := storage.DockerRegistry.DeleteRepoImage(ctx, freshInfo); retryErr != nil {
 		return fmt.Errorf("unable to delete image %q after dummy overwrite: %w (original delete error: %s)", fullImageName, retryErr, origErr)
 	}
 	return nil
-}
-
-// refreshImageInfoAfterDummyPush polls the registry for the freshly pushed dummy image. Some
-// registries (GCR/ACR/ECR) exhibit read-after-write lag where the just-pushed tag is briefly
-// invisible. Returning a nil-but-no-error result without retry would let callers treat a delayed
-// push as a successful delete, leaving a real dummy tag behind.
-func (storage *RepoStagesStorage) refreshImageInfoAfterDummyPush(ctx context.Context, fullImageName string) (*image.Info, error) {
-	var lastInfo *image.Info
-	for attempt := 1; attempt <= brokenFallbackRefreshAttempts; attempt++ {
-		info, err := storage.DockerRegistry.TryGetRepoImage(ctx, fullImageName)
-		if err != nil {
-			return nil, err
-		}
-		if info != nil {
-			return info, nil
-		}
-		lastInfo = info
-		if attempt == brokenFallbackRefreshAttempts {
-			break
-		}
-		logboek.Context(ctx).Debug().LogF("-- refreshImageInfoAfterDummyPush: %q not visible yet (attempt %d/%d), retrying after %s\n", fullImageName, attempt, brokenFallbackRefreshAttempts, brokenFallbackRefreshDelay)
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(brokenFallbackRefreshDelay):
-		}
-	}
-	return lastInfo, nil
 }
 
 // rejectedStageTagRegexp matches exactly the format produced by RejectStage:
@@ -496,7 +456,7 @@ func (storage *RepoStagesStorage) DeleteStageCustomTag(ctx context.Context, tag 
 		return nil
 	}
 
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -529,7 +489,7 @@ func (storage *RepoStagesStorage) deleteStageCustomTagMetadata(ctx context.Conte
 		panic("unexpected condition")
 	}
 
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -620,7 +580,7 @@ func (storage *RepoStagesStorage) RmManagedImage(ctx context.Context, projectNam
 		return nil
 	}
 
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, imgInfo, fullImageName); err != nil {
 		return fmt.Errorf("unable to delete image %q from repo: %w", fullImageName, err)
 	}
 
@@ -727,7 +687,7 @@ func (storage *RepoStagesStorage) RmImageMetadata(ctx context.Context, projectNa
 	}
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.RmImageMetadata full image name: %s\n", img.Tag)
 
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, img); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, img, img.Name); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", img.Tag, err)
 	}
 
@@ -865,7 +825,7 @@ func (storage *RepoStagesStorage) RmImportMetadata(ctx context.Context, _, id st
 		return nil
 	}
 
-	if err := storage.DockerRegistry.DeleteRepoImage(ctx, img); err != nil {
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, img, fullImageName); err != nil {
 		return fmt.Errorf("unable to remove repo image %s: %w", img.Tag, err)
 	}
 

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -201,9 +201,6 @@ func (storage *RepoStagesStorage) deleteRejectedImageRecord(ctx context.Context,
 	return nil
 }
 
-// deleteRepoImageWithBrokenFallback deletes a repo image. If the registry rejects the call with a
-// broken-image error (corrupt manifest/blob), the tag is overwritten with a manifest-only dummy
-// image via PushImage and the deletion is retried so cleanup can finish.
 func (storage *RepoStagesStorage) deleteRepoImageWithBrokenFallback(ctx context.Context, imgInfo *image.Info, fullImageName string) error {
 	origErr := storage.DockerRegistry.DeleteRepoImage(ctx, imgInfo)
 	if origErr == nil {
@@ -234,10 +231,6 @@ func (storage *RepoStagesStorage) deleteRepoImageWithBrokenFallback(ctx context.
 	return nil
 }
 
-// rejectedStageTagRegexp matches exactly the format produced by RejectStage:
-// <56-char lowercase-hex sha3-224 digest>-<positive int creation ts>-rejected. Tightening the
-// parse to this exact shape avoids accidentally deleting user-created tags that happen to end
-// with "-rejected".
 var rejectedStageTagRegexp = regexp.MustCompile(`^([0-9a-f]{56})-([0-9]+)-rejected$`)
 
 func (storage *RepoStagesStorage) GetRejectedStageIDs(ctx context.Context, opts ...Option) ([]image.StageID, error) {
@@ -252,14 +245,14 @@ func (storage *RepoStagesStorage) GetRejectedStageIDs(ctx context.Context, opts 
 		match := rejectedStageTagRegexp.FindStringSubmatch(tag)
 		if match == nil {
 			if strings.HasSuffix(tag, RepoRejectedStageImageRecord_ImageTagSuffix) {
-				logboek.Context(ctx).Info().LogF("Skipping tag %q: does not match werf rejected-stage format\n", tag)
+				logboek.Context(ctx).Debug().LogF("Skipping tag %q: does not match werf rejected-stage format\n", tag)
 			}
 			continue
 		}
 
 		creationTs, err := image.ParseCreationTs(match[2])
 		if err != nil {
-			logboek.Context(ctx).Info().LogF("Skipping rejected tag %q: cannot parse creation timestamp %q: %s\n", tag, match[2], err)
+			logboek.Context(ctx).Debug().LogF("Skipping rejected tag %q: cannot parse creation timestamp %q: %s\n", tag, match[2], err)
 			continue
 		}
 
@@ -269,18 +262,22 @@ func (storage *RepoStagesStorage) GetRejectedStageIDs(ctx context.Context, opts 
 	return res, nil
 }
 
-func (storage *RepoStagesStorage) DeleteRejectedStage(ctx context.Context, stageID image.StageID, _ DeleteImageOptions) error {
+func (storage *RepoStagesStorage) DeleteRejectedStageImage(ctx context.Context, stageID image.StageID, _ DeleteImageOptions) error {
 	stageName := storage.ConstructStageImageName("", stageID.Digest, stageID.CreationTs)
 	stageImgInfo, err := storage.DockerRegistry.TryGetRepoImage(ctx, stageName)
 	if err != nil {
 		return fmt.Errorf("unable to get stage image info %q: %w", stageName, err)
 	}
-	if stageImgInfo != nil {
-		if err := storage.deleteRepoImageWithBrokenFallback(ctx, stageImgInfo, stageName); err != nil {
-			return fmt.Errorf("unable to remove rejected stage image %q: %w", stageName, err)
-		}
+	if stageImgInfo == nil {
+		return nil
 	}
+	if err := storage.deleteRepoImageWithBrokenFallback(ctx, stageImgInfo, stageName); err != nil {
+		return fmt.Errorf("unable to remove rejected stage image %q: %w", stageName, err)
+	}
+	return nil
+}
 
+func (storage *RepoStagesStorage) DeleteRejectedStageRecord(ctx context.Context, stageID image.StageID, _ DeleteImageOptions) error {
 	return storage.deleteRejectedImageRecord(ctx, stageID.Digest, stageID.CreationTs)
 }
 

--- a/pkg/storage/repo_stages_storage_ai_test.go
+++ b/pkg/storage/repo_stages_storage_ai_test.go
@@ -245,6 +245,45 @@ func TestAI_DeleteRejectedStage_FallbackVanishedTreatedAsDeleted(t *testing.T) {
 	assert.Equal(t, 1, r.deleteCall[rejectedRef], "marker still deleted")
 }
 
+func TestAI_DeleteStageCustomTag_BrokenFallback(t *testing.T) {
+	tag := "v1.0.0"
+	customRef := "registry.example/project:v1.0.0"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[customRef] = &image.Info{Name: customRef}
+	r.deleteErrs[customRef] = []error{errors.New("BLOB_UNKNOWN: corrupted custom tag"), nil}
+
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteStageCustomTag(context.Background(), tag)
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.deleteCall[customRef], "custom tag delete retried after dummy push")
+	assert.Equal(t, 1, r.pushCall[customRef], "dummy push exactly once")
+}
+
+func TestAI_DeleteStageCustomTag_HappyPath(t *testing.T) {
+	tag := "latest"
+	customRef := "registry.example/project:latest"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[customRef] = &image.Info{Name: customRef}
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteStageCustomTag(context.Background(), tag)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.deleteCall[customRef])
+	assert.Equal(t, 0, r.pushCall[customRef], "must not push when delete works")
+}
+
+func TestAI_DeleteStageCustomTag_Missing(t *testing.T) {
+	r := newFakeRegistry()
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteStageCustomTag(context.Background(), "missing")
+	require.NoError(t, err)
+	assert.Empty(t, r.deleteCall, "no delete when tag absent")
+}
+
 type vanishingRegistry struct {
 	*fakeRegistry
 	origInfo *image.Info

--- a/pkg/storage/repo_stages_storage_ai_test.go
+++ b/pkg/storage/repo_stages_storage_ai_test.go
@@ -125,70 +125,49 @@ func TestAI_GetRejectedStageIDs(t *testing.T) {
 	}
 }
 
-func TestAI_DeleteRejectedStage_HappyPath(t *testing.T) {
+func TestAI_DeleteRejectedStageImage_HappyPath(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
 	stageRef := "registry.example/project:" + digest + "-1700000000"
-	rejectedRef := stageRef + "-rejected"
 
 	r := newFakeRegistry()
 	r.tryGetInfo[stageRef] = &image.Info{Name: stageRef}
-	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
-	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	err := s.DeleteRejectedStageImage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, r.deleteCall[stageRef], "must delete stage image")
-	assert.Equal(t, 1, r.deleteCall[rejectedRef], "must delete rejected marker")
+	assert.Equal(t, 1, r.deleteCall[stageRef])
 }
 
-func TestAI_DeleteRejectedStage_MissingBoth(t *testing.T) {
+func TestAI_DeleteRejectedStageImage_AlreadyGone(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
 	r := newFakeRegistry()
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
-	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, 1700000000), DeleteImageOptions{})
+	err := s.DeleteRejectedStageImage(context.Background(), *image.NewStageID(digest, 1700000000), DeleteImageOptions{})
 	require.NoError(t, err)
-	assert.Empty(t, r.deleteCall, "no delete attempt when both tags absent")
+	assert.Empty(t, r.deleteCall, "no delete attempt when stage image absent")
 }
 
-func TestAI_DeleteRejectedStage_StageAlreadyGone(t *testing.T) {
-	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-	const ts int64 = 1700000000
-	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
-
-	r := newFakeRegistry()
-	// stage image already gone, only marker present
-	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
-	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
-
-	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, r.deleteCall[rejectedRef], "must still delete marker")
-}
-
-func TestAI_DeleteRejectedStage_BrokenStageFallback(t *testing.T) {
+func TestAI_DeleteRejectedStageImage_BrokenFallback(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
 	stageRef := "registry.example/project:" + digest + "-1700000000"
-	rejectedRef := stageRef + "-rejected"
 
 	r := newFakeRegistry()
 	r.tryGetInfo[stageRef] = &image.Info{Name: stageRef}
-	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
-	// stage delete fails with broken image error first, then succeeds
 	r.deleteErrs[stageRef] = []error{errors.New("BLOB_UNKNOWN: corrupted blob"), nil}
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
-	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	err := s.DeleteRejectedStageImage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 2, r.deleteCall[stageRef], "stage delete retried after dummy push")
-	assert.Equal(t, 1, r.pushCall[stageRef], "dummy push exactly once for stage")
-	assert.Equal(t, 1, r.deleteCall[rejectedRef], "marker also deleted")
+	assert.Equal(t, 1, r.pushCall[stageRef], "dummy push exactly once")
 }
 
-func TestAI_DeleteRejectedStage_NonBrokenErrorPropagates(t *testing.T) {
+func TestAI_DeleteRejectedStageImage_NonBrokenErrorPropagates(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
 	stageRef := "registry.example/project:" + digest + "-1700000000"
@@ -199,13 +178,13 @@ func TestAI_DeleteRejectedStage_NonBrokenErrorPropagates(t *testing.T) {
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
-	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	err := s.DeleteRejectedStageImage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "UNAUTHORIZED")
 	assert.Equal(t, 0, r.pushCall[stageRef], "must not push on non-broken errors")
 }
 
-func TestAI_DeleteRejectedStage_PushFallbackFails(t *testing.T) {
+func TestAI_DeleteRejectedStageImage_PushFallbackFails(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
 	stageRef := "registry.example/project:" + digest + "-1700000000"
@@ -217,39 +196,31 @@ func TestAI_DeleteRejectedStage_PushFallbackFails(t *testing.T) {
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
-	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	err := s.DeleteRejectedStageImage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "overwrite broken image")
 	assert.Contains(t, err.Error(), "MANIFEST_INVALID")
 }
 
-func TestAI_DeleteRejectedStage_FallbackVanishedAfterPushTreatedAsDeleted(t *testing.T) {
-	// If the tag vanishes after the dummy push (some registries GC immediately or
-	// the tag was already gone by the time we re-fetch), treat it as successfully
-	// deleted rather than erroring out.
+func TestAI_DeleteRejectedStageImage_FallbackVanishedAfterPushTreatedAsDeleted(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
 	stageRef := "registry.example/project:" + digest + "-1700000000"
-	rejectedRef := stageRef + "-rejected"
 
 	r := newFakeRegistry()
 	origInfo := &image.Info{Name: stageRef}
 	r.deleteErrs[stageRef] = []error{errors.New("DIGEST_INVALID")}
-	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
 	calls := 0
 	wrap := &vanishingRegistry{fakeRegistry: r, origInfo: origInfo, ref: stageRef, calls: &calls}
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: wrap}
 
-	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	err := s.DeleteRejectedStageImage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 1, r.deleteCall[stageRef], "no retry needed when stage vanished after dummy push")
 	assert.Equal(t, 1, r.pushCall[stageRef])
-	assert.Equal(t, 1, r.deleteCall[rejectedRef], "marker still deleted")
 }
 
-func TestAI_DeleteRejectedStage_FallbackPushSucceedsRetryFails(t *testing.T) {
-	// Push succeeds, retry-delete fails. The function must surface the retry error
-	// and preserve the original error; it must NOT pretend success.
+func TestAI_DeleteRejectedStageImage_FallbackPushSucceedsRetryFails(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
 	stageRef := "registry.example/project:" + digest + "-1700000000"
@@ -260,18 +231,14 @@ func TestAI_DeleteRejectedStage_FallbackPushSucceedsRetryFails(t *testing.T) {
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
-	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	err := s.DeleteRejectedStageImage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "after dummy overwrite")
 	assert.Contains(t, err.Error(), "BLOB_UNKNOWN")
 	assert.Contains(t, err.Error(), "MANIFEST_INVALID", "original delete error must be preserved")
-	assert.Equal(t, 2, r.deleteCall[stageRef])
-	assert.Equal(t, 1, r.pushCall[stageRef])
 }
 
-func TestAI_DeleteRejectedStage_FallbackPushImmutableTag(t *testing.T) {
-	// ECR with immutable tags: PushImage rejects the overwrite. The fallback must
-	// surface push error with the original delete error preserved.
+func TestAI_DeleteRejectedStageImage_FallbackPushImmutableTag(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
 	stageRef := "registry.example/project:" + digest + "-1700000000"
@@ -283,28 +250,79 @@ func TestAI_DeleteRejectedStage_FallbackPushImmutableTag(t *testing.T) {
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
-	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	err := s.DeleteRejectedStageImage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "overwrite broken image")
 	assert.Contains(t, err.Error(), "immutable")
 	assert.Contains(t, err.Error(), "MANIFEST_INVALID")
 }
 
-func TestAI_DeleteStageCustomTag_BrokenErrorPropagates(t *testing.T) {
-	tag := "v1.0.0"
-	customRef := "registry.example/project:v1.0.0"
+func TestAI_DeleteRejectedStageRecord_HappyPath(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
 
 	r := newFakeRegistry()
-	r.tryGetInfo[customRef] = &image.Info{Name: customRef}
-	r.deleteErrs[customRef] = []error{errors.New("BLOB_UNKNOWN: corrupted custom tag")}
+	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteRejectedStageRecord(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.deleteCall[rejectedRef])
+}
+
+func TestAI_DeleteRejectedStageRecord_AlreadyGone(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	r := newFakeRegistry()
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteRejectedStageRecord(context.Background(), *image.NewStageID(digest, 1700000000), DeleteImageOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, r.deleteCall, "no delete attempt when marker absent")
+}
+
+func TestAI_DeleteRejectedStageRecord_BrokenErrorPropagatesNoFallback(t *testing.T) {
+	// Marker is a metadata record without business payload — a broken marker must
+	// surface as an error, not be silently replaced with an empty dummy.
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
+	r.deleteErrs[rejectedRef] = []error{errors.New("BLOB_UNKNOWN: corrupted marker")}
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
-	err := s.DeleteStageCustomTag(context.Background(), tag)
+	err := s.DeleteRejectedStageRecord(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "BLOB_UNKNOWN")
-	assert.Equal(t, 1, r.deleteCall[customRef])
-	assert.Equal(t, 0, r.pushCall[customRef], "must not use broken-image fallback for custom tags")
+	assert.Equal(t, 0, r.pushCall[rejectedRef], "marker delete must NOT use broken-image fallback")
+}
+
+func TestAI_DeleteStage_DoesNotTouchRejectedMarker(t *testing.T) {
+	// Regression guard: DeleteStage has a single responsibility (remove the stage
+	// image only). The rejected marker, if any, is cleaned up by the
+	// deleteRejectedStagesWithLinkedTags phase, not by DeleteStage.
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	stageRef := "registry.example/project:" + digest + "-1700000000"
+	rejectedRef := stageRef + "-rejected"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[stageRef] = &image.Info{Name: stageRef}
+	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	stageDesc := &image.StageDesc{
+		StageID: image.NewStageID(digest, ts),
+		Info:    &image.Info{Name: stageRef},
+	}
+	err := s.DeleteStage(context.Background(), stageDesc, DeleteImageOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.deleteCall[stageRef], "stage image deleted")
+	assert.Equal(t, 0, r.deleteCall[rejectedRef], "marker MUST NOT be touched by DeleteStage")
 }
 
 func TestAI_DeleteStageCustomTag_HappyPath(t *testing.T) {
@@ -328,6 +346,24 @@ func TestAI_DeleteStageCustomTag_Missing(t *testing.T) {
 	err := s.DeleteStageCustomTag(context.Background(), "missing")
 	require.NoError(t, err)
 	assert.Empty(t, r.deleteCall, "no delete when tag absent")
+}
+
+func TestAI_DeleteStageCustomTag_BrokenErrorPropagatesNoFallback(t *testing.T) {
+	// Custom tag carries data the user pushed under that tag — a broken custom
+	// tag must surface as an error, not be silently replaced with an empty dummy.
+	tag := "v1.0.0"
+	customRef := "registry.example/project:v1.0.0"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[customRef] = &image.Info{Name: customRef}
+	r.deleteErrs[customRef] = []error{errors.New("BLOB_UNKNOWN: corrupted custom tag")}
+
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteStageCustomTag(context.Background(), tag)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "BLOB_UNKNOWN")
+	assert.Equal(t, 0, r.pushCall[customRef], "custom tag delete must NOT use broken-image fallback")
 }
 
 type vanishingRegistry struct {

--- a/pkg/storage/repo_stages_storage_ai_test.go
+++ b/pkg/storage/repo_stages_storage_ai_test.go
@@ -1,0 +1,245 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/werf/werf/v2/pkg/docker_registry"
+	"github.com/werf/werf/v2/pkg/image"
+)
+
+type fakeRegistry struct {
+	docker_registry.Interface
+
+	mu sync.Mutex
+
+	tags    []string
+	tagsErr error
+
+	tryGetInfo map[string]*image.Info
+	tryGetErr  map[string]error
+
+	deleteErrs map[string][]error
+	deleteCall map[string]int
+
+	pushErrs map[string]error
+	pushCall map[string]int
+}
+
+func newFakeRegistry() *fakeRegistry {
+	return &fakeRegistry{
+		tryGetInfo: map[string]*image.Info{},
+		tryGetErr:  map[string]error{},
+		deleteErrs: map[string][]error{},
+		deleteCall: map[string]int{},
+		pushErrs:   map[string]error{},
+		pushCall:   map[string]int{},
+	}
+}
+
+func (r *fakeRegistry) Tags(_ context.Context, _ string, _ ...docker_registry.Option) ([]string, error) {
+	return r.tags, r.tagsErr
+}
+
+func (r *fakeRegistry) TryGetRepoImage(_ context.Context, reference string) (*image.Info, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err, ok := r.tryGetErr[reference]; ok {
+		return nil, err
+	}
+	return r.tryGetInfo[reference], nil
+}
+
+func (r *fakeRegistry) DeleteRepoImage(_ context.Context, info *image.Info) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ref := info.Name
+	r.deleteCall[ref]++
+	errs := r.deleteErrs[ref]
+	if len(errs) == 0 {
+		return nil
+	}
+	err := errs[0]
+	r.deleteErrs[ref] = errs[1:]
+	return err
+}
+
+func (r *fakeRegistry) PushImage(_ context.Context, reference string, _ *docker_registry.PushImageOptions) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pushCall[reference]++
+	return r.pushErrs[reference]
+}
+
+func TestAI_GetRejectedStageIDs(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	tests := []struct {
+		name     string
+		tags     []string
+		expectN  int
+		expectTs []int64
+	}{
+		{
+			name:    "empty tag list returns nothing",
+			tags:    nil,
+			expectN: 0,
+		},
+		{
+			name:    "ignores non-rejected tags",
+			tags:    []string{digest + "-1700000000", digest},
+			expectN: 0,
+		},
+		{
+			name:     "picks rejected tags",
+			tags:     []string{digest + "-1700000000-rejected", digest + "-1700000001-rejected", digest + "-1700000002"},
+			expectN:  2,
+			expectTs: []int64{1700000000, 1700000001},
+		},
+		{
+			name:    "skips malformed rejected tag",
+			tags:    []string{"garbage-rejected", digest + "-1700000000-rejected"},
+			expectN: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newFakeRegistry()
+			r.tags = tc.tags
+			s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+			got, err := s.GetRejectedStageIDs(context.Background())
+			require.NoError(t, err)
+			assert.Len(t, got, tc.expectN)
+			for i, ts := range tc.expectTs {
+				assert.Equal(t, digest, got[i].Digest)
+				assert.Equal(t, ts, got[i].CreationTs)
+			}
+		})
+	}
+}
+
+func TestAI_DeleteRejectedStage_HappyPath(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.deleteCall[rejectedRef])
+	assert.Equal(t, 0, r.pushCall[rejectedRef], "must not push when delete works")
+}
+
+func TestAI_DeleteRejectedStage_MissingMarker(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	r := newFakeRegistry()
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, 1700000000), DeleteImageOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, r.deleteCall, "no delete attempt when marker absent")
+}
+
+func TestAI_DeleteRejectedStage_BrokenFallback(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
+
+	r := newFakeRegistry()
+	// first TryGet returns broken info, second (after push) returns fresh info
+	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
+	// first delete fails with broken image error, second succeeds
+	r.deleteErrs[rejectedRef] = []error{errors.New("BLOB_UNKNOWN: corrupted blob"), nil}
+
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.deleteCall[rejectedRef], "expected delete retried after dummy push")
+	assert.Equal(t, 1, r.pushCall[rejectedRef], "expected dummy push exactly once")
+}
+
+func TestAI_DeleteRejectedStage_NonBrokenErrorPropagates(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
+	r.deleteErrs[rejectedRef] = []error{errors.New("UNAUTHORIZED")}
+
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UNAUTHORIZED")
+	assert.Equal(t, 0, r.pushCall[rejectedRef], "must not push on non-broken errors")
+}
+
+func TestAI_DeleteRejectedStage_PushFallbackFails(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
+	r.deleteErrs[rejectedRef] = []error{errors.New("MANIFEST_INVALID")}
+	r.pushErrs[rejectedRef] = errors.New("registry write denied")
+
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overwrite broken image")
+	assert.Contains(t, err.Error(), "MANIFEST_INVALID")
+}
+
+func TestAI_DeleteRejectedStage_FallbackVanishedTreatedAsDeleted(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
+
+	r := newFakeRegistry()
+	// first call returns broken image; after push registry still returns nil meaning the tag
+	// is gone (some registries garbage-collect during overwrite).
+	calls := 0
+	r.tryGetErr = nil
+	origInfo := &image.Info{Name: rejectedRef}
+	r.deleteErrs[rejectedRef] = []error{errors.New("DIGEST_INVALID")}
+	// custom TryGet: first call returns info, second returns nil
+	wrap := &vanishingRegistry{fakeRegistry: r, origInfo: origInfo, ref: rejectedRef, calls: &calls}
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: wrap}
+
+	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.deleteCall[rejectedRef], "no retry needed when fallback finds tag gone")
+	assert.Equal(t, 1, r.pushCall[rejectedRef])
+}
+
+type vanishingRegistry struct {
+	*fakeRegistry
+	origInfo *image.Info
+	ref      string
+	calls    *int
+}
+
+func (r *vanishingRegistry) TryGetRepoImage(_ context.Context, reference string) (*image.Info, error) {
+	if reference != r.ref {
+		return r.fakeRegistry.TryGetRepoImage(context.Background(), reference)
+	}
+	*r.calls++
+	if *r.calls == 1 {
+		return r.origInfo, nil
+	}
+	return nil, nil
+}

--- a/pkg/storage/repo_stages_storage_ai_test.go
+++ b/pkg/storage/repo_stages_storage_ai_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,6 +13,11 @@ import (
 	"github.com/werf/werf/v2/pkg/docker_registry"
 	"github.com/werf/werf/v2/pkg/image"
 )
+
+// Tests run with a near-zero refresh delay so the bounded retry loop completes quickly.
+func init() {
+	brokenFallbackRefreshDelay = time.Millisecond
+}
 
 type fakeRegistry struct {
 	docker_registry.Interface
@@ -223,7 +229,11 @@ func TestAI_DeleteRejectedStage_PushFallbackFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "MANIFEST_INVALID")
 }
 
-func TestAI_DeleteRejectedStage_FallbackVanishedTreatedAsDeleted(t *testing.T) {
+func TestAI_DeleteRejectedStage_FallbackVanishedAfterPushIsHardFailure(t *testing.T) {
+	// Reverts the previous "vanished after push == success" behavior, which masked
+	// read-after-write lag: a delayed push could look like a successful delete and
+	// leave a dummy tag behind. The new behavior MUST refuse to claim success when
+	// the freshly-pushed dummy is not observable.
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
 	stageRef := "registry.example/project:" + digest + "-1700000000"
@@ -233,32 +243,102 @@ func TestAI_DeleteRejectedStage_FallbackVanishedTreatedAsDeleted(t *testing.T) {
 	origInfo := &image.Info{Name: stageRef}
 	r.deleteErrs[stageRef] = []error{errors.New("DIGEST_INVALID")}
 	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
-	// stage vanishes after dummy push
 	calls := 0
 	wrap := &vanishingRegistry{fakeRegistry: r, origInfo: origInfo, ref: stageRef, calls: &calls}
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: wrap}
 
 	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, r.deleteCall[stageRef], "no retry needed when stage vanished after dummy push")
-	assert.Equal(t, 1, r.pushCall[stageRef])
-	assert.Equal(t, 1, r.deleteCall[rejectedRef], "marker still deleted")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to treat as deleted")
+	assert.Contains(t, err.Error(), "DIGEST_INVALID", "original delete error must be preserved")
+	assert.Equal(t, 1, r.pushCall[stageRef], "dummy push happened exactly once")
 }
 
-func TestAI_DeleteStageCustomTag_BrokenFallback(t *testing.T) {
+func TestAI_DeleteRejectedStage_FallbackRefreshesAfterRetry(t *testing.T) {
+	// Simulates GCR/ACR/ECR read-after-write lag: TryGetRepoImage returns nil for
+	// the first 2 attempts, then yields the dummy. The retry-delete must use the
+	// fresh dummy info and succeed.
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	stageRef := "registry.example/project:" + digest + "-1700000000"
+	rejectedRef := stageRef + "-rejected"
+	dummyInfo := &image.Info{Name: stageRef, Tag: "dummy-after-push"}
+
+	r := newFakeRegistry()
+	origInfo := &image.Info{Name: stageRef, Tag: "original-broken"}
+	r.deleteErrs[stageRef] = []error{errors.New("MANIFEST_INVALID"), nil}
+	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
+	wrap := &lateAppearingRegistry{fakeRegistry: r, ref: stageRef, origInfo: origInfo, info: dummyInfo, appearOnRefreshCall: 3}
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: wrap}
+
+	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.deleteCall[stageRef], "stage delete retried after push and refresh")
+	assert.Equal(t, 1, r.pushCall[stageRef])
+	assert.Equal(t, 1, r.deleteCall[rejectedRef])
+}
+
+func TestAI_DeleteRejectedStage_FallbackPushSucceedsRetryFails(t *testing.T) {
+	// Push succeeds, retry-delete fails. The function must surface the retry error
+	// and preserve the original error; it must NOT pretend success.
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	stageRef := "registry.example/project:" + digest + "-1700000000"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[stageRef] = &image.Info{Name: stageRef}
+	r.deleteErrs[stageRef] = []error{errors.New("MANIFEST_INVALID"), errors.New("BLOB_UNKNOWN: still corrupt")}
+
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "after dummy overwrite")
+	assert.Contains(t, err.Error(), "BLOB_UNKNOWN")
+	assert.Contains(t, err.Error(), "MANIFEST_INVALID", "original delete error must be preserved")
+	assert.Equal(t, 2, r.deleteCall[stageRef])
+	assert.Equal(t, 1, r.pushCall[stageRef])
+}
+
+func TestAI_DeleteRejectedStage_FallbackPushImmutableTag(t *testing.T) {
+	// ECR with immutable tags: PushImage rejects the overwrite. The fallback must
+	// surface push error with the original delete error preserved.
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	stageRef := "registry.example/project:" + digest + "-1700000000"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[stageRef] = &image.Info{Name: stageRef}
+	r.deleteErrs[stageRef] = []error{errors.New("MANIFEST_INVALID")}
+	r.pushErrs[stageRef] = errors.New("ImageTagAlreadyExistsException: tag is immutable")
+
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overwrite broken image")
+	assert.Contains(t, err.Error(), "immutable")
+	assert.Contains(t, err.Error(), "MANIFEST_INVALID")
+}
+
+func TestAI_DeleteStageCustomTag_BrokenErrorPropagatesNoFallback(t *testing.T) {
+	// Custom-tag deletion must NOT use the broken-image fallback: a dummy-but-
+	// undeleted custom tag would leave a parseable-but-empty tag behind. The
+	// broken error must propagate to the caller verbatim.
 	tag := "v1.0.0"
 	customRef := "registry.example/project:v1.0.0"
 
 	r := newFakeRegistry()
 	r.tryGetInfo[customRef] = &image.Info{Name: customRef}
-	r.deleteErrs[customRef] = []error{errors.New("BLOB_UNKNOWN: corrupted custom tag"), nil}
+	r.deleteErrs[customRef] = []error{errors.New("BLOB_UNKNOWN: corrupted custom tag")}
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
 	err := s.DeleteStageCustomTag(context.Background(), tag)
-	require.NoError(t, err)
-	assert.Equal(t, 2, r.deleteCall[customRef], "custom tag delete retried after dummy push")
-	assert.Equal(t, 1, r.pushCall[customRef], "dummy push exactly once")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "BLOB_UNKNOWN")
+	assert.Equal(t, 1, r.deleteCall[customRef], "custom tag delete must NOT retry after dummy push")
+	assert.Equal(t, 0, r.pushCall[customRef], "custom tag delete must NOT use broken-image fallback")
 }
 
 func TestAI_DeleteStageCustomTag_HappyPath(t *testing.T) {
@@ -300,4 +380,47 @@ func (r *vanishingRegistry) TryGetRepoImage(_ context.Context, reference string)
 		return r.origInfo, nil
 	}
 	return nil, nil
+}
+
+// lateAppearingRegistry models read-after-write lag: TryGetRepoImage(ref) returns origInfo on the
+// initial fetch (before the broken-image fallback), then nil for the first few refresh attempts
+// inside the fallback, and finally returns info starting at appearOnRefreshCall (1-based among
+// refresh calls only).
+type lateAppearingRegistry struct {
+	*fakeRegistry
+	ref                 string
+	origInfo            *image.Info
+	info                *image.Info
+	appearOnRefreshCall int
+
+	mu              sync.Mutex
+	calls           int
+	postPushCalls   int
+	pushHasHappened bool
+}
+
+func (r *lateAppearingRegistry) TryGetRepoImage(ctx context.Context, reference string) (*image.Info, error) {
+	if reference != r.ref {
+		return r.fakeRegistry.TryGetRepoImage(ctx, reference)
+	}
+	r.mu.Lock()
+	r.calls++
+	if !r.pushHasHappened {
+		r.mu.Unlock()
+		return r.origInfo, nil
+	}
+	r.postPushCalls++
+	current := r.postPushCalls
+	r.mu.Unlock()
+	if current < r.appearOnRefreshCall {
+		return nil, nil
+	}
+	return r.info, nil
+}
+
+func (r *lateAppearingRegistry) PushImage(ctx context.Context, reference string, opts *docker_registry.PushImageOptions) error {
+	r.mu.Lock()
+	r.pushHasHappened = true
+	r.mu.Unlock()
+	return r.fakeRegistry.PushImage(ctx, reference, opts)
 }

--- a/pkg/storage/repo_stages_storage_ai_test.go
+++ b/pkg/storage/repo_stages_storage_ai_test.go
@@ -128,73 +128,92 @@ func TestAI_GetRejectedStageIDs(t *testing.T) {
 func TestAI_DeleteRejectedStage_HappyPath(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
-	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
+	stageRef := "registry.example/project:" + digest + "-1700000000"
+	rejectedRef := stageRef + "-rejected"
 
 	r := newFakeRegistry()
+	r.tryGetInfo[stageRef] = &image.Info{Name: stageRef}
 	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
 	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, r.deleteCall[rejectedRef])
-	assert.Equal(t, 0, r.pushCall[rejectedRef], "must not push when delete works")
+	assert.Equal(t, 1, r.deleteCall[stageRef], "must delete stage image")
+	assert.Equal(t, 1, r.deleteCall[rejectedRef], "must delete rejected marker")
 }
 
-func TestAI_DeleteRejectedStage_MissingMarker(t *testing.T) {
+func TestAI_DeleteRejectedStage_MissingBoth(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	r := newFakeRegistry()
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
 	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, 1700000000), DeleteImageOptions{})
 	require.NoError(t, err)
-	assert.Empty(t, r.deleteCall, "no delete attempt when marker absent")
+	assert.Empty(t, r.deleteCall, "no delete attempt when both tags absent")
 }
 
-func TestAI_DeleteRejectedStage_BrokenFallback(t *testing.T) {
+func TestAI_DeleteRejectedStage_StageAlreadyGone(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
 	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
 
 	r := newFakeRegistry()
-	// first TryGet returns broken info, second (after push) returns fresh info
+	// stage image already gone, only marker present
 	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
-	// first delete fails with broken image error, second succeeds
-	r.deleteErrs[rejectedRef] = []error{errors.New("BLOB_UNKNOWN: corrupted blob"), nil}
+	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
+
+	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.deleteCall[rejectedRef], "must still delete marker")
+}
+
+func TestAI_DeleteRejectedStage_BrokenStageFallback(t *testing.T) {
+	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	const ts int64 = 1700000000
+	stageRef := "registry.example/project:" + digest + "-1700000000"
+	rejectedRef := stageRef + "-rejected"
+
+	r := newFakeRegistry()
+	r.tryGetInfo[stageRef] = &image.Info{Name: stageRef}
+	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
+	// stage delete fails with broken image error first, then succeeds
+	r.deleteErrs[stageRef] = []error{errors.New("BLOB_UNKNOWN: corrupted blob"), nil}
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
 	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 2, r.deleteCall[rejectedRef], "expected delete retried after dummy push")
-	assert.Equal(t, 1, r.pushCall[rejectedRef], "expected dummy push exactly once")
+	assert.Equal(t, 2, r.deleteCall[stageRef], "stage delete retried after dummy push")
+	assert.Equal(t, 1, r.pushCall[stageRef], "dummy push exactly once for stage")
+	assert.Equal(t, 1, r.deleteCall[rejectedRef], "marker also deleted")
 }
 
 func TestAI_DeleteRejectedStage_NonBrokenErrorPropagates(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
-	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
+	stageRef := "registry.example/project:" + digest + "-1700000000"
 
 	r := newFakeRegistry()
-	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
-	r.deleteErrs[rejectedRef] = []error{errors.New("UNAUTHORIZED")}
+	r.tryGetInfo[stageRef] = &image.Info{Name: stageRef}
+	r.deleteErrs[stageRef] = []error{errors.New("UNAUTHORIZED")}
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
 	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "UNAUTHORIZED")
-	assert.Equal(t, 0, r.pushCall[rejectedRef], "must not push on non-broken errors")
+	assert.Equal(t, 0, r.pushCall[stageRef], "must not push on non-broken errors")
 }
 
 func TestAI_DeleteRejectedStage_PushFallbackFails(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
-	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
+	stageRef := "registry.example/project:" + digest + "-1700000000"
 
 	r := newFakeRegistry()
-	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
-	r.deleteErrs[rejectedRef] = []error{errors.New("MANIFEST_INVALID")}
-	r.pushErrs[rejectedRef] = errors.New("registry write denied")
+	r.tryGetInfo[stageRef] = &image.Info{Name: stageRef}
+	r.deleteErrs[stageRef] = []error{errors.New("MANIFEST_INVALID")}
+	r.pushErrs[stageRef] = errors.New("registry write denied")
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
@@ -207,23 +226,23 @@ func TestAI_DeleteRejectedStage_PushFallbackFails(t *testing.T) {
 func TestAI_DeleteRejectedStage_FallbackVanishedTreatedAsDeleted(t *testing.T) {
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
-	rejectedRef := "registry.example/project:" + digest + "-1700000000-rejected"
+	stageRef := "registry.example/project:" + digest + "-1700000000"
+	rejectedRef := stageRef + "-rejected"
 
 	r := newFakeRegistry()
-	// first call returns broken image; after push registry still returns nil meaning the tag
-	// is gone (some registries garbage-collect during overwrite).
+	origInfo := &image.Info{Name: stageRef}
+	r.deleteErrs[stageRef] = []error{errors.New("DIGEST_INVALID")}
+	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
+	// stage vanishes after dummy push
 	calls := 0
-	r.tryGetErr = nil
-	origInfo := &image.Info{Name: rejectedRef}
-	r.deleteErrs[rejectedRef] = []error{errors.New("DIGEST_INVALID")}
-	// custom TryGet: first call returns info, second returns nil
-	wrap := &vanishingRegistry{fakeRegistry: r, origInfo: origInfo, ref: rejectedRef, calls: &calls}
+	wrap := &vanishingRegistry{fakeRegistry: r, origInfo: origInfo, ref: stageRef, calls: &calls}
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: wrap}
 
 	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, r.deleteCall[rejectedRef], "no retry needed when fallback finds tag gone")
-	assert.Equal(t, 1, r.pushCall[rejectedRef])
+	assert.Equal(t, 1, r.deleteCall[stageRef], "no retry needed when stage vanished after dummy push")
+	assert.Equal(t, 1, r.pushCall[stageRef])
+	assert.Equal(t, 1, r.deleteCall[rejectedRef], "marker still deleted")
 }
 
 type vanishingRegistry struct {

--- a/pkg/storage/repo_stages_storage_ai_test.go
+++ b/pkg/storage/repo_stages_storage_ai_test.go
@@ -290,20 +290,21 @@ func TestAI_DeleteRejectedStage_FallbackPushImmutableTag(t *testing.T) {
 	assert.Contains(t, err.Error(), "MANIFEST_INVALID")
 }
 
-func TestAI_DeleteStageCustomTag_BrokenFallback(t *testing.T) {
+func TestAI_DeleteStageCustomTag_BrokenErrorPropagates(t *testing.T) {
 	tag := "v1.0.0"
 	customRef := "registry.example/project:v1.0.0"
 
 	r := newFakeRegistry()
 	r.tryGetInfo[customRef] = &image.Info{Name: customRef}
-	r.deleteErrs[customRef] = []error{errors.New("BLOB_UNKNOWN: corrupted custom tag"), nil}
+	r.deleteErrs[customRef] = []error{errors.New("BLOB_UNKNOWN: corrupted custom tag")}
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
 	err := s.DeleteStageCustomTag(context.Background(), tag)
-	require.NoError(t, err)
-	assert.Equal(t, 2, r.deleteCall[customRef], "custom tag delete retried after dummy push")
-	assert.Equal(t, 1, r.pushCall[customRef], "dummy push exactly once")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "BLOB_UNKNOWN")
+	assert.Equal(t, 1, r.deleteCall[customRef])
+	assert.Equal(t, 0, r.pushCall[customRef], "must not use broken-image fallback for custom tags")
 }
 
 func TestAI_DeleteStageCustomTag_HappyPath(t *testing.T) {

--- a/pkg/storage/repo_stages_storage_ai_test.go
+++ b/pkg/storage/repo_stages_storage_ai_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,11 +12,6 @@ import (
 	"github.com/werf/werf/v2/pkg/docker_registry"
 	"github.com/werf/werf/v2/pkg/image"
 )
-
-// Tests run with a near-zero refresh delay so the bounded retry loop completes quickly.
-func init() {
-	brokenFallbackRefreshDelay = time.Millisecond
-}
 
 type fakeRegistry struct {
 	docker_registry.Interface
@@ -229,11 +223,10 @@ func TestAI_DeleteRejectedStage_PushFallbackFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "MANIFEST_INVALID")
 }
 
-func TestAI_DeleteRejectedStage_FallbackVanishedAfterPushIsHardFailure(t *testing.T) {
-	// Reverts the previous "vanished after push == success" behavior, which masked
-	// read-after-write lag: a delayed push could look like a successful delete and
-	// leave a dummy tag behind. The new behavior MUST refuse to claim success when
-	// the freshly-pushed dummy is not observable.
+func TestAI_DeleteRejectedStage_FallbackVanishedAfterPushTreatedAsDeleted(t *testing.T) {
+	// If the tag vanishes after the dummy push (some registries GC immediately or
+	// the tag was already gone by the time we re-fetch), treat it as successfully
+	// deleted rather than erroring out.
 	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	const ts int64 = 1700000000
 	stageRef := "registry.example/project:" + digest + "-1700000000"
@@ -248,34 +241,10 @@ func TestAI_DeleteRejectedStage_FallbackVanishedAfterPushIsHardFailure(t *testin
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: wrap}
 
 	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "refusing to treat as deleted")
-	assert.Contains(t, err.Error(), "DIGEST_INVALID", "original delete error must be preserved")
-	assert.Equal(t, 1, r.pushCall[stageRef], "dummy push happened exactly once")
-}
-
-func TestAI_DeleteRejectedStage_FallbackRefreshesAfterRetry(t *testing.T) {
-	// Simulates GCR/ACR/ECR read-after-write lag: TryGetRepoImage returns nil for
-	// the first 2 attempts, then yields the dummy. The retry-delete must use the
-	// fresh dummy info and succeed.
-	digest := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-	const ts int64 = 1700000000
-	stageRef := "registry.example/project:" + digest + "-1700000000"
-	rejectedRef := stageRef + "-rejected"
-	dummyInfo := &image.Info{Name: stageRef, Tag: "dummy-after-push"}
-
-	r := newFakeRegistry()
-	origInfo := &image.Info{Name: stageRef, Tag: "original-broken"}
-	r.deleteErrs[stageRef] = []error{errors.New("MANIFEST_INVALID"), nil}
-	r.tryGetInfo[rejectedRef] = &image.Info{Name: rejectedRef}
-	wrap := &lateAppearingRegistry{fakeRegistry: r, ref: stageRef, origInfo: origInfo, info: dummyInfo, appearOnRefreshCall: 3}
-	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: wrap}
-
-	err := s.DeleteRejectedStage(context.Background(), *image.NewStageID(digest, ts), DeleteImageOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 2, r.deleteCall[stageRef], "stage delete retried after push and refresh")
+	assert.Equal(t, 1, r.deleteCall[stageRef], "no retry needed when stage vanished after dummy push")
 	assert.Equal(t, 1, r.pushCall[stageRef])
-	assert.Equal(t, 1, r.deleteCall[rejectedRef])
+	assert.Equal(t, 1, r.deleteCall[rejectedRef], "marker still deleted")
 }
 
 func TestAI_DeleteRejectedStage_FallbackPushSucceedsRetryFails(t *testing.T) {
@@ -321,24 +290,20 @@ func TestAI_DeleteRejectedStage_FallbackPushImmutableTag(t *testing.T) {
 	assert.Contains(t, err.Error(), "MANIFEST_INVALID")
 }
 
-func TestAI_DeleteStageCustomTag_BrokenErrorPropagatesNoFallback(t *testing.T) {
-	// Custom-tag deletion must NOT use the broken-image fallback: a dummy-but-
-	// undeleted custom tag would leave a parseable-but-empty tag behind. The
-	// broken error must propagate to the caller verbatim.
+func TestAI_DeleteStageCustomTag_BrokenFallback(t *testing.T) {
 	tag := "v1.0.0"
 	customRef := "registry.example/project:v1.0.0"
 
 	r := newFakeRegistry()
 	r.tryGetInfo[customRef] = &image.Info{Name: customRef}
-	r.deleteErrs[customRef] = []error{errors.New("BLOB_UNKNOWN: corrupted custom tag")}
+	r.deleteErrs[customRef] = []error{errors.New("BLOB_UNKNOWN: corrupted custom tag"), nil}
 
 	s := &RepoStagesStorage{RepoAddress: "registry.example/project", DockerRegistry: r}
 
 	err := s.DeleteStageCustomTag(context.Background(), tag)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "BLOB_UNKNOWN")
-	assert.Equal(t, 1, r.deleteCall[customRef], "custom tag delete must NOT retry after dummy push")
-	assert.Equal(t, 0, r.pushCall[customRef], "custom tag delete must NOT use broken-image fallback")
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.deleteCall[customRef], "custom tag delete retried after dummy push")
+	assert.Equal(t, 1, r.pushCall[customRef], "dummy push exactly once")
 }
 
 func TestAI_DeleteStageCustomTag_HappyPath(t *testing.T) {
@@ -380,47 +345,4 @@ func (r *vanishingRegistry) TryGetRepoImage(_ context.Context, reference string)
 		return r.origInfo, nil
 	}
 	return nil, nil
-}
-
-// lateAppearingRegistry models read-after-write lag: TryGetRepoImage(ref) returns origInfo on the
-// initial fetch (before the broken-image fallback), then nil for the first few refresh attempts
-// inside the fallback, and finally returns info starting at appearOnRefreshCall (1-based among
-// refresh calls only).
-type lateAppearingRegistry struct {
-	*fakeRegistry
-	ref                 string
-	origInfo            *image.Info
-	info                *image.Info
-	appearOnRefreshCall int
-
-	mu              sync.Mutex
-	calls           int
-	postPushCalls   int
-	pushHasHappened bool
-}
-
-func (r *lateAppearingRegistry) TryGetRepoImage(ctx context.Context, reference string) (*image.Info, error) {
-	if reference != r.ref {
-		return r.fakeRegistry.TryGetRepoImage(ctx, reference)
-	}
-	r.mu.Lock()
-	r.calls++
-	if !r.pushHasHappened {
-		r.mu.Unlock()
-		return r.origInfo, nil
-	}
-	r.postPushCalls++
-	current := r.postPushCalls
-	r.mu.Unlock()
-	if current < r.appearOnRefreshCall {
-		return nil, nil
-	}
-	return r.info, nil
-}
-
-func (r *lateAppearingRegistry) PushImage(ctx context.Context, reference string, opts *docker_registry.PushImageOptions) error {
-	r.mu.Lock()
-	r.pushHasHappened = true
-	r.mu.Unlock()
-	return r.fakeRegistry.PushImage(ctx, reference, opts)
 }

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -64,7 +64,8 @@ type StagesStorage interface {
 
 	RejectStage(ctx context.Context, projectName, digest string, creationTs int64) error
 	GetRejectedStageIDs(ctx context.Context, opts ...Option) ([]image.StageID, error)
-	DeleteRejectedStage(ctx context.Context, stageID image.StageID, options DeleteImageOptions) error
+	DeleteRejectedStageImage(ctx context.Context, stageID image.StageID, options DeleteImageOptions) error
+	DeleteRejectedStageRecord(ctx context.Context, stageID image.StageID, options DeleteImageOptions) error
 
 	ConstructStageImageName(projectName, digest string, creationTs int64) string
 

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -63,6 +63,8 @@ type StagesStorage interface {
 	DeleteStageCustomTag(ctx context.Context, tag string) error
 
 	RejectStage(ctx context.Context, projectName, digest string, creationTs int64) error
+	GetRejectedStageIDs(ctx context.Context, opts ...Option) ([]image.StageID, error)
+	DeleteRejectedStage(ctx context.Context, stageID image.StageID, options DeleteImageOptions) error
 
 	ConstructStageImageName(projectName, digest string, creationTs int64) string
 


### PR DESCRIPTION
## Summary

Add a new cleanup/purge phase that unconditionally deletes all \`*-rejected\` stage tags from the registry together with the underlying stage image and the custom tags pointing to the same stage ID. Add a broken-image overwrite fallback so a corrupted rejected stage image no longer blocks cleanup. The rejected marker doubles as a retry flag: it is removed strictly after the stage image and its linked custom tags are gone, so a transient failure on any of those leaves the marker in place for the next cleanup to retry.

## Key changes

- **\`StagesStorage\` interface**: three new methods —
  - \`GetRejectedStageIDs\` scans repo tags with a strict regexp anchored to the werf rejected-stage format \`<56-char-hex-digest>-<ts>-rejected\`,
  - \`DeleteRejectedStageImage\` removes the underlying stage image (with broken-image fallback),
  - \`DeleteRejectedStageRecord\` removes the rejected marker (no fallback — a metadata-only record has no payload worth preserving via dummy overwrite).
- **\`RepoStagesStorage\`**: implements the three methods. The fallback helper \`deleteRepoImageWithBrokenFallback\` (on \`IsBrokenImageError\` overwrites the tag with a manifest-only dummy via \`PushImage\`, then retries delete; tag vanishing after push is treated as deleted) is now used only by \`DeleteRejectedStageImage\`. Custom tags and the rejected marker use plain \`DeleteRepoImage\`.
- **\`LocalStagesStorage\`**: no-op stubs.
- **\`StorageManager\`**: \`ForEachDeleteRejectedStage\` is a thin parallel dispatcher — the callback owns the deletion logic so the cleanup layer controls per-stage ordering.
- **\`cleanupManager.run()\`** (\`pkg/cleaning/cleanup.go\`): new \`deleteRejectedStagesWithLinkedTags\` phase runs before \`cleanupUnusedStages\`. For each rejected stage in the parallel callback:
  1. delete stage image (\`DeleteRejectedStageImage\`),
  2. delete linked custom tags sequentially with fail-fast (avoids workers-squared concurrency that would throttle registries),
  3. delete rejected marker (\`DeleteRejectedStageRecord\`).

  Any failure in step 1 or 2 keeps the marker in place: the next cleanup picks the stage up again via \`GetRejectedStageIDs\`. The stage ID is reported as deleted (and the stage manager state forgotten) only after all three steps complete.

- **\`purgeManager.run()\`** (\`pkg/cleaning/purge.go\`): new \`purgeRejectedStages\` phase after \`deleteCustomTags\`; reuses \`deleteRejectedStagesWithLinkedTags\`.
- **\`DeleteStage\`**: removes only the stage image. The rejected marker for a stage is handled exclusively by \`deleteRejectedStagesWithLinkedTags\`, which runs before \`cleanupUnusedStages\`. Single responsibility, no rejected-marker side effect.
- **Tests**:
  - storage layer: \`GetRejectedStageIDs\` regexp filtering; \`DeleteRejectedStageImage\` happy/missing/broken-fallback/non-broken-error/push-fallback-fails/vanished-after-push/retry-fails/immutable-tag; \`DeleteRejectedStageRecord\` happy/missing/broken-error-propagates-no-fallback; \`DeleteStageCustomTag\` happy/missing/broken-error-propagates-no-fallback; regression: \`DeleteStage\` does not touch the rejected marker.
  - cleanup orchestration: empty/dry-run/get-error; correct order stage→tags→marker; partial-failure cases for each of the three steps (stage image fail / custom tag fail / marker fail) all keep the marker in place and exclude the stage from the deleted list; fatal errors propagate.

## Why

Rejected-stage markers (\`repo:digest-creationTs-rejected\`) created by \`RejectStage()\` accumulated indefinitely. They were cleaned up only when the parent stage was deleted by \`DeleteStage()\`, leaving orphans when the parent was already gone. Additionally, broken/corrupt stage tags caused \`DeleteRepoImage\` to fail with no recovery path, permanently blocking cleanup for affected repos.

The split into image-delete + record-delete (instead of one combined call) makes the marker a real retry flag: until both the stage image and all linked custom tags are confirmed gone, the marker stays so cleanup can be run again safely.

## Review focus / risks

- **Per-stage ordering**: stage image → linked custom tags (sequential, fail-fast) → marker. A non-fatal failure on steps 1 or 2 keeps the marker and excludes the stage from \`deleted\`. Fatal errors (e.g. \`UNAUTHORIZED\`) propagate out of the parallel dispatcher and abort cleanup.
- **Broken-image fallback scope**: only \`DeleteRejectedStageImage\`. The marker and custom tags carry information that should not be silently replaced with an empty dummy, so a broken marker / custom tag surfaces as an error.
- **Unconditional deletion**: rejected stages are purged regardless of any protection policy. A rejected marker means the stage is broken by construction; keeping it to protect a deployed reference would perpetuate the corruption.
- **\`DeleteStage\` no longer cleans up the rejected marker**: any marker that survives the dedicated rejected-cleanup phase (e.g. created concurrently after the phase ran) is picked up on the next cleanup cycle.
- **No nested parallelism**: linked custom tags are deleted sequentially inside the parallel rejected-stage dispatcher. This caps concurrency at \`MaxNumberOfWorkers\` instead of \`workers²\`, avoiding registry throttling.
- **\`LocalStagesStorage\` stubs**: return \`nil, nil\` / \`nil\` — safe because local storage has no concept of rejected tags.