### PR TITLE
refactor(build): thin out remaining --log-debug noise

### DIFF
--- a/docs/pages_en/reference/debug_env_vars.md
+++ b/docs/pages_en/reference/debug_env_vars.md
@@ -24,7 +24,7 @@ The variables below enable narrow debug channels. Channels that write to the deb
 | `WERF_DEBUG_CONVEYOR_PHASES` | Build conveyor phase wrappers (BeforeImages, OnImageStage, AfterImages, etc.). Requires `--log-debug` |
 | `WERF_DEBUG_IMAGE_SPEC` | YAML snapshots of the image spec configuration (source image info, prepared and pushed config). Requires `--log-debug` |
 | `WERF_DEBUG_IMPORT_SERVER` | Rsync import server traces. Requires `--log-debug` |
-| `WERF_DEBUG_STAGE_DIGEST` | Stage digest calculation arguments (the named values the digest is derived from). The resulting digest itself is always logged. Requires `--log-debug` |
+| `WERF_DEBUG_STAGE_DIGEST` | Stage digest calculation arguments (the named values the digest is derived from). The resulting digest itself is logged with `--log-debug` regardless of this variable. Requires `--log-debug` |
 | `WERF_DEBUG_USER_STAGE_CHECKSUM` | User stage checksum calculation details. Requires `--log-debug` |
 | `WERF_DEBUG_IMPORT_SOURCE_CHECKSUM` | Import source checksum calculation details. Requires `--log-debug` |
 | `WERF_DEBUG_DOCKERFILE_STAGE_DEPENDENCIES` | Controls two channels: Dockerfile stage dependency calculation and per-match build context paths during context checksum calculation. Requires `--log-debug` |

--- a/docs/pages_en/reference/debug_env_vars.md
+++ b/docs/pages_en/reference/debug_env_vars.md
@@ -24,6 +24,7 @@ The variables below enable narrow debug channels. Channels that write to the deb
 | `WERF_DEBUG_CONVEYOR_PHASES` | Build conveyor phase wrappers (BeforeImages, OnImageStage, AfterImages, etc.). Requires `--log-debug` |
 | `WERF_DEBUG_IMAGE_SPEC` | YAML snapshots of the image spec configuration (source image info, prepared and pushed config). Requires `--log-debug` |
 | `WERF_DEBUG_IMPORT_SERVER` | Rsync import server traces. Requires `--log-debug` |
+| `WERF_DEBUG_STAGE_DIGEST` | Stage digest calculation arguments (the named values the digest is derived from). The resulting digest itself is always logged. Requires `--log-debug` |
 | `WERF_DEBUG_USER_STAGE_CHECKSUM` | User stage checksum calculation details. Requires `--log-debug` |
 | `WERF_DEBUG_IMPORT_SOURCE_CHECKSUM` | Import source checksum calculation details. Requires `--log-debug` |
 | `WERF_DEBUG_DOCKERFILE_STAGE_DEPENDENCIES` | Controls two channels: Dockerfile stage dependency calculation and per-match build context paths during context checksum calculation. Requires `--log-debug` |

--- a/docs/pages_ru/reference/debug_env_vars.md
+++ b/docs/pages_ru/reference/debug_env_vars.md
@@ -24,6 +24,7 @@ werf поддерживает набор переменных окружения
 | `WERF_DEBUG_CONVEYOR_PHASES` | Обёртки фаз сборочного конвейера (BeforeImages, OnImageStage, AfterImages и др.). Требует `--log-debug` |
 | `WERF_DEBUG_IMAGE_SPEC` | YAML-снимки конфигурации image spec (информация об исходном образе, подготовленный и публикуемый конфиг). Требует `--log-debug` |
 | `WERF_DEBUG_IMPORT_SERVER` | Трейсы rsync-сервера импортов. Требует `--log-debug` |
+| `WERF_DEBUG_STAGE_DIGEST` | Аргументы расчёта digest'а стадии (именованные значения, из которых он вычисляется). Сам итоговый digest логируется всегда. Требует `--log-debug` |
 | `WERF_DEBUG_USER_STAGE_CHECKSUM` | Детали расчёта контрольной суммы пользовательских стадий. Требует `--log-debug` |
 | `WERF_DEBUG_IMPORT_SOURCE_CHECKSUM` | Детали расчёта контрольной суммы источников импорта. Требует `--log-debug` |
 | `WERF_DEBUG_DOCKERFILE_STAGE_DEPENDENCIES` | Управляет двумя каналами: расчёт зависимостей стадий Dockerfile и перечисление совпавших путей build-контекста при расчёте его контрольной суммы. Требует `--log-debug` |

