### PR TITLE
fix(build, buildah): retry pull when cached image id is missing

### DIFF
--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -86,6 +86,14 @@ func platformMatches(inspect *thirdparty.BuilderInfo, targetPlatform string) boo
 	return true
 }
 
+func isImageNotKnownError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(err.Error()), "image not known")
+}
+
 func (backend *BuildahBackend) Info(ctx context.Context) (info.Info, error) {
 	return backend.buildah.Info(ctx)
 }
@@ -132,9 +140,11 @@ func (backend *BuildahBackend) createContainers(ctx context.Context, images []st
 		}
 
 		resolvedImg := img
+		usedCachedImageID := false
 		if opts.TargetPlatform != "" {
 			if id, ok := backend.getPulledImageID(img, opts.TargetPlatform); ok {
 				resolvedImg = id
+				usedCachedImageID = true
 			} else if inspect, err := backend.buildah.Inspect(ctx, img); err == nil && inspect != nil {
 				if !platformMatches(inspect, opts.TargetPlatform) {
 					return nil, fmt.Errorf("local image %q has platform %s/%s, but target platform is %q; pull the correct image first", img, inspect.OCIv1.OS, inspect.OCIv1.Architecture, opts.TargetPlatform)
@@ -142,7 +152,26 @@ func (backend *BuildahBackend) createContainers(ctx context.Context, images []st
 			}
 		}
 
-		_, err := backend.buildah.FromCommand(ctx, containerID, resolvedImg, buildah.FromCommandOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+		fromCommandOpts := buildah.FromCommandOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform))
+		_, err := backend.buildah.FromCommand(ctx, containerID, resolvedImg, fromCommandOpts)
+		if err != nil && opts.TargetPlatform != "" && usedCachedImageID && isImageNotKnownError(err) {
+			logboek.Context(ctx).Debug().LogF("Cached imageID %q for %q not found locally, pulling by ref and retrying\n", resolvedImg, img)
+
+			backend.pulledImageIDs.Delete(pulledImageKey{img, opts.TargetPlatform})
+
+			pulledImageID, pullErr := backend.buildah.Pull(ctx, img, buildah.PullOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+			if pullErr != nil {
+				return nil, fmt.Errorf("unable to pull image %q after cached imageID miss: %w", img, pullErr)
+			}
+
+			resolvedImg = img
+			if pulledImageID != "" {
+				backend.storePulledImageID(img, opts.TargetPlatform, pulledImageID)
+				resolvedImg = pulledImageID
+			}
+
+			_, err = backend.buildah.FromCommand(ctx, containerID, resolvedImg, fromCommandOpts)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("unable to create container using base image %q: %w", img, err)
 		}

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containers/storage/types"
 	"github.com/google/uuid"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
@@ -115,7 +116,7 @@ func isImageNotKnownError(err error) bool {
 		return false
 	}
 
-	return strings.Contains(strings.ToLower(err.Error()), "image not known")
+	return strings.HasSuffix(err.Error(), types.ErrImageUnknown.Error())
 }
 
 func (backend *BuildahBackend) Info(ctx context.Context) (info.Info, error) {
@@ -180,8 +181,6 @@ func (backend *BuildahBackend) createContainers(ctx context.Context, images []st
 		_, err := backend.buildah.FromCommand(ctx, containerID, resolvedImg, fromCommandOpts)
 		if err != nil && opts.TargetPlatform != "" && usedCachedImageID && isImageNotKnownError(err) {
 			logboek.Context(ctx).Debug().LogF("Cached imageID %q for %q not found locally, pulling by ref and retrying\n", resolvedImg, img)
-
-			backend.pulledImageIDs.Delete(pulledImageKey{img, opts.TargetPlatform})
 
 			pulledImageID, pullErr := backend.buildah.Pull(ctx, img, buildah.PullOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
 			if pullErr != nil {

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -110,6 +110,14 @@ func platformMatches(inspect *thirdparty.BuilderInfo, targetPlatform string) boo
 	return true
 }
 
+func isImageNotKnownError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(err.Error()), "image not known")
+}
+
 func (backend *BuildahBackend) Info(ctx context.Context) (info.Info, error) {
 	return backend.buildah.Info(ctx)
 }
@@ -156,9 +164,11 @@ func (backend *BuildahBackend) createContainers(ctx context.Context, images []st
 		}
 
 		resolvedImg := img
+		usedCachedImageID := false
 		if opts.TargetPlatform != "" {
 			if id, ok := backend.getPulledImageID(img, opts.TargetPlatform); ok {
 				resolvedImg = id
+				usedCachedImageID = true
 			} else if inspect, err := backend.buildah.Inspect(ctx, img); err == nil && inspect != nil {
 				if !platformMatches(inspect, opts.TargetPlatform) {
 					return nil, fmt.Errorf("local image %q has platform %s/%s, but target platform is %q; pull the correct image first", img, inspect.OCIv1.OS, inspect.OCIv1.Architecture, opts.TargetPlatform)
@@ -166,7 +176,26 @@ func (backend *BuildahBackend) createContainers(ctx context.Context, images []st
 			}
 		}
 
-		_, err := backend.buildah.FromCommand(ctx, containerID, resolvedImg, buildah.FromCommandOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+		fromCommandOpts := buildah.FromCommandOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform))
+		_, err := backend.buildah.FromCommand(ctx, containerID, resolvedImg, fromCommandOpts)
+		if err != nil && opts.TargetPlatform != "" && usedCachedImageID && isImageNotKnownError(err) {
+			logboek.Context(ctx).Debug().LogF("Cached imageID %q for %q not found locally, pulling by ref and retrying\n", resolvedImg, img)
+
+			backend.pulledImageIDs.Delete(pulledImageKey{img, opts.TargetPlatform})
+
+			pulledImageID, pullErr := backend.buildah.Pull(ctx, img, buildah.PullOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+			if pullErr != nil {
+				return nil, fmt.Errorf("unable to pull image %q after cached imageID miss: %w", img, pullErr)
+			}
+
+			resolvedImg = img
+			if pulledImageID != "" {
+				backend.storePulledImageID(img, opts.TargetPlatform, pulledImageID)
+				resolvedImg = pulledImageID
+			}
+
+			_, err = backend.buildah.FromCommand(ctx, containerID, resolvedImg, fromCommandOpts)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("unable to create container using base image %q: %w", img, err)
 		}

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -1,11 +1,16 @@
 package container_backend
 
 import (
+	"context"
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/werf/werf/v2/pkg/buildah"
 	"github.com/werf/werf/v2/pkg/buildah/thirdparty"
+	"github.com/werf/werf/v2/test/pkg/buildahstub"
 )
 
 var _ = Describe("BuildahBackend pulledImageIDs", func() {
@@ -81,4 +86,37 @@ var _ = Describe("platformMatches", func() {
 		// (OCI default: arm64 without explicit variant is equivalent to v8)
 		Entry("target has variant, image variant empty", "linux", "arm64", "", "linux/arm64/v8", true),
 	)
+})
+
+var _ = Describe("BuildahBackend createContainers", func() {
+	It("re-pulls image by ref when cached imageID is missing locally", func() {
+		fakeBuildah := &buildahstub.BuildahStub{}
+		fakeBuildah.FromCommandFunc = func(_ context.Context, _ string, imageRef string, _ buildah.FromCommandOpts) (string, error) {
+			switch imageRef {
+			case "sha256:stale":
+				return "", errors.New("image not known")
+			case "sha256:fresh":
+				return "container-id", nil
+			default:
+				return "", errors.New("unexpected image ref")
+			}
+		}
+		fakeBuildah.PullFunc = func(_ context.Context, ref string, _ buildah.PullOpts) (string, error) {
+			Expect(ref).To(Equal("registry.example.org/project/stage:tag"))
+			return "sha256:fresh", nil
+		}
+
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+		backend.storePulledImageID("registry.example.org/project/stage:tag", "linux/amd64", "sha256:stale")
+
+		containers, err := backend.createContainers(context.Background(), []string{"registry.example.org/project/stage:tag"}, CommonOpts{TargetPlatform: "linux/amd64"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(containers).To(HaveLen(1))
+		Expect(fakeBuildah.FromCommandImages).To(Equal([]string{"sha256:stale", "sha256:fresh"}))
+		Expect(fakeBuildah.PullRefs).To(Equal([]string{"registry.example.org/project/stage:tag"}))
+
+		cachedID, ok := backend.getPulledImageID("registry.example.org/project/stage:tag", "linux/amd64")
+		Expect(ok).To(BeTrue())
+		Expect(cachedID).To(Equal("sha256:fresh"))
+	})
 })

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -91,7 +91,7 @@ var _ = Describe("platformMatches", func() {
 var _ = Describe("BuildahBackend createContainers", func() {
 	It("re-pulls image by ref when cached imageID is missing locally", func() {
 		fakeBuildah := &buildahstub.BuildahStub{}
-		fakeBuildah.FromCommandFunc = func(_ context.Context, _ string, imageRef string, _ buildah.FromCommandOpts) (string, error) {
+		fakeBuildah.FromCommandFunc = func(_ context.Context, _, imageRef string, _ buildah.FromCommandOpts) (string, error) {
 			switch imageRef {
 			case "sha256:stale":
 				return "", errors.New("image not known")

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -3,7 +3,9 @@ package container_backend
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"github.com/containers/storage/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -94,7 +96,7 @@ var _ = Describe("BuildahBackend createContainers", func() {
 		fakeBuildah.FromCommandFunc = func(_ context.Context, _, imageRef string, _ buildah.FromCommandOpts) (string, error) {
 			switch imageRef {
 			case "sha256:stale":
-				return "", errors.New("image not known")
+				return "", fmt.Errorf("locating image with name %q: %w", imageRef, types.ErrImageUnknown)
 			case "sha256:fresh":
 				return "container-id", nil
 			default:

--- a/test/pkg/buildahstub/stub.go
+++ b/test/pkg/buildahstub/stub.go
@@ -1,0 +1,118 @@
+package buildahstub
+
+import (
+	"context"
+	"io"
+
+	"github.com/werf/werf/v2/pkg/buildah"
+	"github.com/werf/werf/v2/pkg/buildah/thirdparty"
+	"github.com/werf/werf/v2/pkg/container_backend/info"
+	"github.com/werf/werf/v2/pkg/image"
+)
+
+type BuildahStub struct {
+	FromCommandFunc   func(ctx context.Context, container, image string, opts buildah.FromCommandOpts) (string, error)
+	PullFunc          func(ctx context.Context, ref string, opts buildah.PullOpts) (string, error)
+	FromCommandImages []string
+	PullRefs          []string
+}
+
+func (b *BuildahStub) Info(context.Context) (info.Info, error) {
+	return info.Info{}, nil
+}
+
+func (b *BuildahStub) GetDefaultPlatform() string {
+	return ""
+}
+
+func (b *BuildahStub) GetRuntimePlatform() string {
+	return ""
+}
+
+func (b *BuildahStub) Tag(context.Context, string, string, buildah.TagOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Push(context.Context, string, buildah.PushOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) BuildFromDockerfile(context.Context, string, buildah.BuildFromDockerfileOpts) (string, error) {
+	return "", nil
+}
+
+func (b *BuildahStub) RunCommand(context.Context, string, []string, buildah.RunCommandOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) FromCommand(ctx context.Context, container, image string, opts buildah.FromCommandOpts) (string, error) {
+	b.FromCommandImages = append(b.FromCommandImages, image)
+	if b.FromCommandFunc != nil {
+		return b.FromCommandFunc(ctx, container, image, opts)
+	}
+	return "", nil
+}
+
+func (b *BuildahStub) Pull(ctx context.Context, ref string, opts buildah.PullOpts) (string, error) {
+	b.PullRefs = append(b.PullRefs, ref)
+	if b.PullFunc != nil {
+		return b.PullFunc(ctx, ref, opts)
+	}
+	return "", nil
+}
+
+func (b *BuildahStub) Inspect(context.Context, string) (*thirdparty.BuilderInfo, error) {
+	return nil, nil
+}
+
+func (b *BuildahStub) Rm(context.Context, string, buildah.RmOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Rmi(context.Context, string, buildah.RmiOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Mount(context.Context, string, buildah.MountOpts) (string, error) {
+	return "", nil
+}
+
+func (b *BuildahStub) Umount(context.Context, string, buildah.UmountOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Commit(context.Context, string, buildah.CommitOpts) (string, error) {
+	return "", nil
+}
+
+func (b *BuildahStub) Config(context.Context, string, buildah.ConfigOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Copy(context.Context, string, string, []string, string, buildah.CopyOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Add(context.Context, string, []string, string, buildah.AddOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Images(context.Context, buildah.ImagesOptions) (image.ImagesList, error) {
+	return nil, nil
+}
+
+func (b *BuildahStub) Containers(context.Context, buildah.ContainersOptions) (image.ContainerList, error) {
+	return nil, nil
+}
+
+func (b *BuildahStub) PruneImages(context.Context, buildah.PruneImagesOptions) (buildah.PruneImagesReport, error) {
+	return buildah.PruneImagesReport{}, nil
+}
+
+func (b *BuildahStub) SaveImageToStream(context.Context, string) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (b *BuildahStub) LoadImageFromStream(context.Context, io.Reader) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
## Summary

With the Buildah backend a build fails with `unable to create container using base image ...: image not known` even though the stage image exists in the registry. It needs a pre-existing host state: werf pulled the image earlier in the same run and cached its local image ID in memory, and the local image behind that ID was then removed (host cleanup, `buildah rmi`, parallel prune) before the stage was used as a base.

## What

- When creating a build container from a cached platform-specific image ID and buildah reports `image not known`, werf re-pulls the image by ref, refreshes the cached ID, and retries container creation once — the build proceeds instead of failing.
- The fallback triggers only when a target platform is set and the image was resolved through the in-memory pulled-image cache; any other container creation error fails as before.
- If the re-pull fails, the build fails with `unable to pull image ... after cached imageID miss`.
- `image not known` is detected by suffix match against the canonical `containers/storage` error, so wrapped errors match too.
- UNVERIFIED: not reproduced end-to-end on a live buildah host — covered by a unit regression test with a stubbed buildah; an e2e run on Linux deleting the local image between stages would settle it.
- Deliberately unchanged: a failed re-pull keeps the stale cache entry, so the next attempt goes through the same fallback instead of starting from an empty cache.

## Why

`BuildahBackend` keeps an in-memory ref+platform → imageID map populated on pull, and `createContainers` resolves base images through it. The map is never invalidated when the local image behind an ID disappears, so `buildah from` receives a dangling ID while the tag is still perfectly pullable from the registry. Left alone, this intermittently fails multi-stage staged-Dockerfile builds on shared runners where host cleanup runs between stages.
