### PR TITLE
fix(build): use UUID-based naming for scratch base images to prevent …

### DIFF
--- a/pkg/build/image/image.go
+++ b/pkg/build/image/image.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gookit/color"
 
 	"github.com/werf/logboek"
@@ -297,7 +298,11 @@ func (i *Image) SetupBaseImage(ctx context.Context, storageManager manager.Stora
 		}
 
 		// TODO: do not use container_backend.LegacyStageImage for base image.
-		i.baseStageImage = i.Conveyor.GetOrCreateStageImage(i.baseImageReference, nil, nil, i)
+		stageImageName := i.baseImageReference
+		if i.baseImageReference == "scratch" {
+			stageImageName = fmt.Sprintf("werf-scratch-%s", uuid.New().String())
+		}
+		i.baseStageImage = i.Conveyor.GetOrCreateStageImage(stageImageName, nil, nil, i)
 
 		// Do not override the base image description if it is already set.
 		// TODO: It might be a stage as base image (passed as dependency), and the absence of StageID in the description will lead to breaking the logic.

--- a/test/e2e/build/_fixtures/scratch/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/scratch/state0/werf.yaml
@@ -2,5 +2,15 @@ project: werf-test-e2e-build-scratch
 configVersion: 1
 
 ---
+image: source
+from: alpine
+shell:
+  install:
+  - echo "werf-test-scratch-import" > /etc/werf-test-scratch-import
+---
 image: stapel-scratch
 from: scratch
+import:
+- image: source
+  add: /etc/werf-test-scratch-import
+  to: /etc/werf-test-scratch-import

--- a/test/e2e/build/_fixtures/scratch/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/scratch/state0/werf.yaml
@@ -14,3 +14,4 @@ import:
 - image: source
   add: /etc/werf-test-scratch-import
   to: /etc/werf-test-scratch-import
+  before: install

