### PR TITLE
feat(deploy): make container backend optional for converge and render

### DIFF
--- a/cmd/werf/common/components_manager.go
+++ b/cmd/werf/common/components_manager.go
@@ -70,53 +70,12 @@ func InitCommonComponents(ctx context.Context, opts InitCommonComponentsOptions)
 		}
 	}
 
-	var resolvedBuildahMode buildah.Mode
 	if opts.InitProcessContainerBackend || opts.InitDockerRegistry {
-		buildahMode, _, err := GetBuildahMode()
+		newCtx, err := cmanager.InitContainerBackendComponents(ctx, opts.Cmd, opts.InitDockerRegistry, opts.InitProcessContainerBackend)
 		if err != nil {
-			return nil, ctx, fmt.Errorf("unable to determine buildah mode: %w", err)
-		}
-		resolvedBuildahMode = *buildahMode
-		cmanager.buildahMode = resolvedBuildahMode
-	}
-
-	// Set DOCKER_CONFIG early so that authn.DefaultKeychain (used by go-containerregistry)
-	// picks up custom credentials even when the full container backend is not initialized.
-	if opts.InitDockerRegistry || opts.InitProcessContainerBackend {
-		if err := docker.InitDockerConfig(docker.InitOptions{DockerConfigDir: *opts.Cmd.DockerConfig}); err != nil {
-			return nil, ctx, fmt.Errorf("init docker config: %w", err)
-		}
-	}
-
-	if opts.InitProcessContainerBackend && resolvedBuildahMode == buildah.ModeDisabled {
-		newCtx, err := InitProcessDocker(ctx, opts.Cmd)
-		if err != nil {
-			return nil, ctx, fmt.Errorf("unable to init docker: %w", err)
+			return nil, ctx, err
 		}
 		ctx = newCtx
-	}
-
-	if opts.InitDockerRegistry || opts.InitProcessContainerBackend {
-		rm, err := GetContainerRegistryMirror(ctx, opts.Cmd, resolvedBuildahMode)
-		if err != nil {
-			return nil, ctx, fmt.Errorf("error get container registry mirrors: %w", err)
-		}
-		cmanager.registryMirrors = &rm
-	}
-
-	if opts.InitDockerRegistry {
-		if err := DockerRegistryInit(ctx, opts.Cmd, *cmanager.registryMirrors, resolvedBuildahMode); err != nil {
-			return nil, ctx, fmt.Errorf("docker registry initialization error: %w", err)
-		}
-	}
-
-	if opts.InitProcessContainerBackend {
-		cb, newCtx, err := InitProcessContainerBackend(ctx, opts.Cmd, *cmanager.registryMirrors)
-		if err != nil {
-			return nil, ctx, fmt.Errorf("container backend initialization error: %w", err)
-		}
-		cmanager.containerBackend = cb
-		ctx = newCtx // context reinitialization
 	}
 
 	if opts.InitGitDataManager {
@@ -157,6 +116,70 @@ func InitCommonComponents(ctx context.Context, opts InitCommonComponentsOptions)
 	return cmanager, ctx, nil
 }
 