--- a/docs/pages_ru/reference/debug_env_vars.md
+++ b/docs/pages_ru/reference/debug_env_vars.md
@@ -24,7 +24,7 @@ werf поддерживает набор переменных окружения
 | `WERF_DEBUG_CONVEYOR_PHASES` | Обёртки фаз сборочного конвейера (BeforeImages, OnImageStage, AfterImages и др.). Требует `--log-debug` |
 | `WERF_DEBUG_IMAGE_SPEC` | YAML-снимки конфигурации image spec (информация об исходном образе, подготовленный и публикуемый конфиг). Требует `--log-debug` |
 | `WERF_DEBUG_IMPORT_SERVER` | Трейсы rsync-сервера импортов. Требует `--log-debug` |
-| `WERF_DEBUG_STAGE_DIGEST` | Аргументы расчёта digest'а стадии (именованные значения, из которых он вычисляется). Сам итоговый digest логируется всегда. Требует `--log-debug` |
+| `WERF_DEBUG_STAGE_DIGEST` | Аргументы расчёта digest'а стадии (именованные значения, из которых он вычисляется). Сам итоговый digest логируется при `--log-debug` независимо от этой переменной. Требует `--log-debug` |
 | `WERF_DEBUG_USER_STAGE_CHECKSUM` | Детали расчёта контрольной суммы пользовательских стадий. Требует `--log-debug` |
 | `WERF_DEBUG_IMPORT_SOURCE_CHECKSUM` | Детали расчёта контрольной суммы источников импорта. Требует `--log-debug` |
 | `WERF_DEBUG_DOCKERFILE_STAGE_DEPENDENCIES` | Управляет двумя каналами: расчёт зависимостей стадий Dockerfile и перечисление совпавших путей build-контекста при расчёте его контрольной суммы. Требует `--log-debug` |

--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -1270,12 +1270,12 @@ func calculateDigest(ctx context.Context, stageName, stageDependencies string, p
 
 	digest := util.Sha3_224Hash(checksumArgs...)
 
-	blockMsg := fmt.Sprintf("Stage %s digest %s", stageName, digest)
-	logboek.Context(ctx).Debug().LogBlock(blockMsg).Do(func() {
+	logboek.Context(ctx).Debug().LogF("Stage %s digest %s\n", stageName, digest)
+	if debugStageDigest() {
 		for ind, checksumArg := range checksumArgs {
 			logboek.Context(ctx).Debug().LogF("%s => %q\n", checksumArgsNames[ind], checksumArg)
 		}
-	})
+	}
 
 	return digest, nil
 }
@@ -1337,4 +1337,8 @@ func (phase *BuildPhase) Clone() Phase {
 
 func (phase *BuildPhase) Report() *ImagesReport {
 	return phase.ImagesReport
+}
+
+func debugStageDigest() bool {
+	return os.Getenv("WERF_DEBUG_STAGE_DIGEST") == "1"
 }

--- a/pkg/build/build_report.go
+++ b/pkg/build/build_report.go
@@ -294,9 +294,6 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 		}
 	}
 
-	debugJsonData, err := phase.ImagesReport.ToJsonData()
-	logboek.Context(ctx).Debug().LogF("ImagesReport: (err: %v)\n%s", err, debugJsonData)
-
 	phase.ImagesReport.sendTelemetry(ctx)
 
 	for imageName, record := range phase.ImagesReport.Images {
@@ -318,10 +315,10 @@ func createBuildReport(ctx context.Context, phase *BuildPhase, imagePairs []util
 			if data, err = phase.ImagesReport.ToJsonData(); err != nil {
 				return fmt.Errorf("unable to prepare report json: %w", err)
 			}
-			logboek.Context(ctx).Debug().LogF("Writing json report to the %q:\n%s", phase.ReportPath, data)
+			logboek.Context(ctx).Debug().LogF("Writing json report to the %q\n", phase.ReportPath)
 		case ReportEnvFile:
 			data = phase.ImagesReport.ToEnvFileData()
-			logboek.Context(ctx).Debug().LogF("Writing envfile report to the %q:\n%s", phase.ReportPath, data)
+			logboek.Context(ctx).Debug().LogF("Writing envfile report to the %q\n", phase.ReportPath)
 		default:
 			panic(fmt.Sprintf("unknown report format %q", phase.ReportFormat))
 		}

--- a/pkg/build/image/dockerfile.go
+++ b/pkg/build/image/dockerfile.go
@@ -364,8 +364,6 @@ func mapLegacyDockerfileToImage(ctx context.Context, metaConfig *config.Meta, do
 		img.stages = append(img.stages, stage.GenerateImageSpecStage(dockerfileImageConfig.ImageSpec, baseStageOptions))
 	}
 
-	logboek.Context(ctx).Info().LogFDetails("Using stage %s\n", dockerfileStage.Name())
-
 	return img, nil
 }
 

