### PR TITLE
refactor(build, git): skip git diff when no matching paths changed

### DIFF
--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -853,6 +853,12 @@ func (gm *GitMapping) PatchSize(ctx context.Context, c Conveyor, fromCommit stri
 		return 0, nil
 	}
 
+	if isEmpty, resolved, err := gm.isPatchEmptyByChangedPaths(ctx, fromCommit, toCommitInfo.Commit); err != nil {
+		return 0, err
+	} else if resolved && isEmpty {
+		return 0, nil
+	}
+
 	patchOpts, err := gm.makePatchOptions(ctx, fromCommit, toCommitInfo.Commit, true, true)
 	if err != nil {
 		return 0, err
@@ -965,6 +971,12 @@ func (gm *GitMapping) baseIsPatchEmpty(ctx context.Context, fromCommit, toCommit
 		return true, nil
 	}
 
+	if isEmpty, resolved, err := gm.isPatchEmptyByChangedPaths(ctx, fromCommit, toCommit); err != nil {
+		return false, err
+	} else if resolved {
+		return isEmpty, nil
+	}
+
 	patchOpts, err := gm.makePatchOptions(ctx, fromCommit, toCommit, false, false)
 	if err != nil {
 		return false, err
@@ -976,6 +988,33 @@ func (gm *GitMapping) baseIsPatchEmpty(ctx context.Context, fromCommit, toCommit
 	}
 
 	return patch.IsEmpty(), nil
+}
+
+// isPatchEmptyByChangedPaths determines patch emptiness by the list of paths changed between
+// two commits, avoiding expensive patch content generation. The changed paths list is computed
+// once per commit pair and shared by all git mappings. resolved=false means emptiness cannot be
+// decided without a real patch: a changed submodule potentially overlaps the mapping paths.
+func (gm *GitMapping) isPatchEmptyByChangedPaths(ctx context.Context, fromCommit, toCommit string) (isEmpty, resolved bool, err error) {
+	changedPaths, err := gm.GitRepo().GetOrCreateChangedPaths(ctx, fromCommit, toCommit)
+	if err != nil {
+		return false, false, fmt.Errorf("unable to get changed paths between %q and %q commits for git mapping %s: %w", fromCommit, toCommit, gm.GetFullName(), err)
+	}
+
+	pathMatcher := gm.getPathMatcher()
+	for _, changedPath := range changedPaths {
+		if changedPath.IsSubmodule {
+			if pathMatcher.IsDirOrSubmodulePathMatched(changedPath.Path) {
+				return false, false, nil
+			}
+			continue
+		}
+
+		if pathMatcher.IsPathMatched(changedPath.Path) {
+			return false, true, nil
+		}
+	}
+
+	return true, true, nil
 }
 
 func (gm *GitMapping) prepareArchiveFile(archive git_repo.Archive) (*ContainerFileDescriptor, error) {

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -49,13 +49,15 @@ func NewBase(name string, initRepoHandleBackedByWorkTreeFunc func(context.Contex
 }
 
 type Cache struct {
-	Patches   sync.Map // map[patchID]Patch
-	Archives  map[string]Archive
-	Checksums sync.Map
+	Patches      sync.Map // map[patchID]Patch
+	Archives     map[string]Archive
+	Checksums    sync.Map
+	ChangedPaths sync.Map // map[fromCommit_toCommit][]true_git.ChangedPath
 
-	archivesMutex  sync.Mutex
-	patchesMutex   sync.Map
-	checksumsMutex sync.Map
+	archivesMutex     sync.Mutex
+	patchesMutex      sync.Map
+	checksumsMutex    sync.Map
+	changedPathsMutex sync.Map
 }
 
 func (repo *Base) initRepoHandleBackedByWorkTree(ctx context.Context, commit string) (repo_handle.Handle, error) {
@@ -174,6 +176,26 @@ func (repo *Base) getOrCreatePatch(ctx context.Context, repoPath, gitDir, repoID
 	repo.Cache.Patches.Store(patchID, patch)
 
 	return patch, nil
+}
+
+func (repo *Base) getOrCreateChangedPaths(ctx context.Context, gitDir, fromCommit, toCommit string) ([]true_git.ChangedPath, error) {
+	key := fmt.Sprintf("%s_%s", fromCommit, toCommit)
+
+	mutex := util.MapLoadOrCreateMutex(&repo.Cache.changedPathsMutex, key)
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if val, ok := repo.Cache.ChangedPaths.Load(key); ok {
+		return val.([]true_git.ChangedPath), nil
+	}
+
+	changedPaths, err := true_git.ListChangedPaths(ctx, gitDir, fromCommit, toCommit)
+	if err != nil {
+		return nil, fmt.Errorf("list changed paths between %q and %q commits: %w", fromCommit, toCommit, err)
+	}
+	repo.Cache.ChangedPaths.Store(key, changedPaths)
+
+	return changedPaths, nil
 }
 
 func (repo *Base) CreatePatch(ctx context.Context, repoPath, gitDir, repoID, workTreeCacheDir string, opts PatchOptions) (patch Patch, err error) {

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -60,6 +60,7 @@ type GitRepo interface {
 	GetCommitTreeEntry(ctx context.Context, commit, path string) (*ls_tree.LsTreeEntry, error)
 	GetMergeCommitParents(ctx context.Context, commit string) ([]string, error)
 	GetOrCreateArchive(ctx context.Context, opts ArchiveOptions) (Archive, error)
+	GetOrCreateChangedPaths(ctx context.Context, fromCommit, toCommit string) ([]true_git.ChangedPath, error)
 	GetOrCreateChecksum(ctx context.Context, opts ChecksumOptions) (string, error)
 	GetOrCreatePatch(ctx context.Context, opts PatchOptions) (Patch, error)
 	HeadCommitHash(ctx context.Context) (string, error)

--- a/pkg/git_repo/local.go
+++ b/pkg/git_repo/local.go
@@ -280,6 +280,10 @@ func (repo *Local) GetOrCreatePatch(ctx context.Context, opts PatchOptions) (Pat
 	return repo.getOrCreatePatch(ctx, repo.WorkTreeDir, repo.GitDir, repo.getRepoID(), repo.getRepoWorkTreeCacheDir(repo.getRepoID()), opts)
 }
 
+func (repo *Local) GetOrCreateChangedPaths(ctx context.Context, fromCommit, toCommit string) ([]true_git.ChangedPath, error) {
+	return repo.getOrCreateChangedPaths(ctx, repo.GitDir, fromCommit, toCommit)
+}
+
 func (repo *Local) GetOrCreateArchive(ctx context.Context, opts ArchiveOptions) (Archive, error) {
 	return repo.getOrCreateArchive(ctx, repo.WorkTreeDir, repo.GitDir, repo.getRepoID(), repo.getRepoWorkTreeCacheDir(repo.getRepoID()), opts)
 }

--- a/pkg/git_repo/remote.go
+++ b/pkg/git_repo/remote.go
@@ -544,6 +544,10 @@ func (repo *Remote) GetOrCreatePatch(ctx context.Context, opts PatchOptions) (Pa
 	return repo.getOrCreatePatch(ctx, repo.GetClonePath(), repo.GetClonePath(), repo.getRepoID(), repo.getWorkTreeCacheDir(repo.getRepoID()), opts)
 }
 
+func (repo *Remote) GetOrCreateChangedPaths(ctx context.Context, fromCommit, toCommit string) ([]true_git.ChangedPath, error) {
+	return repo.getOrCreateChangedPaths(ctx, repo.GetClonePath(), fromCommit, toCommit)
+}
+
 func (repo *Remote) GetOrCreateArchive(ctx context.Context, opts ArchiveOptions) (Archive, error) {
 	return repo.getOrCreateArchive(ctx, repo.GetClonePath(), repo.GetClonePath(), repo.getRepoID(), repo.getWorkTreeCacheDir(repo.getRepoID()), opts)
 }

--- a/pkg/true_git/changed_paths.go
+++ b/pkg/true_git/changed_paths.go
@@ -1,0 +1,55 @@
+package true_git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const submoduleFileMode = "160000"
+
+type ChangedPath struct {
+	Path        string
+	IsSubmodule bool
+}
+
+// ListChangedPaths returns repo-relative paths changed between two commits without generating
+// patch content. Submodule entries are reported with the submodule path itself (no recursion).
+func ListChangedPaths(ctx context.Context, gitDir, fromCommit, toCommit string) ([]ChangedPath, error) {
+	diffCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: gitDir},
+		"-c", "core.quotePath=false",
+		"diff", "--raw", "-z", "--no-renames", fromCommit, toCommit,
+	)
+	if err := diffCmd.Run(ctx); err != nil {
+		return nil, fmt.Errorf("git diff --raw command failed: %w", err)
+	}
+
+	return parseRawDiffPaths(diffCmd.OutBuf.String())
+}
+
+func parseRawDiffPaths(out string) ([]ChangedPath, error) {
+	var result []ChangedPath
+
+	tokens := strings.Split(out, "\x00")
+	for i := 0; i+1 < len(tokens); i += 2 {
+		meta, path := tokens[i], tokens[i+1]
+
+		if !strings.HasPrefix(meta, ":") {
+			return nil, fmt.Errorf("unexpected git raw diff entry %q", meta)
+		}
+
+		metaFields := strings.Fields(strings.TrimPrefix(meta, ":"))
+		if len(metaFields) < 5 {
+			return nil, fmt.Errorf("unexpected git raw diff entry %q", meta)
+		}
+
+		srcMode, dstMode := metaFields[0], metaFields[1]
+
+		result = append(result, ChangedPath{
+			Path:        path,
+			IsSubmodule: srcMode == submoduleFileMode || dstMode == submoduleFileMode,
+		})
+	}
+
+	return result, nil
+}

--- a/pkg/true_git/changed_paths_test.go
+++ b/pkg/true_git/changed_paths_test.go
@@ -1,0 +1,43 @@
+package true_git
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("parseRawDiffPaths", func() {
+	DescribeTable("parsing git diff --raw -z --no-renames output",
+		func(out string, expected []ChangedPath) {
+			changedPaths, err := parseRawDiffPaths(out)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changedPaths).To(Equal(expected))
+		},
+		Entry("empty output", "", nil),
+		Entry("modified file",
+			":100644 100644 bcd1234567890123456789012345678901234567 0123456789012345678901234567890123456789 M\x00dir/file.go\x00",
+			[]ChangedPath{{Path: "dir/file.go"}},
+		),
+		Entry("added and deleted files",
+			":000000 100644 0000000000000000000000000000000000000000 1111111111111111111111111111111111111111 A\x00new.txt\x00"+
+				":100755 000000 2222222222222222222222222222222222222222 0000000000000000000000000000000000000000 D\x00old.sh\x00",
+			[]ChangedPath{{Path: "new.txt"}, {Path: "old.sh"}},
+		),
+		Entry("changed submodule pin",
+			":160000 160000 3333333333333333333333333333333333333333 4444444444444444444444444444444444444444 M\x00sub\x00",
+			[]ChangedPath{{Path: "sub", IsSubmodule: true}},
+		),
+		Entry("path converted to submodule",
+			":100644 160000 5555555555555555555555555555555555555555 6666666666666666666666666666666666666666 T\x00sub\x00",
+			[]ChangedPath{{Path: "sub", IsSubmodule: true}},
+		),
+		Entry("path with spaces and unicode",
+			":100644 100644 bcd1234567890123456789012345678901234567 0123456789012345678901234567890123456789 M\x00dir with spaces/файл.txt\x00",
+			[]ChangedPath{{Path: "dir with spaces/файл.txt"}},
+		),
+	)
+
+	It("fails on malformed entry", func() {
+		_, err := parseRawDiffPaths("garbage\x00path\x00")
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/true_git/patch.go
+++ b/pkg/true_git/patch.go
@@ -157,6 +157,12 @@ func writePatch(ctx context.Context, out io.Writer, gitDir, workTreeCacheDir str
 		gitArgs = append(gitArgs, diffOpts...)
 		gitArgs = append(gitArgs, opts.FromCommit, opts.ToCommit)
 
+		// Limit diff computation to the path scope. Not used with submodules: pathspec is
+		// evaluated at the superproject level and would not match paths inside submodules.
+		if pathScope := filepath.ToSlash(filepath.Clean(opts.PathScope)); pathScope != "." && pathScope != "/" && !strings.HasPrefix(pathScope, ":") {
+			gitArgs = append(gitArgs, "--", ":(literal)"+pathScope)
+		}
+
 		if debugPatch() {
 			fmt.Printf("# git %s\n", strings.Join(gitArgs, " "))
 		}

--- a/test/mock/git_repo.go
+++ b/test/mock/git_repo.go
@@ -17,6 +17,7 @@ import (
 	git_repo "github.com/werf/werf/v2/pkg/git_repo"
 	repo_handle "github.com/werf/werf/v2/pkg/git_repo/repo_handle"
 	path_matcher "github.com/werf/werf/v2/pkg/path_matcher"
+	true_git "github.com/werf/werf/v2/pkg/true_git"
 	ls_tree "github.com/werf/werf/v2/pkg/true_git/ls_tree"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -131,6 +132,21 @@ func (m *MockGitRepo) GetOrCreateArchive(ctx context.Context, opts git_repo.Arch
 func (mr *MockGitRepoMockRecorder) GetOrCreateArchive(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateArchive", reflect.TypeOf((*MockGitRepo)(nil).GetOrCreateArchive), ctx, opts)
+}
+
+// GetOrCreateChangedPaths mocks base method.
+func (m *MockGitRepo) GetOrCreateChangedPaths(ctx context.Context, fromCommit, toCommit string) ([]true_git.ChangedPath, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrCreateChangedPaths", ctx, fromCommit, toCommit)
+	ret0, _ := ret[0].([]true_git.ChangedPath)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrCreateChangedPaths indicates an expected call of GetOrCreateChangedPaths.
+func (mr *MockGitRepoMockRecorder) GetOrCreateChangedPaths(ctx, fromCommit, toCommit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateChangedPaths", reflect.TypeOf((*MockGitRepo)(nil).GetOrCreateChangedPaths), ctx, fromCommit, toCommit)
 }
 
 // GetOrCreateChecksum mocks base method.
@@ -671,6 +687,21 @@ func (m *MockgitRepo) GetOrCreateArchive(ctx context.Context, opts git_repo.Arch
 func (mr *MockgitRepoMockRecorder) GetOrCreateArchive(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateArchive", reflect.TypeOf((*MockgitRepo)(nil).GetOrCreateArchive), ctx, opts)
+}
+
+// GetOrCreateChangedPaths mocks base method.
+func (m *MockgitRepo) GetOrCreateChangedPaths(ctx context.Context, fromCommit, toCommit string) ([]true_git.ChangedPath, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrCreateChangedPaths", ctx, fromCommit, toCommit)
+	ret0, _ := ret[0].([]true_git.ChangedPath)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrCreateChangedPaths indicates an expected call of GetOrCreateChangedPaths.
+func (mr *MockgitRepoMockRecorder) GetOrCreateChangedPaths(ctx, fromCommit, toCommit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateChangedPaths", reflect.TypeOf((*MockgitRepo)(nil).GetOrCreateChangedPaths), ctx, fromCommit, toCommit)
 }
 
 // GetOrCreateChecksum mocks base method.


### PR DESCRIPTION
## Summary

Stage patch emptiness for `gitCache` and `gitLatestPatch` is now determined from a cheap, shared list of changed paths instead of generating full patch content per image. On large monorepos with hundreds of images (e.g. deckhouse) this cuts minutes of pure `git diff` work from builds where no relevant paths changed.

## Key changes

- `pkg/true_git/changed_paths.go` (new): `ListChangedPaths` runs `git diff --raw -z --no-renames <from> <to>` and returns changed paths with submodule (gitlink, mode `160000`) flags — no patch content is generated.
- `pkg/git_repo`: new `GitRepo.GetOrCreateChangedPaths` interface method; `Base.getOrCreateChangedPaths` caches the result in-memory per `(fromCommit, toCommit)` pair, so one raw diff serves all git mappings of all images; implementations for `Local` and `Remote`.
- `pkg/build/stage/git_mapping.go`: `isPatchEmptyByChangedPaths` fast path wired into `baseIsPatchEmpty` (gitLatestPatch `IsEmpty`) and `PatchSize` (gitCache `IsEmpty`). A changed regular path matched by the mapping's `PathMatcher` → non-empty; a changed submodule overlapping the matcher → undecidable, falls back to real patch generation; no matches → empty.
- `pkg/true_git/patch.go`: real patch generation is now limited to the mapping path scope via `-- :(literal)<PathScope>` pathspec — only for repositories without submodules (superproject-level pathspec does not reach inside submodules).
- Regenerated `test/mock/git_repo.go`; added Ginkgo `DescribeTable` specs for the raw diff parser.

## Why

Analysis of a real deckhouse frontend build log showed 1486 "Creating patch" operations totaling ~1300s (≈6 min wall clock with 5 parallel workers), all to conclude that patches were empty. Each `gitCache`/`gitLatestPatch` emptiness check ran a whole-repo `git diff` between a months-old base commit and HEAD (for `gitCache` — with `diff.context=999999999` and `--binary`), streamed hundreds of MB through the Go diff parser, and discarded almost all of it: `PathScope`/`PathMatcher` were applied only in-process, and the patch cache key includes the matcher ID, so nothing was shared between images. With this change the same build performs ~30 cheap raw diffs (one per unique commit pair) plus in-memory path filtering.

## Review focus / risks

- Emptiness equivalence: a `--raw` entry exists iff the full diff contains a `diff --git` header for that path iff the parser previously added it to `Paths` (both use `--no-renames`/`diff.renames=false`; mode-only changes produce a header and are counted by both). Please sanity-check this reasoning against `pkg/true_git/diff_parser.go` (`handleDiffBegin`).
- Cache compatibility: stage digests are unchanged by construction — `gitCache` digest buckets by patch size (fast path returns 0 only where the filtered patch file was already 0 bytes), `gitLatestPatch` digest hashes patch content, and the pathspec only excludes diffs the parser dropped anyway. No registry cache invalidation, host patch cache keys (`PatchOptions.ID()`) untouched.
- Submodule handling is conservative: any changed gitlink overlapping the mapping matcher (`IsDirOrSubmodulePathMatched`) falls back to the old full-patch path; pathspec is not applied in the submodule branch of `writePatch`.
- `:(literal)` pathspec magic guards against glob characters (`*`, `?`, `[`) in `add:` paths being interpreted by git wildmatch.
- Not addressed (out of scope): worktree cache lock serializing patch creation for submodule repos; worktree pool is still opt-in via `WERF_GIT_WORK_TREE_POOL_LIMIT`.
