### PR TITLE
fix(build): error on ambiguous trailing slash in export/import to: path

### DIFF
--- a/pkg/config/raw_export_base.go
+++ b/pkg/config/raw_export_base.go
@@ -1,11 +1,9 @@
 package config
 
 import (
-	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
-
-	"github.com/werf/logboek"
 )
 
 type rawExportBase struct {
@@ -29,10 +27,10 @@ func (c *rawExportBase) toDirective() (exportBase *ExportBase, err error) {
 
 	if strings.HasSuffix(c.To, "/") && c.To != "/" {
 		toWithoutTrailingSlash := strings.TrimSuffix(c.To, "/")
-		logboek.Context(context.Background()).Warn().LogF(
-			"WARNING: `to: %s` will be treated like `to: %s`, i.e. file/directory from `add: %s` will NOT be copied inside of the %q, instead it will be copied as %q! To hide this warning, change `to: %s` to `to: %s`.\n",
-			c.To, toWithoutTrailingSlash, c.Add, c.To, toWithoutTrailingSlash, c.To, toWithoutTrailingSlash,
-		)
+		return nil, newDetailedConfigError(fmt.Sprintf(
+			"`to: %s` is ambiguous: file/directory from `add: %s` would NOT be copied inside of %q, but copied as %q instead! Change `to: %s` to `to: %s`.",
+			c.To, c.Add, c.To, toWithoutTrailingSlash, c.To, toWithoutTrailingSlash,
+		), c.rawOrigin.configSection(), c.rawOrigin.doc())
 	}
 	exportBase.To = filepath.ToSlash(filepath.Clean(c.To))
 

--- a/pkg/true_git/diff_parser.go
+++ b/pkg/true_git/diff_parser.go
@@ -339,7 +339,7 @@ func (p *diffParser) handleModifyFileDiff(line string) error {
 	return p.writeOutLine(line)
 }
 
-// TODO: remove index line from resulting patch completely in v1.2
+// TODO(major): remove index line from resulting patch completely
 func (p *diffParser) handleIndexDiffLine(line string) error {
 	var prefix, hashes, suffix string
 
@@ -360,7 +360,6 @@ func (p *diffParser) handleIndexDiffLine(line string) error {
 	}
 
 	stripHashFunc := func(h string) string {
-		// TODO: remove index line from resulting patch completely in v1.2
 		if len(h) < 8 {
 			return h
 		}


### PR DESCRIPTION
## Summary

Port of #7626 to the `3` branch.

- Turn the `to: PATH/` trailing-slash WARNING into a hard config error for export/import directives (`add`/`to` in stapel and dockerfile-stage imports). Previously werf silently reinterpreted `to: /usr/sbin/` as `to: /usr/sbin`, copying the source itself instead of placing it inside the target directory — a warning was easy to miss and could lead to incorrect image contents going unnoticed.
- Fix a stale `in v1.2` reference in a `pkg/true_git/diff_parser.go` TODO, replacing it with `TODO(major)` since the underlying cleanup is still pending.

Note: the `resources_waiter.go` TODO consolidation from #7626 does not apply here — that legacy helm/kubedog waiter file no longer exists on `3` (deploy waiting is now handled by nelm).

## Breaking change

`werf.yaml` files with a trailing slash in an export/import `to:` path (other than `to: /`) will now fail to build with a clear error message instead of just logging a warning. Fix by dropping the trailing slash, e.g. `to: /usr/sbin/` → `to: /usr/sbin`.