--- a/pkg/build/image/image_tree.go
+++ b/pkg/build/image/image_tree.go
@@ -340,9 +340,8 @@ func filterAndLogGitMappings(ctx context.Context, gitMappings []*stage.GitMappin
 	return res, nil
 }
 
-func appendIfExist(ctx context.Context, stages []stage.Interface, stage stage.Interface) []stage.Interface {
+func appendIfExist(stages []stage.Interface, stage stage.Interface) []stage.Interface {
 	if !reflect.ValueOf(stage).IsNil() {
-		logboek.Context(ctx).Info().LogFDetails("Using stage %s\n", stage.Name())
 		return append(stages, stage)
 	}
 

--- a/pkg/build/image/stapel.go
+++ b/pkg/build/image/stapel.go
@@ -104,20 +104,20 @@ func initStages(ctx context.Context, image *Image, metaConfig *config.Meta, stap
 
 	imageCacheVersion := option.ValueOrDefault(stapelImageConfig.CacheVersion(), metaConfig.Build.CacheVersion)
 
-	stages = appendIfExist(ctx, stages, stage.GenerateFromStage(imageBaseConfig, image.baseImageRepoId, imageCacheVersion, baseStageOptions))
-	stages = appendIfExist(ctx, stages, stage.GenerateBeforeInstallStage(ctx, imageBaseConfig, baseStageOptions))
-	stages = appendIfExist(ctx, stages, stage.GenerateDependenciesBeforeInstallStage(imageBaseConfig, baseStageOptions))
+	stages = appendIfExist(stages, stage.GenerateFromStage(imageBaseConfig, image.baseImageRepoId, imageCacheVersion, baseStageOptions))
+	stages = appendIfExist(stages, stage.GenerateBeforeInstallStage(ctx, imageBaseConfig, baseStageOptions))
+	stages = appendIfExist(stages, stage.GenerateDependenciesBeforeInstallStage(imageBaseConfig, baseStageOptions))
 
 	if gitMappingsExist {
 		stages = append(stages, stage.NewGitArchiveStage(gitArchiveStageOptions, baseStageOptions))
 	}
 
-	stages = appendIfExist(ctx, stages, stage.GenerateInstallStage(ctx, imageBaseConfig, gitPatchStageOptions, baseStageOptions))
-	stages = appendIfExist(ctx, stages, stage.GenerateDependenciesAfterInstallStage(imageBaseConfig, baseStageOptions))
-	stages = appendIfExist(ctx, stages, stage.GenerateBeforeSetupStage(ctx, imageBaseConfig, gitPatchStageOptions, baseStageOptions))
-	stages = appendIfExist(ctx, stages, stage.GenerateDependenciesBeforeSetupStage(imageBaseConfig, baseStageOptions))
-	stages = appendIfExist(ctx, stages, stage.GenerateSetupStage(ctx, imageBaseConfig, gitPatchStageOptions, baseStageOptions))
-	stages = appendIfExist(ctx, stages, stage.GenerateDependenciesAfterSetupStage(imageBaseConfig, baseStageOptions))
+	stages = appendIfExist(stages, stage.GenerateInstallStage(ctx, imageBaseConfig, gitPatchStageOptions, baseStageOptions))
+	stages = appendIfExist(stages, stage.GenerateDependenciesAfterInstallStage(imageBaseConfig, baseStageOptions))
+	stages = appendIfExist(stages, stage.GenerateBeforeSetupStage(ctx, imageBaseConfig, gitPatchStageOptions, baseStageOptions))
+	stages = appendIfExist(stages, stage.GenerateDependenciesBeforeSetupStage(imageBaseConfig, baseStageOptions))
+	stages = appendIfExist(stages, stage.GenerateSetupStage(ctx, imageBaseConfig, gitPatchStageOptions, baseStageOptions))
+	stages = appendIfExist(stages, stage.GenerateDependenciesAfterSetupStage(imageBaseConfig, baseStageOptions))
 
 	if !stapelImageConfig.IsGitAfterPatchDisabled() {
 		if gitMappingsExist {
@@ -125,11 +125,11 @@ func initStages(ctx context.Context, image *Image, metaConfig *config.Meta, stap
 			stages = append(stages, stage.NewGitLatestPatchStage(gitPatchStageOptions, baseStageOptions))
 		}
 
-		stages = appendIfExist(ctx, stages, stage.GenerateStapelDockerInstructionsStage(stapelImageConfig.(*config.StapelImage), baseStageOptions))
+		stages = appendIfExist(stages, stage.GenerateStapelDockerInstructionsStage(stapelImageConfig.(*config.StapelImage), baseStageOptions))
 	}
 
 	if imageBaseConfig.ImageSpec != nil && !opts.Conveyor.SkipImageSpecStage() {
-		stages = appendIfExist(ctx, stages, stage.GenerateImageSpecStage(imageBaseConfig.ImageSpec, baseStageOptions))
+		stages = appendIfExist(stages, stage.GenerateImageSpecStage(imageBaseConfig.ImageSpec, baseStageOptions))
 	}
 
 	if len(gitMappings) != 0 {

--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -739,7 +739,7 @@ func (m *StorageManager) SelectSuitableStageDesc(ctx context.Context, c stage.Co
 	}
 
 	var stageDesc *image.StageDesc
-	if err := logboek.Context(ctx).Info().LogProcess("Selecting suitable image for stage %s by digest %s", stg.Name(), stg.GetDigest()).
+	if err := logboek.Context(ctx).Debug().LogProcess("Selecting suitable image for stage %s by digest %s", stg.Name(), stg.GetDigest()).
 		DoError(func() error {
 			var err error
 			stageDesc, err = stg.SelectSuitableStageDesc(ctx, c, stageDescSet)
@@ -896,14 +896,16 @@ func getStageDescFromLocalManifestCache(ctx context.Context, projectName string,
 	}
 
 	if imgInfo != nil {
-		logboek.Context(ctx).Info().LogF("Got image %s info from the manifest cache (CACHE HIT)\n", stageImageName)
+		if debugStagesStorage() {
+			logboek.Context(ctx).Debug().LogF("Got image %s info from the manifest cache (CACHE HIT)\n", stageImageName)
+		}
 
 		return &image.StageDesc{
 			StageID: image.NewStageID(stageID.Digest, stageID.CreationTs),
 			Info:    imgInfo,
 		}, nil
-	} else {
-		logboek.Context(ctx).Info().LogF("Not found %s image info in the manifest cache (CACHE MISS)\n", stageImageName)
+	} else if debugStagesStorage() {
+		logboek.Context(ctx).Debug().LogF("Not found %s image info in the manifest cache (CACHE MISS)\n", stageImageName)
 	}
 
 	return nil, nil

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -365,7 +365,9 @@ FindSuitableStages:
 			}
 			return nil, fmt.Errorf("unable to get digest and creation timestamp from tag %q: %w", tag, err)
 		} else if parentStageCreationTs > creationTs {
-			logboek.Context(ctx).Debug().LogF("Skip stage %s (parent stage creation timestamp %d is greater than the stage creation timestamp %d)\n", tag, parentStageCreationTs, creationTs)
+			if debugStagesStorage() {
+				logboek.Context(ctx).Debug().LogF("Skip stage %s (parent stage creation timestamp %d is greater than the stage creation timestamp %d)\n", tag, parentStageCreationTs, creationTs)
+			}
 			continue
 		} else {
 			stageID := image.NewStageID(digest, creationTs)
@@ -377,7 +379,9 @@ FindSuitableStages:
 				}
 			}
 
-			logboek.Context(ctx).Debug().LogF("Stage %q is suitable for digest %q\n", tag, digest)
+			if debugStagesStorage() {
+				logboek.Context(ctx).Debug().LogF("Stage %q is suitable for digest %q\n", tag, digest)
+			}
 			res = append(res, *stageID)
 		}
 	}
@@ -1189,25 +1193,19 @@ func (storage *RepoStagesStorage) PostSyncServerRecord(ctx context.Context, proj
 }
 
 func (storage *RepoStagesStorage) Tags(ctx context.Context, reference string, opts ...docker_registry.Option) ([]string, error) {
-	var tags []string
-	if err := logboek.Context(ctx).Info().LogProcess("List tags for repo %s", reference).DoError(func() error {
-		var err error
-		tags, err = storage.DockerRegistry.Tags(ctx, reference, opts...)
-		if err != nil {
-			return err
-		}
-		logboek.Context(ctx).Info().LogF("Total tags listed: %d\n", len(tags))
-
-		if !storage.skipMetaCheck {
-			if err := storage.checkMeta(ctx, tags, opts...); err != nil {
-				logboek.Context(ctx).Warn().LogF("unable to check meta tags: %s\n", err)
-			}
-		}
-
-		return nil
-	}); err != nil {
+	startedAt := time.Now()
+	tags, err := storage.DockerRegistry.Tags(ctx, reference, opts...)
+	if err != nil {
 		return nil, err
 	}
+	logboek.Context(ctx).Debug().LogF("Listed %d tags for repo %s (%.2f seconds)\n", len(tags), reference, time.Since(startedAt).Seconds())
+
+	if !storage.skipMetaCheck {
+		if err := storage.checkMeta(ctx, tags, opts...); err != nil {
+			logboek.Context(ctx).Warn().LogF("unable to check meta tags: %s\n", err)
+		}
+	}
+
 	return tags, nil
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #7683: thins out the remaining high-volume channels of `werf build --log-debug` — the images report JSON dumps, the per-stage digest argument blocks, registry tag listing, manifest-cache and stage-selection chatter. Measured on a real 821K-line production build log, the base `--log-debug` output shrinks by ≈251K lines with no functional change.

## Key changes

- `build_report.go`: drop both full images report JSON dumps (~192K lines, one of them marshaled even without `--log-debug`); keep a one-line `Writing … report` trace — the report stays available via `--save-build-report`.
- `calculateDigest`: replace the per-stage `LogBlock` of `Name => value` argument lines with a single Debug anchor `Stage <name> digest <hash>`; the argument dump moves behind the new `WERF_DEBUG_STAGE_DIGEST=1` (documented in both locales of the debug env vars reference).
- `SelectSuitableStageDesc`: demote the `Selecting suitable image …` `LogProcess` Info → Debug, keeping per-stage timing on `--log-debug`.
- `GetStagesIDsByDigest`: gate the per-candidate `is suitable` / `Skip stage` lines behind the existing `WERF_DEBUG_STAGES_STORAGE`.
- `RepoStagesStorage.Tags`: replace the Info `LogProcess` + `Total tags listed` (3+ lines per call, ~5.4K calls per large build) with one Debug line `Listed N tags for repo X (T seconds)`, timing only the registry call.
- Manifest cache: `CACHE HIT`/`CACHE MISS` Info → Debug behind `WERF_DEBUG_STAGES_STORAGE`.
- Remove the tree-construction `Using stage <stage-name>` chronicle (`image_tree.go`, `dockerfile.go`) together with `appendIfExist`'s now-orphaned `ctx` parameter; the cache-selection `Using stage <image>` lines in `stage/base.go` stay at Info.

## Why

#7683 curated ~470K lines but deliberately left Info-level channels and the debug "core" untouched. On large projects the remaining noise still makes `--log-debug` impractical: the digest argument blocks alone are ~33K lines, tag listing ~16K, and the report is dumped twice in full. This PR keeps every diagnostic anchor (digest per stage, selection timing, registry latency) while pushing the bulk behind opt-in `WERF_DEBUG_*` variables.

## Review focus / risks

- Info-level output changes on purpose: `List tags for repo`, `Total tags listed`, `CACHE HIT/MISS` and the tree-construction `Using stage` no longer appear at `--log-verbose`; cleanup commands lose the tag-listing progress process. External pipelines grepping these strings would notice (no in-repo consumer does). Worth a release-note line.
- `Tags()` restructure (`repo_stages_storage.go`): the registry error path and the best-effort `checkMeta` warning must stay behaviourally identical — verified by review and by comparing cache-reuse behaviour against a binary built from the parent commit (the demoted `LogProcess` still executes its body when `--log-debug` is off).
- The kept `Using stage <image>` Info line loses its enclosing `Selecting suitable image` frame at `--log-verbose`; it is self-identifying and the sibling `Get … stages by digest … from storage` process still gives context.
