### PR TITLE
feat(giterminism): strict schema validation for werf-giterminism.yaml

### DIFF
--- a/pkg/giterminism_manager/config/openapi_spec.go
+++ b/pkg/giterminism_manager/config/openapi_spec.go
@@ -16,7 +16,7 @@ const (
 	schemaYaml = `type: object
 required:
   - giterminismConfigVersion
-additionalProperties: {}
+additionalProperties: false
 properties:
   giterminismConfigVersion:
     oneOf:
@@ -30,16 +30,18 @@ properties:
     $ref: '#/definitions/Config'
   helm:
     $ref: '#/definitions/Helm'
+  includes:
+    $ref: '#/definitions/Includes'
 definitions:
   CLI:
     type: object
-    additionalProperties: {}
+    additionalProperties: false
     properties:
       allowCustomTags:
         type: boolean
   Config:
     type: object
-    additionalProperties: {}
+    additionalProperties: false
     properties:
       allowUncommitted:
         type: boolean
@@ -49,13 +51,15 @@ definitions:
           type: string
       goTemplateRendering:
         $ref: '#/definitions/ConfigGoTemplateRendering'
+      secrets:
+        $ref: '#/definitions/ConfigSecrets'
       stapel:
         $ref: '#/definitions/ConfigStapel'
       dockerfile:
         $ref: '#/definitions/ConfigDockerfile'
   ConfigGoTemplateRendering:
     type: object
-    additionalProperties: {}
+    additionalProperties: false
     properties:
       allowEnvVariables:
         type: array
@@ -65,9 +69,25 @@ definitions:
         type: array
         items:
           type: string
+  ConfigSecrets:
+    type: object
+    additionalProperties: false
+    properties:
+      allowEnvVariables:
+        type: array
+        items:
+          type: string
+      allowFiles:
+        type: array
+        items:
+          type: string
+      allowValueIds:
+        type: array
+        items:
+          type: string
   ConfigStapel:
     type: object
-    additionalProperties: {}
+    additionalProperties: false
     properties:
       allowFromLatest:
         type: boolean
@@ -77,13 +97,13 @@ definitions:
         $ref: '#/definitions/ConfigStapelMount'
   ConfigStapelGit:
     type: object
-    additionalProperties: {}
+    additionalProperties: false
     properties:
       allowBranch:
         type: boolean
   ConfigStapelMount:
     type: object
-    additionalProperties: {}
+    additionalProperties: false
     properties:
       allowBuildDir:
         type: boolean
@@ -93,7 +113,7 @@ definitions:
           type: string
   ConfigDockerfile:
     type: object
-    additionalProperties: {}
+    additionalProperties: false
     properties:
       allowUncommitted:
         type: array
@@ -109,12 +129,18 @@ definitions:
           type: string
   Helm:
     type: object
-    additionalProperties: {}
+    additionalProperties: false
     properties:
       allowUncommittedFiles:
         type: array
         items:
           type: string
+  Includes:
+    type: object
+    additionalProperties: false
+    properties:
+      allowIncludesUpdate:
+        type: boolean
 `
 )
 

