### PR TITLE
fix(build): stop leaking build-time env vars into final image config

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -1229,9 +1229,9 @@ func (phase *BuildPhase) prepareStageInstructions(ctx context.Context, img *imag
 		}
 
 		if phase.Conveyor.UseLegacyStapelBuilder(phase.Conveyor.ContainerBackend) {
-			stageImage.Builder.LegacyStapelStageBuilder().Container().RunOptions().AddEnv(commitEnvs)
+			stageImage.Builder.LegacyStapelStageBuilder().Container().AddBuildTimeEnv(commitEnvs)
 		} else {
-			stageImage.Builder.StapelStageBuilder().AddEnvs(commitEnvs)
+			stageImage.Builder.StapelStageBuilder().AddBuildTimeEnvs(commitEnvs)
 		}
 	} else if _, ok := stg.(*stage.FullDockerfileStage); ok {
 		var labels []string

--- a/pkg/container_backend/build_stapel_stage_options.go
+++ b/pkg/container_backend/build_stapel_stage_options.go
@@ -14,6 +14,7 @@ type BuildStapelStageOptionsInterface interface {
 	AddVolumes(volumes []string) BuildStapelStageOptionsInterface
 	AddExpose(expose []string) BuildStapelStageOptionsInterface
 	AddEnvs(envs map[string]string) BuildStapelStageOptionsInterface
+	AddBuildTimeEnvs(envs map[string]string) BuildStapelStageOptionsInterface
 	SetCmd(cmd []string) BuildStapelStageOptionsInterface
 	SetEntrypoint(entrypoint []string) BuildStapelStageOptionsInterface
 	SetUser(user string) BuildStapelStageOptionsInterface
@@ -33,16 +34,17 @@ type BuildStapelStageOptionsInterface interface {
 type BuildStapelStageOptions struct {
 	TargetPlatform string
 
-	Labels      []string
-	Volumes     []string
-	Expose      []string
-	Envs        map[string]string
-	Cmd         []string
-	Entrypoint  []string
-	User        string
-	Workdir     string
-	Healthcheck string
-	Network     string
+	Labels        []string
+	Volumes       []string
+	Expose        []string
+	Envs          map[string]string
+	BuildTimeEnvs map[string]string
+	Cmd           []string
+	Entrypoint    []string
+	User          string
+	Workdir       string
+	Healthcheck   string
+	Network       string
 
 	BuildVolumes []string
 	Commands     []string
@@ -116,6 +118,18 @@ func (opts *BuildStapelStageOptions) AddEnvs(envs map[string]string) BuildStapel
 
 	for k, v := range envs {
 		opts.Envs[k] = v
+	}
+
+	return opts
+}
+
+func (opts *BuildStapelStageOptions) AddBuildTimeEnvs(envs map[string]string) BuildStapelStageOptionsInterface {
+	if opts.BuildTimeEnvs == nil {
+		opts.BuildTimeEnvs = map[string]string{}
+	}
+
+	for k, v := range envs {
+		opts.BuildTimeEnvs[k] = v
 	}
 
 	return opts
@@ -200,5 +214,5 @@ func (opts *BuildStapelStageOptions) MountSSHAgentSocket(sshAuthSock string) {
 	}
 	vol, env := setSSHMountPoint(sshAuthSock)
 	opts.AddBuildVolumes(vol)
-	opts.AddEnvs(env)
+	opts.AddBuildTimeEnvs(env)
 }

--- a/pkg/container_backend/build_stapel_stage_options_ai_test.go
+++ b/pkg/container_backend/build_stapel_stage_options_ai_test.go
@@ -1,0 +1,26 @@
+package container_backend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAI_BuildStapelStageOptions_BuildTimeEnvsSeparateFromEnvs(t *testing.T) {
+	opts := &BuildStapelStageOptions{}
+	opts.AddEnvs(map[string]string{"PERSISTENT": "1"})
+	opts.AddBuildTimeEnvs(map[string]string{"SSH_AUTH_SOCK": "/tmp/ssh.sock"})
+
+	assert.Equal(t, map[string]string{"PERSISTENT": "1"}, opts.Envs)
+	assert.Equal(t, map[string]string{"SSH_AUTH_SOCK": "/tmp/ssh.sock"}, opts.BuildTimeEnvs)
+
+	mergedEnvs := make(map[string]string, len(opts.Envs)+len(opts.BuildTimeEnvs))
+	for k, v := range opts.Envs {
+		mergedEnvs[k] = v
+	}
+	for k, v := range opts.BuildTimeEnvs {
+		mergedEnvs[k] = v
+	}
+
+	assert.Equal(t, map[string]string{"PERSISTENT": "1", "SSH_AUTH_SOCK": "/tmp/ssh.sock"}, mergedEnvs)
+}

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -254,12 +254,20 @@ func (backend *BuildahBackend) applyCommands(ctx context.Context, container *con
 		mounts = append(mounts, m...)
 	}
 
+	mergedEnvs := make(map[string]string, len(opts.Envs)+len(opts.BuildTimeEnvs))
+	for k, v := range opts.Envs {
+		mergedEnvs[k] = v
+	}
+	for k, v := range opts.BuildTimeEnvs {
+		mergedEnvs[k] = v
+	}
+
 	if err := backend.buildah.RunCommand(ctx, container.Name, []string{"sh", destScriptPath}, buildah.RunCommandOpts{
 		CommonOpts:   backend.getBuildahCommonOpts(ctx, false, nil, opts.TargetPlatform),
 		User:         "0:0",
 		WorkingDir:   "/",
 		GlobalMounts: mounts,
-		Envs:         makeBuildahEnvs(opts.Envs),
+		Envs:         makeBuildahEnvs(mergedEnvs),
 	}); err != nil {
 		return fmt.Errorf("unable to run commands script: %w", err)
 	}

--- a/pkg/container_backend/legacy_interface.go
+++ b/pkg/container_backend/legacy_interface.go
@@ -57,6 +57,8 @@ type LegacyContainer interface {
 	RunOptions() LegacyContainerOptions
 	CommitChangeOptions() LegacyContainerOptions
 	ServiceCommitChangeOptions() LegacyContainerOptions
+
+	AddBuildTimeEnv(envs map[string]string)
 }
 
 type LegacyBuilderContainer interface {

--- a/pkg/container_backend/legacy_stage_image_builder_container.go
+++ b/pkg/container_backend/legacy_stage_image_builder_container.go
@@ -26,6 +26,10 @@ func (c *LegacyStageImageBuilderContainer) AddEnv(envs map[string]string) {
 	c.image.container.runOptions.AddEnv(envs)
 }
 
+func (c *LegacyStageImageBuilderContainer) AddBuildTimeEnv(envs map[string]string) {
+	c.image.container.AddBuildTimeEnv(envs)
+}
+
 func (c *LegacyStageImageBuilderContainer) AddLabel(labels map[string]string) {
 	c.image.container.runOptions.AddLabel(labels)
 }
@@ -36,5 +40,5 @@ func (c *LegacyStageImageBuilderContainer) MountSSHAgentSocket(sshAuthSock strin
 	}
 	vol, env := setSSHMountPoint(sshAuthSock)
 	c.AddVolume(vol)
-	c.AddEnv(env)
+	c.AddBuildTimeEnv(env)
 }

--- a/pkg/container_backend/legacy_stage_image_container.go
+++ b/pkg/container_backend/legacy_stage_image_container.go
@@ -24,6 +24,7 @@ type LegacyStageImageContainer struct {
 	runOptions                 *LegacyStageImageContainerOptions
 	commitChangeOptions        *LegacyStageImageContainerOptions
 	serviceCommitChangeOptions *LegacyStageImageContainerOptions
+	buildTimeEnv               map[string]string
 }
 
 func newLegacyStageImageContainer(img *LegacyStageImage) *LegacyStageImageContainer {
@@ -33,6 +34,7 @@ func newLegacyStageImageContainer(img *LegacyStageImage) *LegacyStageImageContai
 	c.runOptions = newLegacyStageContainerOptions()
 	c.commitChangeOptions = newLegacyStageContainerOptions()
 	c.serviceCommitChangeOptions = newLegacyStageContainerOptions()
+	c.buildTimeEnv = make(map[string]string)
 	return c
 }
 
@@ -68,6 +70,12 @@ func (c *LegacyStageImageContainer) ServiceCommitChangeOptions() LegacyContainer
 	return c.serviceCommitChangeOptions
 }
 
+func (c *LegacyStageImageContainer) AddBuildTimeEnv(envs map[string]string) {
+	for k, v := range envs {
+		c.buildTimeEnv[k] = v
+	}
+}
+
 func (c *LegacyStageImageContainer) prepareRunArgs(ctx context.Context) ([]string, error) {
 	var args []string
 	args = append(args, fmt.Sprintf("--name=%s", c.name))
@@ -86,19 +94,35 @@ func (c *LegacyStageImageContainer) prepareRunArgs(ctx context.Context) ([]strin
 		return nil, err
 	}
 
-	setColumnsEnv := fmt.Sprintf("--env=COLUMNS=%d", logboek.Context(ctx).Streams().ContentWidth())
-	runArgs = append(runArgs, setColumnsEnv)
-
 	args = append(args, runArgs...)
 	args = append(args, c.imageRef(c.image.fromImage))
 	args = append(args, "-ec")
-	args = append(args, c.prepareRunCommand())
+	args = append(args, c.prepareRunCommand(ctx))
 
 	return args, nil
 }
 
-func (c *LegacyStageImageContainer) prepareRunCommand() string {
-	return ShelloutPack(strings.Join(c.prepareRunCommands(), " && "))
+func shellSingleQuote(v string) string {
+	return "'" + strings.ReplaceAll(v, "'", `'\''`) + "'"
+}
+
+func (c *LegacyStageImageContainer) prepareBuildTimeEnvExports(ctx context.Context) []string {
+	envs := make(map[string]string, len(c.buildTimeEnv)+1)
+	for k, v := range c.buildTimeEnv {
+		envs[k] = v
+	}
+	envs["COLUMNS"] = fmt.Sprintf("%d", logboek.Context(ctx).Streams().ContentWidth())
+
+	var exports []string
+	for _, k := range sortStrings(getKeys(envs)) {
+		exports = append(exports, fmt.Sprintf("export %s=%s", k, shellSingleQuote(envs[k])))
+	}
+	return exports
+}
+
+func (c *LegacyStageImageContainer) prepareRunCommand(ctx context.Context) string {
+	commands := append(c.prepareBuildTimeEnvExports(ctx), c.prepareRunCommands()...)
+	return ShelloutPack(strings.Join(commands, " && "))
 }
 
 func (c *LegacyStageImageContainer) prepareRunCommands() []string {

--- a/pkg/container_backend/legacy_stage_image_container_ai_test.go
+++ b/pkg/container_backend/legacy_stage_image_container_ai_test.go
@@ -1,0 +1,32 @@
+package container_backend
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/werf/logboek"
+)
+
+func TestAI_PrepareBuildTimeEnvExports(t *testing.T) {
+	ctx := logboek.NewContext(context.Background(), logboek.NewLogger(io.Discard, io.Discard))
+
+	c := &LegacyStageImageContainer{buildTimeEnv: make(map[string]string)}
+	c.AddBuildTimeEnv(map[string]string{
+		"WERF_COMMIT_HASH":       "abc123",
+		"WERF_COMMIT_TIME_HUMAN": "Mon Jan 2 15:04:05 2006",
+		"WITH_QUOTE":             "it's",
+	})
+
+	exports := c.prepareBuildTimeEnvExports(ctx)
+
+	columnsExport := fmt.Sprintf("export COLUMNS='%d'", logboek.Context(ctx).Streams().ContentWidth())
+
+	assert.Contains(t, exports, columnsExport)
+	assert.Contains(t, exports, "export WERF_COMMIT_HASH='abc123'")
+	assert.Contains(t, exports, "export WERF_COMMIT_TIME_HUMAN='Mon Jan 2 15:04:05 2006'")
+	assert.Contains(t, exports, `export WITH_QUOTE='it'\''s'`)
+}

--- a/test/mock/legacy_interface.go
+++ b/test/mock/legacy_interface.go
@@ -13,10 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	container_backend "github.com/werf/werf/v2/pkg/container_backend"
 	image "github.com/werf/werf/v2/pkg/image"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockLegacyImageInterface is a mock of LegacyImageInterface interface.
@@ -345,6 +344,18 @@ func NewMockLegacyContainer(ctrl *gomock.Controller) *MockLegacyContainer {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLegacyContainer) EXPECT() *MockLegacyContainerMockRecorder {
 	return m.recorder
+}
+
+// AddBuildTimeEnv mocks base method.
+func (m *MockLegacyContainer) AddBuildTimeEnv(envs map[string]string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddBuildTimeEnv", envs)
+}
+
+// AddBuildTimeEnv indicates an expected call of AddBuildTimeEnv.
+func (mr *MockLegacyContainerMockRecorder) AddBuildTimeEnv(envs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBuildTimeEnv", reflect.TypeOf((*MockLegacyContainer)(nil).AddBuildTimeEnv), envs)
 }
 
 // AddRunCommands mocks base method.


### PR DESCRIPTION
## Summary

`COLUMNS`, `WERF_COMMIT_HASH`/`WERF_COMMIT_TIME_HUMAN`/`WERF_COMMIT_TIME_UNIX`, and `SSH_AUTH_SOCK` were leaking into the `ENV` config of every built image on both the docker-server and buildah backends, even when no `imageSpec` cleanup was configured in `werf.yaml`. This PR stops these build-time-only variables from ever reaching the final committed image config.

## Key changes

- **Docker-server backend** (`pkg/container_backend/legacy_stage_image_container.go`, `legacy_stage_image_builder_container.go`, `legacy_interface.go`): stop passing build-time vars via `docker run -e`. `docker commit` implicitly inherits the container's live runtime env into the resulting image config regardless of `--change` overrides (verified against moby's `daemon/commit.go` merge logic), so anything passed as `-e` ends up in the image. Added `AddBuildTimeEnv()` and route `COLUMNS`, `WERF_COMMIT_*`, and SSH agent socket env through it; these are now injected via shell `export` at the top of the executed build script instead, so they never touch the container's persistent config.
- **Buildah backend** (`pkg/container_backend/build_stapel_stage_options.go`, `buildah_backend.go`): `BuildStapelStageOptions.Envs` was reused both for the transient `RunCommand` exec and for the final persistent `Config()` call — no separation existed. Added a `BuildTimeEnvs` field merged into `RunCommand` exec only; `Config()` (which produces the final image) keeps using `Envs` exclusively.
- `LANG`/`LC_ALL` restoration and `imageSpec`'s `modifyEnv()` cleanup are untouched — both were already correct and the latter remains as defense-in-depth for users who configure `imageSpec`.
- Added `test/mock/legacy_interface.go` regeneration (new `AddBuildTimeEnv` method on `LegacyContainer` interface) and two focused unit tests (`TestAI_PrepareBuildTimeEnvExports`, `TestAI_BuildStapelStageOptions_BuildTimeEnvsSeparateFromEnvs`).

## Why

Users inspecting their built images (`docker inspect`, `image_spec` diffing, security scanning) would see internal werf implementation details (commit hash/time, terminal width, SSH agent socket path) baked into `ENV`, none of which are meaningful or safe outside the build container. `SSH_AUTH_SOCK` in particular pointed to a build-time-only mount path that doesn't exist in the shipped image — cosmetic noise at best, a minor info leak at worst.

## Review focus / risks

- The docker-server fix changes how build-time env vars reach the build container: from `docker run -e` flags to `export` statements prefixed onto the executed shell script. Values are shell-single-quote-escaped (`'` → `'\''`); worth double-checking edge cases if any build-time value can contain unusual characters.
- `SSH_AUTH_SOCK` is now `BuildTimeEnvs`-only on both backends — confirm no other code path expects it to also be present in the final image's persistent config (none found in this repo, but flagging for reviewer awareness).
- No changes to `pkg/build/stage/dependencies.go` or `image_spec.go` — persistent envs (dependency imports, user-configured `imageSpec.Env`) are unaffected by design.