### PR TITLE
feat(deploy): enable specific images params by default for converge/plan

### DIFF
--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -41,23 +41,11 @@ var cmdData struct {
 
 var commonCmdData common.CmdData
 
-// TODO: support specific images in v3 by default.
-func isSpecificImagesEnabled() bool {
-	return util.GetBoolEnvironmentDefaultFalse("WERF_CONVERGE_ENABLE_IMAGES_PARAMS")
-}
-
 func NewCmd(ctx context.Context) *cobra.Command {
 	ctx = common.NewContextWithCmdData(ctx, &commonCmdData)
 
-	var useMsg string
-	if isSpecificImagesEnabled() {
-		useMsg = "converge [IMAGE_NAME ...]"
-	} else {
-		useMsg = "converge"
-	}
-
 	cmd := common.SetCommandContext(ctx, &cobra.Command{
-		Use:   useMsg,
+		Use:   "converge [IMAGE_NAME ...]",
 		Short: "Build and push images, then deploy application into Kubernetes",
 		Long:  common.GetLongCommandDescription(GetConvergeDocs().Long),
 		Example: `# Build and deploy current application state into production environment
@@ -80,12 +68,7 @@ werf converge --repo registry.mydomain.com/web --env production`,
 			common.LogVersion()
 
 			return common.LogRunningTime(func() error {
-				var imageNameListFromArgs []string
-				if isSpecificImagesEnabled() {
-					imageNameListFromArgs = args
-				}
-
-				return runMain(ctx, imageNameListFromArgs)
+				return runMain(ctx, args)
 			})
 		},
 	})
@@ -120,7 +103,6 @@ werf converge --repo registry.mydomain.com/web --env production`,
 
 	common.SetupLogOptions(&commonCmdData, cmd)
 	common.SetupLogProjectDir(&commonCmdData, cmd)
-
 
 	commonCmdData.SetupWithoutImages(cmd)
 	commonCmdData.SetupFinalImagesOnly(cmd, true)

--- a/cmd/werf/plan/plan.go
+++ b/cmd/werf/plan/plan.go
@@ -45,22 +45,11 @@ var cmdData struct {
 
 var commonCmdData common.CmdData
 
-func isSpecificImagesEnabled() bool {
-	return util.GetBoolEnvironmentDefaultFalse("WERF_CONVERGE_ENABLE_IMAGES_PARAMS")
-}
-
 func NewCmd(ctx context.Context) *cobra.Command {
 	ctx = common.NewContextWithCmdData(ctx, &commonCmdData)
 
-	var useMsg string
-	if isSpecificImagesEnabled() {
-		useMsg = "plan [IMAGE_NAME ...]"
-	} else {
-		useMsg = "plan"
-	}
-
 	cmd := common.SetCommandContext(ctx, &cobra.Command{
-		Use:   useMsg,
+		Use:   "plan [IMAGE_NAME ...]",
 		Short: "Prepare deploy plan and show how resources in a Kubernetes cluster would change on next deploy",
 		Long:  common.GetLongCommandDescription(GetPlanDocs().Long),
 		Example: `# Prepare and show deploy plan
@@ -83,12 +72,7 @@ werf plan --repo registry.mydomain.com/web --env production`,
 			common.LogVersion()
 
 			return common.LogRunningTime(func() error {
-				var imageNameListFromArgs []string
-				if isSpecificImagesEnabled() {
-					imageNameListFromArgs = args
-				}
-
-				return runMain(ctx, imageNameListFromArgs)
+				return runMain(ctx, args)
 			})
 		},
 	})
@@ -123,7 +107,6 @@ werf plan --repo registry.mydomain.com/web --env production`,
 
 	common.SetupLogOptions(&commonCmdData, cmd)
 	common.SetupLogProjectDir(&commonCmdData, cmd)
-
 
 	commonCmdData.SetupWithoutImages(cmd)
 	commonCmdData.SetupFinalImagesOnly(cmd, true)


### PR DESCRIPTION
## Summary

Makes `converge`/`plan` support for `[IMAGE_NAME ...]` args always-on instead of opt-in via `WERF_CONVERGE_ENABLE_IMAGES_PARAMS`.

## Key changes

- Removed `isSpecificImagesEnabled()` and the `WERF_CONVERGE_ENABLE_IMAGES_PARAMS` env var check from `cmd/werf/converge/converge.go` and `cmd/werf/plan/plan.go`.
- `converge`/`plan` command `Use` strings now unconditionally show `[IMAGE_NAME ...]`.
- `args` are always passed through to `runMain` instead of being gated behind the flag.

## Why

The specific-images feature has been stable behind the flag; this promotes it to default behavior in v3, removing dead conditional code and the associated TODO.

## Review focus / risks

- Behavioral change: `werf converge <image>` / `werf plan <image>` now always filters to specific images, even without setting `WERF_CONVERGE_ENABLE_IMAGES_PARAMS=1`. Any CI/scripts relying on old default (ignoring positional image args) will see different behavior.