### PR TITLE
fix(build): honor COPY --parents in staged Dockerfile build

### DIFF
--- a/pkg/build/image/build_context_archive.go
+++ b/pkg/build/image/build_context_archive.go
@@ -130,7 +130,7 @@ func (a *BuildContextArchive) CleanupExtractedDir(ctx context.Context) {
 	}
 }
 
-func (a *BuildContextArchive) CalculateGlobsChecksum(ctx context.Context, globs []string, checkForArchives bool) (string, error) {
+func (a *BuildContextArchive) CalculateGlobsChecksum(ctx context.Context, globs []string, opts container_backend.CalculateGlobsChecksumOptions) (string, error) {
 	contextDir, err := a.ExtractOrGetExtractedDir(ctx)
 	if err != nil {
 		return "", fmt.Errorf("unable to get build context dir: %w", err)
@@ -142,7 +142,7 @@ func (a *BuildContextArchive) CalculateGlobsChecksum(ctx context.Context, globs 
 	}
 	logboek.Context(ctx).Debug().LogF("Calculating checksum for globs %v in context dir %q: will scan following dirs globs: %v\n", globs, contextDir, contextGlobs)
 
-	globStats, err := copier.Stat(contextDir, contextDir, copier.StatOptions{CheckForArchives: checkForArchives}, contextGlobs)
+	globStats, err := copier.Stat(contextDir, contextDir, copier.StatOptions{CheckForArchives: opts.CheckForArchives}, contextGlobs)
 	if err != nil {
 		return "", fmt.Errorf("unable to stat globs: %w", err)
 	}
@@ -164,12 +164,19 @@ func (a *BuildContextArchive) CalculateGlobsChecksum(ctx context.Context, globs 
 		}
 	}
 
+	sort.Strings(matches)
+	matches = util.UniqStrings(matches)
+
 	pathsChecksum, err := a.CalculatePathsChecksum(ctx, matches)
 	if err != nil {
 		return "", fmt.Errorf("unable to calculate build context paths checksum: %w", err)
 	}
 
-	return pathsChecksum, nil
+	if !opts.IncludeMatchedPaths {
+		return pathsChecksum, nil
+	}
+
+	return util.Sha256Hash(append(matches, pathsChecksum)...), nil
 }
 
 func (a *BuildContextArchive) CalculatePathsChecksum(ctx context.Context, paths []string) (string, error) {

--- a/pkg/build/image/build_context_archive_ai_test.go
+++ b/pkg/build/image/build_context_archive_ai_test.go
@@ -1,0 +1,49 @@
+package image
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/werf/werf/v2/pkg/container_backend"
+)
+
+func newBuildContextArchiveAI(t *testing.T, dirName string) *BuildContextArchive {
+	t.Helper()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, dirName), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, dirName, "x"), []byte("data"), 0o644))
+
+	return &BuildContextArchive{path: filepath.Join(root, "context.tar"), extractionDir: root}
+}
+
+func TestAI_CalculateGlobsChecksumMatchedPaths(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		name  string
+		opts  container_backend.CalculateGlobsChecksumOptions
+		equal bool
+	}{
+		{"contents only", container_backend.CalculateGlobsChecksumOptions{}, true},
+		{"matched paths included", container_backend.CalculateGlobsChecksumOptions{IncludeMatchedPaths: true}, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			checksumAAA, err := newBuildContextArchiveAI(t, "aaa").CalculateGlobsChecksum(ctx, []string{"./*"}, tt.opts)
+			require.NoError(t, err)
+
+			checksumCCC, err := newBuildContextArchiveAI(t, "ccc").CalculateGlobsChecksum(ctx, []string{"./*"}, tt.opts)
+			require.NoError(t, err)
+
+			if tt.equal {
+				require.Equal(t, checksumAAA, checksumCCC)
+			} else {
+				require.NotEqual(t, checksumAAA, checksumCCC)
+			}
+		})
+	}
+}

