### PR TITLE
chore(deps): bump github.com/werf/logboek to v0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/werf/kubedog v0.13.1-0.20260616105957-2c00b08fb99e
 	github.com/werf/kubedog-for-werf-helm v0.0.0-20241217155728-9d45c48b82b6
 	github.com/werf/lockgate v0.1.1
-	github.com/werf/logboek v0.6.1
+	github.com/werf/logboek v0.7.1
 	github.com/werf/nelm v1.24.4-0.20260618090926-7f5713b27219
 	github.com/werf/nelm-for-werf-helm v0.0.0-20241217155925-b0e6734d1dbf
 	go.opentelemetry.io/otel v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -1414,8 +1414,8 @@ github.com/werf/kubedog-for-werf-helm v0.0.0-20241217155728-9d45c48b82b6 h1:lpgQ
 github.com/werf/kubedog-for-werf-helm v0.0.0-20241217155728-9d45c48b82b6/go.mod h1:PA9xGVKX9Il6sCgvPrcB3/FahRme3bXRz4BuylvAssc=
 github.com/werf/lockgate v0.1.1 h1:S400JFYjtWfE4i4LY9FA8zx0fMdfui9DPrBiTciCrx4=
 github.com/werf/lockgate v0.1.1/go.mod h1:0yIFSLq9ausy6ejNxF5uUBf/Ib6daMAfXuCaTMZJzIE=
-github.com/werf/logboek v0.6.1 h1:oEe6FkmlKg0z0n80oZjLplj6sXcBeLleCkjfOOZEL2g=
-github.com/werf/logboek v0.6.1/go.mod h1:Gez5J4bxekyr6MxTmIJyId1F61rpO+0/V4vjCIEIZmk=
+github.com/werf/logboek v0.7.1 h1:Ck8L7LVmj/wyrW/jk+EkkpGwdmpkOrsWAwoIgLHupc8=
+github.com/werf/logboek v0.7.1/go.mod h1:Gez5J4bxekyr6MxTmIJyId1F61rpO+0/V4vjCIEIZmk=
 github.com/werf/nelm v1.24.4-0.20260618090926-7f5713b27219 h1:wZjBQJnQPMZRdhtS1/4vOQfuoFSybY1BHtbkY+AUg+E=
 github.com/werf/nelm v1.24.4-0.20260618090926-7f5713b27219/go.mod h1:D3uU5e1dSBc0l0oo/iB6SjM2sLaXICqRDSWXAYF+vpk=
 github.com/werf/nelm-for-werf-helm v0.0.0-20241217155925-b0e6734d1dbf h1:K51qz209c1yJgKzPw8AeS72T21F/ACp0VI3RJvT4THA=


### PR DESCRIPTION
Bumps `github.com/werf/logboek` from v0.6.1 to v0.7.1.

## Changes in logboek v0.6.1..v0.7.1

- fix: cut multibyte runs on rune boundary in `sequence.Slice` (github.com/werf/logboek#80)
- perf: rune-slice sequence + cached TWidth, linear long-word wrap (github.com/werf/logboek#79)
- test: cover `Context`/`MustContext` fallback and panic paths (github.com/werf/logboek#78)
- fix: make `Context(ctx)` panic-free, add `MustContext(ctx)` for strict fallback (github.com/werf/logboek#75, github.com/werf/logboek#76)
- perf: eliminate quadratic string growth for long log lines (github.com/werf/logboek#77)
- docs(readme): translate

Only `go.mod` and `go.sum` change.