### PR TITLE
fix(build): avoid splitting UTF-8 runes across parallel worker log reads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/werf/common-go v0.0.0-20260504183956-43da716392f7
 	github.com/werf/copy-recurse v0.2.7
 	github.com/werf/lockgate v0.2.0
-	github.com/werf/logboek v0.6.1
+	github.com/werf/logboek v0.7.1
 	github.com/werf/nelm v1.23.3-0.20260514121649-29d4e8bfbc01
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -1030,8 +1030,8 @@ github.com/werf/kubedog v0.13.1-0.20260320165832-7d97aaf7aab9 h1:N+XKTPiXT5pf5lx
 github.com/werf/kubedog v0.13.1-0.20260320165832-7d97aaf7aab9/go.mod h1:93L6aIdpj7iIhL30Obkv7bWgUyTeuxas1ijtzjmyb4Q=
 github.com/werf/lockgate v0.2.0 h1:wntfccZmtHQuntPjrPUFA2FcKejhmteKEekQx3VsHC4=
 github.com/werf/lockgate v0.2.0/go.mod h1:h8P6tpGRZymd0bS5FlnS+AdIwO2jDlpOLy9St2tbs30=
-github.com/werf/logboek v0.6.1 h1:oEe6FkmlKg0z0n80oZjLplj6sXcBeLleCkjfOOZEL2g=
-github.com/werf/logboek v0.6.1/go.mod h1:Gez5J4bxekyr6MxTmIJyId1F61rpO+0/V4vjCIEIZmk=
+github.com/werf/logboek v0.7.1 h1:Ck8L7LVmj/wyrW/jk+EkkpGwdmpkOrsWAwoIgLHupc8=
+github.com/werf/logboek v0.7.1/go.mod h1:Gez5J4bxekyr6MxTmIJyId1F61rpO+0/V4vjCIEIZmk=
 github.com/werf/nelm v1.23.3-0.20260514121649-29d4e8bfbc01 h1:YwMg7JGcNOCfBkWztuOxWmWUdwHAsA+TftJIUUO8e7M=
 github.com/werf/nelm v1.23.3-0.20260514121649-29d4e8bfbc01/go.mod h1:J5jhcjodcSV5ATzT6yzOku6niDSj1n6X1gkIs+c39rc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/pkg/util/parallel/worker.go
+++ b/pkg/util/parallel/worker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sync/atomic"
+	"unicode/utf8"
 
 	"github.com/werf/werf/v2/pkg/tmp_manager"
 )