+// InitContainerBackendComponents initializes buildah mode, docker config, registry mirrors,
+// docker registry and/or container backend, storing results on m. Safe to call multiple times;
+// each initXxx section only runs the parts requested by initDockerRegistry/initProcessContainerBackend.
+func (m *ComponentsManager) InitContainerBackendComponents(ctx context.Context, cmd *CmdData, initDockerRegistry, initProcessContainerBackend bool) (context.Context, error) {
+	buildahMode, _, err := GetBuildahMode()
+	if err != nil {
+		return ctx, fmt.Errorf("unable to determine buildah mode: %w", err)
+	}
+	m.buildahMode = *buildahMode
+
+	// Set DOCKER_CONFIG early so that authn.DefaultKeychain (used by go-containerregistry)
+	// picks up custom credentials even when the full container backend is not initialized.
+	if err := docker.InitDockerConfig(docker.InitOptions{DockerConfigDir: *cmd.DockerConfig}); err != nil {
+		return ctx, fmt.Errorf("init docker config: %w", err)
+	}
+
+	if initProcessContainerBackend && m.buildahMode == buildah.ModeDisabled {
+		newCtx, err := InitProcessDocker(ctx, cmd)
+		if err != nil {
+			return ctx, fmt.Errorf("unable to init docker: %w", err)
+		}
+		ctx = newCtx
+	}
+
+	rm, err := GetContainerRegistryMirror(ctx, cmd, m.buildahMode)
+	if err != nil {
+		return ctx, fmt.Errorf("error get container registry mirrors: %w", err)
+	}
+	m.registryMirrors = &rm
+
+	if initDockerRegistry {
+		if err := DockerRegistryInit(ctx, cmd, *m.registryMirrors, m.buildahMode); err != nil {
+			return ctx, fmt.Errorf("docker registry initialization error: %w", err)
+		}
+	}
+
+	if initProcessContainerBackend {
+		cb, newCtx, err := InitProcessContainerBackend(ctx, cmd, *m.registryMirrors)
+		if err != nil {
+			return ctx, fmt.Errorf("container backend initialization error: %w", err)
+		}
+		m.containerBackend = cb
+		ctx = newCtx
+	}
+
+	return ctx, nil
+}
+
+// EnsureContainerBackend lazily initializes the container backend (and, optionally, the docker
+// registry) on first call and reuses it on subsequent calls. Intended for commands where the
+// backend is only required conditionally (e.g. project has images to build).
+func (m *ComponentsManager) EnsureContainerBackend(ctx context.Context, cmd *CmdData, initDockerRegistry bool) (container_backend.ContainerBackend, context.Context, error) {
+	if m.containerBackend != nil {
+		return m.containerBackend, ctx, nil
+	}
+
+	newCtx, err := m.InitContainerBackendComponents(ctx, cmd, initDockerRegistry, true)
+	if err != nil {
+		return nil, ctx, err
+	}
+
+	return m.containerBackend, newCtx, nil
+}
+
 func (m *ComponentsManager) RegistryMirrors() []string {
 	if m.registryMirrors == nil {
 		panic("bug: init required!")
@@ -169,6 +192,13 @@ func (m *ComponentsManager) ContainerBackend() container_backend.ContainerBacken
 		panic("bug: init required!")
 	}
 	return m.containerBackend
+}
+
+// TryContainerBackend returns the container backend and true if it has been initialized,
+// or nil and false otherwise. Use this instead of ContainerBackend() when backend
+// initialization is optional.
+func (m *ComponentsManager) TryContainerBackend() (container_backend.ContainerBackend, bool) {
+	return m.containerBackend, m.containerBackend != nil
 }
 
 func (m *ComponentsManager) BuildahMode() buildah.Mode {

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -22,7 +22,6 @@ import (
 	"github.com/werf/werf/v2/pkg/build"
 	"github.com/werf/werf/v2/pkg/config"
 	"github.com/werf/werf/v2/pkg/config/deploy_params"
-	"github.com/werf/werf/v2/pkg/container_backend"
 	"github.com/werf/werf/v2/pkg/deploy"
 	"github.com/werf/werf/v2/pkg/docker"
 	"github.com/werf/werf/v2/pkg/giterminism_manager"
@@ -190,26 +189,26 @@ func runMain(ctx context.Context, imageNameListFromArgs []string) error {
 		InitTrueGitWithOptions: &common.InitTrueGitOptions{
 			Options: true_git.Options{LiveGitOutput: *commonCmdData.LogDebug},
 		},
-		InitDockerRegistry:          true,
-		InitProcessContainerBackend: true,
-		InitWerf:                    true,
-		InitGitDataManager:          true,
-		InitManifestCache:           true,
-		InitLRUImagesCache:          true,
-		InitSSHAgent:                true,
+		InitWerf:           true,
+		InitGitDataManager: true,
+		InitManifestCache:  true,
+		InitLRUImagesCache: true,
+		InitSSHAgent:       true,
 	})
 	if err != nil {
 		return fmt.Errorf("component init error: %w", err)
 	}
 
-	containerBackend := commonManager.ContainerBackend()
+	cleanupCtx := ctx
 
 	defer func() {
-		if err := tmp_manager.DelegateCleanup(ctx); err != nil {
-			logboek.Context(ctx).Warn().LogF("Temporary files cleanup preparation failed: %s\n", err)
+		if err := tmp_manager.DelegateCleanup(cleanupCtx); err != nil {
+			logboek.Context(cleanupCtx).Warn().LogF("Temporary files cleanup preparation failed: %s\n", err)
 		}
-		if err := common.RunAutoHostCleanup(ctx, &commonCmdData, containerBackend); err != nil {
-			logboek.Context(ctx).Error().LogF("Auto host cleanup failed: %s\n", err)
+		if containerBackend, ok := commonManager.TryContainerBackend(); ok {
+			if err := common.RunAutoHostCleanup(cleanupCtx, &commonCmdData, containerBackend); err != nil {
+				logboek.Context(cleanupCtx).Error().LogF("Auto host cleanup failed: %s\n", err)
+			}
 		}
 	}()
 
@@ -230,19 +229,23 @@ func runMain(ctx context.Context, imageNameListFromArgs []string) error {
 			ctx context.Context,
 			headCommitGiterminismManager *giterminism_manager.Manager,
 		) error {
-			return run(ctx, containerBackend, headCommitGiterminismManager, imageNameListFromArgs)
+			newCtx, err := run(ctx, commonManager, headCommitGiterminismManager, imageNameListFromArgs)
+			cleanupCtx = newCtx
+			return err
 		})
 	} else {
-		return run(ctx, containerBackend, giterminismManager, imageNameListFromArgs)
+		newCtx, err := run(ctx, commonManager, giterminismManager, imageNameListFromArgs)
+		cleanupCtx = newCtx
+		return err
 	}
 }
 
 func run(
 	ctx context.Context,
-	containerBackend container_backend.ContainerBackend,
+	commonManager *common.ComponentsManager,
 	giterminismManager *giterminism_manager.Manager,
 	imageNameListFromArgs []string,
-) error {
+) (context.Context, error) {
 	var err error
 
 	var releaseName, releaseNamespace, relChartPath, registryCredentialsPath string
@@ -256,19 +259,19 @@ func run(
 
 	werfConfigPath, werfConfig, err := common.GetRequiredWerfConfig(ctx, &commonCmdData, giterminismManager, common.GetWerfConfigOptions(&commonCmdData, true))
 	if err != nil {
-		return fmt.Errorf("unable to load werf config: %w", err)
+		return ctx, fmt.Errorf("unable to load werf config: %w", err)
 	}
 
 	imagesToProcess, err := config.NewImagesToProcess(werfConfig, imageNameListFromArgs, *commonCmdData.FinalImagesOnly, *commonCmdData.WithoutImages)
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	projectName := werfConfig.Meta.Project
 
 	projectTmpDir, err := tmp_manager.CreateProjectDir(ctx)
 	if err != nil {
-		return fmt.Errorf("getting project tmp dir failed: %w", err)
+		return ctx, fmt.Errorf("getting project tmp dir failed: %w", err)
 	}
 
 	usePlanArtifact := cmdData.PlanArtifactPath != ""
@@ -276,7 +279,7 @@ func run(
 	if !usePlanArtifact {
 		buildOptions, err := common.GetBuildOptions(ctx, &commonCmdData, werfConfig, imagesToProcess)
 		if err != nil {
-			return err
+			return ctx, err
 		}
 
 		var imagesInfoGetters []*image.InfoGetter
@@ -285,9 +288,15 @@ func run(
 		if !imagesToProcess.WithoutImages {
 			logboek.LogOptionalLn()
 
+			containerBackend, newCtx, err := commonManager.EnsureContainerBackend(ctx, &commonCmdData, true)
+			if err != nil {
+				return ctx, fmt.Errorf("container backend initialization error: %w", err)
+			}
+			ctx = newCtx
+
 			useCustomTagFunc, err := common.GetUseCustomTagFunc(&commonCmdData, giterminismManager, imagesToProcess)
 			if err != nil {
-				return err
+				return ctx, err
 			}
 
 			storageManager, err := common.NewStorageManager(ctx, &common.NewStorageManagerConfig{
@@ -298,14 +307,14 @@ func run(
 				GitHistoryBasedCleanupDisabled: werfConfig.Meta.Cleanup.DisableGitHistoryBasedPolicy,
 			})
 			if err != nil {
-				return fmt.Errorf("unable to init storage manager: %w", err)
+				return ctx, fmt.Errorf("unable to init storage manager: %w", err)
 			}
 
 			imagesRepo = storageManager.GetServiceValuesRepo()
 
 			conveyorOptions, err := common.GetConveyorOptionsWithParallel(ctx, &commonCmdData, imagesToProcess, buildOptions)
 			if err != nil {
-				return err
+				return ctx, err
 			}
 
 			conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, giterminismManager, giterminismManager.ProjectDir(), projectTmpDir, containerBackend, storageManager, conveyorOptions)
@@ -343,7 +352,7 @@ func run(
 
 				return nil
 			}); err != nil {
-				return err
+				return ctx, err
 			}
 
 			logboek.LogOptionalLn()
@@ -355,7 +364,7 @@ func run(
 			giterminismManager,
 		)
 		if err != nil {
-			return fmt.Errorf("get relative helm chart directory: %w", err)
+			return ctx, fmt.Errorf("get relative helm chart directory: %w", err)
 		}
 
 		releaseNamespace, err = deploy_params.GetKubernetesNamespace(
@@ -364,7 +373,7 @@ func run(
 			werfConfig,
 		)
 		if err != nil {
-			return fmt.Errorf("get kubernetes namespace: %w", err)
+			return ctx, fmt.Errorf("get kubernetes namespace: %w", err)
 		}
 
 		releaseName, err = deploy_params.GetHelmRelease(
@@ -374,12 +383,12 @@ func run(
 			werfConfig,
 		)
 		if err != nil {
-			return fmt.Errorf("get helm release name: %w", err)
+			return ctx, fmt.Errorf("get helm release name: %w", err)
 		}
 
 		serviceAnnotations := map[string]string{}
 		if annos, err := common.GetUserExtraAnnotations(&commonCmdData); err != nil {
-			return fmt.Errorf("get user extra annotations: %w", err)
+			return ctx, fmt.Errorf("get user extra annotations: %w", err)
 		} else {
 			for key, value := range annos {
 				if strings.HasPrefix(key, "project.werf.io/") ||
@@ -401,17 +410,17 @@ func run(
 
 		extraLabels, err = common.GetUserExtraLabels(&commonCmdData)
 		if err != nil {
-			return fmt.Errorf("get user extra labels: %w", err)
+			return ctx, fmt.Errorf("get user extra labels: %w", err)
 		}
 
 		headHash, err := giterminismManager.LocalGitRepo().HeadCommitHash(ctx)
 		if err != nil {
-			return fmt.Errorf("get HEAD commit hash: %w", err)
+			return ctx, fmt.Errorf("get HEAD commit hash: %w", err)
 		}
 
 		headTime, err := giterminismManager.LocalGitRepo().HeadCommitTime(ctx)
 		if err != nil {
-			return fmt.Errorf("get HEAD commit time: %w", err)
+			return ctx, fmt.Errorf("get HEAD commit time: %w", err)
 		}
 
 		registryCredentialsPath := docker.GetDockerConfigCredentialsFile(*commonCmdData.DockerConfig)
@@ -425,12 +434,12 @@ func run(
 			CommitDate:               headTime,
 		})
 		if err != nil {
-			return fmt.Errorf("get service values: %w", err)
+			return ctx, fmt.Errorf("get service values: %w", err)
 		}
 
 		releaseLabels, err = common.GetReleaseLabels(&commonCmdData)
 		if err != nil {
-			return fmt.Errorf("get release labels: %w", err)
+			return ctx, fmt.Errorf("get release labels: %w", err)
 		}
 
 		nelmcommon.ChartFileReader = giterminismManager.FileManager
@@ -493,8 +502,8 @@ func run(
 			ReleaseStorageSQLConnection: commonCmdData.ReleaseStorageSQLConnection,
 		},
 	}); err != nil {
-		return fmt.Errorf("release install: %w", err)
+		return ctx, fmt.Errorf("release install: %w", err)
 	}
 
-	return nil
+	return ctx, nil
 }

--- a/cmd/werf/render/render.go
+++ b/cmd/werf/render/render.go
@@ -99,7 +99,6 @@ func NewCmd(ctx context.Context) *cobra.Command {
 	common.SetupFinalRepo(&commonCmdData, cmd)
 	common.SetupStubTags(&commonCmdData, cmd)
 
-
 	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified repo and to pull base images")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
@@ -159,12 +158,11 @@ func runRender(ctx context.Context, imageNameListFromArgs []string) error {
 		InitTrueGitWithOptions: &common.InitTrueGitOptions{
 			Options: true_git.Options{LiveGitOutput: *commonCmdData.LogDebug},
 		},
-		InitProcessContainerBackend: true,
-		InitWerf:                    true,
-		InitGitDataManager:          true,
-		InitManifestCache:           true,
-		InitLRUImagesCache:          true,
-		InitSSHAgent:                true,
+		InitWerf:           true,
+		InitGitDataManager: true,
+		InitManifestCache:  true,
+		InitLRUImagesCache: true,
+		InitSSHAgent:       true,
 	})
 	if err != nil {
 		return fmt.Errorf("component init error: %w", err)
@@ -175,8 +173,6 @@ func runRender(ctx context.Context, imageNameListFromArgs []string) error {
 			logboek.Context(ctx).Warn().LogF("Temporary files cleanup preparation failed: %s\n", err)
 		}
 	}()
-
-	containerBackend := commonManager.ContainerBackend()
 
 	defer func() {
 		commonManager.TerminateSSHAgent()
@@ -230,6 +226,12 @@ func runRender(ctx context.Context, imageNameListFromArgs []string) error {
 		isStub = true
 		stubImageNameList = append(stubImageNameList, imagesToProcess.FinalImageNameList...)
 	default:
+		containerBackend, newCtx, err := commonManager.EnsureContainerBackend(ctx, &commonCmdData, false)
+		if err != nil {
+			return fmt.Errorf("container backend initialization error: %w", err)
+		}
+		ctx = newCtx
+
 		if err := common.DockerRegistryInit(ctx, &commonCmdData, commonManager.RegistryMirrors(), commonManager.BuildahMode()); err != nil {
 			return err
 		}

--- a/docs/_includes/reference/cli/werf_converge.md
+++ b/docs/_includes/reference/cli/werf_converge.md
@@ -14,7 +14,7 @@ Environment is a required param for the deploy by default, because it is needed 
 {{ header }} Syntax
 
 ```shell
-werf converge [options]
+werf converge [IMAGE_NAME ...] [options]
 ```
 
 {{ header }} Examples

--- a/docs/_includes/reference/cli/werf_plan.md
+++ b/docs/_includes/reference/cli/werf_plan.md
@@ -12,7 +12,7 @@ Environment is a required param by default, because it is needed to construct He
 {{ header }} Syntax
 
 ```shell
-werf plan [options]
+werf plan [IMAGE_NAME ...] [options]
 ```
 
 {{ header }} Examples


### PR DESCRIPTION
Skip Buildah/Docker initialization for `werf converge` and `werf render` until an image actually needs to be built. Previously both commands eagerly initialized the container backend before even loading werf.yaml, so a host without Buildah/Docker could not run these commands even for image-less, helm-chart-only projects.

Extract the backend/registry init logic from InitCommonComponents into ComponentsManager.InitContainerBackendComponents (pure refactor, no behavior change for the 25+ other commands that still init eagerly). Add ComponentsManager.EnsureContainerBackend for memoized lazy init and ComponentsManager.TryContainerBackend as a non-panicking accessor.

In converge, drop the eager InitDockerRegistry/InitProcessContainerBackend flags; run() now returns the context so a lazily-initialized backend propagates to the deferred cleanup, and RunAutoHostCleanup is skipped if no backend was ever initialized. In render, drop the eager InitProcessContainerBackend flag; the backend is now only initialized in the switch branch that actually builds images.