--- a/pkg/build/stage/instruction/add.go
+++ b/pkg/build/stage/instruction/add.go
@@ -57,7 +57,7 @@ func (stg *Add) GetDependencies(ctx context.Context, c stage.Conveyor, cb contai
 	}
 
 	if len(fileGlobSrc) > 0 {
-		if srcChecksum, err := buildContextArchive.CalculateGlobsChecksum(ctx, fileGlobSrc, true); err != nil {
+		if srcChecksum, err := buildContextArchive.CalculateGlobsChecksum(ctx, fileGlobSrc, container_backend.CalculateGlobsChecksumOptions{CheckForArchives: true}); err != nil {
 			return "", fmt.Errorf("unable to calculate build context globs checksum: %w", err)
 		} else {
 			args = append(args, "SourcesChecksum", srcChecksum)

--- a/pkg/build/stage/instruction/copy.go
+++ b/pkg/build/stage/instruction/copy.go
@@ -63,7 +63,7 @@ func (stg *Copy) GetDependencies(ctx context.Context, c stage.Conveyor, cb conta
 	}
 
 	if stg.UsesBuildContext() {
-		if srcChecksum, err := buildContextArchive.CalculateGlobsChecksum(ctx, stg.instruction.Data.SourcePaths, false); err != nil {
+		if srcChecksum, err := buildContextArchive.CalculateGlobsChecksum(ctx, stg.instruction.Data.SourcePaths, container_backend.CalculateGlobsChecksumOptions{IncludeMatchedPaths: stg.instruction.Data.Parents}); err != nil {
 			return "", fmt.Errorf("unable to calculate build context globs checksum: %w", err)
 		} else {
 			args = append(args, "SourcesChecksum", srcChecksum)

--- a/pkg/build/stage/instruction/copy.go
+++ b/pkg/build/stage/instruction/copy.go
@@ -57,6 +57,11 @@ func (stg *Copy) GetDependencies(ctx context.Context, c stage.Conveyor, cb conta
 	args = append(args, "Chmod", stg.instruction.Data.Chmod)
 	args = append(args, "ExpandedFrom", stg.backendInstruction.From)
 
+	// appended only when set to keep digests of already built COPY stages intact
+	if stg.instruction.Data.Parents {
+		args = append(args, "Parents", "true")
+	}
+
 	if stg.UsesBuildContext() {
 		if srcChecksum, err := buildContextArchive.CalculateGlobsChecksum(ctx, stg.instruction.Data.SourcePaths, false); err != nil {
 			return "", fmt.Errorf("unable to calculate build context globs checksum: %w", err)

--- a/pkg/build/stage/instruction/copy_ai_test.go
+++ b/pkg/build/stage/instruction/copy_ai_test.go
@@ -1,0 +1,66 @@
+package instruction_test
+
+import (
+	"bytes"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/werf/v2/pkg/build/stage"
+	"github.com/werf/werf/v2/pkg/build/stage/instruction"
+)
+
+func newCopyStageAI(dockerfileText string) *instruction.Copy {
+	p, err := parser.Parse(bytes.NewReader([]byte(dockerfileText)))
+	Expect(err).To(Succeed())
+
+	dockerStages, _, err := instructions.Parse(p.AST, nil)
+	Expect(err).To(Succeed())
+	Expect(dockerStages).NotTo(BeEmpty())
+
+	var copyCommand *instructions.CopyCommand
+	for _, cmd := range dockerStages[len(dockerStages)-1].Commands {
+		if c, ok := cmd.(*instructions.CopyCommand); ok {
+			copyCommand = c
+		}
+	}
+	Expect(copyCommand).NotTo(BeNil())
+
+	return instruction.NewCopy(
+		NewDockerfileStageInstructionWithDependencyStages(copyCommand, nil),
+		nil, false,
+		&stage.BaseStageOptions{ImageName: "example-image", ProjectName: "example-project"},
+	)
+}
+
+var _ = Describe("TestAI_ COPY --parents", func() {
+	const dockerfileWithParents = "FROM alpine\nCOPY --parents ./aaa/ ./bbb/ /target\n"
+	const dockerfileWithoutParents = "FROM alpine\nCOPY ./aaa/ ./bbb/ /target\n"
+
+	It("TestAI_ propagates the parents flag to the backend instruction", func(ctx SpecContext) {
+		stg := newCopyStageAI(dockerfileWithParents)
+		data := NewTestData(stg, "", TestDataOptions{})
+
+		Expect(stg.ExpandInstruction(data.Conveyor, map[string]string{})).To(Succeed())
+
+		backend, source := instruction.ExportCopyCommands(stg)
+		Expect(source.Parents).To(BeTrue())
+		Expect(backend.Parents).To(BeTrue())
+	})
+
+	It("TestAI_ changes the stage digest", func(ctx SpecContext) {
+		files := []*FileData{{Name: "aaa/x", Data: []byte(`x`)}, {Name: "bbb/y", Data: []byte(`y`)}}
+
+		withParents := NewTestData(newCopyStageAI(dockerfileWithParents), "", TestDataOptions{Files: files})
+		digestWithParents, err := withParents.Stage.GetDependencies(ctx, withParents.Conveyor, withParents.ContainerBackend, nil, withParents.StageImage, withParents.BuildContext)
+		Expect(err).To(Succeed())
+
+		withoutParents := NewTestData(newCopyStageAI(dockerfileWithoutParents), "", TestDataOptions{Files: files})
+		digestWithoutParents, err := withoutParents.Stage.GetDependencies(ctx, withoutParents.Conveyor, withoutParents.ContainerBackend, nil, withoutParents.StageImage, withoutParents.BuildContext)
+		Expect(err).To(Succeed())
+
+		Expect(digestWithParents).NotTo(Equal(digestWithoutParents))
+	})
+})

--- a/pkg/build/stage/instruction/stubs_test.go
+++ b/pkg/build/stage/instruction/stubs_test.go
@@ -80,7 +80,7 @@ func NewBuildContextStub(files []*FileData) *BuildContextStub {
 	return &BuildContextStub{Files: files}
 }
 
-func (buildContext *BuildContextStub) CalculateGlobsChecksum(ctx context.Context, globs []string, checkForArchive bool) (string, error) {
+func (buildContext *BuildContextStub) CalculateGlobsChecksum(ctx context.Context, globs []string, opts container_backend.CalculateGlobsChecksumOptions) (string, error) {
 	var args []string
 
 	for _, p := range globs {

--- a/pkg/buildah/common.go
+++ b/pkg/buildah/common.go
@@ -151,6 +151,7 @@ type CopyOpts struct {
 
 	Chown   string
 	Chmod   string
+	Parents bool
 	Ignores []string
 }
 

--- a/pkg/buildah/native_linux.go
+++ b/pkg/buildah/native_linux.go
@@ -945,12 +945,18 @@ func (b *NativeBuildah) Copy(ctx context.Context, container, contextDir string, 
 
 	var absSrc []string
 	for _, s := range src {
+		// filepath.Join cleans away the "/./" pivot point which --parents relies on
+		if prefix, suffix, found := strings.Cut(s, "/./"); found && opts.Parents {
+			absSrc = append(absSrc, filepath.Join(contextDir, prefix)+"/./"+filepath.Clean(suffix))
+			continue
+		}
 		absSrc = append(absSrc, filepath.Join(contextDir, s))
 	}
 
 	if err := builder.Add(dst, false, buildah.AddAndCopyOptions{
 		Chown:             opts.Chown,
 		Chmod:             opts.Chmod,
+		Parents:           opts.Parents,
 		PreserveOwnership: false,
 		ContextDir:        contextDir,
 		Excludes:          opts.Ignores,

--- a/pkg/container_backend/archive_interface.go
+++ b/pkg/container_backend/archive_interface.go
@@ -7,8 +7,14 @@ type BuildContextArchiver interface {
 	Path() string
 	ExtractOrGetExtractedDir(ctx context.Context) (string, error)
 	CalculatePathsChecksum(ctx context.Context, paths []string) (string, error)
-	CalculateGlobsChecksum(ctx context.Context, globs []string, checkForArchive bool) (string, error)
+	CalculateGlobsChecksum(ctx context.Context, globs []string, opts CalculateGlobsChecksumOptions) (string, error)
 	CleanupExtractedDir(ctx context.Context)
+}
+
+type CalculateGlobsChecksumOptions struct {
+	CheckForArchives bool
+	// COPY --parents turns matched paths into destination paths, so their names affect the result
+	IncludeMatchedPaths bool
 }
 
 type BuildContextArchiveCreateOptions struct {

--- a/pkg/container_backend/instruction/copy.go
+++ b/pkg/container_backend/instruction/copy.go
@@ -46,6 +46,7 @@ func (i *Copy) Apply(ctx context.Context, containerName string, drv buildah.Buil
 		CommonOpts: drvOpts,
 		Chown:      i.Chown,
 		Chmod:      i.Chmod,
+		Parents:    i.Parents,
 	}); err != nil {
 		return fmt.Errorf("error copying %v to %s for container %s: %w", i.SourcePaths, i.DestPath, containerName, err)
 	}


### PR DESCRIPTION
## Problem

`COPY --parents` was parsed (buildkit fills `CopyCommand.Parents`) but never passed to buildah, so in a staged Dockerfile build the flag was silently ignored: sources were flattened into the destination instead of preserving their directory structure.

```dockerfile
COPY --parents ./aaa/ ./bbb/ /target
```

Expected `/target/aaa/...` and `/target/bbb/...`; got the contents of both directories merged into `/target`.

Only the staged Buildah path is affected: the non-staged path goes through imagebuilder, which already handles `--parents`, and staged builds are not supported on the Docker Server backend.

## Changes

- `pkg/buildah`: plumb `Parents` into `buildah.AddAndCopyOptions` (buildah implements it), and keep the `/./` pivot point intact when making source paths absolute — `filepath.Join` cleans it away, and buildah derives the prefix to strip from it (same approach as buildah's own `stage_executor`).
- `pkg/container_backend/instruction/copy.go`: pass `Parents` to the buildah driver.
- `pkg/build/stage/instruction/copy.go`: add `Parents` to the stage digest, only when set, so digests of already built `COPY` stages stay unchanged.
- `CalculateGlobsChecksum`: hash the matched paths, not just their contents, when `--parents` is set. Without `--parents` matched directory names never reach the image (only their contents are copied), so the paths were irrelevant; with `--parents` they become destination paths, and a wildcard source whose matched directory was renamed (same contents) produced the same digest for a different image, reusing a stale stage. Gated by the new `IncludeMatchedPaths` option, so `ADD` stages and `COPY` stages without `--parents` keep their digests.

## Tests

- `copy_ai_test.go`: the flag reaches the backend instruction; the digest changes with `--parents`.
- `build_context_archive_ai_test.go`: renaming a matched directory changes the checksum only when matched paths are included.
