### PR TITLE
fix(slug): strip trailing hyphen instead of leading

### DIFF
--- a/pkg/slug/slug.go
+++ b/pkg/slug/slug.go
@@ -179,9 +179,7 @@ func slug(data string, maxSize int) string {
 	if sluggedData != "" {
 		croppedSluggedData := cropSluggedData(sluggedData, murmurHash, maxSize)
 
-		// legacy: this check cannot be fixed without breaking reproducibility.
-		// Fix by replacing HasPrefix on HasSuffix in the following major releases.
-		if strings.HasPrefix(croppedSluggedData, "-") {
+		if strings.HasSuffix(croppedSluggedData, "-") {
 			slugParts = append(slugParts, croppedSluggedData[:len(croppedSluggedData)-1])
 		} else {
 			slugParts = append(slugParts, croppedSluggedData)

--- a/pkg/slug/slug_test.go
+++ b/pkg/slug/slug_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestSlug(t *testing.T) {
-	legacyCaseWithTwoHyphensMaxSize := 48
+	trailingHyphenMaxSize := 48
 
 	tests := []struct {
 		name    string
@@ -35,16 +35,16 @@ func TestSlug(t *testing.T) {
 			result: strings.Repeat("x", DefaultSlugMaxSize-len("-27e2f02f")) + "-27e2f02f",
 		},
 		{
-			name:    "legacyCaseWithTwoHyphen",
+			name:    "trailingHyphenStripped",
 			data:    "postgres-feature-31981-change-delivery-date-del-result",
-			maxSize: &legacyCaseWithTwoHyphensMaxSize,
-			result:  "postgres-feature-31981-change-delivery--852739dc",
+			maxSize: &trailingHyphenMaxSize,
+			result:  "postgres-feature-31981-change-delivery-852739dc",
 		},
 		{
-			name:    "legacyCaseWithTwoHyphen_2",
+			name:    "trailingHyphenStripped_2",
 			data:    "php_fpm_exporter-monitoring-dev-encrypt-1",
-			maxSize: &legacyCaseWithTwoHyphensMaxSize,
-			result:  "php-fpm-exporter-monitoring-dev-encrypt--83286e5",
+			maxSize: &trailingHyphenMaxSize,
+			result:  "php-fpm-exporter-monitoring-dev-encrypt-83286e5",
 		},
 	}
 


### PR DESCRIPTION
Part of v3 breaking-change cleanup.

## What

Replaces \`strings.HasPrefix\` with \`strings.HasSuffix\` in \`pkg/slug/slug.go\`. The intent was to strip a trailing \`-\` from the cropped slug data so the join with the separator does not produce \`something---hash\`; the code accidentally checked the prefix instead, which never matched (slugified data never starts with \`-\`) and left the double-hyphen bug in place.

The block was flagged in-code:

> \`\`\`\n> // legacy: this check cannot be fixed without breaking reproducibility.\n> // Fix by replacing HasPrefix on HasSuffix in the following major releases.\n> \`\`\`

## Breaking changes

For inputs whose cropped slugged form would end with \`-\`, the resulting slug now has one hyphen instead of two before the hash suffix. Slugs feed into k8s resource names, image tags, etc., so any resource named with the buggy \`--\` slug gets a new name after upgrade.

## Tests

Existing test cases \`legacyCaseWithTwoHyphen\` / \`legacyCaseWithTwoHyphen_2\` renamed and updated to reflect the fixed output.