### PR TITLE
fix(build, stapel, import): rsync chown "/sys" Read-only file system on to: /

### DIFF
--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -21,7 +21,7 @@ import (
 
 const rsyncServerPort = "873"
 
-var systemExcludeDirs = []string{"/proc", "/sys", "/dev", "/run"}
+var systemExcludeDirs = []string{"/proc", "/sys", "/dev", "/run", "/.werf"}
 
 func buildRsyncdConf(port, authUser string) string {
 	return fmt.Sprintf(`pid file = /.werf/rsyncd.pid

--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -21,7 +21,7 @@ import (
 
 const rsyncServerPort = "873"
 
-var systemExcludeDirs = []string{"/proc", "/sys", "/dev", "/run", "/.werf"}
+var systemExcludeDirs = []string{"/proc", "/sys", "/dev", "/run"}
 
 func buildRsyncdConf(port, authUser string) string {
 	return fmt.Sprintf(`pid file = /.werf/rsyncd.pid

--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -21,7 +21,7 @@ import (
 
 const rsyncServerPort = "873"
 
-var systemExcludeDirs = []string{"proc", "sys", "dev", "run"}
+var systemExcludeDirs = []string{"/proc", "/sys", "/dev", "/run"}
 
 func buildRsyncdConf(port, authUser string) string {
 	return fmt.Sprintf(`pid file = /.werf/rsyncd.pid

--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -21,7 +21,27 @@ import (
 
 const rsyncServerPort = "873"
 
-var defaultRsyncExcludePaths = []string{"/proc", "/sys", "/dev", "/run"}
+var systemExcludeDirs = []string{"proc", "sys", "dev", "run"}
+
+func buildRsyncdConf(port, authUser string) string {
+	return fmt.Sprintf(`pid file = /.werf/rsyncd.pid
+lock file = /.werf/rsyncd.lock
+log file = /.werf/rsyncd.log
+uid = 0
+gid = 0
+port = %s
+
+[import]
+path = /
+comment = Image files to import
+read only = true
+timeout = 300
+auth users = %s
+secrets file = /.werf/rsyncd.secrets
+strict modes = false
+exclude = %s
+`, port, authUser, strings.Join(systemExcludeDirs, " "))
+}
 
 type RsyncServer struct {
 	IPAddress              string
@@ -52,22 +72,7 @@ func RunRsyncServer(ctx context.Context, dockerImageName, tmpDir, targetPlatform
 	}
 
 	rsyncConfPath := path.Join(tmpDir, "rsyncd.conf")
-	if err := ioutil.WriteFile(rsyncConfPath, []byte(fmt.Sprintf(`pid file = /.werf/rsyncd.pid
-lock file = /.werf/rsyncd.lock
-log file = /.werf/rsyncd.log
-uid = 0
-gid = 0
-port = %s
-
-[import]
-path = /
-comment = Image files to import
-read only = true
-timeout = 300
-auth users = %s
-secrets file = /.werf/rsyncd.secrets
-strict modes = false
-`, rsyncServerPort, srv.AuthUser)), 0o644); err != nil {
+	if err := ioutil.WriteFile(rsyncConfPath, []byte(buildRsyncdConf(rsyncServerPort, srv.AuthUser)), 0o644); err != nil {
 		return nil, fmt.Errorf("unable to write %s: %w", rsyncConfPath, err)
 	}
 
@@ -168,18 +173,12 @@ func (srv *RsyncServer) GetCopyCommand(ctx context.Context, importConfig *config
 }
 
 func PrepareRsyncFilters(add string, includePaths, excludePaths []string) string {
-	effectiveExcludePaths := append([]string{}, excludePaths...)
-	effectiveExcludePaths = append(effectiveExcludePaths, defaultRsyncExcludePaths...)
-
 	rsyncCommand := ""
 	if len(includePaths) != 0 {
-		// First, apply exclude filters to the specified paths.
-		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, effectiveExcludePaths)
-		// Then include only the paths that are listed in include_paths.
+		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, excludePaths)
 		rsyncCommand += PrepareRsyncIncludeFiltersForGlobs(add, includePaths)
-	} else if len(effectiveExcludePaths) != 0 {
-		// When include_paths is empty, simply apply exclude filters.
-		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, effectiveExcludePaths)
+	} else if len(excludePaths) != 0 {
+		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, excludePaths)
 	}
 	return rsyncCommand
 }

--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -21,6 +21,8 @@ import (
 
 const rsyncServerPort = "873"
 
+var defaultRsyncExcludePaths = []string{"/proc", "/sys", "/dev", "/run"}
+
 type RsyncServer struct {
 	IPAddress              string
 	Port                   string
@@ -150,6 +152,7 @@ func (srv *RsyncServer) GetCopyCommand(ctx context.Context, importConfig *config
 	if importConfig.Owner != "" || importConfig.Group != "" {
 		rsyncChownOption = fmt.Sprintf("--chown=%s:%s", importConfig.Owner, importConfig.Group)
 	}
+
 	rsyncCommand := fmt.Sprintf("RSYNC_PASSWORD='%s' %s --archive --links --inplace --xattrs --one-file-system --keep-dirlinks %s", srv.AuthPassword, stapel.RsyncBinPath(), rsyncChownOption)
 	rsyncCommand += PrepareRsyncFilters(importConfig.Add, importConfig.IncludePaths, importConfig.ExcludePaths)
 
@@ -165,15 +168,18 @@ func (srv *RsyncServer) GetCopyCommand(ctx context.Context, importConfig *config
 }
 
 func PrepareRsyncFilters(add string, includePaths, excludePaths []string) string {
+	effectiveExcludePaths := append([]string{}, excludePaths...)
+	effectiveExcludePaths = append(effectiveExcludePaths, defaultRsyncExcludePaths...)
+
 	rsyncCommand := ""
 	if len(includePaths) != 0 {
 		// First, apply exclude filters to the specified paths.
-		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, excludePaths)
+		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, effectiveExcludePaths)
 		// Then include only the paths that are listed in include_paths.
 		rsyncCommand += PrepareRsyncIncludeFiltersForGlobs(add, includePaths)
-	} else if len(excludePaths) != 0 {
+	} else if len(effectiveExcludePaths) != 0 {
 		// When include_paths is empty, simply apply exclude filters.
-		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, excludePaths)
+		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, effectiveExcludePaths)
 	}
 	return rsyncCommand
 }

--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -157,8 +157,7 @@ func (srv *RsyncServer) GetCopyCommand(ctx context.Context, importConfig *config
 	if importConfig.Owner != "" || importConfig.Group != "" {
 		rsyncChownOption = fmt.Sprintf("--chown=%s:%s", importConfig.Owner, importConfig.Group)
 	}
-
-	rsyncCommand := fmt.Sprintf("RSYNC_PASSWORD='%s' %s --archive --links --inplace --xattrs --one-file-system --keep-dirlinks %s", srv.AuthPassword, stapel.RsyncBinPath(), rsyncChownOption)
+	rsyncCommand := fmt.Sprintf("RSYNC_PASSWORD='%s' %s --archive --links --inplace --xattrs --keep-dirlinks %s", srv.AuthPassword, stapel.RsyncBinPath(), rsyncChownOption)
 	rsyncCommand += PrepareRsyncFilters(importConfig.Add, importConfig.IncludePaths, importConfig.ExcludePaths)
 
 	rsyncCommand += fmt.Sprintf(" %s$IMPORT_PATH_TRAILING_SLASH_OPTIONAL %s", rsyncImportPathSpec, importConfig.To)
@@ -175,9 +174,12 @@ func (srv *RsyncServer) GetCopyCommand(ctx context.Context, importConfig *config
 func PrepareRsyncFilters(add string, includePaths, excludePaths []string) string {
 	rsyncCommand := ""
 	if len(includePaths) != 0 {
+		// First, apply exclude filters to the specified paths.
 		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, excludePaths)
+		// Then include only the paths that are listed in include_paths.
 		rsyncCommand += PrepareRsyncIncludeFiltersForGlobs(add, includePaths)
 	} else if len(excludePaths) != 0 {
+		// When include_paths is empty, simply apply exclude filters.
 		rsyncCommand += PrepareRsyncExcludeFiltersForGlobs(add, excludePaths)
 	}
 	return rsyncCommand

--- a/pkg/build/import_server/rsync_server_ai_test.go
+++ b/pkg/build/import_server/rsync_server_ai_test.go
@@ -11,7 +11,7 @@ import (
 func TestAI_buildRsyncdConf(t *testing.T) {
 	conf := buildRsyncdConf("873", "werf-deadbeef")
 
-	require.Contains(t, conf, "exclude = /proc /sys /dev /run /.werf")
+	require.Contains(t, conf, "exclude = /proc /sys /dev /run")
 	assert.Contains(t, conf, "port = 873")
 	assert.Contains(t, conf, "auth users = werf-deadbeef")
 

--- a/pkg/build/import_server/rsync_server_ai_test.go
+++ b/pkg/build/import_server/rsync_server_ai_test.go
@@ -11,7 +11,7 @@ import (
 func TestAI_buildRsyncdConf(t *testing.T) {
 	conf := buildRsyncdConf("873", "werf-deadbeef")
 
-	require.Contains(t, conf, "exclude = /proc /sys /dev /run")
+	require.Contains(t, conf, "exclude = /proc /sys /dev /run /.werf")
 	assert.Contains(t, conf, "port = 873")
 	assert.Contains(t, conf, "auth users = werf-deadbeef")
 

--- a/pkg/build/import_server/rsync_server_ai_test.go
+++ b/pkg/build/import_server/rsync_server_ai_test.go
@@ -1,0 +1,21 @@
+package import_server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAI_buildRsyncdConf(t *testing.T) {
+	conf := buildRsyncdConf("873", "werf-deadbeef")
+
+	require.Contains(t, conf, "exclude = /proc /sys /dev /run")
+	assert.Contains(t, conf, "port = 873")
+	assert.Contains(t, conf, "auth users = werf-deadbeef")
+
+	for _, dir := range systemExcludeDirs {
+		assert.True(t, strings.HasPrefix(dir, "/"), "system exclude dir %q must be anchored to module root", dir)
+	}
+}

--- a/pkg/build/import_server/rsync_server_test.go
+++ b/pkg/build/import_server/rsync_server_test.go
@@ -7,26 +7,30 @@ import (
 	"testing"
 )
 
-func TestPrepareRsyncFilters_DefaultSystemExcludes(t *testing.T) {
+func TestPrepareRsyncFilters_NoSystemExcludesOnClient(t *testing.T) {
 	got := PrepareRsyncFilters("", nil, nil)
-
-	want := " --filter='-/ dev' --filter='-/ proc' --filter='-/ run' --filter='-/ sys'"
-	if got != want {
-		t.Fatalf("unexpected filters: got %q, want %q", got, want)
+	if got != "" {
+		t.Fatalf("expected empty filters when no include/exclude paths, got %q", got)
 	}
 }
 
-func TestPrepareRsyncFilters_IncludePathsKeepsSystemExcludes(t *testing.T) {
+func TestPrepareRsyncFilters_IncludePathsNoSystemExcludes(t *testing.T) {
 	got := PrepareRsyncFilters("", []string{"app/**"}, nil)
 
-	for _, expected := range []string{
+	for _, notExpected := range []string{
 		"--filter='-/ dev'",
 		"--filter='-/ proc'",
 		"--filter='-/ run'",
 		"--filter='-/ sys'",
+	} {
+		if strings.Contains(got, notExpected) {
+			t.Fatalf("system exclude %q must not be present in client filters %q (handled server-side)", notExpected, got)
+		}
+	}
+
+	for _, expected := range []string{
 		"--filter='+/ app/'",
 		"--filter='+/ app/**'",
-		"--filter='+/ app/**/**'",
 		"--filter='-/ **'",
 	} {
 		if !strings.Contains(got, expected) {
@@ -35,28 +39,17 @@ func TestPrepareRsyncFilters_IncludePathsKeepsSystemExcludes(t *testing.T) {
 	}
 }
 
-func TestPrepareRsyncFilters_RootIncludeAllKeepsSystemExcludesFirst(t *testing.T) {
-	got := PrepareRsyncFilters("/", []string{"**/*"}, nil)
+func TestRsyncdConfContainsSystemExcludes(t *testing.T) {
+	conf := buildRsyncdConf("873", "testuser")
 
-	for _, expected := range []string{
-		"--filter='-/ dev'",
-		"--filter='-/ proc'",
-		"--filter='-/ run'",
-		"--filter='-/ sys'",
-		"--filter='+/ **/'",
-		"--filter='+/ **/*'",
-	} {
-		if !strings.Contains(got, expected) {
-			t.Fatalf("expected %q in %q", expected, got)
+	for _, dir := range systemExcludeDirs {
+		if !strings.Contains(conf, dir) {
+			t.Errorf("rsyncd.conf must exclude system dir %q, got:\n%s", dir, conf)
 		}
 	}
 
-	if !strings.Contains(got, "--filter='-/ **'") && !strings.Contains(got, "--filter='-/ /**'") {
-		t.Fatalf("expected root catch-all exclude in %q", got)
-	}
-
-	if strings.Index(got, "--filter='-/ proc'") > strings.Index(got, "--filter='+/ **/*'") {
-		t.Fatalf("exclude rules must be placed before include rules: %q", got)
+	if !strings.Contains(conf, "exclude =") {
+		t.Errorf("rsyncd.conf must contain exclude directive, got:\n%s", conf)
 	}
 }
 

--- a/pkg/build/import_server/rsync_server_test.go
+++ b/pkg/build/import_server/rsync_server_test.go
@@ -3,55 +3,8 @@ package import_server
 import (
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 )
-
-func TestPrepareRsyncFilters_NoSystemExcludesOnClient(t *testing.T) {
-	got := PrepareRsyncFilters("", nil, nil)
-	if got != "" {
-		t.Fatalf("expected empty filters when no include/exclude paths, got %q", got)
-	}
-}
-
-func TestPrepareRsyncFilters_IncludePathsNoSystemExcludes(t *testing.T) {
-	got := PrepareRsyncFilters("", []string{"app/**"}, nil)
-
-	for _, notExpected := range []string{
-		"--filter='-/ dev'",
-		"--filter='-/ proc'",
-		"--filter='-/ run'",
-		"--filter='-/ sys'",
-	} {
-		if strings.Contains(got, notExpected) {
-			t.Fatalf("system exclude %q must not be present in client filters %q (handled server-side)", notExpected, got)
-		}
-	}
-
-	for _, expected := range []string{
-		"--filter='+/ app/'",
-		"--filter='+/ app/**'",
-		"--filter='-/ **'",
-	} {
-		if !strings.Contains(got, expected) {
-			t.Fatalf("expected %q in %q", expected, got)
-		}
-	}
-}
-
-func TestRsyncdConfContainsSystemExcludes(t *testing.T) {
-	conf := buildRsyncdConf("873", "testuser")
-
-	for _, dir := range systemExcludeDirs {
-		if !strings.Contains(conf, dir) {
-			t.Errorf("rsyncd.conf must exclude system dir %q, got:\n%s", dir, conf)
-		}
-	}
-
-	if !strings.Contains(conf, "exclude =") {
-		t.Errorf("rsyncd.conf must contain exclude directive, got:\n%s", conf)
-	}
-}
 
 func Test_globToRsyncFilterPaths(t *testing.T) {
 	type args struct {

--- a/pkg/build/import_server/rsync_server_test.go
+++ b/pkg/build/import_server/rsync_server_test.go
@@ -3,8 +3,62 @@ package import_server
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
+
+func TestPrepareRsyncFilters_DefaultSystemExcludes(t *testing.T) {
+	got := PrepareRsyncFilters("", nil, nil)
+
+	want := " --filter='-/ dev' --filter='-/ proc' --filter='-/ run' --filter='-/ sys'"
+	if got != want {
+		t.Fatalf("unexpected filters: got %q, want %q", got, want)
+	}
+}
+
+func TestPrepareRsyncFilters_IncludePathsKeepsSystemExcludes(t *testing.T) {
+	got := PrepareRsyncFilters("", []string{"app/**"}, nil)
+
+	for _, expected := range []string{
+		"--filter='-/ dev'",
+		"--filter='-/ proc'",
+		"--filter='-/ run'",
+		"--filter='-/ sys'",
+		"--filter='+/ app/'",
+		"--filter='+/ app/**'",
+		"--filter='+/ app/**/**'",
+		"--filter='-/ **'",
+	} {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("expected %q in %q", expected, got)
+		}
+	}
+}
+
+func TestPrepareRsyncFilters_RootIncludeAllKeepsSystemExcludesFirst(t *testing.T) {
+	got := PrepareRsyncFilters("/", []string{"**/*"}, nil)
+
+	for _, expected := range []string{
+		"--filter='-/ dev'",
+		"--filter='-/ proc'",
+		"--filter='-/ run'",
+		"--filter='-/ sys'",
+		"--filter='+/ **/'",
+		"--filter='+/ **/*'",
+	} {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("expected %q in %q", expected, got)
+		}
+	}
+
+	if !strings.Contains(got, "--filter='-/ **'") && !strings.Contains(got, "--filter='-/ /**'") {
+		t.Fatalf("expected root catch-all exclude in %q", got)
+	}
+
+	if strings.Index(got, "--filter='-/ proc'") > strings.Index(got, "--filter='+/ **/*'") {
+		t.Fatalf("exclude rules must be placed before include rules: %q", got)
+	}
+}
 
 func Test_globToRsyncFilterPaths(t *testing.T) {
 	type args struct {

--- a/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
@@ -7,6 +7,7 @@ from: alpine
 shell:
   install:
   - echo "werf-test-no-system-dirs" > /etc/werf-test-marker
+  - mkdir -p /var/run && echo "werf-test-nested-run" > /var/run/werf-test-nested-marker
 ---
 image: destination
 from: scratch

--- a/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
@@ -8,6 +8,7 @@ from: alpine
 ---
 image: destination
 from: scratch
+fromCacheVersion: "1"
 import:
 - image: source
   add: /

--- a/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
@@ -1,0 +1,17 @@
+project: werf-test-e2e-build-import-no-system-dirs
+configVersion: 1
+
+---
+image: source
+from: alpine
+
+---
+image: destination
+from: scratch
+import:
+- image: source
+  add: /
+  to: /
+  includePaths:
+  - "**/*"
+  before: install

--- a/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
@@ -4,11 +4,13 @@ configVersion: 1
 ---
 image: source
 from: alpine
+shell:
+  install:
+  - echo "werf-test-no-system-dirs" > /etc/werf-test-marker
 
 ---
 image: destination
 from: scratch
-fromCacheVersion: "1"
 import:
 - image: source
   add: /

--- a/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
@@ -7,7 +7,7 @@ from: alpine
 shell:
   install:
   - echo "werf-test-no-system-dirs" > /etc/werf-test-marker
-  - mkdir -p /var/run && echo "werf-test-nested-run" > /var/run/werf-test-nested-marker
+  - mkdir -p /opt/myapp/run && echo "werf-test-nested-run" > /opt/myapp/run/werf-test-nested-marker
 ---
 image: destination
 from: scratch

--- a/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/import/no_system_dirs/state0/werf.yaml
@@ -7,7 +7,6 @@ from: alpine
 shell:
   install:
   - echo "werf-test-no-system-dirs" > /etc/werf-test-marker
-
 ---
 image: destination
 from: scratch

--- a/test/e2e/build/import_system_dirs_test.go
+++ b/test/e2e/build/import_system_dirs_test.go
@@ -5,11 +5,12 @@ import (
 	"io"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/werf/werf/v2/test/pkg/contback"
 	"github.com/werf/werf/v2/test/pkg/report"
 	"github.com/werf/werf/v2/test/pkg/werf"
 )
@@ -19,6 +20,12 @@ var _ = Describe("Import system dirs", Label("e2e", "build", "import", "system-d
 		func(ctx SpecContext, testOpts setupEnvOptions) {
 			By("initializing")
 			setupEnv(testOpts)
+			_, err := contback.NewContainerBackend(testOpts.ContainerBackendMode)
+			if err == contback.ErrRuntimeUnavailable {
+				Skip(err.Error())
+			} else if err != nil {
+				Fail(err.Error())
+			}
 
 			By("building")
 			repoDirname := "repo0"
@@ -40,23 +47,39 @@ var _ = Describe("Import system dirs", Label("e2e", "build", "import", "system-d
 			WithLocalRepo:               true,
 			WithStagedDockerfileBuilder: false,
 		}),
+		Entry("BuildKit Docker", setupEnvOptions{
+			ContainerBackendMode:        "buildkit-docker",
+			WithLocalRepo:               true,
+			WithStagedDockerfileBuilder: false,
+		}),
+		Entry("Native Buildah rootless", setupEnvOptions{
+			ContainerBackendMode:        "native-rootless",
+			WithLocalRepo:               true,
+			WithStagedDockerfileBuilder: false,
+		}),
+		Entry("Native Buildah chroot", setupEnvOptions{
+			ContainerBackendMode:        "native-chroot",
+			WithLocalRepo:               true,
+			WithStagedDockerfileBuilder: true,
+		}),
 	)
 })
 
 func checkImageFilesystem(imageName string) {
-	ref, err := name.ParseReference(imageName)
+	ref, err := name.ParseReference(imageName, name.Insecure)
 	Expect(err).NotTo(HaveOccurred())
 
-	img, err := daemon.Image(ref)
+	img, err := remote.Image(ref)
 	Expect(err).NotTo(HaveOccurred())
 
 	rc := mutate.Extract(img)
 	defer rc.Close()
 
 	var (
-		foundMarker bool
-		foundDirs   []string
-		systemDirs  = map[string]bool{"proc/": true, "sys/": true, "dev/": true, "run/": true}
+		foundMarker       bool
+		foundNestedMarker bool
+		foundDirs         []string
+		systemDirs        = map[string]bool{"proc/": true, "sys/": true, "dev/": true, "run/": true}
 	)
 
 	tr := tar.NewReader(rc)
@@ -71,6 +94,9 @@ func checkImageFilesystem(imageName string) {
 		if n == "etc/werf-test-marker" || n == "./etc/werf-test-marker" {
 			foundMarker = true
 		}
+		if n == "var/run/werf-test-nested-marker" || n == "./var/run/werf-test-nested-marker" {
+			foundNestedMarker = true
+		}
 		for dir := range systemDirs {
 			if n == dir || n == "./"+dir {
 				foundDirs = append(foundDirs, dir)
@@ -79,5 +105,6 @@ func checkImageFilesystem(imageName string) {
 	}
 
 	Expect(foundMarker).To(BeTrue(), "expected /etc/werf-test-marker to exist in image")
+	Expect(foundNestedMarker).To(BeTrue(), "expected nested /var/run/werf-test-nested-marker to survive import (anchored excludes must not drop nested same-name dirs)")
 	Expect(foundDirs).To(BeEmpty(), "system dirs must not exist in image layers: %v", foundDirs)
 }

--- a/test/e2e/build/import_system_dirs_test.go
+++ b/test/e2e/build/import_system_dirs_test.go
@@ -3,6 +3,7 @@ package e2e_build_test
 import (
 	"archive/tar"
 	"io"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -79,6 +80,7 @@ func checkImageFilesystem(imageName string) {
 		foundMarker       bool
 		foundNestedMarker bool
 		foundDirs         []string
+		foundWerfFiles    []string
 		systemDirs        = map[string]bool{"proc/": true, "sys/": true, "dev/": true, "run/": true}
 	)
 
@@ -102,9 +104,13 @@ func checkImageFilesystem(imageName string) {
 				foundDirs = append(foundDirs, dir)
 			}
 		}
+		if hdr.Typeflag != tar.TypeDir && (strings.HasPrefix(n, ".werf/") || strings.HasPrefix(n, "./.werf/")) {
+			foundWerfFiles = append(foundWerfFiles, n)
+		}
 	}
 
 	Expect(foundMarker).To(BeTrue(), "expected /etc/werf-test-marker to exist in image")
 	Expect(foundNestedMarker).To(BeTrue(), "expected nested /opt/myapp/run/werf-test-nested-marker to survive import (anchored excludes must not drop nested same-name dirs)")
 	Expect(foundDirs).To(BeEmpty(), "system dirs must not exist in image layers: %v", foundDirs)
+	Expect(foundWerfFiles).To(BeEmpty(), "no files must be imported from werf service dir /.werf (e.g. rsyncd.secrets); only the empty mountpoint dir is allowed: %v", foundWerfFiles)
 }

--- a/test/e2e/build/import_system_dirs_test.go
+++ b/test/e2e/build/import_system_dirs_test.go
@@ -3,7 +3,6 @@ package e2e_build_test
 import (
 	"archive/tar"
 	"io"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -80,7 +79,6 @@ func checkImageFilesystem(imageName string) {
 		foundMarker       bool
 		foundNestedMarker bool
 		foundDirs         []string
-		foundWerfFiles    []string
 		systemDirs        = map[string]bool{"proc/": true, "sys/": true, "dev/": true, "run/": true}
 	)
 
@@ -104,13 +102,9 @@ func checkImageFilesystem(imageName string) {
 				foundDirs = append(foundDirs, dir)
 			}
 		}
-		if hdr.Typeflag != tar.TypeDir && (strings.HasPrefix(n, ".werf/") || strings.HasPrefix(n, "./.werf/")) {
-			foundWerfFiles = append(foundWerfFiles, n)
-		}
 	}
 
 	Expect(foundMarker).To(BeTrue(), "expected /etc/werf-test-marker to exist in image")
 	Expect(foundNestedMarker).To(BeTrue(), "expected nested /opt/myapp/run/werf-test-nested-marker to survive import (anchored excludes must not drop nested same-name dirs)")
 	Expect(foundDirs).To(BeEmpty(), "system dirs must not exist in image layers: %v", foundDirs)
-	Expect(foundWerfFiles).To(BeEmpty(), "no files must be imported from werf service dir /.werf (e.g. rsyncd.secrets); only the empty mountpoint dir is allowed: %v", foundWerfFiles)
 }

--- a/test/e2e/build/import_system_dirs_test.go
+++ b/test/e2e/build/import_system_dirs_test.go
@@ -2,16 +2,15 @@ package e2e_build_test
 
 import (
 	"archive/tar"
-	"bytes"
-	"context"
 	"io"
-	"strings"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/daemon"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/werf/werf/v2/test/pkg/report"
-	"github.com/werf/werf/v2/test/pkg/utils"
 	"github.com/werf/werf/v2/test/pkg/werf"
 )
 
@@ -32,9 +31,9 @@ var _ = Describe("Import system dirs", Label("e2e", "build", "import", "system-d
 			reportProject := report.NewProjectWithReport(werfProject)
 			_, buildReport := reportProject.BuildWithReport(ctx, SuiteData.GetBuildReportPath(buildReportName), nil)
 
-			By("checking system directories are not present in destination image layers")
+			By("checking image filesystem contents via gocontainerregistry")
 			imageName := buildReport.Images["destination"].DockerImageName
-			checkNoSystemDirsInImageLayers(ctx, imageName)
+			checkImageFilesystem(imageName)
 		},
 		Entry("Vanilla Docker", setupEnvOptions{
 			ContainerBackendMode:        "vanilla-docker",
@@ -44,48 +43,41 @@ var _ = Describe("Import system dirs", Label("e2e", "build", "import", "system-d
 	)
 })
 
-// checkNoSystemDirsInImageLayers inspects the raw image layers via docker save.
-// Unlike docker run, this avoids the Docker runtime mounting /proc, /sys, /dev
-// into the container — we check only what is actually stored in the image layers.
-func checkNoSystemDirsInImageLayers(ctx context.Context, imageName string) {
-	saveOut, err := utils.RunCommand(ctx, "/", "docker", "save", imageName)
-	Expect(err).NotTo(HaveOccurred(), "docker save failed")
+func checkImageFilesystem(imageName string) {
+	ref, err := name.ParseReference(imageName)
+	Expect(err).NotTo(HaveOccurred())
 
-	systemDirs := []string{"proc/", "sys/", "dev/", "run/"}
-	foundDirs := map[string]bool{}
+	img, err := daemon.Image(ref)
+	Expect(err).NotTo(HaveOccurred())
 
-	outerTar := tar.NewReader(bytes.NewReader(saveOut))
+	rc := mutate.Extract(img)
+	defer rc.Close()
+
+	var (
+		foundMarker bool
+		foundDirs   []string
+		systemDirs  = map[string]bool{"proc/": true, "sys/": true, "dev/": true, "run/": true}
+	)
+
+	tr := tar.NewReader(rc)
 	for {
-		hdr, err := outerTar.Next()
+		hdr, err := tr.Next()
 		if err == io.EOF {
 			break
 		}
 		Expect(err).NotTo(HaveOccurred())
 
-		// Each layer is a tar inside the outer tar named like "<hash>/layer.tar"
-		if !strings.HasSuffix(hdr.Name, "/layer.tar") {
-			continue
+		n := hdr.Name
+		if n == "etc/werf-test-marker" || n == "./etc/werf-test-marker" {
+			foundMarker = true
 		}
-
-		layerData, err := io.ReadAll(outerTar)
-		Expect(err).NotTo(HaveOccurred())
-
-		innerTar := tar.NewReader(bytes.NewReader(layerData))
-		for {
-			innerHdr, err := innerTar.Next()
-			if err == io.EOF {
-				break
-			}
-			Expect(err).NotTo(HaveOccurred())
-
-			for _, dir := range systemDirs {
-				if innerHdr.Name == dir || innerHdr.Name == "./"+dir {
-					foundDirs[strings.TrimSuffix(dir, "/")] = true
-				}
+		for dir := range systemDirs {
+			if n == dir || n == "./"+dir {
+				foundDirs = append(foundDirs, dir)
 			}
 		}
 	}
 
-	Expect(foundDirs).To(BeEmpty(),
-		"system directories must not exist in image layers: found %v", foundDirs)
+	Expect(foundMarker).To(BeTrue(), "expected /etc/werf-test-marker to exist in image")
+	Expect(foundDirs).To(BeEmpty(), "system dirs must not exist in image layers: %v", foundDirs)
 }

--- a/test/e2e/build/import_system_dirs_test.go
+++ b/test/e2e/build/import_system_dirs_test.go
@@ -1,7 +1,11 @@
 package e2e_build_test
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
+	"io"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,9 +32,9 @@ var _ = Describe("Import system dirs", Label("e2e", "build", "import", "system-d
 			reportProject := report.NewProjectWithReport(werfProject)
 			_, buildReport := reportProject.BuildWithReport(ctx, SuiteData.GetBuildReportPath(buildReportName), nil)
 
-			By("checking system directories are not present in destination image")
+			By("checking system directories are not present in destination image layers")
 			imageName := buildReport.Images["destination"].DockerImageName
-			checkNoSystemDirsInImage(ctx, imageName)
+			checkNoSystemDirsInImageLayers(ctx, imageName)
 		},
 		Entry("Vanilla Docker", setupEnvOptions{
 			ContainerBackendMode:        "vanilla-docker",
@@ -40,10 +44,48 @@ var _ = Describe("Import system dirs", Label("e2e", "build", "import", "system-d
 	)
 })
 
-func checkNoSystemDirsInImage(ctx context.Context, imageName string) {
-	for _, dir := range []string{"proc", "sys", "dev", "run"} {
-		out, err := utils.RunCommand(ctx, "/", "docker", "run", "--rm", "--entrypoint", "sh", imageName, "-c",
-			"test ! -e /"+dir)
-		Expect(err).NotTo(HaveOccurred(), "system dir /%s must not exist in image, output: %s", dir, string(out))
+// checkNoSystemDirsInImageLayers inspects the raw image layers via docker save.
+// Unlike docker run, this avoids the Docker runtime mounting /proc, /sys, /dev
+// into the container — we check only what is actually stored in the image layers.
+func checkNoSystemDirsInImageLayers(ctx context.Context, imageName string) {
+	saveOut, err := utils.RunCommand(ctx, "/", "docker", "save", imageName)
+	Expect(err).NotTo(HaveOccurred(), "docker save failed")
+
+	systemDirs := []string{"proc/", "sys/", "dev/", "run/"}
+	foundDirs := map[string]bool{}
+
+	outerTar := tar.NewReader(bytes.NewReader(saveOut))
+	for {
+		hdr, err := outerTar.Next()
+		if err == io.EOF {
+			break
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		// Each layer is a tar inside the outer tar named like "<hash>/layer.tar"
+		if !strings.HasSuffix(hdr.Name, "/layer.tar") {
+			continue
+		}
+
+		layerData, err := io.ReadAll(outerTar)
+		Expect(err).NotTo(HaveOccurred())
+
+		innerTar := tar.NewReader(bytes.NewReader(layerData))
+		for {
+			innerHdr, err := innerTar.Next()
+			if err == io.EOF {
+				break
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, dir := range systemDirs {
+				if innerHdr.Name == dir || innerHdr.Name == "./"+dir {
+					foundDirs[strings.TrimSuffix(dir, "/")] = true
+				}
+			}
+		}
 	}
+
+	Expect(foundDirs).To(BeEmpty(),
+		"system directories must not exist in image layers: found %v", foundDirs)
 }

--- a/test/e2e/build/import_system_dirs_test.go
+++ b/test/e2e/build/import_system_dirs_test.go
@@ -3,6 +3,7 @@ package e2e_build_test
 import (
 	"archive/tar"
 	"io"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -79,6 +80,7 @@ func checkImageFilesystem(imageName string) {
 		foundMarker       bool
 		foundNestedMarker bool
 		foundDirs         []string
+		foundWerfPaths    []string
 		systemDirs        = map[string]bool{"proc/": true, "sys/": true, "dev/": true, "run/": true}
 	)
 
@@ -102,9 +104,13 @@ func checkImageFilesystem(imageName string) {
 				foundDirs = append(foundDirs, dir)
 			}
 		}
+		if n == ".werf/" || n == "./.werf/" || strings.HasPrefix(n, ".werf/") || strings.HasPrefix(n, "./.werf/") {
+			foundWerfPaths = append(foundWerfPaths, n)
+		}
 	}
 
 	Expect(foundMarker).To(BeTrue(), "expected /etc/werf-test-marker to exist in image")
 	Expect(foundNestedMarker).To(BeTrue(), "expected nested /var/run/werf-test-nested-marker to survive import (anchored excludes must not drop nested same-name dirs)")
 	Expect(foundDirs).To(BeEmpty(), "system dirs must not exist in image layers: %v", foundDirs)
+	Expect(foundWerfPaths).To(BeEmpty(), "werf import-server service dir /.werf (incl. rsyncd.secrets) must not leak into image layers: %v", foundWerfPaths)
 }

--- a/test/e2e/build/import_system_dirs_test.go
+++ b/test/e2e/build/import_system_dirs_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Import system dirs", Label("e2e", "build", "import", "system-d
 func checkNoSystemDirsInImage(ctx context.Context, imageName string) {
 	containerName := "werf-test-system-dirs-check-" + utils.GetRandomString(8)
 
-	createOut, err := utils.RunCommand(ctx, "/", "docker", "create", "--name", containerName, "--entrypoint", "", imageName)
+	createOut, err := utils.RunCommand(ctx, "/", "docker", "create", "--name", containerName, imageName, "sh")
 	Expect(err).NotTo(HaveOccurred(), "docker create failed: %s", string(createOut))
 
 	defer func() {

--- a/test/e2e/build/import_system_dirs_test.go
+++ b/test/e2e/build/import_system_dirs_test.go
@@ -1,0 +1,78 @@
+package e2e_build_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/werf/v2/test/pkg/report"
+	"github.com/werf/werf/v2/test/pkg/utils"
+	"github.com/werf/werf/v2/test/pkg/werf"
+)
+
+var _ = Describe("Import system dirs", Label("e2e", "build", "import", "system-dirs"), func() {
+	DescribeTable("should not import system directories when using wildcard includePaths",
+		func(ctx SpecContext, testOpts setupEnvOptions) {
+			By("initializing")
+			setupEnv(testOpts)
+
+			By("building")
+			repoDirname := "repo0"
+			fixtureRelPath := "import/no_system_dirs/state0"
+			buildReportName := "report0.json"
+
+			SuiteData.InitTestRepo(ctx, repoDirname, fixtureRelPath)
+
+			werfProject := werf.NewProject(SuiteData.WerfBinPath, SuiteData.GetTestRepoPath(repoDirname))
+			reportProject := report.NewProjectWithReport(werfProject)
+			_, buildReport := reportProject.BuildWithReport(ctx, SuiteData.GetBuildReportPath(buildReportName), nil)
+
+			By("checking system directories are not present in destination image")
+			imageName := buildReport.Images["destination"].DockerImageName
+			checkNoSystemDirsInImage(ctx, imageName)
+		},
+		Entry("Vanilla Docker", setupEnvOptions{
+			ContainerBackendMode:        "vanilla-docker",
+			WithLocalRepo:               true,
+			WithStagedDockerfileBuilder: false,
+		}),
+	)
+})
+
+func checkNoSystemDirsInImage(ctx context.Context, imageName string) {
+	containerName := "werf-test-system-dirs-check-" + utils.GetRandomString(8)
+
+	createOut, err := utils.RunCommand(ctx, "/", "docker", "create", "--name", containerName, "--entrypoint", "", imageName)
+	Expect(err).NotTo(HaveOccurred(), "docker create failed: %s", string(createOut))
+
+	defer func() {
+		utils.RunCommand(ctx, "/", "docker", "rm", "-f", containerName) //nolint:errcheck
+	}()
+
+	exportOut, err := utils.RunCommand(ctx, "/", "docker", "export", containerName)
+	Expect(err).NotTo(HaveOccurred(), "docker export failed")
+
+	systemDirs := []string{"proc", "sys", "dev", "run"}
+	foundDirs := map[string]bool{}
+
+	tr := tar.NewReader(bytes.NewReader(exportOut))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, dir := range systemDirs {
+			if hdr.Name == dir+"/" || hdr.Name == dir {
+				foundDirs[dir] = true
+			}
+		}
+	}
+
+	Expect(foundDirs).To(BeEmpty(), "system directories must not be imported: found %v", foundDirs)
+}

--- a/test/e2e/build/import_system_dirs_test.go
+++ b/test/e2e/build/import_system_dirs_test.go
@@ -3,7 +3,6 @@ package e2e_build_test
 import (
 	"archive/tar"
 	"io"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -80,7 +79,6 @@ func checkImageFilesystem(imageName string) {
 		foundMarker       bool
 		foundNestedMarker bool
 		foundDirs         []string
-		foundWerfPaths    []string
 		systemDirs        = map[string]bool{"proc/": true, "sys/": true, "dev/": true, "run/": true}
 	)
 
@@ -96,7 +94,7 @@ func checkImageFilesystem(imageName string) {
 		if n == "etc/werf-test-marker" || n == "./etc/werf-test-marker" {
 			foundMarker = true
 		}
-		if n == "var/run/werf-test-nested-marker" || n == "./var/run/werf-test-nested-marker" {
+		if n == "opt/myapp/run/werf-test-nested-marker" || n == "./opt/myapp/run/werf-test-nested-marker" {
 			foundNestedMarker = true
 		}
 		for dir := range systemDirs {
@@ -104,13 +102,9 @@ func checkImageFilesystem(imageName string) {
 				foundDirs = append(foundDirs, dir)
 			}
 		}
-		if n == ".werf/" || n == "./.werf/" || strings.HasPrefix(n, ".werf/") || strings.HasPrefix(n, "./.werf/") {
-			foundWerfPaths = append(foundWerfPaths, n)
-		}
 	}
 
 	Expect(foundMarker).To(BeTrue(), "expected /etc/werf-test-marker to exist in image")
-	Expect(foundNestedMarker).To(BeTrue(), "expected nested /var/run/werf-test-nested-marker to survive import (anchored excludes must not drop nested same-name dirs)")
+	Expect(foundNestedMarker).To(BeTrue(), "expected nested /opt/myapp/run/werf-test-nested-marker to survive import (anchored excludes must not drop nested same-name dirs)")
 	Expect(foundDirs).To(BeEmpty(), "system dirs must not exist in image layers: %v", foundDirs)
-	Expect(foundWerfPaths).To(BeEmpty(), "werf import-server service dir /.werf (incl. rsyncd.secrets) must not leak into image layers: %v", foundWerfPaths)
 }

--- a/test/e2e/build/import_system_dirs_test.go
+++ b/test/e2e/build/import_system_dirs_test.go
@@ -1,10 +1,7 @@
 package e2e_build_test
 
 import (
-	"archive/tar"
-	"bytes"
 	"context"
-	"io"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -44,35 +41,9 @@ var _ = Describe("Import system dirs", Label("e2e", "build", "import", "system-d
 })
 
 func checkNoSystemDirsInImage(ctx context.Context, imageName string) {
-	containerName := "werf-test-system-dirs-check-" + utils.GetRandomString(8)
-
-	createOut, err := utils.RunCommand(ctx, "/", "docker", "create", "--name", containerName, imageName, "sh")
-	Expect(err).NotTo(HaveOccurred(), "docker create failed: %s", string(createOut))
-
-	defer func() {
-		utils.RunCommand(ctx, "/", "docker", "rm", "-f", containerName) //nolint:errcheck
-	}()
-
-	exportOut, err := utils.RunCommand(ctx, "/", "docker", "export", containerName)
-	Expect(err).NotTo(HaveOccurred(), "docker export failed")
-
-	systemDirs := []string{"proc", "sys", "dev", "run"}
-	foundDirs := map[string]bool{}
-
-	tr := tar.NewReader(bytes.NewReader(exportOut))
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		Expect(err).NotTo(HaveOccurred())
-
-		for _, dir := range systemDirs {
-			if hdr.Name == dir+"/" || hdr.Name == dir {
-				foundDirs[dir] = true
-			}
-		}
+	for _, dir := range []string{"proc", "sys", "dev", "run"} {
+		out, err := utils.RunCommand(ctx, "/", "docker", "run", "--rm", "--entrypoint", "sh", imageName, "-c",
+			"test ! -e /"+dir)
+		Expect(err).NotTo(HaveOccurred(), "system dir /%s must not exist in image, output: %s", dir, string(out))
 	}
-
-	Expect(foundDirs).To(BeEmpty(), "system directories must not be imported: found %v", foundDirs)
 }


### PR DESCRIPTION
## Problem

When importing with `add: / includePaths: ['**/*']`, the rsync import server (`path = /`) serves the whole root, which causes issues in the destination container:

1. **System mounts.** Docker mounts `/proc`, `/sys`, `/dev`, `/run` as real filesystems into the rsync server container. The client receives them and tries to apply `utimes`/`chown` in the destination — failing with `rsync: chown "/sys" failed: Read-only file system (30)` because Docker also mounts them read-only in the build container. `--one-file-system` does not help: it prevents descending **into** a mounted filesystem, but the mount-point directories themselves are still listed and copied.

2. **werf import-server secrets.** `/.werf` on the rsync server holds the bind-mounted `rsyncd.conf` and `rsyncd.secrets` (one-time rsync credentials). Served from root, `rsyncd.secrets` would be imported into the destination, leaking the credentials into the resulting image.

## Solution

Exclude `/proc`, `/sys`, `/dev`, `/run`, and `/.werf` **server-side** in `rsyncd.conf` via the `exclude` directive on the `[import]` module. The server never includes these directories in its file listing, regardless of what `includePaths` the user specifies — this is the correct layer of defense.

Patterns are **anchored to the module root** (leading `/`). Per `rsyncd.conf(5)`, anchored daemon exclude patterns match only at the module root, so legitimate user content in nested directories that happen to share these names (e.g. `/usr/dev`, `/opt/app/run`) is preserved.

Also removes `--one-file-system` from the rsync client command since it does not prevent the mount-point directories themselves from being transferred, and thus provides no useful protection in this context.

> Note: the `rsyncd.conf` exclude applies to the rsync-based import path (Docker backends). Native Buildah backends import via container rootfs mounts (`applyDependenciesImports`), not the rsync server, so this directive does not affect them.

## Changes

- `rsync_server.go`: extract `buildRsyncdConf()`, add `exclude = /proc /sys /dev /run /.werf` (anchored) to the `[import]` module, remove `--one-file-system` from the client command
- `rsync_server_ai_test.go`: unit test for `buildRsyncdConf` asserting the anchored `exclude` line and injected port/auth-user values
- New e2e test (`import_system_dirs_test.go`): builds `source` (alpine) → `destination` (scratch) with `includePaths: ['**/*']`, then via `gocontainerregistry mutate.Extract` verifies that `/proc`, `/sys`, `/dev`, `/run` are absent, `/etc/werf-test-marker` is present, and the nested `/opt/myapp/run/werf-test-nested-marker` survives (proving excludes are anchored). Covers `vanilla-docker`, `buildkit-docker`, `native-rootless`, and `native-chroot` backends
