### PR TITLE
feat(telemetry): add OpenTelemetry (OTLP) metrics push exporter

### DIFF
--- a/cmd/werf/common/telemetry.go
+++ b/cmd/werf/common/telemetry.go
@@ -39,6 +39,11 @@ func InitTelemetry(ctx context.Context) {
 func ShutdownTelemetry(ctx context.Context, exitCode int) {
 	telemetry.GetTelemetryWerfIO().CommandExited(ctx, exitCode)
 
+	telemetry.MetricsEnd(ctx, exitCode)
+	if err := telemetry.MetricsShutdown(ctx); err != nil {
+		telemetry.LogF("unable to shutdown metrics: %s", err)
+	}
+
 	if err := telemetry.Shutdown(ctx); err != nil {
 		telemetry.LogF("unable to shutdown: %s", err)
 	}
@@ -56,7 +61,18 @@ func TelemetryPreRun(cmd *cobra.Command, args []string) error {
 	}
 
 	InitTelemetry(ctx)
+
+	// Initialize OTLP metrics push exporter if enabled via flags
+	if root := cmd.Root(); root != nil {
+		enabled, _ := root.PersistentFlags().GetBool("telemetry-enabled")
+		endpoint, _ := root.PersistentFlags().GetString("telemetry-otlp-endpoint")
+		if err := telemetry.InitMetrics(ctx, enabled, endpoint); err != nil {
+			telemetry.LogF("error: %s", err)
+		}
+	}
+
 	telemetry.GetTelemetryWerfIO().SetCommand(ctx, command)
+	telemetry.MetricsStart(ctx, command)
 
 	var commandOptions []telemetry.CommandOption
 	for _, fs := range []*flag.FlagSet{cmd.Flags(), cmd.PersistentFlags(), cmd.LocalFlags(), cmd.InheritedFlags()} {

--- a/cmd/werf/common/telemetry.go
+++ b/cmd/werf/common/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -21,6 +22,22 @@ var telemetryIgnoreCommands = []string{
 	"werf synchronization",
 	"werf completion",
 }
+
+// Flag and env var names for the OTLP metrics push exporter. Kept as
+// constants because they're referenced from both root.go (flag
+// registration) and here (flag lookup).
+const (
+	FlagOTLPMetricsEnabled  = "otlp-metrics-enabled"
+	FlagOTLPMetricsEndpoint = "otlp-metrics-endpoint"
+	EnvOTLPMetricsEnabled   = "WERF_OTLP_METRICS_ENABLED"
+	EnvOTLPMetricsEndpoint  = "WERF_OTLP_METRICS_ENDPOINT"
+)
+
+// metricsHandle bridges the PreRun (where the OTLP pipeline is initialized
+// from CLI flags) to ShutdownTelemetry (called once from main.go after the
+// command finishes). pkg/telemetry itself holds no package-level state; see
+// telemetry.MetricsHandle.
+var metricsHandle *telemetry.MetricsHandle
 
 func InitTelemetry(ctx context.Context) {
 	if err := telemetry.Init(ctx, telemetry.TelemetryOptions{
@@ -39,8 +56,8 @@ func InitTelemetry(ctx context.Context) {
 func ShutdownTelemetry(ctx context.Context, exitCode int) {
 	telemetry.GetTelemetryWerfIO().CommandExited(ctx, exitCode)
 
-	telemetry.MetricsEnd(ctx, exitCode)
-	if err := telemetry.MetricsShutdown(ctx); err != nil {
+	metricsHandle.MetricsEnd(ctx, exitCode)
+	if err := metricsHandle.MetricsShutdown(ctx); err != nil {
 		telemetry.LogF("unable to shutdown metrics: %s", err)
 	}
 
@@ -62,17 +79,32 @@ func TelemetryPreRun(cmd *cobra.Command, args []string) error {
 
 	InitTelemetry(ctx)
 
-	// Initialize OTLP metrics push exporter if enabled via flags
+	// Initialize OTLP metrics push exporter if enabled via flags/env.
 	if root := cmd.Root(); root != nil {
-		enabled, _ := root.PersistentFlags().GetBool("telemetry-enabled")
-		endpoint, _ := root.PersistentFlags().GetString("telemetry-otlp-endpoint")
-		if err := telemetry.InitMetrics(ctx, enabled, endpoint); err != nil {
+		enabled, err := root.PersistentFlags().GetBool(FlagOTLPMetricsEnabled)
+		if err != nil {
+			return fmt.Errorf("get --%s flag: %w", FlagOTLPMetricsEnabled, err)
+		}
+		endpoint, err := root.PersistentFlags().GetString(FlagOTLPMetricsEndpoint)
+		if err != nil {
+			return fmt.Errorf("get --%s flag: %w", FlagOTLPMetricsEndpoint, err)
+		}
+
+		handle, err := telemetry.InitMetrics(ctx, enabled, endpoint)
+		if err != nil {
+			if enabled {
+				// The user explicitly opted in: a misconfiguration must be
+				// visible instead of silently discarded (telemetry.LogF only
+				// writes when WERF_TELEMETRY_LOG_FILE is set).
+				fmt.Fprintf(os.Stderr, "WARNING: otlp metrics: %s\n", err)
+			}
 			telemetry.LogF("error: %s", err)
 		}
+		metricsHandle = handle
 	}
 
 	telemetry.GetTelemetryWerfIO().SetCommand(ctx, command)
-	telemetry.MetricsStart(ctx, command)
+	metricsHandle.MetricsStart(ctx, command)
 
 	var commandOptions []telemetry.CommandOption
 	for _, fs := range []*flag.FlagSet{cmd.Flags(), cmd.PersistentFlags(), cmd.LocalFlags(), cmd.InheritedFlags()} {

--- a/cmd/werf/root/root.go
+++ b/cmd/werf/root/root.go
@@ -140,6 +140,10 @@ func ConstructRootCmd(ctx context.Context) (*cobra.Command, error) {
 
 	templates.ActsAsRootCommand(rootCmd, *groups...)
 
+	// Global telemetry flags (OTLP metrics push)
+	rootCmd.PersistentFlags().Bool("telemetry-enabled", false, "Enable OTLP metrics exporter (push)")
+	rootCmd.PersistentFlags().String("telemetry-otlp-endpoint", "", "OTLP collector endpoint, e.g., http://collector:4318/v1/metrics")
+
 	return rootCmd, nil
 }
 

--- a/cmd/werf/root/root.go
+++ b/cmd/werf/root/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/werf/common-go/pkg/util"
 	"github.com/werf/werf/v2/cmd/werf/build"
 	bundle_apply "github.com/werf/werf/v2/cmd/werf/bundle/apply"
 	bundle_copy "github.com/werf/werf/v2/cmd/werf/bundle/copy"
@@ -140,9 +141,8 @@ func ConstructRootCmd(ctx context.Context) (*cobra.Command, error) {
 
 	templates.ActsAsRootCommand(rootCmd, *groups...)
 
-	// Global telemetry flags (OTLP metrics push)
-	rootCmd.PersistentFlags().Bool("telemetry-enabled", false, "Enable OTLP metrics exporter (push)")
-	rootCmd.PersistentFlags().String("telemetry-otlp-endpoint", "", "OTLP collector endpoint, e.g., http://collector:4318/v1/metrics")
+	rootCmd.PersistentFlags().Bool(common.FlagOTLPMetricsEnabled, util.GetBoolEnvironmentDefaultFalse(common.EnvOTLPMetricsEnabled), fmt.Sprintf("Enable pushing werf_runs/werf_run_duration_seconds metrics to an OTLP HTTP collector (default $%s). Unauthenticated collectors only", common.EnvOTLPMetricsEnabled))
+	rootCmd.PersistentFlags().String(common.FlagOTLPMetricsEndpoint, os.Getenv(common.EnvOTLPMetricsEndpoint), fmt.Sprintf("OTLP metrics collector endpoint, e.g. http://collector:4318/v1/metrics (default $%s)", common.EnvOTLPMetricsEndpoint))
 
 	return rootCmd, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -370,11 +370,11 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.46.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.44.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v0.44.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v0.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.21.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.44.0 // indirect
-	go.opentelemetry.io/otel/metric v1.24.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.21.0 // indirect
+	go.opentelemetry.io/otel/metric v1.24.0
+	go.opentelemetry.io/otel/sdk/metric v1.21.0
 	go.opentelemetry.io/proto/otlp v1.1.0 // indirect
 	go.starlark.net v0.0.0-20231121155337-90ade8b19d09 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/pkg/telemetry/otlp_metrics.go
+++ b/pkg/telemetry/otlp_metrics.go
@@ -1,0 +1,126 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	neturl "net/url"
+	"runtime"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// Metrics push exporter (OTLP). NOP-safe when disabled.
+
+var metricsState struct {
+	mu       sync.Mutex
+	enabled  bool
+	provider *sdkmetric.MeterProvider
+	meter    metric.Meter
+	start    time.Time
+	command  string
+}
+
+// InitMetrics initializes the OTLP metrics pipeline when enabled.
+// endpoint example: http://collector:4318/v1/metrics or https://collector/v1/metrics
+func InitMetrics(ctx context.Context, enabled bool, endpoint string) error {
+	metricsState.mu.Lock()
+	defer metricsState.mu.Unlock()
+
+	if !enabled {
+		metricsState.enabled = false
+		return nil
+	}
+	if endpoint == "" {
+		return fmt.Errorf("telemetry enabled but --telemetry-otlp-endpoint is empty")
+	}
+
+	urlObj, err := neturl.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("bad otlp endpoint: %w", err)
+	}
+
+	var opts []otlpmetrichttp.Option
+	if urlObj.Scheme == "http" {
+		opts = append(opts, otlpmetrichttp.WithInsecure())
+	}
+	opts = append(opts,
+		otlpmetrichttp.WithEndpoint(urlObj.Host),
+		otlpmetrichttp.WithURLPath(urlObj.Path),
+		otlpmetrichttp.WithTimeout(5*time.Second),
+		otlpmetrichttp.WithRetry(otlpmetrichttp.RetryConfig{Enabled: false}),
+	)
+
+	client := otlpmetrichttp.NewClient(opts...)
+	exporter, err := otlpmetric.New(ctx, client)
+	if err != nil {
+		return fmt.Errorf("create otlp metric exporter: %w", err)
+	}
+
+	reader := sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(2*time.Second))
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	otel.SetMeterProvider(provider)
+	metricsState.provider = provider
+	metricsState.meter = otel.Meter("github.com/werf/werf")
+	metricsState.enabled = true
+	return nil
+}
+
+// MetricsStart marks the beginning of a command execution.
+func MetricsStart(_ context.Context, command string) {
+	metricsState.mu.Lock()
+	defer metricsState.mu.Unlock()
+	if !metricsState.enabled {
+		return
+	}
+	metricsState.command = command
+	metricsState.start = time.Now()
+}
+
+// MetricsEnd records final counters/histograms with exit code and duration.
+func MetricsEnd(ctx context.Context, exitCode int) {
+	metricsState.mu.Lock()
+	enabled := metricsState.enabled
+	meter := metricsState.meter
+	command := metricsState.command
+	start := metricsState.start
+	metricsState.mu.Unlock()
+
+	if !enabled {
+		return
+	}
+
+	runs, _ := meter.Int64Counter("werf_runs")
+	dur, _ := meter.Float64Histogram("werf_run_duration_seconds")
+
+	attrs := []attribute.KeyValue{
+		attribute.String("command", command),
+		attribute.String("os", runtime.GOOS),
+		attribute.String("arch", runtime.GOARCH),
+		attribute.Int("exit_code", exitCode),
+	}
+
+	runs.Add(ctx, 1, attrs...)
+	if !start.IsZero() {
+		dur.Record(ctx, time.Since(start).Seconds(), attrs...)
+	}
+}
+
+// MetricsShutdown flushes and shuts down the provider.
+func MetricsShutdown(ctx context.Context) error {
+	metricsState.mu.Lock()
+	defer metricsState.mu.Unlock()
+	if !metricsState.enabled || metricsState.provider == nil {
+		return nil
+	}
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return metricsState.provider.Shutdown(cctx)
+}

--- a/pkg/telemetry/otlp_metrics.go
+++ b/pkg/telemetry/otlp_metrics.go
@@ -10,7 +10,6 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -18,32 +17,43 @@ import (
 
 // Metrics push exporter (OTLP). NOP-safe when disabled.
 
-var metricsState struct {
+// MetricsHandle is an opaque handle for a single InitMetrics/MetricsEnd/
+// MetricsShutdown lifecycle. Passing it explicitly (instead of a package-level
+// global) keeps the pipeline testable.
+type MetricsHandle struct {
 	mu       sync.Mutex
 	enabled  bool
 	provider *sdkmetric.MeterProvider
-	meter    metric.Meter
+	runs     metric.Int64Counter
+	dur      metric.Float64Histogram
 	start    time.Time
 	command  string
 }
 
-// InitMetrics initializes the OTLP metrics pipeline when enabled.
+// InitMetrics initializes the OTLP metrics pipeline when enabled and returns a
+// handle for the rest of the lifecycle. When disabled, it returns a No-Op
+// handle so callers can unconditionally call MetricsStart/End/Shutdown.
 // endpoint example: http://collector:4318/v1/metrics or https://collector/v1/metrics
-func InitMetrics(ctx context.Context, enabled bool, endpoint string) error {
-	metricsState.mu.Lock()
-	defer metricsState.mu.Unlock()
-
+func InitMetrics(ctx context.Context, enabled bool, endpoint string) (*MetricsHandle, error) {
+	h := &MetricsHandle{}
 	if !enabled {
-		metricsState.enabled = false
-		return nil
+		return h, nil
 	}
 	if endpoint == "" {
-		return fmt.Errorf("telemetry enabled but --telemetry-otlp-endpoint is empty")
+		return h, fmt.Errorf("otlp metrics enabled but endpoint is not set")
 	}
 
 	urlObj, err := neturl.Parse(endpoint)
 	if err != nil {
-		return fmt.Errorf("bad otlp endpoint: %w", err)
+		return h, fmt.Errorf("parse otlp endpoint: %w", err)
+	}
+	switch urlObj.Scheme {
+	case "http", "https":
+	default:
+		return h, fmt.Errorf("parse otlp endpoint: unsupported scheme %q (must be http or https)", urlObj.Scheme)
+	}
+	if urlObj.Host == "" {
+		return h, fmt.Errorf("parse otlp endpoint: missing host in %q", endpoint)
 	}
 
 	var opts []otlpmetrichttp.Option
@@ -54,51 +64,68 @@ func InitMetrics(ctx context.Context, enabled bool, endpoint string) error {
 		otlpmetrichttp.WithEndpoint(urlObj.Host),
 		otlpmetrichttp.WithURLPath(urlObj.Path),
 		otlpmetrichttp.WithTimeout(5*time.Second),
-		otlpmetrichttp.WithRetry(otlpmetrichttp.RetryConfig{Enabled: false}),
 	)
 
-	client := otlpmetrichttp.NewClient(opts...)
-	exporter, err := otlpmetric.New(ctx, client)
+	exporter, err := otlpmetrichttp.New(ctx, opts...)
 	if err != nil {
-		return fmt.Errorf("create otlp metric exporter: %w", err)
+		return h, fmt.Errorf("create otlp metric exporter: %w", err)
 	}
 
-	reader := sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(2*time.Second))
+	// No WithInterval: this is a short-lived CLI process, so the only
+	// guaranteed delivery point is the forced flush inside provider.Shutdown.
+	reader := sdkmetric.NewPeriodicReader(exporter)
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 
+	meter := provider.Meter("github.com/werf/werf")
+	runs, err := meter.Int64Counter("werf_runs")
+	if err != nil {
+		return h, fmt.Errorf("create werf_runs counter: %w", err)
+	}
+	dur, err := meter.Float64Histogram("werf_run_duration_seconds")
+	if err != nil {
+		return h, fmt.Errorf("create werf_run_duration_seconds histogram: %w", err)
+	}
+
 	otel.SetMeterProvider(provider)
-	metricsState.provider = provider
-	metricsState.meter = otel.Meter("github.com/werf/werf")
-	metricsState.enabled = true
-	return nil
+	h.provider = provider
+	h.runs = runs
+	h.dur = dur
+	h.enabled = true
+	return h, nil
 }
 
-// MetricsStart marks the beginning of a command execution.
-func MetricsStart(_ context.Context, command string) {
-	metricsState.mu.Lock()
-	defer metricsState.mu.Unlock()
-	if !metricsState.enabled {
+// MetricsStart marks the beginning of a command execution. Safe to call on a
+// nil handle (no-op), so callers don't need to guard InitMetrics failures.
+func (h *MetricsHandle) MetricsStart(_ context.Context, command string) {
+	if h == nil {
 		return
 	}
-	metricsState.command = command
-	metricsState.start = time.Now()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.enabled {
+		return
+	}
+	h.command = command
+	h.start = time.Now()
 }
 
 // MetricsEnd records final counters/histograms with exit code and duration.
-func MetricsEnd(ctx context.Context, exitCode int) {
-	metricsState.mu.Lock()
-	enabled := metricsState.enabled
-	meter := metricsState.meter
-	command := metricsState.command
-	start := metricsState.start
-	metricsState.mu.Unlock()
+// Safe to call on a nil handle (no-op).
+func (h *MetricsHandle) MetricsEnd(ctx context.Context, exitCode int) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	enabled := h.enabled
+	runs := h.runs
+	dur := h.dur
+	command := h.command
+	start := h.start
+	h.mu.Unlock()
 
 	if !enabled {
 		return
 	}
-
-	runs, _ := meter.Int64Counter("werf_runs")
-	dur, _ := meter.Float64Histogram("werf_run_duration_seconds")
 
 	attrs := []attribute.KeyValue{
 		attribute.String("command", command),
@@ -107,20 +134,24 @@ func MetricsEnd(ctx context.Context, exitCode int) {
 		attribute.Int("exit_code", exitCode),
 	}
 
-	runs.Add(ctx, 1, attrs...)
+	runs.Add(ctx, 1, metric.WithAttributes(attrs...))
 	if !start.IsZero() {
-		dur.Record(ctx, time.Since(start).Seconds(), attrs...)
+		dur.Record(ctx, time.Since(start).Seconds(), metric.WithAttributes(attrs...))
 	}
 }
 
-// MetricsShutdown flushes and shuts down the provider.
-func MetricsShutdown(ctx context.Context) error {
-	metricsState.mu.Lock()
-	defer metricsState.mu.Unlock()
-	if !metricsState.enabled || metricsState.provider == nil {
+// MetricsShutdown flushes and shuts down the provider. Safe to call on a nil
+// handle (no-op).
+func (h *MetricsHandle) MetricsShutdown(ctx context.Context) error {
+	if h == nil {
+		return nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.enabled || h.provider == nil {
 		return nil
 	}
 	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	return metricsState.provider.Shutdown(cctx)
+	return h.provider.Shutdown(cctx)
 }

--- a/pkg/telemetry/otlp_metrics_test.go
+++ b/pkg/telemetry/otlp_metrics_test.go
@@ -1,0 +1,63 @@
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitMetrics_Disabled(t *testing.T) {
+	h, err := InitMetrics(context.Background(), false, "")
+	require.NoError(t, err)
+	require.NotNil(t, h)
+
+	// No-Op path must be safe to drive through the full lifecycle.
+	h.MetricsStart(context.Background(), "werf build")
+	h.MetricsEnd(context.Background(), 0)
+	require.NoError(t, h.MetricsShutdown(context.Background()))
+}
+
+func TestInitMetrics_EnabledWithoutEndpoint(t *testing.T) {
+	_, err := InitMetrics(context.Background(), true, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "endpoint is not set")
+}
+
+func TestInitMetrics_RejectsUnsupportedScheme(t *testing.T) {
+	_, err := InitMetrics(context.Background(), true, "ftp://collector:4318/v1/metrics")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported scheme")
+}
+
+func TestInitMetrics_RejectsMissingHost(t *testing.T) {
+	_, err := InitMetrics(context.Background(), true, "http:///v1/metrics")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing host")
+}
+
+func TestInitMetrics_EnabledLifecycle(t *testing.T) {
+	// A fake local OTLP collector so the shutdown flush has somewhere to
+	// succeed, instead of depending on a real network endpoint.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h, err := InitMetrics(context.Background(), true, srv.URL+"/v1/metrics")
+	require.NoError(t, err)
+	require.NotNil(t, h)
+
+	h.MetricsStart(context.Background(), "werf build")
+	h.MetricsEnd(context.Background(), 0)
+	require.NoError(t, h.MetricsShutdown(context.Background()))
+}
+
+func TestMetricsHandle_NilIsSafe(t *testing.T) {
+	var h *MetricsHandle
+	h.MetricsStart(context.Background(), "werf build")
+	h.MetricsEnd(context.Background(), 0)
+	require.NoError(t, h.MetricsShutdown(context.Background()))
+}


### PR DESCRIPTION
While evaluating werf's behavior within automated and ephemeral CI/CD environments, we identified that a push-based telemetry framework is useful for capturing basic run metrics before the short-lived CLI process terminates.

Architectural approach:
- Introduces an OTLP metrics push exporter using the standard `otlpmetrichttp` driver.
- Isolated in `pkg/telemetry`; falls back to a safe No-Op path when disabled. `InitMetrics` returns a `*MetricsHandle` (no package-level mutable state), so the pipeline can be unit tested directly.
- Wired into the existing `TelemetryPreRun`/`ShutdownTelemetry` hooks; a forced flush happens at shutdown (no periodic interval, since the process is short-lived).

Changes:
- `pkg/telemetry/otlp_metrics.go`: MeterProvider init + the two emitted instruments.
- Root CLI flags `--otlp-metrics-enabled` (bool, default false) and `--otlp-metrics-endpoint` (string), each with a `WERF_OTLP_METRICS_ENABLED` / `WERF_OTLP_METRICS_ENDPOINT` env fallback like other werf flags. Renamed from the original `--telemetry-enabled`/`--telemetry-otlp-endpoint` to avoid implying this controls werf's existing, separate `WERF_TELEMETRY` mechanism.
- Endpoint is validated (scheme must be `http`/`https`, host required) before the exporter is constructed.
- Tests covering the No-Op path, endpoint validation, and the full start/end/shutdown lifecycle.

What is actually emitted (scoped down from the original description):
- `werf_runs` (counter) and `werf_run_duration_seconds` (histogram), tagged with `command`, `os`, `arch`, `exit_code`.
- Only unauthenticated OTLP HTTP collectors are supported right now (e.g. an OpenTelemetry Collector in front of Prometheus/Grafana). Datadog/Honeycomb-style endpoints that require an API-key header are **not** supported yet — no `otlpmetrichttp.WithHeaders` wiring exists. Happy to add a headers option in a follow-up if there's interest.

This revision addresses the review feedback: fixed the otel v1.24 API mismatch (branch didn't compile before), promoted `otlpmetrichttp`/`sdk/metric` to direct `go.mod` dependencies, stopped discarding errors, and renamed the flags per the naming-collision concern.
