### PR TITLE
feat(config): add dependencies.from directive, deprecate dependencies.image

### DIFF
--- a/docs/_data/werf_yaml.yml
+++ b/docs/_data/werf_yaml.yml
@@ -359,11 +359,16 @@ sections:
         collapsible: true
         isCollapsedByDefault: false
         directiveList:
-          - name: image
+          - name: from
             value: "string"
             description:
               en: "Dependency image name, which should be built before building current image"
               ru: "Имя зависимого образа, который должен быть собран до сборки текущего образа"
+          - name: image
+            value: "string"
+            description:
+              en: "Dependency image name, which should be built before building current image (DEPRECATED)"
+              ru: "Имя зависимого образа, который должен быть собран до сборки текущего образа (DEPRECATED)"
           - name: imports
             description:
               en: "Define target build args to import image information into current image (optional)"
@@ -846,11 +851,16 @@ sections:
         collapsible: true
         isCollapsedByDefault: false
         directiveList:
-          - name: image
+          - name: from
             value: "string"
             description:
               en: "Dependency image name, which should be built before building current image"
               ru: "Имя зависимого образа, который должен быть собран до сборки текущего образа"
+          - name: image
+            value: "string"
+            description:
+              en: "Dependency image name, which should be built before building current image (DEPRECATED)"
+              ru: "Имя зависимого образа, который должен быть собран до сборки текущего образа (DEPRECATED)"
           - name: before
             value: "string"
             description:

--- a/docs/pages_en/usage/build/images.md
+++ b/docs/pages_en/usage/build/images.md
@@ -610,7 +610,7 @@ dockerfile: base.Dockerfile
 image: app
 dockerfile: Dockerfile
 dependencies:
-- image: base
+- from: base
   imports:
   - type: ImageName
     targetBuildArg: BASE_IMAGE
@@ -636,7 +636,7 @@ shell:
 image: app
 dockerfile: Dockerfile
 dependencies:
-- image: builder
+- from: builder
   imports:
   - type: ImageName
     targetBuildArg: BUILDER_IMAGE
@@ -705,13 +705,13 @@ context: modules/controlplane/
 image: app
 dockerfile: Dockerfile
 dependencies:
-- image: auth
+- from: auth
   imports:
   - type: ImageName
     targetBuildArg: AUTH_IMAGE_NAME
   - type: ImageDigest
     targetBuildArg: AUTH_IMAGE_DIGEST
-- image: controlplane
+- from: controlplane
   imports:
   - type: ImageName
     targetBuildArg: CONTROLPLANE_IMAGE_NAME
@@ -744,7 +744,7 @@ dockerfile: Dockerfile.builder
 image: app
 dockerfile: Dockerfile.app
 dependencies:
-- image: builder
+- from: builder
   imports:
   - type: ImageName
     targetBuildArg: BUILDER_IMAGE_NAME

--- a/docs/pages_ru/usage/build/images.md
+++ b/docs/pages_ru/usage/build/images.md
@@ -608,7 +608,7 @@ dockerfile: base.Dockerfile
 image: app
 dockerfile: Dockerfile
 dependencies:
-- image: base
+- from: base
   imports:
   - type: ImageName
     targetBuildArg: BASE_IMAGE
@@ -634,7 +634,7 @@ shell:
 image: app
 dockerfile: Dockerfile
 dependencies:
-- image: builder
+- from: builder
   imports:
   - type: ImageName
     targetBuildArg: BUILDER_IMAGE
@@ -703,13 +703,13 @@ context: modules/controlplane/
 image: app
 dockerfile: Dockerfile
 dependencies:
-- image: auth
+- from: auth
   imports:
   - type: ImageName
     targetBuildArg: AUTH_IMAGE_NAME
   - type: ImageDigest
     targetBuildArg: AUTH_IMAGE_DIGEST
-- image: controlplane
+- from: controlplane
   imports:
   - type: ImageName
     targetBuildArg: CONTROLPLANE_IMAGE_NAME
@@ -742,7 +742,7 @@ dockerfile: Dockerfile.builder
 image: app
 dockerfile: Dockerfile.app
 dependencies:
