### PR TITLE
chore(dev): fix review skills sub-skills

### DIFF
--- a/.agents/skills/review-multi/SKILL.md
+++ b/.agents/skills/review-multi/SKILL.md
@@ -29,18 +29,16 @@ Orchestrate a multi-role review. Two roles run in parallel, then the third consu
 
 1. **DoD first.** Ask user for numbered acceptance criteria. Block until received. Nothing proceeds without DoD. Record the criteria — they will be passed inline to every sub-skill.
 2. **Get branch name:** `git rev-parse --abbrev-ref HEAD` → `$BRANCH`. Create safe directory name: `$SAFE_BRANCH=$(echo "$BRANCH" | sed 's|/|-|g')`. Create directory `reviews/$SAFE_BRANCH/`.
-3. **Save diff to file:** `git --no-pager diff origin/main...HEAD > reviews/$SAFE_BRANCH/pr_diff.txt`. Avoids terminal truncation.
+3. **Save diff to file:** `git --no-pager diff origin/main..origin/$BRANCH > reviews/$SAFE_BRANCH/pr_diff.txt`. This uses the branch name from step 2, assuming the branch exists on `origin` (as is the case for an open PR from a fork). Avoids terminal truncation.
 4. **Diff analysis:** Identify modified files, change types (feature/fix/refactor/docs), patterns, concerns.
 5. **Deep analysis:** Read changed files and their consumers. Examine key functions and their callers in the codebase.
-6. **Read diff for sub-skills (MANDATORY):** Use `read_file(path="reviews/$SAFE_BRANCH/pr_diff.txt")` to get the full diff content.
-   - If read_file returns the full text → include the COMPLETE diff inline in every spawn_agent message.
-   - If read_file returns an outline/truncation (file too large) → output `ERROR: Diff too large for review-multi workflow.` and STOP. Do NOT split, summarize, or pass a file path.
-7. **Phase 1a — Technical Reviewer (parallel).** Activate **review-tech**. Provide: the COMPLETE diff content inline (NOT a file path or summary), the DoD criteria inline, analysis.
+6. **Diff file saved:** The diff is now saved at `reviews/$SAFE_BRANCH/pr_diff.txt`. Each sub-skill in subsequent phases will read this file itself — you do NOT need to read or pass the diff content.
+7. **Phase 1a — Technical Reviewer (parallel).** Activate **review-tech**. Provide: the diff file path `reviews/$SAFE_BRANCH/pr_diff.txt` (the sub-skill will read it using `read_file`), the DoD criteria inline, your analysis.
    → **Output of Phase 1a:** best practices table + DoD tech checklist + issues found.
-8. **Phase 1b — Product Reviewer (parallel with 1a).** Activate **review-product**. Provide: the COMPLETE diff content inline (NOT a file path or summary), the DoD criteria inline, analysis.
+8. **Phase 1b — Product Reviewer (parallel with 1a).** Activate **review-product**. Provide: the diff file path `reviews/$SAFE_BRANCH/pr_diff.txt` (the sub-skill will read it using `read_file`), the DoD criteria inline, your analysis.
    → **Output of Phase 1b:** DoD product checklist + product impact assessment + gaps.
    → **Wait for BOTH Phase 1a and Phase 1b to complete before proceeding.**
-9. **Phase 2 — Risk Analyst.** Activate **review-risk**. Provide: the COMPLETE diff content inline (NOT a file path or summary), the DoD criteria inline, analysis, AND full outputs from Phase 1a + Phase 1b.
+9. **Phase 2 — Risk Analyst.** Activate **review-risk**. Provide: the diff file path `reviews/$SAFE_BRANCH/pr_diff.txt` (the sub-skill will read it using `read_file`), the DoD criteria inline, your analysis, AND full outputs from Phase 1a + Phase 1b.
    → **Output of Phase 2:** risk analysis table with numbered rows.
 10. **Phase 3 — Final report.** Assemble combined report (format below). Save to `reviews/$SAFE_BRANCH/REPORT.md`.
 

