### PR TITLE
refactor(image-spec): drop hardcoded WERF_COMMIT_* env removal

### DIFF
--- a/pkg/build/stage/image_spec.go
+++ b/pkg/build/stage/image_spec.go
@@ -330,13 +330,6 @@ func modifyEnv(env, removeKeys []string, addKeysMap map[string]string) ([]string
 		}
 	}
 
-	// TODO(major): This is a temporary solution to remove werf commit envs that persist after build.
-	removeKeys = append(removeKeys, []string{
-		"WERF_COMMIT_HASH",
-		"WERF_COMMIT_TIME_HUMAN",
-		"WERF_COMMIT_TIME_UNIX",
-	}...)
-
 	exactMatches, regexPatterns, err := compileRemovePatterns(removeKeys)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Part of v3 breaking-change cleanup.

## What

Removes the hardcoded removal of `WERF_COMMIT_HASH` / `WERF_COMMIT_TIME_HUMAN` / `WERF_COMMIT_TIME_UNIX` from the imageSpec env-modification path. Flagged in-code as `TODO(major): This is a temporary solution to remove werf commit envs that persist after build.`

## Why

Historically these vars were injected into stage containers via `docker run -e KEY=VAL`, which `docker commit` persisted into the resulting image env. That was fixed at the source long ago — commit envs are now shell-`export`ed only inside the build run (legacy stapel) or passed as ephemeral `Envs` (buildah), neither of which persists after commit. The defensive imageSpec-side cleanup only masked leaks from pre-fix images used as base images.

For v3 we drop the auto-cleanup:

- Fresh v3 builds don't leak these vars.
- Users who inherit them from an old base image can add them to `imageSpec.config.removeEnv` explicitly.

## Breaking changes

Users chaining v3 builds on top of pre-fix werf-built base images that had `WERF_COMMIT_*` baked in will now see those envs in the final image unless they add them to `imageSpec.config.removeEnv:`.

## Tests

`TestEnvExpander/remove_all` (which uses the `/.*/ ` regex) still passes — the WERF_COMMIT_* entries in its input are removed via the user-provided regex, not the hardcode.
