### PR TITLE
fix(build): honor COPY/ADD --exclude in staged Dockerfile build

### DIFF
--- a/pkg/build/stage/instruction/add.go
+++ b/pkg/build/stage/instruction/add.go
@@ -49,6 +49,11 @@ func (stg *Add) GetDependencies(ctx context.Context, c stage.Conveyor, cb contai
 	args = append(args, "Chown", stg.instruction.Data.Chown)
 	args = append(args, "Chmod", stg.instruction.Data.Chmod)
 
+	// appended only when set to keep digests of already built ADD stages intact
+	if len(stg.instruction.Data.ExcludePatterns) > 0 {
+		args = append(args, append([]string{"ExcludePatterns"}, stg.instruction.Data.ExcludePatterns...)...)
+	}
+
 	var fileGlobSrc []string
 	for _, src := range stg.instruction.Data.SourcePaths {
 		if !strings.HasPrefix(src, "http://") && !strings.HasPrefix(src, "https://") {

--- a/pkg/build/stage/instruction/copy.go
+++ b/pkg/build/stage/instruction/copy.go
@@ -61,6 +61,9 @@ func (stg *Copy) GetDependencies(ctx context.Context, c stage.Conveyor, cb conta
 	if stg.instruction.Data.Parents {
 		args = append(args, "Parents", "true")
 	}
+	if len(stg.instruction.Data.ExcludePatterns) > 0 {
+		args = append(args, append([]string{"ExcludePatterns"}, stg.instruction.Data.ExcludePatterns...)...)
+	}
 
 	if stg.UsesBuildContext() {
 		if srcChecksum, err := buildContextArchive.CalculateGlobsChecksum(ctx, stg.instruction.Data.SourcePaths, container_backend.CalculateGlobsChecksumOptions{IncludeMatchedPaths: stg.instruction.Data.Parents}); err != nil {

--- a/pkg/container_backend/instruction/add.go
+++ b/pkg/container_backend/instruction/add.go
@@ -37,6 +37,7 @@ func (i *Add) Apply(ctx context.Context, containerName string, drv buildah.Build
 		ContextDir: contextDir,
 		Chown:      i.Chown,
 		Chmod:      i.Chmod,
+		Ignores:    contextRelativeExcludes(i.SourcePaths, i.ExcludePatterns),
 	}); err != nil {
 		return fmt.Errorf("error adding %v to %s for container %s: %w", i.SourcePaths, i.DestPath, containerName, err)
 	}

--- a/pkg/container_backend/instruction/copy.go
+++ b/pkg/container_backend/instruction/copy.go
@@ -47,6 +47,7 @@ func (i *Copy) Apply(ctx context.Context, containerName string, drv buildah.Buil
 		Chown:      i.Chown,
 		Chmod:      i.Chmod,
 		Parents:    i.Parents,
+		Ignores:    contextRelativeExcludes(i.SourcePaths, i.ExcludePatterns),
 	}); err != nil {
 		return fmt.Errorf("error copying %v to %s for container %s: %w", i.SourcePaths, i.DestPath, containerName, err)
 	}

--- a/pkg/container_backend/instruction/excludes.go
+++ b/pkg/container_backend/instruction/excludes.go
@@ -1,0 +1,34 @@
+package instruction
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// contextRelativeExcludes rebases --exclude patterns from source paths to the context dir:
+// buildkit matches every pattern against each source path, buildah matches them against the
+// context dir, so a pattern has to be repeated for every source path it may apply to.
+func contextRelativeExcludes(sourcePaths, excludePatterns []string) []string {
+	if len(excludePatterns) == 0 {
+		return nil
+	}
+
+	var res []string
+	for _, sourcePath := range sourcePaths {
+		if strings.HasPrefix(sourcePath, "http://") || strings.HasPrefix(sourcePath, "https://") {
+			continue
+		}
+
+		prefix := strings.TrimPrefix(filepath.Clean(sourcePath), string(filepath.Separator))
+
+		for _, pattern := range excludePatterns {
+			if negated := strings.HasPrefix(pattern, "!"); negated {
+				res = append(res, "!"+filepath.Join(prefix, pattern[1:]))
+				continue
+			}
+			res = append(res, filepath.Join(prefix, pattern))
+		}
+	}
+
+	return res
+}

--- a/pkg/container_backend/instruction/excludes_ai_test.go
+++ b/pkg/container_backend/instruction/excludes_ai_test.go
@@ -1,0 +1,61 @@
+package instruction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAI_ContextRelativeExcludes(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		sourcePaths     []string
+		excludePatterns []string
+		expected        []string
+	}{
+		{
+			name:        "no patterns",
+			sourcePaths: []string{"./aaa/"},
+		},
+		{
+			name:            "pattern per source path",
+			sourcePaths:     []string{"./aaa/", "./bbb"},
+			excludePatterns: []string{"*.md", "node_modules"},
+			expected:        []string{"aaa/*.md", "aaa/node_modules", "bbb/*.md", "bbb/node_modules"},
+		},
+		{
+			name:            "context root source path",
+			sourcePaths:     []string{"."},
+			excludePatterns: []string{"*.md"},
+			expected:        []string{"*.md"},
+		},
+		{
+			name:            "absolute source path from another stage",
+			sourcePaths:     []string{"/app/bin"},
+			excludePatterns: []string{"**/*.debug"},
+			expected:        []string{"app/bin/**/*.debug"},
+		},
+		{
+			name:            "parents pivot point in source path",
+			sourcePaths:     []string{"./aaa/./bbb"},
+			excludePatterns: []string{"*.md"},
+			expected:        []string{"aaa/bbb/*.md"},
+		},
+		{
+			name:            "negated pattern",
+			sourcePaths:     []string{"./aaa"},
+			excludePatterns: []string{"*.md", "!keep.md"},
+			expected:        []string{"aaa/*.md", "!aaa/keep.md"},
+		},
+		{
+			name:            "remote source path skipped",
+			sourcePaths:     []string{"https://example.com/x.tar", "./aaa"},
+			excludePatterns: []string{"*.md"},
+			expected:        []string{"aaa/*.md"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, contextRelativeExcludes(tt.sourcePaths, tt.excludePatterns))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`COPY --exclude` / `ADD --exclude` was parsed (buildkit fills `ExcludePatterns`) but never passed to buildah, so in a staged Dockerfile build the flag was silently ignored — excluded files ended up in the image.

```dockerfile
COPY --exclude=*.md --exclude=node_modules ./app /app
```

Only the staged Buildah path is affected: the non-staged path goes through imagebuilder, which already passes excludes to buildah, and staged builds are not supported on the Docker Server backend.

## Changes

- `pkg/container_backend/instruction`: pass `--exclude` patterns to buildah as excludes for both `COPY` and `ADD`.

  buildkit matches every pattern against **each source path** (`fsutil` walks a source and matches paths relative to it), while buildah matches them against the **context dir** (`copier` matches paths relative to `ContextDir`). Handing the patterns over as-is would silently exclude nothing for any source other than the context root, so patterns are rebased onto every source path first: `--exclude=*.md` with sources `./aaa ./bbb` becomes `aaa/*.md`, `bbb/*.md`. Negated patterns keep their `!` prefix, remote (`http://`, `https://`) sources are skipped.

- `pkg/build/stage/instruction`: add the patterns to the stage digest, only when set, so digests of already built `COPY`/`ADD` stages stay unchanged.

## Known limitation

Excluded files still take part in the build context globs checksum, so changing an excluded file rebuilds a stage that does not need it. That only costs an extra rebuild and never reuses a stale stage; `copier.Stat` has no excludes support, so filtering would mean matching the patterns a second time in werf.

## Tests

`excludes_ai_test.go`: pattern rebasing per source path — context root, absolute path from another stage, `--parents` pivot point, negated pattern, remote source.
