### PR TITLE
refactor(build, stapel, git): fetch only the mapped branch for remote git

### DIFF
--- a/pkg/build/image/stapel.go
+++ b/pkg/build/image/stapel.go
@@ -236,6 +236,9 @@ func generateGitMappings(ctx context.Context, metaConfig *config.Meta, imageBase
 			if err != nil {
 				return nil, fmt.Errorf("unable to open remote git repo %s by url %s: %w", remoteGitMappingConfig.Name, remoteGitMappingConfig.Url, err)
 			}
+			remoteGitRepo.Branch = remoteGitMappingConfig.Branch
+			remoteGitRepo.Tag = remoteGitMappingConfig.Tag
+			remoteGitRepo.Commit = remoteGitMappingConfig.Commit
 
 			if err := logboek.Context(ctx).Info().LogProcess(fmt.Sprintf("Refreshing %s repository", remoteGitMappingConfig.Name)).
 				DoError(func() error {

--- a/pkg/git_repo/remote.go
+++ b/pkg/git_repo/remote.go
@@ -34,6 +34,10 @@ type Remote struct {
 	Endpoint *transport.Endpoint
 
 	BasicAuth *BasicAuth
+
+	Branch string
+	Tag    string
+	Commit string
 }
 
 func OpenRemoteRepo(name, url string, auth *BasicAuthCredentials) (*Remote, error) {
@@ -151,6 +155,34 @@ func (repo *Remote) updateLastAccessAt(ctx context.Context, repoPath string) err
 	return timestamps.WriteTimestampFile(path, time.Now())
 }
 
+func buildCloneOptions(url, branch string) *git.CloneOptions {
+	opts := &git.CloneOptions{
+		URL:               url,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+	}
+
+	if branch != "" {
+		opts.SingleBranch = true
+		opts.ReferenceName = plumbing.NewBranchReferenceName(branch)
+		opts.Tags = git.NoTags
+	}
+
+	return opts
+}
+
+func buildFetchOptions(remoteName, branch string) *git.FetchOptions {
+	tags := git.AllTags
+	if branch != "" {
+		tags = git.NoTags
+	}
+
+	return &git.FetchOptions{
+		RemoteName: remoteName,
+		Force:      true,
+		Tags:       tags,
+	}
+}
+
 func (repo *Remote) Clone(ctx context.Context) (bool, error) {
 	if repo.IsDryRun {
 		return false, nil
@@ -202,10 +234,7 @@ func (repo *Remote) Clone(ctx context.Context) (bool, error) {
 		// Ensure cleanup on failure
 		defer os.RemoveAll(tmpPath)
 
-		cloneOpts := &git.CloneOptions{
-			URL:               repo.Url,
-			RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
-		}
+		cloneOpts := buildCloneOptions(repo.Url, repo.Branch)
 
 		if repo.BasicAuth != nil {
 			cloneOpts.Auth = newBasicAuth(repo.BasicAuth.Username, repo.BasicAuth.Password).AuthMethod
@@ -285,11 +314,7 @@ func (repo *Remote) FetchOrigin(ctx context.Context, opts FetchOptions) error {
 
 		logboek.Context(ctx).Default().LogFDetails("Fetch remote %s of %s\n", remoteName, repo.Url)
 
-		fetchOpts := &git.FetchOptions{
-			RemoteName: remoteName,
-			Force:      true,
-			Tags:       git.AllTags,
-		}
+		fetchOpts := buildFetchOptions(remoteName, repo.Branch)
 
 		if repo.BasicAuth != nil {
 			fetchOpts.Auth = newBasicAuth(repo.BasicAuth.Username, repo.BasicAuth.Password).AuthMethod

--- a/pkg/git_repo/remote_ai_test.go
+++ b/pkg/git_repo/remote_ai_test.go
@@ -10,6 +10,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAI_BuildCloneOptions(t *testing.T) {
+	t.Run("branch mapping clones single branch without tags", func(t *testing.T) {
+		opts := buildCloneOptions("https://example.com/repo.git", "main")
+		assert.True(t, opts.SingleBranch)
+		assert.Equal(t, plumbing.NewBranchReferenceName("main"), opts.ReferenceName)
+		assert.Equal(t, git.NoTags, opts.Tags)
+	})
+
+	t.Run("no branch clones everything", func(t *testing.T) {
+		opts := buildCloneOptions("https://example.com/repo.git", "")
+		assert.False(t, opts.SingleBranch)
+		assert.Empty(t, opts.ReferenceName)
+		assert.NotEqual(t, git.NoTags, opts.Tags)
+	})
+}
+
+func TestAI_BuildFetchOptions(t *testing.T) {
+	t.Run("branch mapping fetches without tags", func(t *testing.T) {
+		opts := buildFetchOptions("origin", "main")
+		assert.Equal(t, git.NoTags, opts.Tags)
+		assert.True(t, opts.Force)
+	})
+
+	t.Run("no branch fetches all tags", func(t *testing.T) {
+		opts := buildFetchOptions("origin", "")
+		assert.Equal(t, git.AllTags, opts.Tags)
+		assert.True(t, opts.Force)
+	})
+}
+
 func TestAI_SyncLocalBranches(t *testing.T) {
 	tmpDir := t.TempDir()
 	rawRepo, err := git.PlainInit(tmpDir, true)


### PR DESCRIPTION
## What

When a remote git mapping targets a branch, clone it with single-branch mode and skip tags.

## Why

Previously werf cloned **every branch and all tags** of the remote repository. On huge repos like `llvm/llvm-project` this means fetching thousands of unused refs (`users/*`, `spr/*`) and minutes of wasted CI time, even when nothing is actually rebuilt and all stages come from cache.

## How

- `Remote` now carries `Branch/Tag/Commit` from the git-mapping config (set in `stapel.go`).
- For **branch** mappings: `SingleBranch + ReferenceName + NoTags`. go-git writes the narrow refspec `+refs/heads/X:refs/remotes/origin/X`, so `refs/remotes/origin/X` is preserved and the rest of `Remote` (`LatestBranchCommit`, `syncLocalBranches`, …) keeps working unchanged. Subsequent fetches reuse that narrow refspec and no longer pull thousands of unused refs.
- **Tag** and **commit** mappings keep the previous full-clone behavior: a commit may live in any branch, and a tag mapping needs tags.
- No `--depth`/shallow — branch history is preserved, so stage digest caching is unaffected.

## Notes

This is the safe, go-git-only part. Switching remote clone/fetch to native `git` shell-out (bigger speedup but rewrites the refs contract) is intentionally left for a separate PR.

## Tests

Unit tests for clone/fetch option selection. `task build`, `task test:unit`, `task lint:golangci-lint` pass.