--- a/.agents/skills/review-product/SKILL.md
+++ b/.agents/skills/review-product/SKILL.md
@@ -22,8 +22,9 @@ description: Product review for changes. Assesses DoD alignment, user impact, co
 3. Be concrete — no vague statements.
 4. NEVER sugarcoat. Deliver honest, fact-based critiques.
 5. First message opens with the full role declaration above.
-6. **MANDATORY:** The full diff is provided to you inline. Do NOT read it from a file or run `git diff` yourself.
-   - If NO diff content is present in the instructions → output `ERROR: No diff provided. Cannot perform review.` and STOP immediately.
+6. **MANDATORY:** The path to the diff file (e.g., `reviews/<safe-branch>/pr_diff.txt`) is provided to you in the instructions. Read the diff file using `read_file(path="<path>")`. Do NOT run `git diff` yourself.
+   - If the diff file path is NOT present in the instructions → output `ERROR: No diff provided. Cannot perform review.` and STOP immediately.
+   - If `read_file` returns an outline/truncation (file too large) → read the file in sections using `start_line`/`end_line` parameters until you have the complete diff content.
 
 Assess whether code changes fulfill product requirements from a user and product perspective.
 

--- a/.agents/skills/review-risk/SKILL.md
+++ b/.agents/skills/review-risk/SKILL.md
@@ -22,8 +22,9 @@ description: Risk analysis for changes. Identifies technical, security, UX, and 
 3. Be realistic about probability and severity — do not inflate.
 4. NEVER sugarcoat. Base risks only on evidence.
 5. First message opens with the full role declaration above.
-6. **MANDATORY:** The full diff is provided to you inline. Do NOT read it from a file or run `git diff` yourself.
-   - If NO diff content is present in the instructions → output `ERROR: No diff provided. Cannot perform review.` and STOP immediately.
+6. **MANDATORY:** The path to the diff file (e.g., `reviews/<safe-branch>/pr_diff.txt`) is provided to you in the instructions. Read the diff file using `read_file(path="<path>")`. Do NOT run `git diff` yourself.
+   - If the diff file path is NOT present in the instructions → output `ERROR: No diff provided. Cannot perform review.` and STOP immediately.
+   - If `read_file` returns an outline/truncation (file too large) → read the file in sections using `start_line`/`end_line` parameters until you have the complete diff content.
 
 Identify and assess risks based on the technical review, product review, and the actual diff. The output is a single table. No prose summary.
 

--- a/.agents/skills/review-tech/SKILL.md
+++ b/.agents/skills/review-tech/SKILL.md
@@ -22,8 +22,9 @@ description: Technical code review for changes. Evaluates Go, werf, Docker, Cont
 3. Be concrete — no vague generalizations.
 4. NEVER sugarcoat. Deliver honest, fact-based critiques.
 5. First message opens with the full role declaration above.
-6. **MANDATORY:** The full diff is provided to you inline. Do NOT read it from a file or run `git diff` yourself.
-   - If NO diff content is present in the instructions → output `ERROR: No diff provided. Cannot perform review.` and STOP immediately.
+6. **MANDATORY:** The path to the diff file (e.g., `reviews/<safe-branch>/pr_diff.txt`) is provided to you in the instructions. Read the diff file using `read_file(path="<path>")`. Do NOT run `git diff` yourself.
+   - If the diff file path is NOT present in the instructions → output `ERROR: No diff provided. Cannot perform review.` and STOP immediately.
+   - If `read_file` returns an outline/truncation (file too large) → read the file in sections using `start_line`/`end_line` parameters until you have the complete diff content.
 
 Review code changes for quality, architecture, and best practices.
 


### PR DESCRIPTION
Sub-skills now read the diff from a saved file rather than receiving it inline,
which avoids terminal truncation and supports reading large diffs in sections.
Also fixes the diff command to use origin/main..origin/$BRANCH, assuming the
branch exists on origin for PRs from forks.