### PR TITLE
refactor(build): use tag cache for rejected stage check in GetStageDesc

### DIFF
--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -402,9 +402,9 @@ func (storage *RepoStagesStorage) GetStageDesc(ctx context.Context, projectName 
 	rejectedImageName := makeRepoRejectedStageImageRecord(storage.RepoAddress, stageID.Digest, stageID.CreationTs)
 	logboek.Context(ctx).Debug().LogF("-- RepoStagesStorage.GetStageDesc check rejected image name: %s\n", rejectedImageName)
 
-	if rejectedImgInfo, err := storage.DockerRegistry.TryGetRepoImage(ctx, rejectedImageName); err != nil {
-		return nil, fmt.Errorf("unable to get repo image %q: %w", rejectedImageName, err)
-	} else if rejectedImgInfo != nil {
+	if rejected, err := storage.DockerRegistry.IsTagExist(ctx, rejectedImageName, docker_registry.WithCachedTags()); err != nil {
+		return nil, fmt.Errorf("unable to check rejected image record %q: %w", rejectedImageName, err)
+	} else if rejected {
 		logboek.Context(ctx).Info().LogF("Stage digest %s creation timestamp %d image is rejected: ignore stage image\n", stageID.Digest, stageID.CreationTs)
 		return nil, ErrStageRejected
 	}


### PR DESCRIPTION
## Problem

`GetStageDesc` checks whether a stage is rejected by calling `TryGetRepoImage` on the `<digest>-<ts>-rejected` tag. This makes a separate HTTP GET to the registry **for every stage** inspected during a build, even though the answer is almost always "not rejected".

## Solution

Replace `TryGetRepoImage` with `IsTagExist(..., WithCachedTags())`. `IsTagExist` delegates to `Tags()` which, when called with `WithCachedTags()`, stores the full tag list in `cachedTagsMap` on the first request and serves all subsequent lookups from memory.

Result: one `Tags()` round-trip for the entire repository, then N-1 in-memory lookups instead of N individual HTTP GETs.