### PR TITLE
refactor(build): mutate imageSpec/content-tag configs via native commit 

### DIFF
--- a/pkg/buildah/common.go
+++ b/pkg/buildah/common.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -99,6 +100,15 @@ type CommitOpts struct {
 	CommonOpts
 
 	Image string
+
+	// ClearHistory and Created are only honored by CommitMutation, not by Commit.
+
+	// ClearHistory, when true, omits the base image's layer history from the committed image.
+	ClearHistory bool
+
+	// Created overrides the "created" timestamp recorded on the committed image.
+	// When nil, the commit time is used.
+	Created *time.Time
 }
 
 type PruneImagesOptions struct {
@@ -191,6 +201,14 @@ type Buildah interface {
 	Umount(ctx context.Context, container string, opts UmountOpts) error
 	Commit(ctx context.Context, container string, opts CommitOpts) (string, error)
 	Config(ctx context.Context, container string, opts ConfigOpts) error
+	// MutateConfig applies a full-replace image config mutation (as described by newConfig) to
+	// container, mirroring image.UpdateConfigFile semantics. Unlike Config, it does not merge
+	// individual fields additively: Labels/Env/Volumes are always fully replaced with the final
+	// resolved values, and Clear* flags reset the corresponding field to its zero value.
+	MutateConfig(ctx context.Context, container string, newConfig image.SpecConfig, opts CommonOpts) error
+	// CommitMutation commits container the same way as Commit, but honors opts.ClearHistory and
+	// opts.Created instead of always omitting history. Intended for use after MutateConfig.
+	CommitMutation(ctx context.Context, container string, opts CommitOpts) (string, error)
 	Copy(ctx context.Context, container, contextDir string, src []string, dst string, opts CopyOpts) error
 	Add(ctx context.Context, container string, src []string, dst string, opts AddOpts) error
 	Images(ctx context.Context, opts ImagesOptions) (image.ImagesList, error)

--- a/pkg/buildah/native_linux.go
+++ b/pkg/buildah/native_linux.go
@@ -686,6 +686,17 @@ func (b *NativeBuildah) PruneImages(ctx context.Context, opts PruneImagesOptions
 }
 
 func (b *NativeBuildah) Commit(ctx context.Context, container string, opts CommitOpts) (string, error) {
+	// Switching "build with registry" from Docker to Buildah causes Buildah's history error:
+	// "internal error: history lists 1 non-empty layers, but we have 7 layers on disk".
+	// To prevent the error we disable the history for regular build commits.
+	return b.commit(ctx, container, opts, true)
+}
+
+func (b *NativeBuildah) CommitMutation(ctx context.Context, container string, opts CommitOpts) (string, error) {
+	return b.commit(ctx, container, opts, !opts.ClearHistory)
+}
+
+func (b *NativeBuildah) commit(ctx context.Context, container string, opts CommitOpts, omitHistory bool) (string, error) {
 	builder, err := b.openContainerBuilder(ctx, container)
 	if err != nil {
 		return "", fmt.Errorf("unable to open container %q builder: %w", container, err)
@@ -709,10 +720,8 @@ func (b *NativeBuildah) Commit(ctx context.Context, container string, opts Commi
 	}
 
 	imgID, _, _, err := builder.Commit(ctx, imageRef, buildah.CommitOptions{
-		// Switching "build with registry" from Docker to Buildah causes Buildah's history error:
-		// "internal error: history lists 1 non-empty layers, but we have 7 layers on disk".
-		// To prevent the error we disable the history.
-		OmitHistory:           true,
+		OmitHistory:           omitHistory,
+		HistoryTimestamp:      opts.Created,
 		PreferredManifestType: buildah.Dockerv2ImageManifest,
 		SignaturePolicyPath:   b.SignaturePolicyPath,
 		ReportWriter:          opts.LogWriter,
@@ -823,6 +832,98 @@ func (b *NativeBuildah) Config(ctx context.Context, container string, opts Confi
 
 	if opts.OnBuild != "" {
 		builder.SetOnBuild(opts.OnBuild)
+	}
+
+	return builder.Save()
+}
+
+// MutateConfig applies newConfig to container using full-replace semantics matching
+// image.UpdateConfigFile: Labels/Env/Volumes are always fully replaced with the resolved final
+// values (not merged additively), and Clear* flags reset fields to their zero value.
+func (b *NativeBuildah) MutateConfig(ctx context.Context, container string, newConfig image.SpecConfig, opts CommonOpts) error {
+	builder, err := b.openContainerBuilder(ctx, container)
+	if err != nil {
+		return fmt.Errorf("unable to open container %q builder: %w", container, err)
+	}
+
+	if newConfig.Author != "" {
+		builder.SetMaintainer(newConfig.Author)
+	}
+
+	builder.ClearLabels()
+	for key, value := range newConfig.Labels {
+		builder.SetLabel(key, value)
+	}
+
+	builder.ClearEnv()
+	for _, entry := range newConfig.Env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		builder.SetEnv(key, value)
+	}
+
+	builder.ClearVolumes()
+	for volume := range newConfig.Volumes {
+		builder.AddVolume(volume)
+	}
+
+	builder.ClearPorts()
+	for expose := range newConfig.ExposedPorts {
+		builder.SetPort(expose)
+	}
+
+	if newConfig.ClearUser {
+		builder.SetUser("")
+	}
+	if newConfig.User != "" {
+		builder.SetUser(newConfig.User)
+	}
+
+	if newConfig.ClearCmd {
+		builder.SetCmd(nil)
+	}
+	if len(newConfig.Cmd) > 0 {
+		builder.SetCmd(newConfig.Cmd)
+	}
+
+	if newConfig.ClearEntrypoint {
+		builder.SetEntrypoint(nil)
+	}
+	if len(newConfig.Entrypoint) > 0 {
+		builder.SetEntrypoint(newConfig.Entrypoint)
+	}
+
+	if newConfig.ClearWorkingDir {
+		builder.SetWorkDir("")
+	}
+	if newConfig.WorkingDir != "" {
+		builder.SetWorkDir(newConfig.WorkingDir)
+	}
+
+	if newConfig.StopSignal != "" {
+		builder.SetStopSignal(newConfig.StopSignal)
+	}
+
+	if newConfig.HealthConfig != nil {
+		builder.SetHealthcheck(&docker.HealthConfig{
+			Test:        newConfig.HealthConfig.Test,
+			Interval:    newConfig.HealthConfig.Interval,
+			Timeout:     newConfig.HealthConfig.Timeout,
+			StartPeriod: newConfig.HealthConfig.StartPeriod,
+			Retries:     newConfig.HealthConfig.Retries,
+		})
+	}
+
+	if opts.TargetPlatform != "" {
+		os, arch, variant, err := parse.Platform(opts.TargetPlatform)
+		if err != nil {
+			return fmt.Errorf("unable to parse platform %q: %w", opts.TargetPlatform, err)
+		}
+		builder.SetOS(os)
+		builder.SetArchitecture(arch)
+		builder.SetVariant(variant)
 	}
 
 	return builder.Save()

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
@@ -1158,6 +1159,47 @@ func (backend *BuildahBackend) Containers(ctx context.Context, opts ContainersOp
 
 func (backend *BuildahBackend) Rm(ctx context.Context, name string, opts RmOpts) error {
 	return backend.buildah.Rm(ctx, name, buildah.RmOpts{})
+}
+
+// MutateAndPushImageNative applies newConfig to src via a native buildah build+commit
+// (create container from src, mutate its config, commit to dest), without the
+// save-to-tar/load-from-tar roundtrip used by MutateAndPushImage. It implements the
+// NativeConfigMutator interface used by storage.LocalStagesStorage.
+func (backend *BuildahBackend) MutateAndPushImageNative(ctx context.Context, src, dest string, newConfig image.SpecConfig, targetPlatform string) error {
+	containerID := uuid.New().String()
+
+	if _, err := backend.buildah.FromCommand(ctx, containerID, src, buildah.FromCommandOpts(backend.getBuildahCommonOpts(ctx, true, nil, targetPlatform))); err != nil {
+		return fmt.Errorf("unable to create container from image %q: %w", src, err)
+	}
+	defer func() {
+		if err := backend.buildah.Rm(ctx, containerID, buildah.RmOpts{}); err != nil {
+			logboek.Context(ctx).Error().LogF("ERROR: unable to remove temporary mutation container %q: %s\n", containerID, err)
+		}
+	}()
+
+	if err := backend.buildah.MutateConfig(ctx, containerID, newConfig, backend.getBuildahCommonOpts(ctx, true, nil, targetPlatform)); err != nil {
+		return fmt.Errorf("unable to mutate config for container %q: %w", containerID, err)
+	}
+
+	var created *time.Time
+	if newConfig.Created != "" {
+		parsed, err := time.Parse(time.RFC3339, newConfig.Created)
+		if err != nil {
+			return fmt.Errorf("unable to parse created timestamp %q: %w", newConfig.Created, err)
+		}
+		created = &parsed
+	}
+
+	if _, err := backend.buildah.CommitMutation(ctx, containerID, buildah.CommitOpts{
+		CommonOpts:   backend.getBuildahCommonOpts(ctx, true, nil, targetPlatform),
+		Image:        dest,
+		ClearHistory: newConfig.ClearHistory,
+		Created:      created,
+	}); err != nil {
+		return fmt.Errorf("unable to commit mutated container %q as %q: %w", containerID, dest, err)
+	}
+
+	return nil
 }
 
 func (backend *BuildahBackend) PostManifest(ctx context.Context, ref string, opts PostManifestOpts) error {

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -1,11 +1,18 @@
 package container_backend
 
 import (
+	"context"
+	"fmt"
+	"io"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/werf/werf/v2/pkg/buildah"
 	"github.com/werf/werf/v2/pkg/buildah/thirdparty"
+	"github.com/werf/werf/v2/pkg/container_backend/info"
+	"github.com/werf/werf/v2/pkg/image"
 )
 
 var _ = Describe("BuildahBackend pulledImageIDs", func() {
@@ -58,6 +65,206 @@ var _ = Describe("BuildahBackend pulledImageIDs", func() {
 		id, ok := backend.getPulledImageID("alpine:latest", "linux/amd64")
 		Expect(ok).To(BeTrue())
 		Expect(id).To(Equal("sha256:amd64"))
+	})
+})
+
+type mutateNativeBuildahStub struct {
+	fromCommandCalls     int
+	fromCommandImage     string
+	fromCommandContainer string
+	rmCalls              []string
+
+	mutateConfigCalls     int
+	mutateConfigContainer string
+	mutateConfigConfig    image.SpecConfig
+	mutateConfigOpts      buildah.CommonOpts
+
+	commitMutationCalls     int
+	commitMutationContainer string
+	commitMutationOpts      buildah.CommitOpts
+
+	fromCommandErr    error
+	mutateConfigErr   error
+	commitMutationErr error
+}
+
+func (s *mutateNativeBuildahStub) FromCommand(_ context.Context, container, image string, _ buildah.FromCommandOpts) (string, error) {
+	s.fromCommandCalls++
+	s.fromCommandImage = image
+	s.fromCommandContainer = container
+	if s.fromCommandErr != nil {
+		return "", s.fromCommandErr
+	}
+	return container, nil
+}
+
+func (s *mutateNativeBuildahStub) Rm(_ context.Context, ref string, _ buildah.RmOpts) error {
+	s.rmCalls = append(s.rmCalls, ref)
+	return nil
+}
+
+func (s *mutateNativeBuildahStub) MutateConfig(_ context.Context, container string, newConfig image.SpecConfig, opts buildah.CommonOpts) error {
+	s.mutateConfigCalls++
+	s.mutateConfigContainer = container
+	s.mutateConfigConfig = newConfig
+	s.mutateConfigOpts = opts
+	return s.mutateConfigErr
+}
+
+func (s *mutateNativeBuildahStub) CommitMutation(_ context.Context, container string, opts buildah.CommitOpts) (string, error) {
+	s.commitMutationCalls++
+	s.commitMutationContainer = container
+	s.commitMutationOpts = opts
+	if s.commitMutationErr != nil {
+		return "", s.commitMutationErr
+	}
+	return "new-image-id", nil
+}
+
+func (s *mutateNativeBuildahStub) Info(context.Context) (info.Info, error) { panic("unexpected call") }
+func (s *mutateNativeBuildahStub) GetDefaultPlatform() string              { panic("unexpected call") }
+func (s *mutateNativeBuildahStub) GetRuntimePlatform() string              { panic("unexpected call") }
+
+func (s *mutateNativeBuildahStub) Tag(context.Context, string, string, buildah.TagOpts) error {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Push(context.Context, string, buildah.PushOpts) error {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) BuildFromDockerfile(context.Context, string, buildah.BuildFromDockerfileOpts) (string, error) {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) RunCommand(context.Context, string, []string, buildah.RunCommandOpts) error {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Pull(context.Context, string, buildah.PullOpts) (string, error) {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Inspect(context.Context, string) (*thirdparty.BuilderInfo, error) {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Rmi(context.Context, string, buildah.RmiOpts) error {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Mount(context.Context, string, buildah.MountOpts) (string, error) {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Umount(context.Context, string, buildah.UmountOpts) error {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Commit(context.Context, string, buildah.CommitOpts) (string, error) {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Config(context.Context, string, buildah.ConfigOpts) error {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Copy(context.Context, string, string, []string, string, buildah.CopyOpts) error {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Add(context.Context, string, []string, string, buildah.AddOpts) error {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Images(context.Context, buildah.ImagesOptions) (image.ImagesList, error) {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) Containers(context.Context, buildah.ContainersOptions) (image.ContainerList, error) {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) PruneImages(context.Context, buildah.PruneImagesOptions) (buildah.PruneImagesReport, error) {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) SaveImageToStream(context.Context, string) (io.ReadCloser, error) {
+	panic("unexpected call")
+}
+
+func (s *mutateNativeBuildahStub) LoadImageFromStream(context.Context, io.Reader) (string, error) {
+	panic("unexpected call")
+}
+
+var _ = Describe("BuildahBackend.MutateAndPushImageNative", func() {
+	It("creates a container from src, mutates its config, commits to dest, and removes the temp container", func(ctx SpecContext) {
+		stub := &mutateNativeBuildahStub{}
+		backend := NewBuildahBackend(stub, BuildahBackendOptions{})
+
+		newConfig := image.SpecConfig{Labels: map[string]string{"foo": "bar"}}
+		err := backend.MutateAndPushImageNative(ctx, "src:latest", "dest:latest", newConfig, "linux/amd64")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(stub.fromCommandCalls).To(Equal(1))
+		Expect(stub.fromCommandImage).To(Equal("src:latest"))
+
+		Expect(stub.mutateConfigCalls).To(Equal(1))
+		Expect(stub.mutateConfigConfig).To(Equal(newConfig))
+		Expect(stub.mutateConfigOpts.TargetPlatform).To(Equal("linux/amd64"))
+		Expect(stub.mutateConfigContainer).To(Equal(stub.fromCommandContainer))
+
+		Expect(stub.commitMutationCalls).To(Equal(1))
+		Expect(stub.commitMutationOpts.Image).To(Equal("dest:latest"))
+		Expect(stub.commitMutationOpts.ClearHistory).To(BeFalse())
+		Expect(stub.commitMutationOpts.Created).To(BeNil())
+		Expect(stub.commitMutationContainer).To(Equal(stub.fromCommandContainer))
+
+		Expect(stub.rmCalls).To(Equal([]string{stub.fromCommandContainer}))
+	})
+
+	It("propagates ClearHistory and parses Created into CommitMutation options", func(ctx SpecContext) {
+		stub := &mutateNativeBuildahStub{}
+		backend := NewBuildahBackend(stub, BuildahBackendOptions{})
+
+		newConfig := image.SpecConfig{ClearHistory: true, Created: "2024-01-02T03:04:05Z"}
+		err := backend.MutateAndPushImageNative(ctx, "src:latest", "dest:latest", newConfig, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(stub.commitMutationOpts.ClearHistory).To(BeTrue())
+		Expect(stub.commitMutationOpts.Created).NotTo(BeNil())
+		Expect(stub.commitMutationOpts.Created.UTC().Format("2006-01-02T15:04:05Z")).To(Equal("2024-01-02T03:04:05Z"))
+	})
+
+	It("removes the temp container even when MutateConfig fails", func(ctx SpecContext) {
+		stub := &mutateNativeBuildahStub{mutateConfigErr: fmt.Errorf("mutate boom")}
+		backend := NewBuildahBackend(stub, BuildahBackendOptions{})
+
+		err := backend.MutateAndPushImageNative(ctx, "src:latest", "dest:latest", image.SpecConfig{}, "")
+		Expect(err).To(MatchError(ContainSubstring("mutate boom")))
+		Expect(stub.commitMutationCalls).To(Equal(0))
+		Expect(stub.rmCalls).To(Equal([]string{stub.fromCommandContainer}))
+	})
+
+	It("returns an error for an unparseable Created timestamp", func(ctx SpecContext) {
+		stub := &mutateNativeBuildahStub{}
+		backend := NewBuildahBackend(stub, BuildahBackendOptions{})
+
+		err := backend.MutateAndPushImageNative(ctx, "src:latest", "dest:latest", image.SpecConfig{Created: "not-a-timestamp"}, "")
+		Expect(err).To(HaveOccurred())
+		Expect(stub.commitMutationCalls).To(Equal(0))
+		Expect(stub.rmCalls).To(Equal([]string{stub.fromCommandContainer}))
+	})
+
+	It("propagates FromCommand errors without calling MutateConfig or CommitMutation", func(ctx SpecContext) {
+		stub := &mutateNativeBuildahStub{fromCommandErr: fmt.Errorf("from boom")}
+		backend := NewBuildahBackend(stub, BuildahBackendOptions{})
+
+		err := backend.MutateAndPushImageNative(ctx, "src:latest", "dest:latest", image.SpecConfig{}, "")
+		Expect(err).To(MatchError(ContainSubstring("from boom")))
+		Expect(stub.mutateConfigCalls).To(Equal(0))
+		Expect(stub.commitMutationCalls).To(Equal(0))
+		Expect(stub.rmCalls).To(BeEmpty())
 	})
 })
 

--- a/pkg/container_backend/docker_server_backend.go
+++ b/pkg/container_backend/docker_server_backend.go
@@ -10,11 +10,14 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/containerd/containerd/platforms"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	dockerImage "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/werf/common-go/pkg/util"
 	"github.com/werf/lockgate"
@@ -26,7 +29,10 @@ import (
 	"github.com/werf/werf/v2/pkg/ssh_agent"
 )
 
-var _ ImageConfigFileGetter = (*DockerServerBackend)(nil)
+var (
+	_ ImageConfigFileGetter = (*DockerServerBackend)(nil)
+	_ NativeConfigMutator   = (*DockerServerBackend)(nil)
+)
 
 type DockerServerBackend struct {
 	locker lockgate.Locker
@@ -406,6 +412,85 @@ func (backend *DockerServerBackend) PruneVolumes(ctx context.Context, options pr
 
 func (backend *DockerServerBackend) SaveImageToStream(ctx context.Context, imageName string) (io.ReadCloser, error) {
 	return docker.CliImageSaveToStream(ctx, imageName)
+}
+
+// MutateAndPushImageNative mutates src's config into dest via a native docker create+commit,
+// avoiding the docker save/load roundtrip. docker commit merges the given config additively over
+// the base image config (re-adding omitted labels/env/volumes, stamping created=now, appending
+// history) and cannot clear fields. It is therefore used only when newConfig is a pure additive
+// superset of the base config (see nativeMutationEligible); otherwise this returns
+// errNativeMutationUnsupported and the caller falls back to the save/load path.
+func (backend *DockerServerBackend) MutateAndPushImageNative(ctx context.Context, src, dest string, newConfig image.SpecConfig, targetPlatform string) error {
+	baseConfig, err := backend.GetImageConfigFile(ctx, src)
+	if err != nil {
+		return fmt.Errorf("unable to get config of image %q: %w", src, err)
+	}
+
+	if !nativeMutationEligible(newConfig, baseConfig) {
+		return ErrNativeMutationUnsupported
+	}
+
+	containerConfig := &dockercontainer.Config{
+		Image:        src,
+		User:         newConfig.User,
+		Env:          newConfig.Env,
+		Entrypoint:   newConfig.Entrypoint,
+		Cmd:          newConfig.Cmd,
+		Labels:       newConfig.Labels,
+		Volumes:      newConfig.Volumes,
+		WorkingDir:   newConfig.WorkingDir,
+		StopSignal:   newConfig.StopSignal,
+		ExposedPorts: toPortSet(newConfig.ExposedPorts),
+	}
+	if newConfig.HealthConfig != nil {
+		containerConfig.Healthcheck = &dockercontainer.HealthConfig{
+			Test:        newConfig.HealthConfig.Test,
+			Interval:    newConfig.HealthConfig.Interval,
+			Timeout:     newConfig.HealthConfig.Timeout,
+			StartPeriod: newConfig.HealthConfig.StartPeriod,
+			Retries:     newConfig.HealthConfig.Retries,
+		}
+	}
+
+	var platform *ocispec.Platform
+	if targetPlatform != "" {
+		parsed, err := platforms.Parse(targetPlatform)
+		if err != nil {
+			return fmt.Errorf("unable to parse platform %q: %w", targetPlatform, err)
+		}
+		platform = &parsed
+	}
+
+	containerID, err := docker.ContainerCreate(ctx, containerConfig, platform, "")
+	if err != nil {
+		return fmt.Errorf("unable to create container from image %q: %w", src, err)
+	}
+	defer func() {
+		if err := docker.ContainerRemove(ctx, containerID, dockercontainer.RemoveOptions{Force: true}); err != nil {
+			logboek.Context(ctx).Error().LogF("ERROR: unable to remove temporary mutation container %q: %s\n", containerID, err)
+		}
+	}()
+
+	if _, err := docker.ContainerCommit(ctx, containerID, dockercontainer.CommitOptions{
+		Reference: dest,
+		Author:    newConfig.Author,
+		Config:    containerConfig,
+	}); err != nil {
+		return fmt.Errorf("unable to commit mutated container %q as %q: %w", containerID, dest, err)
+	}
+
+	return nil
+}
+
+func toPortSet(ports map[string]struct{}) nat.PortSet {
+	if len(ports) == 0 {
+		return nil
+	}
+	set := make(nat.PortSet, len(ports))
+	for port := range ports {
+		set[nat.Port(port)] = struct{}{}
+	}
+	return set
 }
 
 func (backend *DockerServerBackend) GetImageConfigFile(ctx context.Context, imageName string) (*v1.ConfigFile, error) {

--- a/pkg/container_backend/mutation.go
+++ b/pkg/container_backend/mutation.go
@@ -2,9 +2,11 @@ package container_backend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/containerd/containerd/platforms"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -23,6 +25,86 @@ type BackendLoaderStorer interface {
 
 type ImageConfigFileGetter interface {
 	GetImageConfigFile(ctx context.Context, imageName string) (*v1.ConfigFile, error)
+}
+
+// NativeConfigMutator is implemented by backends that can mutate an image's config via a native
+// build+commit flow (create container from src, apply config, commit to dest), avoiding the
+// save-to-tar/load-from-tar roundtrip that MutateAndPushImage otherwise requires.
+type NativeConfigMutator interface {
+	MutateAndPushImageNative(ctx context.Context, src, dest string, newConfig image.SpecConfig, targetPlatform string) error
+}
+
+// ErrNativeMutationUnsupported signals that a backend cannot faithfully perform the requested
+// mutation via its native path and the caller must fall back to MutateAndPushImage (save/load).
+var ErrNativeMutationUnsupported = errors.New("native mutation not supported for this config")
+
+// IsNativeMutationUnsupported reports whether err indicates the native mutation path declined the
+// mutation and the save/load fallback must be used.
+func IsNativeMutationUnsupported(err error) bool {
+	return errors.Is(err, ErrNativeMutationUnsupported)
+}
+
+// nativeMutationEligible reports whether newConfig can be faithfully reproduced by docker commit,
+// whose daemon-side merge is additive-only: it re-adds base labels/env/volumes for omitted keys,
+// cannot clear fields, and cannot drop history. The mutation therefore matches werf's full-replace
+// UpdateConfigFile semantics only when it neither clears anything nor removes any base
+// label/env/volume/exposed-port.
+func nativeMutationEligible(newConfig image.SpecConfig, baseConfig *v1.ConfigFile) bool {
+	if newConfig.ClearHistory || newConfig.ClearCmd || newConfig.ClearEntrypoint || newConfig.ClearUser || newConfig.ClearWorkingDir {
+		return false
+	}
+
+	base := baseConfig.Config
+
+	if newConfig.Labels != nil && !isMapSuperset(newConfig.Labels, base.Labels) {
+		return false
+	}
+	if newConfig.Volumes != nil && !isSetSuperset(newConfig.Volumes, base.Volumes) {
+		return false
+	}
+	if newConfig.ExposedPorts != nil && !isSetSuperset(newConfig.ExposedPorts, base.ExposedPorts) {
+		return false
+	}
+	// Env is replaced unconditionally by UpdateConfigFile (even when nil clears it), so the
+	// superset check must run regardless of whether newConfig.Env is nil.
+	if !isEnvSuperset(newConfig.Env, base.Env) {
+		return false
+	}
+
+	return true
+}
+
+func isMapSuperset(next, base map[string]string) bool {
+	for k := range base {
+		if _, ok := next[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func isSetSuperset(next, base map[string]struct{}) bool {
+	for k := range base {
+		if _, ok := next[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func isEnvSuperset(next, base []string) bool {
+	nextKeys := make(map[string]struct{}, len(next))
+	for _, entry := range next {
+		key, _, _ := strings.Cut(entry, "=")
+		nextKeys[key] = struct{}{}
+	}
+	for _, entry := range base {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, ok := nextKeys[key]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func MutateAndPushImage(ctx context.Context, imageName, targetPlatform string, newConfig image.SpecConfig, backend BackendLoaderStorer) (string, error) {

--- a/pkg/container_backend/native_mutation_eligible_test.go
+++ b/pkg/container_backend/native_mutation_eligible_test.go
@@ -1,0 +1,74 @@
+package container_backend
+
+import (
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/werf/v2/pkg/image"
+)
+
+var _ = Describe("nativeMutationEligible", func() {
+	base := func() *v1.ConfigFile {
+		return &v1.ConfigFile{Config: v1.Config{
+			Labels:       map[string]string{"a": "1"},
+			Env:          []string{"FOO=bar"},
+			Volumes:      map[string]struct{}{"/data": {}},
+			ExposedPorts: map[string]struct{}{"80/tcp": {}},
+		}}
+	}
+
+	DescribeTable("decides docker-commit eligibility",
+		func(cfg image.SpecConfig, expected bool) {
+			Expect(nativeMutationEligible(cfg, base())).To(Equal(expected))
+		},
+		Entry("additive superset labels+env", image.SpecConfig{
+			Labels: map[string]string{"a": "1", "b": "2"},
+			Env:    []string{"FOO=bar", "BAZ=qux"},
+		}, true),
+		Entry("nil labels/volumes/ports keep base (only env replaced)", image.SpecConfig{
+			Env: []string{"FOO=other"},
+		}, true),
+		Entry("removed label", image.SpecConfig{
+			Labels: map[string]string{"b": "2"},
+			Env:    []string{"FOO=bar"},
+		}, false),
+		Entry("removed env var (nil env clears)", image.SpecConfig{
+			Labels: map[string]string{"a": "1"},
+		}, false),
+		Entry("removed env var (non-nil env drops key)", image.SpecConfig{
+			Env: []string{},
+		}, false),
+		Entry("changed env value keeps key", image.SpecConfig{
+			Env: []string{"FOO=changed"},
+		}, true),
+		Entry("removed volume", image.SpecConfig{
+			Env:     []string{"FOO=bar"},
+			Volumes: map[string]struct{}{},
+		}, false),
+		Entry("removed exposed port", image.SpecConfig{
+			Env:          []string{"FOO=bar"},
+			ExposedPorts: map[string]struct{}{},
+		}, false),
+		Entry("ClearHistory", image.SpecConfig{
+			Env:          []string{"FOO=bar"},
+			ClearHistory: true,
+		}, false),
+		Entry("ClearCmd", image.SpecConfig{
+			Env:      []string{"FOO=bar"},
+			ClearCmd: true,
+		}, false),
+		Entry("ClearEntrypoint", image.SpecConfig{
+			Env:             []string{"FOO=bar"},
+			ClearEntrypoint: true,
+		}, false),
+		Entry("ClearUser", image.SpecConfig{
+			Env:       []string{"FOO=bar"},
+			ClearUser: true,
+		}, false),
+		Entry("ClearWorkingDir", image.SpecConfig{
+			Env:             []string{"FOO=bar"},
+			ClearWorkingDir: true,
+		}, false),
+	)
+})

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -6,7 +6,9 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/net/context"
 )
 
@@ -30,6 +32,15 @@ func ContainerAttach(ctx context.Context, ref string, options dockercontainer.At
 
 func ContainerInspect(ctx context.Context, ref string) (types.ContainerJSON, error) {
 	return apiCli(ctx).ContainerInspect(ctx, ref)
+}
+
+func ContainerCreate(ctx context.Context, config *dockercontainer.Config, platform *ocispec.Platform, name string) (string, error) {
+	response, err := apiCli(ctx).ContainerCreate(ctx, config, nil, &network.NetworkingConfig{}, platform, name)
+	if err != nil {
+		return "", err
+	}
+
+	return response.ID, nil
 }
 
 func ContainerCommit(ctx context.Context, ref string, commitOptions dockercontainer.CommitOptions) (string, error) {

--- a/pkg/storage/local_stages_storage.go
+++ b/pkg/storage/local_stages_storage.go
@@ -331,6 +331,17 @@ func (storage *LocalStagesStorage) MutateAndPushImage(ctx context.Context, src, 
 		return err
 	}
 
+	if mutator, ok := storage.ContainerBackend.(container_backend.NativeConfigMutator); ok {
+		err := mutator.MutateAndPushImageNative(ctx, src, dest, newConfig, stageImage.GetTargetPlatform())
+		if err == nil {
+			return nil
+		}
+		if !container_backend.IsNativeMutationUnsupported(err) {
+			return fmt.Errorf("unable to mutate image %q into %q: %w", src, dest, err)
+		}
+		// Fall through to the save/load path when the native mutation declined this config.
+	}
+
 	newId, err := container_backend.MutateAndPushImage(ctx, src, stageImage.GetTargetPlatform(), newConfig, storage.ContainerBackend)
 	if err != nil {
 		return err

--- a/pkg/storage/local_stages_storage_test.go
+++ b/pkg/storage/local_stages_storage_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -55,7 +56,81 @@ var _ = Describe("LocalStagesStorage", func() {
 		Expect(backend.loaded).To(BeTrue())
 		Expect(backend.tagCalls).To(Equal([][2]string{{"sha256:mutated", "tmp-scratch-compare:content-tag"}}))
 	})
+
+	It("uses the native mutator when the backend supports it, bypassing save/load", func(ctx SpecContext) {
+		logCtx := logboek.NewContext(ctx, logboek.NewLogger(io.Discard, io.Discard))
+
+		backend := &nativeMutatorBackendStub{localMutationBackendStub: localMutationBackendStub{}}
+		storage := NewLocalStagesStorage(backend)
+		stageImage := container_backend.NewLegacyStageImage(nil, "tmp-scratch-compare:stage", backend, "linux/amd64")
+
+		newConfig := image.SpecConfig{Labels: map[string]string{"werf-stage-content-digest": "digest"}}
+		err := storage.MutateAndPushImage(logCtx, "tmp-scratch-compare:stage", "tmp-scratch-compare:content-tag", newConfig, stageImage)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(backend.nativeCalls).To(Equal(1))
+		Expect(backend.nativeSrc).To(Equal("tmp-scratch-compare:stage"))
+		Expect(backend.nativeDest).To(Equal("tmp-scratch-compare:content-tag"))
+		Expect(backend.nativeConfig).To(Equal(newConfig))
+		Expect(backend.nativeTargetPlatform).To(Equal("linux/amd64"))
+
+		Expect(backend.savedImageName).To(BeEmpty())
+		Expect(backend.loaded).To(BeFalse())
+		Expect(backend.tagCalls).To(BeEmpty())
+	})
+
+	It("falls back to save/load when the native mutator declines the config", func(ctx SpecContext) {
+		logCtx := logboek.NewContext(ctx, logboek.NewLogger(io.Discard, io.Discard))
+
+		backend := &nativeMutatorBackendStub{nativeErr: container_backend.ErrNativeMutationUnsupported}
+		storage := NewLocalStagesStorage(backend)
+		stageImage := container_backend.NewLegacyStageImage(nil, "tmp-scratch-compare:stage", backend, "")
+
+		err := storage.MutateAndPushImage(logCtx, "tmp-scratch-compare:stage", "tmp-scratch-compare:content-tag", image.SpecConfig{}, stageImage)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(backend.nativeCalls).To(Equal(1))
+		Expect(backend.savedImageName).To(Equal("tmp-scratch-compare:stage"))
+		Expect(backend.loaded).To(BeTrue())
+		Expect(backend.tagCalls).To(Equal([][2]string{{"sha256:mutated", "tmp-scratch-compare:content-tag"}}))
+	})
+
+	It("propagates a native mutator error other than unsupported", func(ctx SpecContext) {
+		logCtx := logboek.NewContext(ctx, logboek.NewLogger(io.Discard, io.Discard))
+
+		backend := &nativeMutatorBackendStub{nativeErr: fmt.Errorf("boom")}
+		storage := NewLocalStagesStorage(backend)
+		stageImage := container_backend.NewLegacyStageImage(nil, "tmp-scratch-compare:stage", backend, "")
+
+		err := storage.MutateAndPushImage(logCtx, "tmp-scratch-compare:stage", "tmp-scratch-compare:content-tag", image.SpecConfig{}, stageImage)
+		Expect(err).To(MatchError(ContainSubstring("boom")))
+
+		Expect(backend.nativeCalls).To(Equal(1))
+		Expect(backend.savedImageName).To(BeEmpty())
+		Expect(backend.loaded).To(BeFalse())
+		Expect(backend.tagCalls).To(BeEmpty())
+	})
 })
+
+type nativeMutatorBackendStub struct {
+	localMutationBackendStub
+
+	nativeCalls          int
+	nativeSrc            string
+	nativeDest           string
+	nativeConfig         image.SpecConfig
+	nativeTargetPlatform string
+	nativeErr            error
+}
+
+func (b *nativeMutatorBackendStub) MutateAndPushImageNative(_ context.Context, src, dest string, newConfig image.SpecConfig, targetPlatform string) error {
+	b.nativeCalls++
+	b.nativeSrc = src
+	b.nativeDest = dest
+	b.nativeConfig = newConfig
+	b.nativeTargetPlatform = targetPlatform
+	return b.nativeErr
+}
 
 func newTinyDockerSaveTar() []byte {
 	ref, err := name.ParseReference("example.com/test:latest")


### PR DESCRIPTION
## Summary

Mutate image config for the `content-tag` and `imageSpec` stages through a native container create+commit instead of the `docker save`/`docker load` (and buildah save/load) tarball roundtrip. This removes an expensive full-image export/import when tagging content-tag and applying imageSpec without `--repo`.

## Key changes

- **Backend interface** (`pkg/container_backend/mutation.go`): add `NativeConfigMutator` interface and `errNativeMutationUnsupported` / `IsNativeMutationUnsupported` for graceful fallback. Add `nativeMutationEligible` gate.
- **Docker backend** (`pkg/container_backend/docker_server_backend.go`): implement `MutateAndPushImageNative` via `docker create` + `docker commit`; add `toPortSet` helper.
- **Docker wrapper** (`pkg/docker/container.go`): add `ContainerCreate`.
- **Buildah backend** (`pkg/buildah/*`, `pkg/container_backend/buildah_backend.go`): add `MutateConfig` (full-replace config mutation) and `CommitMutation` (honors `ClearHistory`/`Created`); implement `MutateAndPushImageNative` via `from` + `commit`.
- **Caller** (`pkg/storage/local_stages_storage.go`): use the native mutator when the backend supports it, falling back to save/load when the mutation is declined.
- **Tests**: eligibility-gate table (`native_mutation_eligible_test.go`), buildah native-mutation flow, and local-storage native-path selection.

## Why

The previous path saved the whole image to a temp tar and loaded it back just to change a few config fields (labels, env, created, parent-stage-id). For large images this is a significant, unnecessary I/O and time cost. Native `docker commit` / buildah `commit` mutate the config in place on the daemon without moving image layers.

## Review focus / risks

- **`nativeMutationEligible` correctness** — docker commit's daemon-side `merge` is **additive-only**: it re-adds base labels/env/volumes for omitted keys, always stamps `created=now()`, appends a history entry, and cannot clear fields. So the docker native path is used *only* when the resolved config is a pure additive superset of the base (no removals, no `Clear*`, no `ClearHistory`); otherwise it returns `errNativeMutationUnsupported` and the caller falls back to save/load. `content-tag` always qualifies; `imageSpec` qualifies unless it removes/clears something. Note: env is compared unconditionally because `UpdateConfigFile` replaces env even when nil.
- **`created` timestamp for imageSpec** — on the docker native path `created` becomes `now()` instead of the base image's value (cosmetic; does not affect stage digest or image name).
- **Buildah path** does full-replace via `MutateConfig` (ClearLabels/ClearEnv + Set), so it needs no eligibility gate and handles removals/clears natively.