--- a/pkg/giterminism_manager/config/openapi_spec_ai_test.go
+++ b/pkg/giterminism_manager/config/openapi_spec_ai_test.go
@@ -1,0 +1,212 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeFileReaderAI struct {
+	exist bool
+	data  []byte
+}
+
+func (f fakeFileReaderAI) IsGiterminismConfigExistAnywhere(_ context.Context, _ string) (bool, error) {
+	return f.exist, nil
+}
+
+func (f fakeFileReaderAI) ReadGiterminismConfig(_ context.Context, _ string) ([]byte, error) {
+	return f.data, nil
+}
+
+func validateAI(t *testing.T, yamlData string) ([]byte, error) {
+	t.Helper()
+	data := []byte(yamlData)
+	err := processWithOpenAPISchema(&data)
+	return data, err
+}
+
+func TestAI_ValidFullConfig(t *testing.T) {
+	data, err := validateAI(t, `
+giterminismConfigVersion: 1
+cli:
+  allowCustomTags: true
+config:
+  allowUncommitted: true
+  allowUncommittedTemplates:
+    - "**/*"
+  goTemplateRendering:
+    allowEnvVariables:
+      - WERF_FOO
+    allowUncommittedFiles:
+      - "**/*"
+  secrets:
+    allowEnvVariables:
+      - SECRET_ENV
+    allowFiles:
+      - .secret
+    allowValueIds:
+      - secret-id
+  stapel:
+    allowFromLatest: true
+    git:
+      allowBranch: true
+    mount:
+      allowBuildDir: true
+      allowFromPaths:
+        - build
+  dockerfile:
+    allowUncommitted:
+      - Dockerfile
+    allowUncommittedDockerignoreFiles:
+      - .dockerignore
+    allowContextAddFiles:
+      - some
+helm:
+  allowUncommittedFiles:
+    - "**/*"
+includes:
+  allowIncludesUpdate: true
+`)
+	require.NoError(t, err)
+
+	var c Config
+	require.NoError(t, json.Unmarshal(data, &c))
+	assert.True(t, c.IsCustomTagsAccepted())
+	assert.True(t, c.IsUpdateIncludesAccepted())
+	assert.True(t, c.IsConfigSecretEnvAccepted("SECRET_ENV"))
+	assert.True(t, c.IsConfigSecretValueAccepted("secret-id"))
+}
+
+func TestAI_VersionAsNumberAndString(t *testing.T) {
+	_, err := validateAI(t, "giterminismConfigVersion: 1\n")
+	require.NoError(t, err)
+
+	_, err = validateAI(t, `giterminismConfigVersion: "1"`+"\n")
+	require.NoError(t, err)
+}
+
+func TestAI_MissingVersionFails(t *testing.T) {
+	_, err := validateAI(t, "cli:\n  allowCustomTags: true\n")
+	require.Error(t, err)
+}
+
+func TestAI_MinimalConfigUnmarshals(t *testing.T) {
+	data, err := validateAI(t, "giterminismConfigVersion: 1\n")
+	require.NoError(t, err)
+
+	var c Config
+	require.NoError(t, json.Unmarshal(data, &c))
+}
+
+func TestAI_UnknownRootKeyRejected(t *testing.T) {
+	_, err := validateAI(t, `
+giterminismConfigVersion: 1
+allowCustomTags: true
+`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowCustomTags")
+}
+
+func TestAI_UnknownNestedKeyRejected(t *testing.T) {
+	cases := map[string]string{
+		"config": `
+giterminismConfigVersion: 1
+config:
+  allowUncommited: true
+`,
+		"config.stapel": `
+giterminismConfigVersion: 1
+config:
+  stapel:
+    allowFromLatests: true
+`,
+		"cli": `
+giterminismConfigVersion: 1
+cli:
+  allowCustomTag: true
+`,
+		"helm": `
+giterminismConfigVersion: 1
+helm:
+  allowUncommittedFile: ["**/*"]
+`,
+		"config.secrets": `
+giterminismConfigVersion: 1
+config:
+  secrets:
+    allowEnvVariable: ["FOO"]
+`,
+		"includes": `
+giterminismConfigVersion: 1
+includes:
+  allowIncludesUpdat: true
+`,
+	}
+
+	for name, yamlData := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := validateAI(t, yamlData)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "forbidden property")
+		})
+	}
+}
+
+func TestAI_ConfigSecretsValid(t *testing.T) {
+	data, err := validateAI(t, `
+giterminismConfigVersion: 1
+config:
+  secrets:
+    allowEnvVariables:
+      - FOO
+    allowFiles:
+      - .secret
+    allowValueIds:
+      - vid
+`)
+	require.NoError(t, err)
+
+	var c Config
+	require.NoError(t, json.Unmarshal(data, &c))
+	assert.True(t, c.IsConfigSecretEnvAccepted("FOO"))
+}
+
+func TestAI_IncludesValid(t *testing.T) {
+	data, err := validateAI(t, `
+giterminismConfigVersion: 1
+includes:
+  allowIncludesUpdate: true
+`)
+	require.NoError(t, err)
+
+	var c Config
+	require.NoError(t, json.Unmarshal(data, &c))
+	assert.True(t, c.IsUpdateIncludesAccepted())
+}
+
+func TestAI_NoFileReturnsEmptyConfig(t *testing.T) {
+	c, err := NewConfig(context.Background(), fakeFileReaderAI{exist: false}, "werf-giterminism.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, Config{}, c)
+}
+
+func TestAI_NewConfigUnknownKeyFails(t *testing.T) {
+	_, err := NewConfig(context.Background(), fakeFileReaderAI{
+		exist: true,
+		data:  []byte("giterminismConfigVersion: 1\nallowCustomTags: true\n"),
+	}, "werf-giterminism.yaml")
+	require.Error(t, err)
+}
+
+func TestAI_WrongTypeRejected(t *testing.T) {
+	_, err := validateAI(t, `
+giterminismConfigVersion: 1
+cli:
+  allowCustomTags: "yes"
+`)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

Make the `werf-giterminism.yaml` OpenAPI schema strict and in sync with the `Config` Go struct.

- Add the previously-missing `config.secrets` block (`allowEnvVariables`, `allowFiles`, `allowValueIds` — string arrays) and the top-level `includes` block (`allowIncludesUpdate` — boolean). These valid fields existed in the Go struct but were absent from the schema.
- Switch every `additionalProperties: {}` to `additionalProperties: false` (root + all definitions), so unknown/misspelled keys now produce a validation error instead of being silently accepted.

## Why

The existing schema was too permissive: a typo'd directive name was ignored rather than flagged, and the schema had drifted from the actual config. Now structure, types, and unknown keys are validated, with error messages that name the offending key (e.g. `config.allowUncommited in body is a forbidden property`).

## Breaking change

⚠️ Configs containing extra/unknown keys will now fail validation. This is intentional and was acknowledged.

## Preserved behavior

- `giterminismConfigVersion` still accepts both numeric `1` and string `"1"` (only required field).
- Absent `werf-giterminism.yaml` still returns an empty `Config{}` with no validation.
- Defaults/marshal flow intact.

## Tests

Added `pkg/giterminism_manager/config/openapi_spec_ai_test.go` covering: valid full config, version as number/string, missing version, unknown key at root and nested in `config`/`config.stapel`/`cli`/`helm`/`config.secrets`/`includes`, valid `secrets`, valid `includes`, wrong type, and the no-file path.

Verified with `task build`, `task test:unit`, `task lint:golangci-lint` (0 issues).