### PR TITLE
feat(build, stapel): deprecate fromImage and import.image directives

### DIFF
--- a/pkg/config/raw_import.go
+++ b/pkg/config/raw_import.go
@@ -1,7 +1,14 @@
 package config
 
+import (
+	"context"
+
+	"github.com/werf/werf/v2/pkg/werf/global_warnings"
+)
+
 type rawImport struct {
 	From   string `yaml:"from,omitempty"`
+	Image  string `yaml:"image,omitempty"` // Deprecated: use `from` instead.
 	Before string `yaml:"before,omitempty"`
 	After  string `yaml:"after,omitempty"`
 
@@ -30,6 +37,14 @@ func (c *rawImport) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	parentStack.Pop()
 	if err != nil {
 		return err
+	}
+
+	if c.Image != "" {
+		if c.From != "" {
+			return newDetailedConfigError("specify only `from: NAME` or deprecated `image: NAME` for import, not both!", c, c.rawStapelImage.doc)
+		}
+		global_warnings.GlobalDeprecationWarningLn(context.Background(), "`image: NAME` for import is deprecated and will be removed in a future version, use `from: NAME` instead.")
+		c.From = c.Image
 	}
 
 	c.rawExport.inlinedIntoRaw(c)

--- a/pkg/config/raw_stapel_image.go
+++ b/pkg/config/raw_stapel_image.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/werf/werf/v2/pkg/giterminism_manager"
 	"github.com/werf/werf/v2/pkg/util/option"
+	"github.com/werf/werf/v2/pkg/werf/global_warnings"
 )
 
 type rawStapelImage struct {
@@ -12,6 +14,7 @@ type rawStapelImage struct {
 	Final            *bool            `yaml:"final,omitempty"`
 	CacheVersion     string           `yaml:"cacheVersion,omitempty"`
 	From             string           `yaml:"from,omitempty"`
+	FromImage        string           `yaml:"fromImage,omitempty"` // Deprecated: use `from` instead.
 	FromLatest       bool             `yaml:"fromLatest,omitempty"`
 	FromCacheVersion string           `yaml:"fromCacheVersion,omitempty"`
 	RawGit           []*rawGit        `yaml:"git,omitempty"`
@@ -158,6 +161,13 @@ func (c *rawStapelImage) toStapelImageBaseDirective(giterminismManager gitermini
 	}
 
 	imageBase.From = c.From
+	if c.FromImage != "" {
+		if c.From != "" {
+			return nil, newDetailedConfigError("specify only `from: NAME` or deprecated `fromImage: NAME`, not both!", c, c.doc)
+		}
+		global_warnings.GlobalDeprecationWarningLn(context.Background(), "`fromImage` directive is deprecated and will be removed in a future version, use `from` instead.")
+		imageBase.From = c.FromImage
+	}
 	imageBase.FromLatest = c.FromLatest
 	imageBase.FromCacheVersion = c.FromCacheVersion
 

--- a/pkg/config/unify_from_ai_test.go
+++ b/pkg/config/unify_from_ai_test.go
@@ -65,10 +65,22 @@ from: ubuntu:22.04
 	assert.Equal(t, "ubuntu:22.04", stapelImage.From)
 }
 
-func TestAI_FromImageFieldIsRejected(t *testing.T) {
+func TestAI_FromImageFieldIsDeprecatedAlias(t *testing.T) {
 	yamlContent := `
 image: testimage
-fromImage: baseimg
+fromImage: ubuntu:22.04
+`
+	stapelImage, err := parseStapelImage(t, yamlContent, "testimage")
+
+	require.NoError(t, err)
+	assert.Equal(t, "ubuntu:22.04", stapelImage.From)
+}
+
+func TestAI_FromAndFromImageBothSpecifiedIsRejected(t *testing.T) {
+	yamlContent := `
+image: testimage
+from: ubuntu:22.04
+fromImage: alpine:3.18
 `
 	_, err := parseStapelImage(t, yamlContent, "testimage")
 
@@ -76,12 +88,30 @@ fromImage: baseimg
 	assert.Contains(t, err.Error(), "fromImage")
 }
 
-func TestAI_ImportImageFieldIsRejected(t *testing.T) {
+func TestAI_ImportImageFieldIsDeprecatedAlias(t *testing.T) {
+	yamlContent := `
+image: testimage
+from: ubuntu:22.04
+import:
+- image: baseimg
+  after: install
+  add: /src
+  to: /app
+`
+	stapelImage, err := parseStapelImage(t, yamlContent, "testimage")
+
+	require.NoError(t, err)
+	require.Len(t, stapelImage.Import, 1)
+	assert.Equal(t, "baseimg", stapelImage.Import[0].From)
+}
+
+func TestAI_ImportFromAndImageBothSpecifiedIsRejected(t *testing.T) {
 	yamlContent := `
 image: testimage
 from: ubuntu:22.04
 import:
 - from: baseimg
+  image: otherimg
   after: install
   add: /src
   to: /app


### PR DESCRIPTION
## Summary
- `fromImage` (stapel image) and `import: - image:` are removed/renamed directives on v3 branch — now emit a deprecation warning and are treated as aliases for `from` instead of hard-failing config parsing.
- Reuses the existing `global_warnings.GlobalDeprecationWarningLn` mechanism, previously used for the now fully-removed `docker:` directive.
- Specifying both the old and new key together (e.g. `from` + `fromImage`) is still a hard error to avoid ambiguity.

## Why
Smooths the v2 → v3 migration for users relying on renamed werf.yaml directives — configs keep working with a warning instead of breaking outright on upgrade.