### PR TITLE
fix(true_git): forward include.path to submodule sync/update commands

### DIFF
--- a/pkg/true_git/common.go
+++ b/pkg/true_git/common.go
@@ -1,11 +1,49 @@
 package true_git
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 func getCommonGitOptions() []string {
 	return []string{"-c", "core.autocrlf=false", "-c", "gc.auto=0", "-c", "commit.gpgsign=false", "-c", "core.untrackedCache=false", "-c", "core.splitIndex=false"}
+}
+
+func getIncludePathOptions(ctx context.Context, repoDir string) ([]string, error) {
+	configCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "config", "--get-all", "include.path")
+	if err := configCmd.Run(ctx); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && configCmd.OutBuf.String() == "" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get git include.path from %s: %w", repoDir, err)
+	}
+
+	var opts []string
+	for _, line := range strings.Split(configCmd.OutBuf.String(), "\n") {
+		includePath := strings.TrimSpace(line)
+		if includePath == "" {
+			continue
+		}
+
+		// include.path passed via -c has no declaring config file, so relative paths must be resolved to absolute up front
+		if !filepath.IsAbs(includePath) {
+			absIncludePath, err := filepath.Abs(includePath)
+			if err != nil {
+				return nil, fmt.Errorf("resolve include.path %q: %w", includePath, err)
+			}
+			includePath = absIncludePath
+		}
+
+		opts = append(opts, "-c", "include.path="+includePath)
+	}
+
+	return opts, nil
 }
 
 func debug() bool {

--- a/pkg/true_git/common.go
+++ b/pkg/true_git/common.go
@@ -15,10 +15,10 @@ func getCommonGitOptions() []string {
 }
 
 func getIncludePathOptions(ctx context.Context, repoDir string) ([]string, error) {
-	configCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "config", "--get-all", "include.path")
+	configCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "config", "--show-origin", "--get-all", "include.path")
 	if err := configCmd.Run(ctx); err != nil {
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && configCmd.OutBuf.String() == "" {
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && configCmd.OutBuf.String() == "" && configCmd.ErrBuf.String() == "" {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("get git include.path from %s: %w", repoDir, err)
@@ -26,18 +26,30 @@ func getIncludePathOptions(ctx context.Context, repoDir string) ([]string, error
 
 	var opts []string
 	for _, line := range strings.Split(configCmd.OutBuf.String(), "\n") {
-		includePath := strings.TrimSpace(line)
-		if includePath == "" {
+		line = strings.TrimSpace(line)
+		if line == "" {
 			continue
 		}
 
-		// include.path passed via -c has no declaring config file, so relative paths must be resolved to absolute up front
-		if !filepath.IsAbs(includePath) {
-			absIncludePath, err := filepath.Abs(includePath)
-			if err != nil {
-				return nil, fmt.Errorf("resolve include.path %q: %w", includePath, err)
+		origin, includePath, found := strings.Cut(line, "\t")
+		if !found {
+			continue
+		}
+
+		// include.path passed via -c has no declaring config file, so relative values are resolved against their origin up front
+		if !strings.HasPrefix(includePath, "~") && !filepath.IsAbs(includePath) {
+			if originFile, ok := strings.CutPrefix(origin, "file:"); ok {
+				if !filepath.IsAbs(originFile) {
+					originFile = filepath.Join(repoDir, originFile)
+				}
+				includePath = filepath.Join(filepath.Dir(originFile), includePath)
+			} else {
+				absIncludePath, err := filepath.Abs(includePath)
+				if err != nil {
+					return nil, fmt.Errorf("resolve include.path %q: %w", includePath, err)
+				}
+				includePath = absIncludePath
 			}
-			includePath = absIncludePath
 		}
 
 		opts = append(opts, "-c", "include.path="+includePath)

--- a/pkg/true_git/helpers_ai_test.go
+++ b/pkg/true_git/helpers_ai_test.go
@@ -1,0 +1,24 @@
+package true_git
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func runGitAI(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+	return string(out)
+}
+
+func initGitRepoAI(t *testing.T, dir string) {
+	t.Helper()
+	runGitAI(t, dir, "init")
+	runGitAI(t, dir, "config", "user.email", "test@werf.io")
+	runGitAI(t, dir, "config", "user.name", "test")
+	runGitAI(t, dir, "commit", "--allow-empty", "-m", "init")
+}

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -10,7 +10,12 @@ import (
 func syncSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 	logProcessMsg := fmt.Sprintf("Sync submodules in work tree %q", workTreeDir)
 	return logboek.Context(ctx).Info().LogProcess(logProcessMsg).DoError(func() error {
-		submSyncCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "submodule", "sync", "--recursive")
+		includePathOpts, err := getIncludePathOptions(ctx, repoDir)
+		if err != nil {
+			return err
+		}
+
+		submSyncCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, append(includePathOpts, "submodule", "sync", "--recursive")...)
 		if err := submSyncCmd.Run(ctx); err != nil {
 			return fmt.Errorf("submodule sync command failed: %w", err)
 		}
@@ -22,7 +27,12 @@ func syncSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 	logProcessMsg := fmt.Sprintf("Update submodules in work tree %q", workTreeDir)
 	return logboek.Context(ctx).Info().LogProcess(logProcessMsg).DoError(func() error {
-		submUpdateCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "submodule", "update", "--checkout", "--force", "--init", "--recursive")
+		includePathOpts, err := getIncludePathOptions(ctx, repoDir)
+		if err != nil {
+			return err
+		}
+
+		submUpdateCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, append(includePathOpts, "submodule", "update", "--checkout", "--force", "--init", "--recursive")...)
 		if err := submUpdateCmd.Run(ctx); err != nil {
 			return fmt.Errorf("submodule update command failed: %w", err)
 		}

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -23,16 +23,20 @@ func TestAI_GetIncludePathOptions(t *testing.T) {
 
 	runGitAI(t, repoDir, "config", "--add", "include.path", "/abs/ext.conf")
 	runGitAI(t, repoDir, "config", "--add", "include.path", "rel/ext.conf")
+	runGitAI(t, repoDir, "config", "--add", "include.path", "~/tilde-ext.conf")
 
 	opts, err = getIncludePathOptions(ctx, gitDir)
 	require.NoError(t, err)
-	require.Len(t, opts, 4)
+	require.Len(t, opts, 6)
 	require.Equal(t, "-c", opts[0])
 	require.Equal(t, "include.path=/abs/ext.conf", opts[1])
 	require.Equal(t, "-c", opts[2])
 	require.True(t, strings.HasPrefix(opts[3], "include.path="))
-	require.True(t, filepath.IsAbs(strings.TrimPrefix(opts[3], "include.path=")))
-	require.True(t, strings.HasSuffix(opts[3], filepath.Join("rel", "ext.conf")))
+	relResolved := strings.TrimPrefix(opts[3], "include.path=")
+	require.True(t, filepath.IsAbs(relResolved))
+	require.Equal(t, filepath.Join(gitDir, "rel", "ext.conf"), relResolved)
+	require.Equal(t, "-c", opts[4])
+	require.Equal(t, "include.path=~/tilde-ext.conf", opts[5])
 }
 
 func TestAI_UpdateSubmodulesForwardsIncludePath(t *testing.T) {

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -34,7 +34,7 @@ func TestAI_GetIncludePathOptions(t *testing.T) {
 	require.True(t, strings.HasPrefix(opts[3], "include.path="))
 	relResolved := strings.TrimPrefix(opts[3], "include.path=")
 	require.True(t, filepath.IsAbs(relResolved))
-	require.Equal(t, filepath.Join(gitDir, "rel", "ext.conf"), relResolved)
+	require.True(t, strings.HasSuffix(relResolved, filepath.Join(".git", "rel", "ext.conf")))
 	require.Equal(t, "-c", opts[4])
 	require.Equal(t, "include.path=~/tilde-ext.conf", opts[5])
 }

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -1,0 +1,76 @@
+package true_git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAI_GetIncludePathOptions(t *testing.T) {
+	ctx := context.Background()
+
+	repoDir := t.TempDir()
+	initGitRepoAI(t, repoDir)
+	gitDir := filepath.Join(repoDir, ".git")
+
+	opts, err := getIncludePathOptions(ctx, gitDir)
+	require.NoError(t, err)
+	require.Empty(t, opts)
+
+	runGitAI(t, repoDir, "config", "--add", "include.path", "/abs/ext.conf")
+	runGitAI(t, repoDir, "config", "--add", "include.path", "rel/ext.conf")
+
+	opts, err = getIncludePathOptions(ctx, gitDir)
+	require.NoError(t, err)
+	require.Len(t, opts, 4)
+	require.Equal(t, "-c", opts[0])
+	require.Equal(t, "include.path=/abs/ext.conf", opts[1])
+	require.Equal(t, "-c", opts[2])
+	require.True(t, strings.HasPrefix(opts[3], "include.path="))
+	require.True(t, filepath.IsAbs(strings.TrimPrefix(opts[3], "include.path=")))
+	require.True(t, strings.HasSuffix(opts[3], filepath.Join("rel", "ext.conf")))
+}
+
+func TestAI_UpdateSubmodulesForwardsIncludePath(t *testing.T) {
+	ctx := context.Background()
+
+	repoDir := t.TempDir()
+	initGitRepoAI(t, repoDir)
+	headSHA := strings.TrimSpace(runGitAI(t, repoDir, "rev-parse", "HEAD"))
+
+	gitmodules := "[submodule \"sub\"]\n\tpath = sub\n\turl = https://werf-test-nonexistent.invalid/sub.git\n"
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".gitmodules"), []byte(gitmodules), 0o644))
+	runGitAI(t, repoDir, "update-index", "--add", "--cacheinfo", "160000,"+headSHA+",sub")
+	runGitAI(t, repoDir, "add", ".gitmodules")
+	runGitAI(t, repoDir, "commit", "-m", "add submodule")
+
+	stubPath := filepath.Join(t.TempDir(), "ext.conf")
+	stub := "[url \"werf-test-marker://rewritten/\"]\n\tinsteadOf = https://\n"
+	require.NoError(t, os.WriteFile(stubPath, []byte(stub), 0o644))
+	runGitAI(t, repoDir, "config", "include.path", stubPath)
+
+	err := updateSubmodules(ctx, filepath.Join(repoDir, ".git"), repoDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "werf-test-marker")
+}
+
+func TestAI_SwitchWorkTreeNonSubmodulesUnaffectedByIncludePath(t *testing.T) {
+	ctx := context.Background()
+
+	repoDir := t.TempDir()
+	initGitRepoAI(t, repoDir)
+	headSHA := strings.TrimSpace(runGitAI(t, repoDir, "rev-parse", "HEAD"))
+
+	stubPath := filepath.Join(t.TempDir(), "ext.conf")
+	stub := "[url \"werf-test-marker://rewritten/\"]\n\tinsteadOf = https://\n"
+	require.NoError(t, os.WriteFile(stubPath, []byte(stub), 0o644))
+	runGitAI(t, repoDir, "config", "include.path", stubPath)
+
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	err := switchWorkTree(ctx, filepath.Join(repoDir, ".git"), workTreeDir, headSHA, false)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Problem

On GitLab Runner 18.6+ git auth is provided via an external git config referenced through `include.path` in the repo's `.git/config` instead of tokenized submodule URLs. werf's cached-worktree submodule preparation (`git submodule sync --recursive` / `git submodule update --checkout --force --init --recursive`) failed with:

```
fatal: could not read Username for 'https://...': No such device or address
```

The child `git fetch`/`clone` processes spawned by those commands run against each submodule's own git dir and do not inherit the parent repo's file-level `include.path`, so the auth chain (credential config, `url.*.insteadOf`) never reaches them.

## Solution

Discover `include.path` values from the source repo (`git config --show-origin --get-all include.path`) and pass them as `-c include.path=<abs>` to the internal `submodule sync`/`submodule update` commands. `-c` is exported to git child processes via `GIT_CONFIG_PARAMETERS`, restoring the auth chain for submodule fetches. Mirrors GitLab Runner MR gitlab-org/gitlab-runner!5962.

- Relative values are resolved against the declaring config file's directory (matching git's own include resolution); `~`-prefixed values pass through (git expands them).
- Only file paths are forwarded — never credential values — so nothing secret lands on argv or in logs.
- Non-submodule cached-worktree flow, common git options, and locking are unchanged.

## Testing

- `TestAI_UpdateSubmodulesForwardsIncludePath`: behavioural regression test — an include stub rewriting `https://` to a bogus transport surfaces in the child clone error only when forwarding works; verified it fails with the fix reverted.
- `TestAI_GetIncludePathOptions`: helper contract (absent key, absolute/relative/tilde values).
- `TestAI_SwitchWorkTreeNonSubmodulesUnaffectedByIncludePath`: non-submodule path unaffected.
- `task build`, `task lint:golangci-lint`, ginkgo suite 32/32 green.