-- image: builder
+- from: builder
   imports:
   - type: ImageName
     targetBuildArg: BUILDER_IMAGE_NAME

--- a/pkg/build/stage/data_test.go
+++ b/pkg/build/stage/data_test.go
@@ -39,7 +39,7 @@ func (dep *TestDependency) GetDockerImageName() string {
 }
 
 func (dep *TestDependency) ToConfigDependency() *config.Dependency {
-	depCfg := &config.Dependency{ImageName: dep.ImageName}
+	depCfg := &config.Dependency{From: dep.ImageName}
 
 	if dep.TargetEnvImageName != "" {
 		depCfg.Imports = append(depCfg.Imports, &config.DependencyImport{

--- a/pkg/build/stage/dependencies.go
+++ b/pkg/build/stage/dependencies.go
@@ -74,7 +74,7 @@ func (s *DependenciesStage) GetDependencies(ctx context.Context, c Conveyor, _ c
 	}
 
 	for _, dep := range s.dependencies {
-		args = append(args, "Dependency", c.GetImageContentTagStageID(s.targetPlatform, dep.ImageName))
+		args = append(args, "Dependency", c.GetImageContentTagStageID(s.targetPlatform, dep.From))
 		for _, imp := range dep.Imports {
 			args = append(args, "DependencyImport", getDependencyImportID(imp))
 		}
@@ -111,8 +111,8 @@ func (s *DependenciesStage) prepareImageWithLegacyStapelBuilder(ctx context.Cont
 	for _, dep := range s.dependencies {
 		depImageServiceOptions := stageImage.Builder.LegacyStapelStageBuilder().Container().ServiceCommitChangeOptions()
 
-		depImageName := c.GetImageContentTagName(s.targetPlatform, dep.ImageName)
-		depImageDigest := c.GetImageContentTagDigest(s.targetPlatform, dep.ImageName)
+		depImageName := c.GetImageContentTagName(s.targetPlatform, dep.From)
+		depImageDigest := c.GetImageContentTagDigest(s.targetPlatform, dep.From)
 		depImageRepo, depImageTag := image.ParseRepositoryAndTag(depImageName)
 
 		for _, img := range dep.Imports {
@@ -165,8 +165,8 @@ func (s *DependenciesStage) prepareImage(ctx context.Context, c Conveyor, cr con
 	}
 
 	for _, dep := range s.dependencies {
-		depImageName := c.GetImageContentTagName(s.targetPlatform, dep.ImageName)
-		depImageDigest := c.GetImageContentTagDigest(s.targetPlatform, dep.ImageName)
+		depImageName := c.GetImageContentTagName(s.targetPlatform, dep.From)
+		depImageDigest := c.GetImageContentTagDigest(s.targetPlatform, dep.From)
 		depImageRepo, depImageTag := image.ParseRepositoryAndTag(depImageName)
 
 		for _, img := range dep.Imports {

--- a/pkg/build/stage/dependencies_test.go
+++ b/pkg/build/stage/dependencies_test.go
@@ -298,28 +298,28 @@ var _ = Describe("getDependencies helper", func() {
 			img := &config.StapelImageBase{
 				Dependencies: []*config.Dependency{
 					{
-						ImageName: "one",
-						Before:    "setup",
+						From:   "one",
+						Before: "setup",
 					},
 					{
-						ImageName: "two",
-						Before:    "setup",
+						From:   "two",
+						Before: "setup",
 					},
 					{
-						ImageName: "three",
-						Before:    "install",
+						From:   "three",
+						Before: "install",
 					},
 					{
-						ImageName: "four",
-						After:     "install",
+						From:  "four",
+						After: "install",
 					},
 					{
-						ImageName: "five",
-						After:     "install",
+						From:  "five",
+						After: "install",
 					},
 					{
-						ImageName: "six",
-						After:     "setup",
+						From:  "six",
+						After: "setup",
 					},
 				},
 			}
@@ -327,27 +327,27 @@ var _ = Describe("getDependencies helper", func() {
 			{
 				deps := getDependencies(img, &getImportsOptions{Before: "install"})
 				Expect(len(deps)).To(Equal(1))
-				Expect(deps[0].ImageName).To(Equal("three"))
+				Expect(deps[0].From).To(Equal("three"))
 			}
 
 			{
 				deps := getDependencies(img, &getImportsOptions{After: "install"})
 				Expect(len(deps)).To(Equal(2))
-				Expect(deps[0].ImageName).To(Equal("four"))
-				Expect(deps[1].ImageName).To(Equal("five"))
+				Expect(deps[0].From).To(Equal("four"))
+				Expect(deps[1].From).To(Equal("five"))
 			}
 
 			{
 				deps := getDependencies(img, &getImportsOptions{Before: "setup"})
 				Expect(len(deps)).To(Equal(2))
-				Expect(deps[0].ImageName).To(Equal("one"))
-				Expect(deps[1].ImageName).To(Equal("two"))
+				Expect(deps[0].From).To(Equal("one"))
+				Expect(deps[1].From).To(Equal("two"))
 			}
 
 			{
 				deps := getDependencies(img, &getImportsOptions{After: "setup"})
 				Expect(len(deps)).To(Equal(1))
-				Expect(deps[0].ImageName).To(Equal("six"))
+				Expect(deps[0].From).To(Equal("six"))
 			}
 		})
 	})

--- a/pkg/build/stage/dependencies_utils.go
+++ b/pkg/build/stage/dependencies_utils.go
@@ -21,8 +21,8 @@ func ResolveDependenciesArgs(targetPlatform string, dependencies []*config.Depen
 	resolved := make(map[string]string)
 
 	for _, dep := range dependencies {
-		depImageName := c.GetImageContentTagName(targetPlatform, dep.ImageName)
-		depImageDigest := c.GetImageContentTagDigest(targetPlatform, dep.ImageName)
+		depImageName := c.GetImageContentTagName(targetPlatform, dep.From)
+		depImageDigest := c.GetImageContentTagDigest(targetPlatform, dep.From)
 		depImageRepo, depImageTag := image.ParseRepositoryAndTag(depImageName)
 
 		for _, imp := range dep.Imports {

--- a/pkg/build/stage/full_dockerfile.go
+++ b/pkg/build/stage/full_dockerfile.go
@@ -615,7 +615,7 @@ func (s *FullDockerfileStage) PrepareImage(ctx context.Context, c Conveyor, cb c
 	}
 
 	for _, dep := range s.dependencies {
-		depStageID := c.GetImageContentTagStageID(s.targetPlatform, dep.ImageName)
+		depStageID := c.GetImageContentTagStageID(s.targetPlatform, dep.From)
 		stageImage.Builder.DockerfileBuilder().AppendLabels(fmt.Sprintf("%s=%s", dependencyLabelKey(depStageID), depStageID))
 	}
 

--- a/pkg/build/stage/instruction/from_test.go
+++ b/pkg/build/stage/instruction/from_test.go
@@ -61,7 +61,7 @@ var _ = Describe("FROM dependency expansion", func() {
 
 	deps := []*config.Dependency{
 		{
-			ImageName: "ssr",
+			From: "ssr",
 			Imports: []*config.DependencyImport{
 				{Type: config.ImageNameImport, TargetBuildArg: "SSR_IMAGE"},
 			},

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -8,17 +8,17 @@ import (
 )
 
 type Dependency struct {
-	ImageName string
-	Before    string
-	After     string
-	Imports   []*DependencyImport
+	From    string
+	Before  string
+	After   string
+	Imports []*DependencyImport
 
 	raw *rawDependency
 }
 
 func (d *Dependency) validate() error {
-	if d.ImageName == "" {
-		return newDetailedConfigError("image name is not specified for dependency", d.raw, d.raw.doc())
+	if d.From == "" {
+		return newDetailedConfigError("`from: NAME` is not specified for dependency (or deprecated `image: NAME`)", d.raw, d.raw.doc())
 	}
 
 	switch imageType := d.raw.imageType(); imageType {

--- a/pkg/config/image_from_dockerfile.go
+++ b/pkg/config/image_from_dockerfile.go
@@ -90,7 +90,7 @@ func (c *ImageFromDockerfile) dependsOn() DependsOn {
 	var dependsOn DependsOn
 
 	for _, dep := range c.Dependencies {
-		dependsOn.Dependencies = append(dependsOn.Dependencies, dep.ImageName)
+		dependsOn.Dependencies = append(dependsOn.Dependencies, dep.From)
 	}
 	dependsOn.Dependencies = util.UniqStrings(dependsOn.Dependencies)
 

--- a/pkg/config/raw_dependency.go
+++ b/pkg/config/raw_dependency.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"context"
+
+	"github.com/werf/werf/v2/pkg/werf/global_warnings"
+)
+
 type dependencyImageType string
 
 var (
@@ -9,7 +15,8 @@ var (
 )
 
 type rawDependency struct {
-	Image   string                 `yaml:"image,omitempty"`
+	From    string                 `yaml:"from,omitempty"`
+	Image   string                 `yaml:"image,omitempty"` // Deprecated: use `from` instead.
 	Before  string                 `yaml:"before,omitempty"`
 	After   string                 `yaml:"after,omitempty"`
 	Imports []*rawDependencyImport `yaml:"imports,omitempty"`
@@ -48,6 +55,14 @@ func (d *rawDependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
+	if d.Image != "" {
+		if d.From != "" {
+			return newDetailedConfigError("specify only `from: NAME` or deprecated `image: NAME` for dependency, not both!", d, d.doc())
+		}
+		global_warnings.GlobalDeprecationWarningLn(context.Background(), "`image: NAME` for dependency is deprecated and will be removed in a future version, use `from: NAME` instead.")
+		d.From = d.Image
+	}
+
 	if err := checkOverflow(d.UnsupportedAttributes, d, d.doc()); err != nil {
 		return err
 	}
@@ -57,10 +72,10 @@ func (d *rawDependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 func (d *rawDependency) toDirective() (*Dependency, error) {
 	dependency := &Dependency{
-		ImageName: d.Image,
-		Before:    d.Before,
-		After:     d.After,
-		raw:       d,
+		From:   d.From,
+		Before: d.Before,
+		After:  d.After,
+		raw:    d,
 	}
 
 	for _, rawDepImport := range d.Imports {

--- a/pkg/config/raw_image_from_dockerfile_test.go
+++ b/pkg/config/raw_image_from_dockerfile_test.go
@@ -83,7 +83,7 @@ var _ = Describe("rawImageFromDockerfile", func() {
 			Expect(err).To(Succeed())
 
 			for i, expectedDep := range expected {
-				Expect(expectedDep.ImageName).To(Equal(dockerfileImage.Dependencies[i].ImageName))
+				Expect(expectedDep.From).To(Equal(dockerfileImage.Dependencies[i].From))
 				Expect(expectedDep.After).To(Equal(dockerfileImage.Dependencies[i].After))
 				Expect(expectedDep.Before).To(Equal(dockerfileImage.Dependencies[i].Before))
 
@@ -104,7 +104,7 @@ var _ = Describe("rawImageFromDockerfile", func() {
 				}},
 			},
 			[]*Dependency{{
-				ImageName: "image2",
+				From: "image2",
 			}},
 		),
 		Entry(
@@ -121,7 +121,7 @@ var _ = Describe("rawImageFromDockerfile", func() {
 				}},
 			},
 			[]*Dependency{{
-				ImageName: "image2",
+				From: "image2",
 				Imports: []*DependencyImport{{
 					Type:           ImageTagImport,
 					TargetBuildArg: "IMAGE_TAG",
@@ -178,10 +178,10 @@ var _ = Describe("rawImageFromDockerfile", func() {
 			},
 			[]*Dependency{
 				{
-					ImageName: "image2",
+					From: "image2",
 				},
 				{
-					ImageName: "image3",
+					From: "image3",
 					Imports: []*DependencyImport{
 						{
 							Type:           ImageTagImport,
@@ -194,7 +194,7 @@ var _ = Describe("rawImageFromDockerfile", func() {
 					},
 				},
 				{
-					ImageName: "image4",
+					From: "image4",
 					Imports: []*DependencyImport{
 						{
 							Type:           ImageTagImport,

--- a/pkg/config/raw_stapel_image_test.go
+++ b/pkg/config/raw_stapel_image_test.go
@@ -85,7 +85,7 @@ var _ = Describe("rawStapelImage", func() {
 			Expect(err).To(Succeed())
 
 			for i, expectedDep := range expected {
-				Expect(expectedDep.ImageName).To(Equal(stapelImage.Dependencies[i].ImageName))
+				Expect(expectedDep.From).To(Equal(stapelImage.Dependencies[i].From))
 				Expect(expectedDep.After).To(Equal(stapelImage.Dependencies[i].After))
 				Expect(expectedDep.Before).To(Equal(stapelImage.Dependencies[i].Before))
 
@@ -107,8 +107,8 @@ var _ = Describe("rawStapelImage", func() {
 				}},
 			},
 			[]*Dependency{{
-				ImageName: "image2",
-				Before:    "install",
+				From:   "image2",
+				Before: "install",
 			}},
 		),
 		Entry(
@@ -126,8 +126,8 @@ var _ = Describe("rawStapelImage", func() {
 				}},
 			},
 			[]*Dependency{{
-				ImageName: "image2",
-				Before:    "install",
+				From:   "image2",
+				Before: "install",
 				Imports: []*DependencyImport{{
 					Type:      ImageTagImport,
 					TargetEnv: "IMAGE_TAG",
@@ -184,12 +184,12 @@ var _ = Describe("rawStapelImage", func() {
 			},
 			[]*Dependency{
 				{
-					ImageName: "image2",
-					Before:    "install",
+					From:   "image2",
+					Before: "install",
 				},
 				{
-					ImageName: "image3",
-					After:     "install",
+					From:  "image3",
+					After: "install",
 					Imports: []*DependencyImport{
 						{
 							Type:      ImageTagImport,
@@ -202,8 +202,8 @@ var _ = Describe("rawStapelImage", func() {
 					},
 				},
 				{
-					ImageName: "image4",
-					After:     "setup",
+					From:  "image4",
+					After: "setup",
 					Imports: []*DependencyImport{
 						{
 							Type:      ImageTagImport,

--- a/pkg/config/stapel_image_base.go
+++ b/pkg/config/stapel_image_base.go
@@ -70,7 +70,7 @@ func (c *StapelImageBase) dependsOn() DependsOn {
 	}
 
 	for _, dep := range c.Dependencies {
-		dependsOn.Dependencies = append(dependsOn.Dependencies, dep.ImageName)
+		dependsOn.Dependencies = append(dependsOn.Dependencies, dep.From)
 	}
 	dependsOn.Dependencies = util.UniqStrings(dependsOn.Dependencies)
 

--- a/pkg/config/unify_from_ai_test.go
+++ b/pkg/config/unify_from_ai_test.go
@@ -450,6 +450,120 @@ from: scratch
 	require.NoError(t, err)
 }
 
+func parseImageFromDockerfile(t *testing.T, yamlContent, imageName string) (*ImageFromDockerfile, error) {
+	t.Helper()
+
+	doc := &doc{Content: []byte(yamlContent)}
+	rawDockerfileImage := &rawImageFromDockerfile{doc: doc}
+
+	err := yaml.Unmarshal(doc.Content, rawDockerfileImage)
+	if err != nil {
+		return nil, err
+	}
+
+	giterminismManager := newTestGiterminismManager()
+	dockerfileImage, err := rawDockerfileImage.toImageFromDockerfileDirective(giterminismManager, imageName)
+	if err != nil {
+		return nil, err
+	}
+
+	return dockerfileImage, nil
+}
+
+func TestAI_DependencyFromFieldWorks(t *testing.T) {
+	yamlContent := `
+image: testimage
+from: ubuntu:22.04
+dependencies:
+- from: baseimg
+  before: install
+`
+	stapelImage, err := parseStapelImage(t, yamlContent, "testimage")
+
+	require.NoError(t, err)
+	require.Len(t, stapelImage.Dependencies, 1)
+	assert.Equal(t, "baseimg", stapelImage.Dependencies[0].From)
+}
+
+func TestAI_DependencyImageFieldIsDeprecatedAlias(t *testing.T) {
+	yamlContent := `
+image: testimage
+from: ubuntu:22.04
+dependencies:
+- image: baseimg
+  before: install
+`
+	stapelImage, err := parseStapelImage(t, yamlContent, "testimage")
+
+	require.NoError(t, err)
+	require.Len(t, stapelImage.Dependencies, 1)
+	assert.Equal(t, "baseimg", stapelImage.Dependencies[0].From)
+}
+
+func TestAI_DependencyFromAndImageBothSpecifiedIsRejected(t *testing.T) {
+	yamlContent := `
+image: testimage
+from: ubuntu:22.04
+dependencies:
+- from: baseimg
+  image: otherimg
+  before: install
+`
+	_, err := parseStapelImage(t, yamlContent, "testimage")
+
+	require.Error(t, err)
+}
+
+func TestAI_DockerfileDependencyFromFieldWorks(t *testing.T) {
+	yamlContent := `
+image: testimage
+dockerfile: Dockerfile
+dependencies:
+- from: baseimg
+  imports:
+  - type: ImageName
+    targetBuildArg: BASE_IMG
+`
+	dockerfileImage, err := parseImageFromDockerfile(t, yamlContent, "testimage")
+
+	require.NoError(t, err)
+	require.Len(t, dockerfileImage.Dependencies, 1)
+	assert.Equal(t, "baseimg", dockerfileImage.Dependencies[0].From)
+}
+
+func TestAI_DockerfileDependencyImageFieldIsDeprecatedAlias(t *testing.T) {
+	yamlContent := `
+image: testimage
+dockerfile: Dockerfile
+dependencies:
+- image: baseimg
+  imports:
+  - type: ImageName
+    targetBuildArg: BASE_IMG
+`
+	dockerfileImage, err := parseImageFromDockerfile(t, yamlContent, "testimage")
+
+	require.NoError(t, err)
+	require.Len(t, dockerfileImage.Dependencies, 1)
+	assert.Equal(t, "baseimg", dockerfileImage.Dependencies[0].From)
+}
+
+func TestAI_DockerfileDependencyFromAndImageBothSpecifiedIsRejected(t *testing.T) {
+	yamlContent := `
+image: testimage
+dockerfile: Dockerfile
+dependencies:
+- from: baseimg
+  image: otherimg
+  imports:
+  - type: ImageName
+    targetBuildArg: BASE_IMG
+`
+	_, err := parseImageFromDockerfile(t, yamlContent, "testimage")
+
+	require.Error(t, err)
+}
+
 func getStapelImageByName(t *testing.T, werfConfig *WerfConfig, name string) (*StapelImage, error) {
 	t.Helper()
 	for _, img := range werfConfig.GetImageNameList(false) {

--- a/pkg/config/unify_from_ai_test.go
+++ b/pkg/config/unify_from_ai_test.go
@@ -548,6 +548,37 @@ dependencies:
 	assert.Equal(t, "baseimg", dockerfileImage.Dependencies[0].From)
 }
 
+func TestAI_DependencyFromPassesPlatformValidator(t *testing.T) {
+	yamlImage1 := `
+image: base
+from: ubuntu:22.04
+`
+	yamlImage2 := `
+image: app
+from: ubuntu:22.04
+dependencies:
+- from: base
+  before: install
+`
+
+	giterminismManager := newTestGiterminismManager()
+
+	doc1 := &doc{Content: []byte(yamlImage1)}
+	rawImage1 := &rawStapelImage{doc: doc1}
+	require.NoError(t, yaml.Unmarshal(doc1.Content, rawImage1))
+
+	doc2 := &doc{Content: []byte(yamlImage2)}
+	rawImage2 := &rawStapelImage{doc: doc2}
+	require.NoError(t, yaml.Unmarshal(doc2.Content, rawImage2))
+
+	meta := &Meta{}
+	meta.ConfigVersion = 1
+	meta.Project = "test"
+
+	_, err := prepareWerfConfig(giterminismManager, []*rawStapelImage{rawImage1, rawImage2}, nil, meta)
+	require.NoError(t, err)
+}
+
 func TestAI_DockerfileDependencyFromAndImageBothSpecifiedIsRejected(t *testing.T) {
 	yamlContent := `
 image: testimage

--- a/pkg/config/validator_image_platform.go
+++ b/pkg/config/validator_image_platform.go
@@ -28,7 +28,7 @@ func (v *imagePlatformValidator) Validate(rawStapelImages []*rawStapelImage, raw
 
 	for _, img := range rawStapelImages {
 		for _, dep := range img.RawDependencies {
-			_, rightDiff := lo.Difference(allImagesPlatforms, v.crossJoinImagesPlatforms([]string{dep.Image}, img.Platform))
+			_, rightDiff := lo.Difference(allImagesPlatforms, v.crossJoinImagesPlatforms([]string{dep.From}, img.Platform))
 
 			if len(rightDiff) > 0 {
 				return v.newDependencyError(img.Images[0], rightDiff[0].A, rightDiff[0].B)
@@ -50,7 +50,7 @@ func (v *imagePlatformValidator) Validate(rawStapelImages []*rawStapelImage, raw
 
 	for _, img := range rawImagesFromDockerfile {
 		for _, dep := range img.RawDependencies {
-			_, rightDiff := lo.Difference(allImagesPlatforms, v.crossJoinImagesPlatforms([]string{dep.Image}, img.Platform))
+			_, rightDiff := lo.Difference(allImagesPlatforms, v.crossJoinImagesPlatforms([]string{dep.From}, img.Platform))
 
 			if len(rightDiff) > 0 {
 				return v.newDependencyError(img.Images[0], rightDiff[0].A, rightDiff[0].B)

--- a/pkg/config/validator_image_platform_test.go
+++ b/pkg/config/validator_image_platform_test.go
@@ -15,7 +15,7 @@ var _ = Describe("imagePlatformValidator", func() {
 						Images:   []string{"app"},
 						Platform: []string{"linux/amd64"},
 						RawDependencies: []*rawDependency{
-							{Image: "missing-base"},
+							{From: "missing-base"},
 						},
 					},
 				},
@@ -42,7 +42,7 @@ var _ = Describe("imagePlatformValidator", func() {
 						Images:   []string{"test-dependency"},
 						Platform: []string{"linux/amd64", "linux/arm64"},
 						RawDependencies: []*rawDependency{
-							{Image: "app"},
+							{From: "app"},
 						},
 					},
 				},
@@ -93,7 +93,7 @@ var _ = Describe("imagePlatformValidator", func() {
 						Images:   []string{"app"},
 						Platform: []string{"linux/amd64"},
 						RawDependencies: []*rawDependency{
-							{Image: "missing-base"},
+							{From: "missing-base"},
 						},
 					},
 					{
@@ -127,7 +127,7 @@ var _ = Describe("imagePlatformValidator", func() {
 						Images:   []string{"app"},
 						Platform: []string{"linux/amd64"},
 						RawDependencies: []*rawDependency{
-							{Image: "base"},
+							{From: "base"},
 						},
 					},
 					{
@@ -147,7 +147,7 @@ var _ = Describe("imagePlatformValidator", func() {
 						Images:   []string{"app"},
 						Platform: []string{"linux/amd64"},
 						RawDependencies: []*rawDependency{
-							{Image: "base"},
+							{From: "base"},
 						},
 					},
 				},
@@ -167,7 +167,7 @@ var _ = Describe("imagePlatformValidator", func() {
 						Images:   []string{"app"},
 						Platform: []string{"linux/amd64"},
 						RawDependencies: []*rawDependency{
-							{Image: "missing-base"},
+							{From: "missing-base"},
 						},
 					},
 				},
@@ -196,7 +196,7 @@ var _ = Describe("imagePlatformValidator", func() {
 						Images:   []string{"app"},
 						Platform: []string{"linux/amd64"},
 						RawDependencies: []*rawDependency{
-							{Image: "base"},
+							{From: "base"},
 						},
 					},
 				},
@@ -216,7 +216,7 @@ var _ = Describe("imagePlatformValidator", func() {
 						Images:   []string{"app"},
 						Platform: []string{"linux/amd64"},
 						RawDependencies: []*rawDependency{
-							{Image: "missing-base"},
+							{From: "missing-base"},
 						},
 					},
 				},

--- a/test/e2e/build/_fixtures/complex/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/complex/state0/werf.yaml
@@ -12,11 +12,11 @@ args:
   USERNAME: "test-username"
   PASSWORD: "test-password"
 dependencies:
-- image: stapel-shell
+- from: stapel-shell
   imports:
   - type: ImageName
     targetBuildArg: STAPEL_SHELL_IMAGE_NAME
-- image: base-stapel-shell
+- from: base-stapel-shell
   imports:
   - type: ImageName
     targetBuildArg: BASE_STAPEL_SHELL_IMAGE_NAME

--- a/test/e2e/build/_fixtures/complex/state1/werf.yaml
+++ b/test/e2e/build/_fixtures/complex/state1/werf.yaml
@@ -14,11 +14,11 @@ args:
   TEST_ARG: "changed-test-arg"
   ANOTHER_ARG: "changed-another-arg"
 dependencies:
-- image: stapel-shell
+- from: stapel-shell
   imports:
   - type: ImageName
     targetBuildArg: STAPEL_SHELL_IMAGE_NAME
-- image: base-stapel-shell
+- from: base-stapel-shell
   imports:
   - type: ImageName
     targetBuildArg: BASE_STAPEL_SHELL_IMAGE_NAME

--- a/test/e2e/build/_fixtures/custom_tag/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/custom_tag/state0/werf.yaml
@@ -14,7 +14,7 @@ platform:
   - linux/amd64
   - linux/arm64
 dependencies:
-  - image: base-dockerfile
+  - from: base-dockerfile
     imports:
       - type: ImageName
         targetBuildArg: BASE_DOCKERFILE_IMAGE_NAME

--- a/test/e2e/build/_fixtures/images_dependencies/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/images_dependencies/state0/werf.yaml
@@ -13,7 +13,7 @@ shell:
 image: stapel
 from: registry.werf.io/base/alpine:latest
 dependencies:
-  - image: base-stapel
+  - from: base-stapel
     after: install
     imports:
       - type: ImageName
@@ -22,7 +22,7 @@ dependencies:
         targetEnv: BASE_STAPEL_IMAGE_REPO
       - type: ImageTag
         targetEnv: BASE_STAPEL_IMAGE_TAG
-  - image: base-dockerfile
+  - from: base-dockerfile
     after: install
     imports:
       - type: ImageName
@@ -56,7 +56,7 @@ shell:
 image: dockerfile
 dockerfile: ./Dockerfile
 dependencies:
-  - image: base-stapel
+  - from: base-stapel
     imports:
       - type: ImageName
         targetBuildArg: BASE_STAPEL_IMAGE_NAME
@@ -66,7 +66,7 @@ dependencies:
         targetBuildArg: BASE_STAPEL_IMAGE_TAG
       - type: ImageName
         targetBuildArg: BASE_IMAGE
-  - image: base-dockerfile
+  - from: base-dockerfile
     imports:
       - type: ImageName
         targetBuildArg: BASE_DOCKERFILE_IMAGE_NAME


### PR DESCRIPTION
Deprecates `dependencies.image` in `werf.yaml` in favour of a new `dependencies.from` directive that matches the wording used elsewhere in the config (e.g. `image.from`, `image.fromImage`).

## Changes

- `pkg/config`: parse `dependencies.from` and keep `dependencies.image` as a deprecated alias (both accepted, only one may be set per entry). Platform validator now reads `rawDependency.From`.
- `pkg/build/stage`: internal readers switched from `dep.Image` to `dep.From`.
- Docs (`pages_en`, `pages_ru`, `_data/werf_yaml.yml`): examples and schema updated to `from:`.
- E2E fixtures updated to `from:`.
- Tests: added AI coverage for the deprecation alias; existing tests migrated to `From`.

## Compatibility

`dependencies.image` continues to work — existing `werf.yaml` files require no changes. Setting both keys on the same dependency is rejected at config-parse time.
