### PR TITLE
fix(build, stapel, git): remove git commit ancestry check on stage reuse

### DIFF
--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/werf/common-go/pkg/util"
@@ -84,25 +83,6 @@ type BaseStageOptions struct {
 	ContainerWerfDir  string
 	ProjectName       string
 	Network           string
-}
-
-const disableGitCommitAncestryCheckEnv = "WERF_DISABLE_GIT_COMMIT_ANCESTRY_CHECK"
-
-func isGitCommitAncestryCheckDisabled() bool {
-	v, hasKey := os.LookupEnv(disableGitCommitAncestryCheckEnv)
-	if !hasKey {
-		return false
-	}
-	if v == "" {
-		return false
-	}
-
-	disabled, err := strconv.ParseBool(v)
-	if err != nil {
-		return false
-	}
-
-	return disabled
 }
 
 func NewBaseStage(name StageName, options *BaseStageOptions) *BaseStage {
@@ -269,11 +249,6 @@ func (s *BaseStage) selectAncestorStageDescByGitMappings(ctx context.Context, c 
 		currentCommitsByIndex = append(currentCommitsByIndex, currentCommitInfo.Commit)
 	}
 
-	disableAncestryCheck := isGitCommitAncestryCheckDisabled()
-	if disableAncestryCheck {
-		logboek.Context(ctx).Debug().LogF("Git commit ancestry check is disabled by %s\n", disableGitCommitAncestryCheckEnv)
-	}
-
 ScanImages:
 	for _, stageDesc := range sortStageDescSetByOldestCreationTs(stageDescSet) {
 		for i, gitMapping := range s.gitMappings {
@@ -295,10 +270,6 @@ ScanImages:
 			if !exist {
 				logboek.Context(ctx).Info().LogF("Skipping stage %s: commit %s does not exist in repo %s\n", stageDesc.Info.Name, commitToCheckAncestry, gitMapping.GitRepo().String())
 				continue ScanImages
-			}
-
-			if disableAncestryCheck {
-				continue
 			}
 
 			isOurAncestor, err := gitMapping.GitRepo().IsAncestor(ctx, commitToCheckAncestry, currentCommit)


### PR DESCRIPTION
## Summary
- Removes the `WERF_DISABLE_GIT_COMMIT_ANCESTRY_CHECK` env toggle and the ancestry validation performed in `selectAncestorStageDescByGitMappings` when werf selects a cached git-related stage (`gitArchive`/`gitCache`/`gitLatestPatch`).
- Previously werf required the cached stage's commit to be a strict git ancestor of the current commit before reusing it; this check is now removed entirely.