### PR TITLE
fix(bundles): update .Values.global.werf.images during bundle copy

### DIFF
--- a/pkg/deploy/bundles/copy_test.go
+++ b/pkg/deploy/bundles/copy_test.go
@@ -442,6 +442,118 @@ werf:
 			Expect(registryClient.ImagesByReference["registry2.example.com/group2/testproject2:tag-3"]).To(Equal([]byte(`image-3-bytes`)))
 		}
 	})
+
+	It("should copy remote to remote updating global werf values", func() {
+		ch := &chart.Chart{
+			Metadata: &chart.Metadata{
+				APIVersion: "v2",
+				Name:       "testproject",
+				Version:    "1.2.3",
+				Type:       "application",
+			},
+			Values: map[string]interface{}{
+				"werf": map[string]interface{}{
+					"image": map[string]interface{}{
+						"myapp": "registry.example.com/group/testproject:tag-1",
+					},
+					"repo": "registry.example.com/group/testproject",
+				},
+				"global": map[string]interface{}{
+					"werf": map[string]interface{}{
+						"repo": "registry.example.com/group/testproject",
+						"images": map[string]interface{}{
+							"myapp": map[string]interface{}{
+								"registry":       "registry.example.com",
+								"namespace":      "group",
+								"name":           "testproject",
+								"tag":            "tag-1",
+								"digest":         "sha256:abcdef1234567890",
+								"tag_digest":     "tag-1@sha256:abcdef1234567890",
+								"image":          "registry.example.com/group/testproject",
+								"repository":     "group/testproject",
+								"ref":            "registry.example.com/group/testproject:tag-1@sha256:abcdef1234567890",
+								"ref_tag":        "registry.example.com/group/testproject:tag-1",
+								"repository_ref": "group/testproject:tag-1@sha256:abcdef1234567890",
+								"repository_tag": "group/testproject:tag-1",
+								"name_ref":       "testproject:tag-1@sha256:abcdef1234567890",
+								"name_tag":       "testproject:tag-1",
+							},
+						},
+					},
+				},
+			},
+			Raw: []*chart.File{
+				{
+					Name: "values.yaml",
+					Data: []byte(`
+werf:
+  image:
+    myapp: registry.example.com/group/testproject:tag-1
+  repo: registry.example.com/group/testproject
+global:
+  werf:
+    repo: registry.example.com/group/testproject
+    images:
+      myapp:
+        registry: registry.example.com
+        namespace: group
+        name: testproject
+        tag: tag-1
+        digest: "sha256:abcdef1234567890"
+        tag_digest: "tag-1@sha256:abcdef1234567890"
+        image: registry.example.com/group/testproject
+        repository: group/testproject
+        ref: "registry.example.com/group/testproject:tag-1@sha256:abcdef1234567890"
+        ref_tag: "registry.example.com/group/testproject:tag-1"
+        repository_ref: "group/testproject:tag-1@sha256:abcdef1234567890"
+        repository_tag: "group/testproject:tag-1"
+        name_ref: "testproject:tag-1@sha256:abcdef1234567890"
+        name_tag: "testproject:tag-1"
+`),
+				},
+			},
+		}
+
+		bundlesRegistryClient := NewBundlesRegistryClientStub()
+		registryClient := NewDockerRegistryStub()
+
+		fromAddr, err := bundles_registry.ParseAddr("registry.example.com/group/testproject:1.2.3")
+		Expect(err).NotTo(HaveOccurred())
+		from := NewRemoteBundle(fromAddr.RegistryAddress, bundlesRegistryClient, registryClient)
+		bundlesRegistryClient.StubCharts[fromAddr.RegistryAddress.FullName()] = ch
+		registryClient.ImagesByReference["registry.example.com/group/testproject:tag-1"] = []byte(`image-1-bytes`)
+
+		toAddr, err := bundles_registry.ParseAddr("registry2.example.com/org/newproject:4.5.6")
+		Expect(err).NotTo(HaveOccurred())
+		to := NewRemoteBundle(toAddr.RegistryAddress, bundlesRegistryClient, registryClient)
+
+		Expect(from.CopyTo(ctx, to, copyToOptions{})).To(Succeed())
+
+		newCh := bundlesRegistryClient.StubCharts[toAddr.RegistryAddress.FullName()]
+		Expect(newCh).NotTo(BeNil())
+
+		globalVals := newCh.Values["global"].(map[string]interface{})
+		globalWerfVals := globalVals["werf"].(map[string]interface{})
+		Expect(globalWerfVals["repo"]).To(Equal("registry2.example.com/org/newproject"))
+
+		imagesVals := globalWerfVals["images"].(map[string]interface{})
+		myappVals := imagesVals["myapp"].(map[string]interface{})
+
+		Expect(myappVals["registry"]).To(Equal("registry2.example.com"))
+		Expect(myappVals["namespace"]).To(Equal("org"))
+		Expect(myappVals["name"]).To(Equal("newproject"))
+		Expect(myappVals["tag"]).To(Equal("tag-1"))
+		Expect(myappVals["digest"]).To(Equal("sha256:abcdef1234567890"))
+		Expect(myappVals["tag_digest"]).To(Equal("tag-1@sha256:abcdef1234567890"))
+		Expect(myappVals["image"]).To(Equal("registry2.example.com/org/newproject"))
+		Expect(myappVals["repository"]).To(Equal("org/newproject"))
+		Expect(myappVals["ref"]).To(Equal("registry2.example.com/org/newproject:tag-1@sha256:abcdef1234567890"))
+		Expect(myappVals["ref_tag"]).To(Equal("registry2.example.com/org/newproject:tag-1"))
+		Expect(myappVals["repository_ref"]).To(Equal("org/newproject:tag-1@sha256:abcdef1234567890"))
+		Expect(myappVals["repository_tag"]).To(Equal("org/newproject:tag-1"))
+		Expect(myappVals["name_ref"]).To(Equal("newproject:tag-1@sha256:abcdef1234567890"))
+		Expect(myappVals["name_tag"]).To(Equal("newproject:tag-1"))
+	})
 })
 
 type BundleArchiveStubReader struct {

--- a/pkg/deploy/bundles/global_values.go
+++ b/pkg/deploy/bundles/global_values.go
@@ -1,0 +1,49 @@
+package bundles
+
+import (
+	"fmt"
+
+	"github.com/werf/werf/v2/pkg/image"
+)
+
+func updateGlobalWerfValues(values map[string]interface{}, newRepo string, newImageRefs map[string]string) error {
+	globalVals, ok := values["global"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	werfVals, ok := globalVals["werf"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	werfVals["repo"] = newRepo
+
+	imagesVals, ok := werfVals["images"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	for imageName, imageVals := range imagesVals {
+		vals, ok := imageVals.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		newRef, hasRef := newImageRefs[imageName]
+		if !hasRef {
+			continue
+		}
+
+		digest, _ := vals["digest"].(string)
+
+		rebuilt, err := image.RebuildImageValuesMap(newRef, digest)
+		if err != nil {
+			return fmt.Errorf("update global werf image values for %q: %w", imageName, err)
+		}
+
+		imagesVals[imageName] = rebuilt
+	}
+
+	return nil
+}

--- a/pkg/deploy/bundles/remote_bundle.go
+++ b/pkg/deploy/bundles/remote_bundle.go
@@ -89,6 +89,8 @@ func (bundle *RemoteBundle) CopyFromArchive(ctx context.Context, fromArchive *Bu
 		return fmt.Errorf("unable to read chart from the bundle archive %q: %w", fromArchive.Reader.String(), err)
 	}
 
+	newImageRefs := make(map[string]string)
+
 	if err := logboek.Context(ctx).LogProcess("Copy images from bundle archive").DoError(func() error {
 		if werfVals, ok := ch.Values["werf"].(map[string]interface{}); ok {
 			if imageVals, ok := werfVals["image"].(map[string]interface{}); ok {
@@ -113,6 +115,7 @@ func (bundle *RemoteBundle) CopyFromArchive(ctx context.Context, fromArchive *Bu
 						}
 
 						newImageVals[imageName] = ref.FullName()
+						newImageRefs[imageName] = ref.FullName()
 					} else {
 						return fmt.Errorf("unexpected value .Values.werf.image.%s=%v", imageName, v)
 					}
@@ -126,6 +129,10 @@ func (bundle *RemoteBundle) CopyFromArchive(ctx context.Context, fromArchive *Bu
 
 		return nil
 	}); err != nil {
+		return err
+	}
+
+	if err := updateGlobalWerfValues(ch.Values, bundle.RegistryAddress.Repo, newImageRefs); err != nil {
 		return err
 	}
 
@@ -161,6 +168,8 @@ func (bundle *RemoteBundle) CopyFromRemote(ctx context.Context, fromRemote *Remo
 		logboek.Context(ctx).Debug().LogF("Values before change (%v):\n%s\n---\n", err, d)
 	}
 
+	newImageRefs := make(map[string]string)
+
 	if err := logboek.Context(ctx).LogProcess("Copy images from remote bundle").DoError(func() error {
 		if werfVals, ok := ch.Values["werf"].(map[string]interface{}); ok {
 			if imageVals, ok := werfVals["image"].(map[string]interface{}); ok {
@@ -186,6 +195,7 @@ func (bundle *RemoteBundle) CopyFromRemote(ctx context.Context, fromRemote *Remo
 						}
 
 						newImageVals[imageName] = ref.FullName()
+						newImageRefs[imageName] = ref.FullName()
 					} else {
 						return fmt.Errorf("unexpected value .Values.werf.image.%s=%v", imageName, v)
 					}
@@ -198,6 +208,10 @@ func (bundle *RemoteBundle) CopyFromRemote(ctx context.Context, fromRemote *Remo
 		}
 		return nil
 	}); err != nil {
+		return err
+	}
+
+	if err := updateGlobalWerfValues(ch.Values, bundle.RegistryAddress.Repo, newImageRefs); err != nil {
 		return err
 	}
 

--- a/pkg/image/image_values.go
+++ b/pkg/image/image_values.go
@@ -24,6 +24,23 @@ func BuildImageValuesMap(infoGetter *InfoGetter) (map[string]interface{}, error)
 	), nil
 }
 
+func RebuildImageValuesMap(newRef, digest string) (map[string]interface{}, error) {
+	tag, err := name.NewTag(newRef)
+	if err != nil {
+		return nil, fmt.Errorf("rebuild image values map: %w", err)
+	}
+
+	return buildValuesMap(
+		tag.RegistryStr(),
+		tag.RepositoryStr(),
+		path.Base(tag.RepositoryStr()),
+		tag.TagStr(),
+		digest,
+		tag.Context().Name(),
+		newRef,
+	), nil
+}
+
 func BuildStubImageValuesMap(repo, tag string) map[string]interface{} {
 	return buildValuesMap(
 		"REGISTRY",


### PR DESCRIPTION
## Problem

`werf bundle copy` updates `.Values.werf.image` and `.Values.werf.repo` for the destination registry, but does not update `.Values.global.werf.images` — the new detailed per-image values added in v2.65.0.

This means templates using `$.Values.global.werf.images.<name>.registry`, `.repository`, `.ref_tag`, etc. still reference the source registry after a bundle copy.

## Fix

After rewriting `.werf.image` entries, also update `.global.werf.images.<name>` by recalculating all registry-dependent fields (`registry`, `namespace`, `name`, `image`, `repository`, `ref`, `ref_tag`, `repository_ref`, `repository_tag`, `name_ref`, `name_tag`) from the new reference, preserving `tag` and `digest`.

Applied to both `RemoteBundle.CopyFromRemote` and `RemoteBundle.CopyFromArchive`.

closes #7597