### PR TITLE
feat(config list): default --final-images-only=true, drop --images-only alias

### DIFF
--- a/cmd/werf/config/list/list.go
+++ b/cmd/werf/config/list/list.go
@@ -44,23 +44,7 @@ func NewCmd(ctx context.Context) *cobra.Command {
 		},
 	})
 
-	// Setup final-images-only flag.
-	{
-		name := "final-images-only"
-		deprecatedName := "images-only"
-		for _, n := range []string{name, deprecatedName} {
-			// FIXME: it should be default behavior.
-			cmd.Flags().BoolVarP(&cmdData.finalImagesOnly, n, "", false, "Show only final images")
-		}
-
-		if err := cmd.Flags().MarkHidden(deprecatedName); err != nil {
-			panic(fmt.Errorf("error marking flag hidden: %w", err))
-		}
-
-		if err := cmd.Flags().MarkDeprecated(deprecatedName, fmt.Sprintf("use --%s instead", name)); err != nil {
-			panic(fmt.Errorf("error marking flag deprecated: %w", err))
-		}
-	}
+	cmd.Flags().BoolVarP(&cmdData.finalImagesOnly, "final-images-only", "", true, "Show only final images (pass --final-images-only=false to include non-final images)")
 
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupGitWorkTree(&commonCmdData, cmd)

--- a/docs/_includes/reference/cli/werf_config_list.md
+++ b/docs/_includes/reference/cli/werf_config_list.md
@@ -42,8 +42,8 @@ werf config list [options]
             should reside (default $WERF_DIR or current working directory)
       --env=""
             Use specified environment (default $WERF_ENV)
-      --final-images-only=false
-            Show only final images
+      --final-images-only=true
+            Show only final images (pass --final-images-only=false to include non-final images)
       --git-work-tree=""
             Use specified git work tree dir (default $WERF_WORK_TREE or lookup for directory that   
             contains .git in the current or parent directories)


### PR DESCRIPTION
Part of v3 breaking-change cleanup.

## What

- \`werf config list --final-images-only\` now defaults to \`true\`. Pass \`--final-images-only=false\` to include non-final images. Resolves the \`// FIXME: it should be default behavior.\` in the flag setup.
- Drop the deprecated \`--images-only\` alias (already hidden + marked \`MarkDeprecated\`).

## Why

For a listing command, showing only the final deployment surface by default matches user expectation. Non-final images are still available via the boolean opt-out.

## Breaking changes

- \`werf config list\` output changes for projects with non-final images — only final images are listed. Add \`--final-images-only=false\` to restore the old output.
- \`--images-only\` no longer accepted.