@@ -42,10 +43,60 @@ func (w *Worker) Write(p []byte) (int, error) {
 // Read implements io.Reader.
 // It reads a file and accumulates total read offset.
 // It resumes reading from "total read offset" and reads until EOF, where EOF is handled with os.File.
+//
+// While the worker is still writing, a trailing incomplete UTF-8 sequence is
+// held back and returned on the next call instead. Without this, a fixed-size
+// read can land its boundary in the middle of a multi-byte rune (e.g. a
+// box-drawing character used for log prefixes), and the downstream logger
+// converts each half independently into a replacement character, producing
+// visible mojibake in the terminal.
 func (w *Worker) Read(p []byte) (int, error) {
-	offset, err := w.file.ReadAt(p, w.readOffset.Load())
-	w.readOffset.Add(int64(offset))
-	return offset, err
+	n, err := w.file.ReadAt(p, w.readOffset.Load())
+
+	if !w.halfClosed.Load() {
+		if complete := completeUTF8Len(p[:n]); complete < n {
+			n = complete
+			err = nil
+		}
+	}
+
+	w.readOffset.Add(int64(n))
+	return n, err
+}
+
+// completeUTF8Len returns the length of the longest prefix of b that does not
+// end with a truncated multi-byte UTF-8 sequence.
+func completeUTF8Len(b []byte) int {
+	n := len(b)
+
+	for i := 1; i < utf8.UTFMax && i <= n; i++ {
+		c := b[n-i]
+		if utf8.RuneStart(c) {
+			if utf8SequenceLen(c) > i {
+				return n - i
+			}
+			break
+		}
+	}
+
+	return n
+}
+
+// utf8SequenceLen returns the expected total byte length of the UTF-8
+// sequence starting with lead byte c.
+func utf8SequenceLen(c byte) int {
+	switch {
+	case c&0x80 == 0x00:
+		return 1
+	case c&0xE0 == 0xC0:
+		return 2
+	case c&0xF0 == 0xE0:
+		return 3
+	case c&0xF8 == 0xF0:
+		return 4
+	default:
+		return 1
+	}
 }
 
 // HalfClose closes writing or returns error if already half-closed

--- a/pkg/util/parallel/worker_ai_test.go
+++ b/pkg/util/parallel/worker_ai_test.go
@@ -1,0 +1,96 @@
+package parallel_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/werf/v2/pkg/util/parallel"
+	"github.com/werf/werf/v2/pkg/werf"
+)
+
+// runeSplittingWriter mimics logboek's internal proxy-formatting layer
+// (github.com/werf/logboek/internal/logger/manager.go's proxyStream.Write ->
+// internal/stream/stream.go's Stream.FormatAndLogF), which decodes each
+// Write() call's byte slice into runes via []rune(string(p)). If a Write()
+// carries a truncated multi-byte UTF-8 sequence, decoding replaces the
+// invalid bytes with the Unicode replacement character (U+FFFD) - mojibake.
+type runeSplittingWriter struct {
+	buf bytes.Buffer
+}
+
+func (w *runeSplittingWriter) Write(p []byte) (int, error) {
+	for _, r := range []rune(string(p)) {
+		w.buf.WriteRune(r)
+	}
+	return len(p), nil
+}
+
+var _ = Describe("Worker.Read UTF-8 boundary safety", func() {
+	It("never splits a multi-byte rune across two reads while the worker is still writing", func() {
+		Expect(werf.Init(GinkgoT().TempDir(), "")).To(Succeed())
+
+		worker, err := parallel.NewWorker(1)
+		Expect(err).To(Succeed())
+
+		// Padding chosen so the 1024-byte read boundary lands in the middle
+		// of the "│" character's 3-byte UTF-8 encoding (E2 94 82), matching
+		// the reported failure mode.
+		line := strings.Repeat("a", 1019) + "│ └ done\n"
+		_, err = worker.Write([]byte(line))
+		Expect(err).To(Succeed())
+
+		// Read while the worker is still open (not half-closed), so the
+		// boundary-holdback logic under test is actually exercised.
+		out := &runeSplittingWriter{}
+		readBuf := make([]byte, 1024) // matches printer.go's read-buffer size
+		n, readErr := worker.Read(readBuf)
+		Expect(readErr).To(Succeed())
+		_, err = out.Write(readBuf[:n])
+		Expect(err).To(Succeed())
+
+		Expect(worker.HalfClose()).To(Succeed())
+
+		for worker.Readable() {
+			n, readErr = worker.Read(readBuf)
+			if n > 0 {
+				_, err = out.Write(readBuf[:n])
+				Expect(err).To(Succeed())
+			}
+			Expect(readErr).To(Or(Succeed(), MatchError(io.EOF)))
+		}
+
+		Expect(out.buf.String()).To(Equal(line))
+		Expect(out.buf.String()).NotTo(ContainSubstring("\uFFFD"))
+
+		Expect(worker.Cleanup()).To(Succeed())
+	})
+
+	It("flushes a trailing incomplete rune once the worker is half-closed, without hanging", func() {
+		Expect(werf.Init(GinkgoT().TempDir(), "")).To(Succeed())
+
+		worker, err := parallel.NewWorker(2)
+		Expect(err).To(Succeed())
+
+		_, err = worker.Write([]byte("└"))
+		Expect(err).To(Succeed())
+		Expect(worker.HalfClose()).To(Succeed())
+
+		var result bytes.Buffer
+		readBuf := make([]byte, 2)
+		for worker.Readable() {
+			n, readErr := worker.Read(readBuf)
+			if n > 0 {
+				result.Write(readBuf[:n])
+			}
+			Expect(readErr).To(Or(Succeed(), MatchError(io.EOF)))
+		}
+
+		Expect(result.String()).To(Equal("└"))
+
+		Expect(worker.Cleanup()).To(Succeed())
+	})
+})


### PR DESCRIPTION
## Summary

Fixes recurring mojibake (`�`) replacing box-drawing prefix characters (`└`, `┌`, `│`) in werf's parallel build log output. Root-caused via bisecting two independent bugs.

## Key changes

- `chore(deps)`: bump `github.com/werf/logboek` v0.6.1 → v0.7.1, restoring a fix (byte/rune boundary bug in `fitter.Slice`) that was lost during an earlier merge conflict resolution.
- `fix(build)`: `pkg/util/parallel/worker.go`'s `Worker.Read` now holds back a trailing incomplete UTF-8 sequence while the worker is still writing, instead of handing a fixed 1024-byte chunk straight to the caller regardless of rune boundaries.
- Added `pkg/util/parallel/worker_ai_test.go` reproducing the exact failure mode: a `└` (3-byte UTF-8) landing on a 1024-byte read boundary, decoded through a rune-splitting writer that mimics logboek's internal proxy-formatting layer.

## Why

During parallel image builds, each worker buffers its logboek output in a temp file; the printer drains it via a fixed-size `ReadAt` with zero UTF-8 awareness. When a multi-byte rune (a tree-log prefix character) straddles a 1024-byte chunk boundary, the split halves get decoded independently by logboek's proxy formatting layer (`[]rune(string(p))`), each becoming `U+FFFD` — visible in the terminal as `���` in place of `└`.

The logboek bump alone did not fix this (confirmed by the reporter after rebuilding) — it fixed a different, legitimate bug in logboek's own line-wrapping logic, but the actual reported corruption originates in werf's own parallel-build log buffering, not in logboek.

## Review focus / risks

- `Worker.Read`'s UTF-8 holdback only applies while the worker is not yet half-closed; once half-closed, incomplete trailing bytes are flushed as-is to avoid ever blocking `Readable()`/hanging the printer loop on genuinely malformed input.
- `go.mod`/`go.sum` diff is scoped strictly to the `logboek` version bump (a stray `// indirect` toggle on an unrelated dependency introduced by `go mod tidy` was reverted to keep the diff minimal).