### PR TITLE
test(build): normalize platform spec variant in multiarch e2e test

### DIFF
--- a/test/e2e/build/multiarch_test.go
+++ b/test/e2e/build/multiarch_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/containerd/containerd/platforms"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -102,6 +103,7 @@ var _ = Describe("Multiarch build", Label("e2e", "build", "multiarch", "simple")
 
 					platformSpec, err := platformutil.ParsePlatform(platform)
 					Expect(err).To(Succeed())
+					platformSpec = platforms.Normalize(platformSpec)
 
 					ref := fmt.Sprintf("%s:%s", SuiteData.WerfRepo, byPlatform[platform].DockerTag)
 					inspect := contBack.GetImageInspect(ctx, ref)


### PR DESCRIPTION
## Problem

The multiarch e2e test at `test/e2e/build/multiarch_test.go:113` compares `inspect.Variant` against `platformSpec.Variant`, where `platformSpec` is obtained via `platformutil.ParsePlatform("linux/arm64")`.

`platforms.Parse("linux/arm64")` returns `Variant: ""`, but Buildah in native-chroot mode writes the real hardware variant (`v8`) into the built image. This causes the assertion to fail:

```
Expected <string>: v8
to equal  <string>: (empty)
```

## Fix

Normalize the parsed platform spec with `platforms.Normalize` before using it in assertions. For `linux/arm64` this sets `Variant: "v8"`, matching what Buildah actually writes.

## Related

Fixes the daily e2e CI failure: https://github.com/deckhouse/delivery-kit/actions/runs/27688246481/job/81892728632