### PR TITLE
refactor(buildah): parallelize dependency imports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/werf/3p-helm-for-werf-helm v0.0.0-20241217155820-089f92cd5c9d
 	github.com/werf/common-go v0.0.0-20260414103517-0558f83edc6d
-	github.com/werf/copy-recurse v0.2.8
+	github.com/werf/copy-recurse v0.3.1
 	github.com/werf/kubedog v0.13.1-0.20260616105957-2c00b08fb99e
 	github.com/werf/kubedog-for-werf-helm v0.0.0-20241217155728-9d45c48b82b6
 	github.com/werf/lockgate v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1408,6 +1408,10 @@ github.com/werf/common-go v0.0.0-20260414103517-0558f83edc6d h1:WFZpNiMTDOu6nRCE
 github.com/werf/common-go v0.0.0-20260414103517-0558f83edc6d/go.mod h1:MXS0JR9zut+oR9oEM8PEkdXXoEbKDILTmWopt0z1eZs=
 github.com/werf/copy-recurse v0.2.8 h1:8IeAx0dGDzvVVaxci7SdVUhOjlkhgDcOVJfxQkxBhUU=
 github.com/werf/copy-recurse v0.2.8/go.mod h1:6Ypb+qN+hRBJgoCgEkX1vpbqcQ+8q69BQ3hi8s8Y6Qc=
+github.com/werf/copy-recurse v0.3.0 h1:OQDPzNPGGPBL5KTPYQjgdDSVZGkTMxm2SQiQfWivvdA=
+github.com/werf/copy-recurse v0.3.0/go.mod h1:6Ypb+qN+hRBJgoCgEkX1vpbqcQ+8q69BQ3hi8s8Y6Qc=
+github.com/werf/copy-recurse v0.3.1 h1:1DXl5+CnxOP9pcvXu7qkY2hnqxUHnE5KWdydALL/Ycs=
+github.com/werf/copy-recurse v0.3.1/go.mod h1:6Ypb+qN+hRBJgoCgEkX1vpbqcQ+8q69BQ3hi8s8Y6Qc=
 github.com/werf/kubedog v0.13.1-0.20260616105957-2c00b08fb99e h1:0GnrtMMti+Qywd4bs4tHtchBS61EzS6t1NYqMPql5dE=
 github.com/werf/kubedog v0.13.1-0.20260616105957-2c00b08fb99e/go.mod h1:gu4EY4hxtiYVDy5o6WE2lRZS0YWqrOV0HS//GTYyrUE=
 github.com/werf/kubedog-for-werf-helm v0.0.0-20241217155728-9d45c48b82b6 h1:lpgQPTCp+wNJfTqJWtR6A5gRA4e4m/eRJFV7V18XCoA=

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -528,8 +529,9 @@ func (backend *BuildahBackend) applyDependenciesImports(ctx context.Context, con
 					relPath := util.GetRelativeToBaseFilepath(absFrom, path)
 					return pathMatcher.IsPathMatched(relPath), err
 				},
