### PR TITLE
fix(build): default --final-images-only to true for consistency

### DIFF
--- a/cmd/werf/build/main.go
+++ b/cmd/werf/build/main.go
@@ -89,7 +89,6 @@ func NewCmd(ctx context.Context) *cobra.Command {
 	common.SetupLogOptions(&commonCmdData, cmd)
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
-
 	common.SetupSaveBuildReport(&commonCmdData, cmd)
 	common.SetupBuildReportPath(&commonCmdData, cmd)
 
@@ -113,7 +112,7 @@ func NewCmd(ctx context.Context) *cobra.Command {
 	commonCmdData.SetupSkipImageSpecStage(cmd)
 	commonCmdData.SetupDebugTemplates(cmd)
 
-	commonCmdData.SetupFinalImagesOnly(cmd, false)
+	commonCmdData.SetupFinalImagesOnly(cmd, true)
 	commonCmdData.SetupAllowIncludesUpdate(cmd)
 
 	return cmd

--- a/docs/_includes/reference/cli/werf_build.md
+++ b/docs/_includes/reference/cli/werf_build.md
@@ -120,8 +120,8 @@ werf build [IMAGE_NAME...] [options]
             repo, to pull base images
       --env=""
             Use specified environment (default $WERF_ENV)
-      --final-images-only=false
-            Process final images only ($WERF_FINAL_IMAGES_ONLY or false by default)
+      --final-images-only=true
+            Process final images only ($WERF_FINAL_IMAGES_ONLY or true by default)
       --final-repo=""
             Container registry storage address (default $WERF_FINAL_REPO)
       --final-repo-container-registry=""

--- a/test/legacy_e2e/suites/managed_images/base_test.go
+++ b/test/legacy_e2e/suites/managed_images/base_test.go
@@ -61,7 +61,7 @@ var _ = Describe("managed images", func() {
 
 			When("werf images have been built", func() {
 				BeforeEach(func(ctx SpecContext) {
-					utils.RunSucceedCommand(ctx, SuiteData.GetProjectWorktree(SuiteData.ProjectName), SuiteData.WerfBinPath, "build")
+					utils.RunSucceedCommand(ctx, SuiteData.GetProjectWorktree(SuiteData.ProjectName), SuiteData.WerfBinPath, "build", "--final-images-only=false")
 				})
 
 				It("ls should return managed image", func(ctx SpecContext) {


### PR DESCRIPTION
## Summary

Aligns `werf build`'s `--final-images-only` default with `converge`, `render`, `export`, `plan`, `lint`, and `bundle publish`, all of which already default to `true`.

## Key changes

- `cmd/werf/build/main.go`: `SetupFinalImagesOnly(cmd, false)` → `SetupFinalImagesOnly(cmd, true)`.
- `docs/_includes/reference/cli/werf_build.md`: regenerated via `task doc:gen`.
- `test/legacy_e2e/suites/managed_images/base_test.go`: pass explicit `--final-images-only=false` since the test asserts that an orphan non-final image (`d`, no consumers) becomes a managed image.

## Why

`build` was the only build-triggering command defaulting to `false`, silently building auxiliary (non-final) images that no other image depends on. Non-final images required as build/import dependencies of a final image are unaffected — `GroupImagesByIndependentSets` builds them transitively regardless of this flag. This is a targeted consistency fix, not a change to dependency resolution.

## Review focus / risks

- **Breaking change**: `werf build` invocations that rely on the old default to build orphan non-final images (images not referenced via `from`/`import`/`dependencies` by any final image) will now skip them unless `--final-images-only=false` is passed explicitly or `$WERF_FINAL_IMAGES_ONLY=false` is set.
- Audited all `final: false` test fixtures repo-wide; confirmed only one test (`managed_images/base_test.go`) exercised an orphan non-final image and needed updating. All others (`cleanup`, `imports_*`, `stages/copy`, `custom_tag`) use non-final images as dependencies of final images and are unaffected.
- CHANGELOG/release notes intentionally not touched per repo convention — flag to maintainers if user-facing notice is needed.