### PR TITLE
fix(host-cleanup): GC stale host lock files on cleanup

### DIFF
--- a/cmd/werf/host/cleanup/cleanup_docs.go
+++ b/cmd/werf/host/cleanup/cleanup_docs.go
@@ -10,6 +10,7 @@ func GetCleanupDocs() structs.DocsStruct {
 The data include:
 * Lost Docker containers and images from interrupted builds.
 * Old service tmp dirs, which werf creates during every build, converge and other commands.
+* Stale host lock files, no longer held by any werf process.
 * Local cache:
   * remote Git clones cache;
   * Git worktree cache.
@@ -20,6 +21,7 @@ It is safe to run this command periodically by automated cleanup job in parallel
 		"The data include:\n" +
 		"* Lost Docker containers and images from interrupted builds.\n" +
 		"* Old service tmp dirs, which werf creates during every `build`, `converge` and other commands.\n" +
+		"* Stale host lock files, no longer held by any werf process.\n" +
 		"* Local cache:\n" +
 		"  * remote Git clones cache;\n" +
 		"  * Git worktree cache.\n\n" +

--- a/docs/_includes/reference/cli/werf_host_cleanup.md
+++ b/docs/_includes/reference/cli/werf_host_cleanup.md
@@ -8,6 +8,7 @@ Cleanup old unused werf cache and data of all projects on host machine.
 The data include:
 * Lost Docker containers and images from interrupted builds.
 * Old service tmp dirs, which werf creates during every `build`, `converge` and other commands.
+* Stale host lock files, no longer held by any werf process.
 * Local cache:
   * remote Git clones cache;
   * Git worktree cache.

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/werf/common-go v0.0.0-20260504183956-43da716392f7
 	github.com/werf/copy-recurse v0.2.7
-	github.com/werf/lockgate v0.1.1
+	github.com/werf/lockgate v0.2.0
 	github.com/werf/logboek v0.6.1
 	github.com/werf/nelm v1.23.3-0.20260514121649-29d4e8bfbc01
 	go.opentelemetry.io/otel v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -864,8 +864,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rodaine/table v1.1.1 h1:zBliy3b4Oj6JRmncse2Z85WmoQvDrXOYuy0JXCt8Qz8=
 github.com/rodaine/table v1.1.1/go.mod h1:iqTRptjn+EVcrVBYtNMlJ2wrJZa3MpULUmcXFpfcziA=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
-github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
-github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
+github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/rubenv/sql-migrate v1.8.1 h1:EPNwCvjAowHI3TnZ+4fQu3a915OpnQoPAjTXCGOy2U0=
 github.com/rubenv/sql-migrate v1.8.1/go.mod h1:BTIKBORjzyxZDS6dzoiw6eAFYJ1iNlGAtjn4LGeVjS8=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -1028,8 +1028,8 @@ github.com/werf/copy-recurse v0.2.7 h1:3FTOarbJ9uhFLi75oeUCioK9zxZwuV7o28kuUBPDZ
 github.com/werf/copy-recurse v0.2.7/go.mod h1:6Ypb+qN+hRBJgoCgEkX1vpbqcQ+8q69BQ3hi8s8Y6Qc=
 github.com/werf/kubedog v0.13.1-0.20260320165832-7d97aaf7aab9 h1:N+XKTPiXT5pf5lxThhaQQPARLUpZTlYJeMNoNtn+540=
 github.com/werf/kubedog v0.13.1-0.20260320165832-7d97aaf7aab9/go.mod h1:93L6aIdpj7iIhL30Obkv7bWgUyTeuxas1ijtzjmyb4Q=
-github.com/werf/lockgate v0.1.1 h1:S400JFYjtWfE4i4LY9FA8zx0fMdfui9DPrBiTciCrx4=
-github.com/werf/lockgate v0.1.1/go.mod h1:0yIFSLq9ausy6ejNxF5uUBf/Ib6daMAfXuCaTMZJzIE=
+github.com/werf/lockgate v0.2.0 h1:wntfccZmtHQuntPjrPUFA2FcKejhmteKEekQx3VsHC4=
+github.com/werf/lockgate v0.2.0/go.mod h1:h8P6tpGRZymd0bS5FlnS+AdIwO2jDlpOLy9St2tbs30=
 github.com/werf/logboek v0.6.1 h1:oEe6FkmlKg0z0n80oZjLplj6sXcBeLleCkjfOOZEL2g=
 github.com/werf/logboek v0.6.1/go.mod h1:Gez5J4bxekyr6MxTmIJyId1F61rpO+0/V4vjCIEIZmk=
 github.com/werf/nelm v1.23.3-0.20260514121649-29d4e8bfbc01 h1:YwMg7JGcNOCfBkWztuOxWmWUdwHAsA+TftJIUUO8e7M=

--- a/pkg/host_cleaning/host_cleanup.go
+++ b/pkg/host_cleaning/host_cleanup.go
@@ -111,6 +111,19 @@ func RunHostCleanup(ctx context.Context, backend container_backend.ContainerBack
 		return err
 	}
 
+	if err := logboek.Context(ctx).LogProcess("Running GC for locks").DoError(func() error {
+		if options.DryRun {
+			return nil
+		}
+		if err := werf.GCHostLockerDir(); err != nil {
+			// non-fatal: lock GC failures must not block the rest of host cleanup
+			logboek.Context(ctx).Warn().LogF("WARNING: host locks GC failed: %s\n", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
 	allowedLocalCacheVolumeUsagePercentage := getOptionValueOrDefault(options.AllowedLocalCacheVolumeUsagePercentage, DefaultAllowedLocalCacheVolumeUsagePercentage)
 	allowedLocalCacheVolumeUsageMarginPercentage := getOptionValueOrDefault(options.AllowedLocalCacheVolumeUsageMarginPercentage, DefaultAllowedLocalCacheVolumeUsageMarginPercentage)
 
@@ -186,6 +199,14 @@ func shouldRunAutoHostCleanup(ctx context.Context, backend container_backend.Con
 	shouldRun, err := tmp_manager.ShouldRunAutoGC()
 	if err != nil {
 		return false, fmt.Errorf("failed to check tmp manager GC: %w", err)
+	}
+	if shouldRun {
+		return true, nil
+	}
+
+	shouldRun, err = werf.ShouldRunHostLocksGC()
+	if err != nil {
+		return false, fmt.Errorf("failed to check host locks GC: %w", err)
 	}
 	if shouldRun {
 		return true, nil

--- a/pkg/werf/gc.go
+++ b/pkg/werf/gc.go
@@ -1,0 +1,82 @@
+package werf
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/werf/lockgate/pkg/file_lock"
+)
+
+// HostLocksGCMinAge is the minimum age a host lock file must reach before GC may
+// remove it. Host locks live for seconds during normal runs, so a conservative
+// window guarantees GC never touches an active lock while still reclaiming the
+// long-lived stale files that exhaust inodes on long-running runners.
+const HostLocksGCMinAge = 24 * time.Hour
+
+// hostLocksAutoGCThreshold is the number of stale host lock files that triggers
+// automatic host cleanup. Lock files are empty, so they never move the byte-based
+// volume-usage thresholds; without this signal GC would never fire on the exact
+// inode-exhaustion failure mode this addresses.
+const hostLocksAutoGCThreshold = 10000
+
+// hostLockerDirSchemaVersion namespaces the host locker directory so that
+// older werf binaries (which acquire locks without the inode-safe retry
+// against GCLockFileDir) never share a locks directory with a GC-capable
+// werf. Mixing the two on the same host could otherwise let a new process's
+// GC pass unlink a lock file an old process just opened, right before the
+// old process takes its flock — the old acquire path has no way to detect
+// the resulting dead inode. Bump this whenever the locking protocol changes
+// in an incompatible way.
+const hostLockerDirSchemaVersion = "2"
+
+func getHostLockerDir() string {
+	return filepath.Join(GetServiceDir(), "locks", hostLockerDirSchemaVersion)
+}
+
+// GCHostLockerDir removes stale host lock files older than HostLocksGCMinAge.
+func GCHostLockerDir() error {
+	return file_lock.GCLockFileDir(getHostLockerDir(), HostLocksGCMinAge)
+}
+
+// ShouldRunHostLocksGC reports whether the host locks dir holds enough GC-eligible
+// (older than HostLocksGCMinAge) files to warrant a cleanup. It scans lazily and
+// stops as soon as the threshold is reached, so it stays cheap even on dirs with
+// millions of entries.
+func ShouldRunHostLocksGC() (bool, error) {
+	dir := getHostLockerDir()
+	f, err := os.Open(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer f.Close()
+
+	cutoff := time.Now().Add(-HostLocksGCMinAge)
+	count := 0
+	for {
+		entries, err := f.ReadDir(1024)
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			info, ierr := entry.Info()
+			if ierr != nil {
+				continue
+			}
+			if info.ModTime().Before(cutoff) {
+				count++
+				if count >= hostLocksAutoGCThreshold {
+					return true, nil
+				}
+			}
+		}
+		if err != nil {
+			break // io.EOF or read error: stop scanning
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/werf/gc_test.go
+++ b/pkg/werf/gc_test.go
@@ -1,0 +1,101 @@
+package werf
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func setupLocksDir(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	serviceDir = filepath.Join(home, "service")
+	locks := getHostLockerDir()
+	if err := os.MkdirAll(locks, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { serviceDir = "" })
+	return locks
+}
+
+func makeLock(t *testing.T, dir, name string, age time.Duration) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mt := time.Now().Add(-age)
+	if err := os.Chtimes(p, mt, mt); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGCHostLockerDir_RemovesStale(t *testing.T) {
+	locks := setupLocksDir(t)
+	makeLock(t, locks, "stale", HostLocksGCMinAge+time.Hour)
+	makeLock(t, locks, "fresh", 0)
+
+	if err := GCHostLockerDir(); err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(locks, "stale")); !os.IsNotExist(err) {
+		t.Fatalf("stale lock must be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(locks, "fresh")); err != nil {
+		t.Fatalf("fresh lock must be kept: %v", err)
+	}
+}
+
+func TestShouldRunHostLocksGC_Threshold(t *testing.T) {
+	locks := setupLocksDir(t)
+
+	should, err := ShouldRunHostLocksGC()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if should {
+		t.Fatal("empty locks dir must not trigger GC")
+	}
+
+	for i := 0; i < hostLocksAutoGCThreshold; i++ {
+		makeLock(t, locks, "stale"+strconv.Itoa(i), HostLocksGCMinAge+time.Hour)
+	}
+
+	should, err = ShouldRunHostLocksGC()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !should {
+		t.Fatal("stale files at threshold must trigger GC")
+	}
+}
+
+func TestShouldRunHostLocksGC_IgnoresFresh(t *testing.T) {
+	locks := setupLocksDir(t)
+	for i := 0; i < hostLocksAutoGCThreshold; i++ {
+		makeLock(t, locks, "fresh"+strconv.Itoa(i), 0)
+	}
+
+	should, err := ShouldRunHostLocksGC()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if should {
+		t.Fatal("fresh files must not trigger GC")
+	}
+}
+
+func TestShouldRunHostLocksGC_MissingDir(t *testing.T) {
+	serviceDir = filepath.Join(t.TempDir(), "service")
+	t.Cleanup(func() { serviceDir = "" })
+
+	should, err := ShouldRunHostLocksGC()
+	if err != nil {
+		t.Fatalf("missing dir must not error: %v", err)
+	}
+	if should {
+		t.Fatal("missing dir must not trigger GC")
+	}
+}

--- a/pkg/werf/main.go
+++ b/pkg/werf/main.go
@@ -131,7 +131,7 @@ func Init(tmpDirOption, homeDirOption string) error {
 	file_lock.LegacyHashFunction = true
 
 	var err error
-	if hostLocker, err = locker.NewHostLocker(filepath.Join(GetServiceDir(), "locks")); err != nil {
+	if hostLocker, err = locker.NewHostLocker(getHostLockerDir()); err != nil {
 		return fmt.Errorf("error creating werf host file locker: %w", err)
 	}
 


### PR DESCRIPTION
## What

Adds a GC stage for stale host lock files to `RunHostCleanup`, lets excessive stale-lock accumulation trigger auto host cleanup on its own, and moves the host locker directory to a versioned path.

## Why

Lock files under `~/.werf/service/locks/` accumulate without bound because `lockgate` never removed the underlying file on `Unlock()`, only released the flock. Lock names are high-cardinality (per-stage digest, per-image, etc.), so months/years of runner usage produce millions of files and exhaust inodes (#6127). Lock files are empty, so pure byte-usage thresholds in `shouldRunAutoHostCleanup` never catch this failure mode.

Older werf binaries acquire locks without the new inode-safe retry. If an old and a new werf run concurrently on the same host, the new process's GC could unlink a lock file the old process just opened, right before the old process takes its flock — the old acquire path has no way to detect the resulting dead inode. Namespacing the locks directory by locking-protocol schema version removes this cross-version race entirely.

## How

- Bumps `github.com/werf/lockgate` to v0.2.0 (werf/lockgate#48), which adds `file_lock.GCLockFileDir` (age-filtered GC of unheld lock files) and an inode-safe acquire path closing the flock+unlink race a naive GC alone would introduce.
- `werf/gc.go`: `GCHostLockerDir()` calls the new lockgate GC against the host locker dir with a 24h `minAge` (hot/active locks live seconds, so this never touches them); `ShouldRunHostLocksGC()` is a cheap, early-exit scan reporting whether stale-lock accumulation alone should trigger auto cleanup.
- Moves the host locker directory from `~/.werf/service/locks` to `~/.werf/service/locks/2` (see Why above). Old lock files under the unversioned `locks/` directory are left untouched — no migration/cleanup added for them.
- `RunHostCleanup` gets a dedicated `LogProcess("Running GC for locks")` stage, run before the volume-usage-based stages, honoring `DryRun`, with failures logged as non-fatal warnings (consistent with the existing tmp-GC stage).
- `shouldRunAutoHostCleanup` now also fires on stale lock-file count, independent of the existing volume-usage signal.
- Updates the `werf host cleanup` command description (Go source + regenerated CLI reference doc) to mention the new stale-lock-file cleanup.

Lock-file naming (`LegacyHashFunction`/MurmurHash) is unchanged.

## Tests

`task build` passes. `task test:unit paths="./pkg/host_cleaning/... ./pkg/werf/..."` — new tests (`TestGCHostLockerDir_RemovesStale`, `TestShouldRunHostLocksGC_Threshold`, `TestShouldRunHostLocksGC_IgnoresFresh`, `TestShouldRunHostLocksGC_MissingDir`) pass; pre-existing, unrelated failure in `pkg/werf/exec` (`ps: cmd: keyword not found`, a macOS sandbox artifact) reproduces identically against the unmodified base commit. `task lint:golangci-lint golangciPaths="./pkg/host_cleaning/... ./pkg/werf/..."` — 0 issues. `go mod tidy` clean. `task doc:gen` regenerated the CLI reference doc.