-				UID: uid,
-				GID: gid,
+				UID:         uid,
+				GID:         gid,
+				Parallelism: dependencyImportParallelism(),
 			})
 			if err != nil {
 				return fmt.Errorf("error creating recursive copy command: %w", err)
@@ -542,6 +544,22 @@ func (backend *BuildahBackend) applyDependenciesImports(ctx context.Context, con
 	}
 
 	return nil
+}
+
+func dependencyImportParallelism() int {
+	if p, ok := os.LookupEnv("WERF_BUILDAH_IMPORT_PARALLELISM"); ok {
+		if n, err := strconv.Atoi(p); err == nil && n > 0 {
+			return n
+		}
+	}
+	n := runtime.NumCPU()
+	if n > 8 {
+		n = 8
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
 }
 
 func normalizeDependencyImportDestination(absFrom, absTo string) (string, error) {


### PR DESCRIPTION
## Summary

Speeds up the Stapel `import` / `dependencies` stage under the Buildah backend by parallelizing per-file copies and dropping redundant `fchmod`/`fchown` syscalls. On real rootless-overlay imports of thousands of files this cuts wall time 2–2.5×.

## Key changes

- Bump `github.com/werf/copy-recurse` to `v0.3.1`, which brings:
  - `Options.Parallelism` — worker pool for per-file copies ([werf/copy-recurse#18](https://github.com/werf/copy-recurse/pull/18)).
  - Syscall diet: mode set at `OpenFile` creation, `fchmod`/`chown`/`lchown` skipped when they would be no-ops ([werf/copy-recurse#18](https://github.com/werf/copy-recurse/pull/18)).
  - `DirMatch` no longer double-processes its subtree, which was surfacing as an `os.Symlink` race under parallelism ([werf/copy-recurse#19](https://github.com/werf/copy-recurse/pull/19)).
- `pkg/container_backend/buildah_backend.go`:
  - `applyDependenciesImports` now passes `Parallelism = dependencyImportParallelism()` to `copyrec.New`.
  - New `dependencyImportParallelism()` helper: returns `min(runtime.NumCPU(), 8)`; overridable via `WERF_BUILDAH_IMPORT_PARALLELISM=<N>` (namespaced with `WERF_BUILDAH_MODE`, `WERF_BUILDAH_STORAGE_DRIVER`, `WERF_BUILDAH_ULIMIT`, `WERF_BUILDAH_DEBUG`).

## Why

`applyDependenciesImports` under Buildah mounts source and target containers on the host and copies between the two mount paths using `copy-recurse`. That walk was fully serial, and every file paid two extra syscalls (`fchmod`, `fchown`) even when they would be no-ops. On rootless overlay / fuse-overlayfs — the actual werf-buildah production path — per-syscall latency dominates copy time.

User report: ~6 minutes for a single import stage on a large tree, while `docker COPY --from` finishes the same copy in seconds. Parallelism plus dropping redundant metadata syscalls closes roughly half of that gap without changing the copy algorithm.

Measured on Ubuntu 22.04, ext4-backed rootless overlay (`buildah from` + `buildah mount` + `copy-recurse` via `buildah unshare` — same code path as werf), 4 vCPU QEMU, 10 000 × 4 KiB files, mean of 3 runs:

| Config                                | Time  | vs baseline |
|---------------------------------------|-------|-------------|
| baseline copy-recurse v0.2.8 (serial) | 6.44s | 1.00×       |
| v0.3.x `p=1` (syscall diet only)      | 4.42s | **1.46×**   |
| v0.3.x `p=4`                          | 2.85s | **2.26×**   |
| v0.3.x `p=8` (this PR's default here) | 2.59s | **2.49×**   |
| v0.3.x `p=12`                         | 2.38s | **2.71×**   |

## Review focus / risks

- `dependencyImportParallelism()` cap of 8: sanity-check for shared/container-limited runners where `runtime.NumCPU()` overreports the effective quota.
- copy-recurse `Parallelism <= 1` keeps the previous serial code path, so any external callers upgrading past `v0.2.8` get only the syscall-diet fast paths, without any new parallel-write side effects. The syscall-diet itself preserves the final on-disk state; the only observable difference is that regular files are now truncated in place with `O_TRUNC` instead of `unlink` + `create`, so pre-existing hardlinks to the destination survive rather than getting broken.
- Only the Stapel/Buildah `import` path is touched. Dockerfile `COPY --from` and the docker-server `rsync`-based import path are unaffected.
- Stage-cache digest is unaffected: `CalculateDependencyImportChecksum` still uses the same `filepath.Walk`+md5.

Follow-ups (out of scope):
- Reuse the checksum walk for the actual copy to eliminate the double pass over source files.
- Consider using the embedded `rsync` (already shipped for the docker-server path) inside buildah backend to close the remaining gap to `buildah COPY`.