--- a/test/e2e/build/scratch_test.go
+++ b/test/e2e/build/scratch_test.go
@@ -44,6 +44,12 @@ var _ = Describe("Scratch stapel build", Label("e2e", "build", "scratch", "simpl
 			if testOpts.WithLocalRepo {
 				contRuntime.Pull(ctx, imageName)
 			}
+			contRuntime.ExpectCmdsToSucceed(
+				ctx,
+				imageName,
+				"test -f /etc/werf-test-scratch-import",
+				"echo 'werf-test-scratch-import' | diff /etc/werf-test-scratch-import -",
+			)
 			inspect := contRuntime.GetImageInspect(ctx, imageName)
 			labels := inspect.Config.Labels
 			Expect(labels).NotTo(BeNil())

--- a/test/e2e/build/scratch_test.go
+++ b/test/e2e/build/scratch_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/werf/werf/v2/pkg/image"
 	"github.com/werf/werf/v2/test/pkg/contback"
 	"github.com/werf/werf/v2/test/pkg/report"
+	"github.com/werf/werf/v2/test/pkg/utils"
 	"github.com/werf/werf/v2/test/pkg/werf"
 )
 
@@ -44,12 +45,7 @@ var _ = Describe("Scratch stapel build", Label("e2e", "build", "scratch", "simpl
 			if testOpts.WithLocalRepo {
 				contRuntime.Pull(ctx, imageName)
 			}
-			contRuntime.ExpectCmdsToSucceed(
-				ctx,
-				imageName,
-				"test -f /etc/werf-test-scratch-import",
-				"echo 'werf-test-scratch-import' | diff /etc/werf-test-scratch-import -",
-			)
+			utils.ExpectFileContentInImage(imageName, "etc/werf-test-scratch-import", "werf-test-scratch-import\n")
 			inspect := contRuntime.GetImageInspect(ctx, imageName)
 			labels := inspect.Config.Labels
 			Expect(labels).NotTo(BeNil())

--- a/test/e2e/build/scratch_test.go
+++ b/test/e2e/build/scratch_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Scratch stapel build", Label("e2e", "build", "scratch", "simpl
 		func(ctx SpecContext, testOpts scratchTestOptions) {
 			By("initializing")
 			setupEnv(testOpts.setupEnvOptions)
-			contRuntime, err := contback.NewContainerBackend(testOpts.ContainerBackendMode)
+			_, err := contback.NewContainerBackend(testOpts.ContainerBackendMode)
 			if err == contback.ErrRuntimeUnavailable {
 				Skip(err.Error())
 			} else if err != nil {
@@ -40,23 +40,15 @@ var _ = Describe("Scratch stapel build", Label("e2e", "build", "scratch", "simpl
 			buildOut, buildReport := reportProject.BuildWithReport(ctx, SuiteData.GetBuildReportPath(buildReportName), nil)
 			Expect(buildOut).To(ContainSubstring("Building stage"))
 
-			By("checking scratch image labels")
+			By("checking scratch image contents and labels")
 			imageName := buildReport.Images["stapel-scratch"].DockerImageName
-			if testOpts.WithLocalRepo {
-				contRuntime.Pull(ctx, imageName)
-			}
-			utils.ExpectFileContentInImage(imageName, "etc/werf-test-scratch-import", "werf-test-scratch-import\n")
-			inspect := contRuntime.GetImageInspect(ctx, imageName)
-			labels := inspect.Config.Labels
-			Expect(labels).NotTo(BeNil())
-			Expect(labels).To(HaveKey(image.WerfLabel))
-			Expect(labels[image.WerfLabel]).NotTo(BeEmpty())
-			Expect(labels).To(HaveKey(image.WerfVersionLabel))
-			Expect(labels[image.WerfVersionLabel]).NotTo(BeEmpty())
-			Expect(labels).To(HaveKey(image.WerfStageContentDigestLabel))
-			Expect(labels[image.WerfStageContentDigestLabel]).NotTo(BeEmpty())
-			Expect(labels).To(HaveKey(image.WerfProjectRepoCommitLabel))
-			Expect(labels[image.WerfProjectRepoCommitLabel]).NotTo(BeEmpty())
+			utils.ExpectFileContentInImage(ctx, testOpts.ContainerBackendMode, imageName, "etc/werf-test-scratch-import", "werf-test-scratch-import\n")
+			utils.ExpectImageHasNonEmptyLabels(ctx, testOpts.ContainerBackendMode, imageName,
+				image.WerfLabel,
+				image.WerfVersionLabel,
+				image.WerfStageContentDigestLabel,
+				image.WerfProjectRepoCommitLabel,
+			)
 		},
 		Entry("using Vanilla Docker", scratchTestOptions{setupEnvOptions{
 			ContainerBackendMode:        "vanilla-docker",

--- a/test/pkg/utils/image.go
+++ b/test/pkg/utils/image.go
@@ -4,21 +4,17 @@ import (
 	"archive/tar"
 	"context"
 	"io"
+	"os"
 	"strings"
 
-	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	. "github.com/onsi/gomega"
 )
 
-func ExpectFileContentInImage(imageName, filePath, expectedContent string) {
-	ref, err := name.ParseReference(imageName, name.Insecure)
-	Expect(err).NotTo(HaveOccurred())
-
-	img, err := remote.Image(ref)
-	Expect(err).NotTo(HaveOccurred())
-
+func ExpectFileContentInImage(ctx context.Context, backendMode, imageName, filePath, expectedContent string) {
+	img := loadLocalImage(ctx, backendMode, imageName)
 	rc := mutate.Extract(img)
 	defer rc.Close()
 
@@ -42,6 +38,43 @@ func ExpectFileContentInImage(imageName, filePath, expectedContent string) {
 	}
 
 	Expect(fileContent).To(Equal(expectedContent), "expected image file content to match for %s", filePath)
+}
+
+func ExpectImageHasNonEmptyLabels(ctx context.Context, backendMode, imageName string, labelKeys ...string) {
+	img := loadLocalImage(ctx, backendMode, imageName)
+	config, err := img.ConfigFile()
+	Expect(err).NotTo(HaveOccurred())
+
+	labels := config.Config.Labels
+	Expect(labels).NotTo(BeNil())
+
+	for _, key := range labelKeys {
+		Expect(labels).To(HaveKey(key))
+		Expect(labels[key]).NotTo(BeEmpty())
+	}
+}
+
+func loadLocalImage(ctx context.Context, backendMode, imageName string) v1.Image {
+	tempFile, err := os.CreateTemp("", "werf-e2e-image-*.tar")
+	Expect(err).NotTo(HaveOccurred())
+
+	tempTarPath := tempFile.Name()
+	Expect(tempFile.Close()).To(Succeed())
+	defer os.Remove(tempTarPath)
+
+	switch backendMode {
+	case "docker", "vanilla-docker", "buildkit-docker":
+		RunSucceedCommand(ctx, "/", "docker", "save", "-o", tempTarPath, imageName)
+	case "native-rootless", "native-chroot":
+		RunSucceedCommand(ctx, "/", "buildah", "push", "--tls-verify=false", "--format", "docker", imageName, "docker-archive:"+tempTarPath)
+	default:
+		Expect(false).To(BeTrue(), "unsupported backend mode: %s", backendMode)
+	}
+
+	img, err := tarball.ImageFromPath(tempTarPath, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	return img
 }
 
 func GetBuiltImageLastStageImageName(ctx context.Context, testDirPath, werfBinPath, imageName string) string {

--- a/test/pkg/utils/image.go
+++ b/test/pkg/utils/image.go
@@ -14,7 +14,8 @@ import (
 )
 
 func ExpectFileContentInImage(ctx context.Context, backendMode, imageName, filePath, expectedContent string) {
-	img := loadLocalImage(ctx, backendMode, imageName)
+	img, cleanup := loadLocalImage(ctx, backendMode, imageName)
+	defer cleanup()
 	rc := mutate.Extract(img)
 	defer rc.Close()
 
@@ -41,7 +42,8 @@ func ExpectFileContentInImage(ctx context.Context, backendMode, imageName, fileP
 }
 
 func ExpectImageHasNonEmptyLabels(ctx context.Context, backendMode, imageName string, labelKeys ...string) {
-	img := loadLocalImage(ctx, backendMode, imageName)
+	img, cleanup := loadLocalImage(ctx, backendMode, imageName)
+	defer cleanup()
 	config, err := img.ConfigFile()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -54,13 +56,12 @@ func ExpectImageHasNonEmptyLabels(ctx context.Context, backendMode, imageName st
 	}
 }
 
-func loadLocalImage(ctx context.Context, backendMode, imageName string) v1.Image {
+func loadLocalImage(ctx context.Context, backendMode, imageName string) (v1.Image, func()) {
 	tempFile, err := os.CreateTemp("", "werf-e2e-image-*.tar")
 	Expect(err).NotTo(HaveOccurred())
 
 	tempTarPath := tempFile.Name()
 	Expect(tempFile.Close()).To(Succeed())
-	defer os.Remove(tempTarPath)
 
 	switch backendMode {
 	case "docker", "vanilla-docker", "buildkit-docker":
@@ -74,7 +75,7 @@ func loadLocalImage(ctx context.Context, backendMode, imageName string) v1.Image
 	img, err := tarball.ImageFromPath(tempTarPath, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	return img
+	return img, func() { os.Remove(tempTarPath) }
 }
 
 func GetBuiltImageLastStageImageName(ctx context.Context, testDirPath, werfBinPath, imageName string) string {

--- a/test/pkg/utils/image.go
+++ b/test/pkg/utils/image.go
@@ -1,9 +1,48 @@
 package utils
 
 import (
+	"archive/tar"
 	"context"
+	"io"
 	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	. "github.com/onsi/gomega"
 )
+
+func ExpectFileContentInImage(imageName, filePath, expectedContent string) {
+	ref, err := name.ParseReference(imageName, name.Insecure)
+	Expect(err).NotTo(HaveOccurred())
+
+	img, err := remote.Image(ref)
+	Expect(err).NotTo(HaveOccurred())
+
+	rc := mutate.Extract(img)
+	defer rc.Close()
+
+	var fileContent string
+
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		if hdr.Name != filePath && hdr.Name != "./"+filePath {
+			continue
+		}
+
+		data, err := io.ReadAll(tr)
+		Expect(err).NotTo(HaveOccurred())
+		fileContent = string(data)
+	}
+
+	Expect(fileContent).To(Equal(expectedContent), "expected image file content to match for %s", filePath)
+}
 
 func GetBuiltImageLastStageImageName(ctx context.Context, testDirPath, werfBinPath, imageName string) string {
 	stageImageName := SucceedCommandOutputString(ctx, testDirPath, werfBinPath, "stage", "image", imageName)


### PR DESCRIPTION
…buildah misinterpretation

When building an image with 'from: scratch' and 'import:', buildah receives the literal string 'scratch' which it interprets as the OCI scratch special value instead of a local image reference. This results in invalid image structure when layers are applied on top.

Use UUID-based naming (e.g., 'werf-scratch-<uuid>') for scratch base images to prevent this conflict while maintaining unique identity for each instance.