### PR TITLE
fix(import): preserve symlinks in rsync-based imports

### DIFF
--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -132,10 +132,7 @@ func (srv *RsyncServer) GetCopyCommand(ctx context.Context, importConfig *config
 
 	rsyncImportPathSpec := fmt.Sprintf("rsync://%s@%s:%s/import/%s", srv.AuthUser, srv.IPAddress, srv.Port, importConfig.Add)
 
-	// TODO(major): remove `-L`
-	// Dereferencing symlinks (`-L`) copies targets instead of symlinks themselves,
-	// which breaks checksums and pulls extra data. Symlinks must be preserved as-is.
-	rsyncStatImportPathCommand := fmt.Sprintf("RSYNC_PASSWORD='%s' %s -L %s", srv.AuthPassword, stapel.RsyncBinPath(), rsyncImportPathSpec)
+	rsyncStatImportPathCommand := fmt.Sprintf("RSYNC_PASSWORD='%s' %s %s", srv.AuthPassword, stapel.RsyncBinPath(), rsyncImportPathSpec)
 
 	// save stat output to variable
 	args = append(args, fmt.Sprintf("statOutput=$(%s)", rsyncStatImportPathCommand))


### PR DESCRIPTION
Part of v3 breaking-change cleanup.

## What

Drops the `-L` flag from the rsync stat command that precedes the actual copy in `pkg/build/import_server/rsync_server.go`. Flagged in-code as `TODO(major): remove -L`.

## Why

`-L` (`--copy-links`) dereferences symlinks — the stat then reports the target's file type instead of the symlink itself. The real copy uses `--archive --links --keep-dirlinks`, so the discrepancy caused:

- Symlink imports pulling target data instead of preserving the symlink.
- Broken checksums (target contents change independently of the symlink).

Dropping `-L` makes stat and copy consistent: symlinks stay symlinks.

## Breaking changes

Projects that relied on the `-L` dereference behavior for imports of symlink paths (target-file materialization) will see symlinks copied as symlinks instead. Change the import source, or use `--archive`-friendly paths.
