### PR TITLE
fix(build, stapel, import): build rsync without lchmod support

### DIFF
--- a/pkg/stapel/stapel.go
+++ b/pkg/stapel/stapel.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	VERSION              = "0.7.1"
+	VERSION              = "0.7.2"
 	IMAGE                = "registry.werf.io/werf/stapel"
 	CONTAINER_MOUNT_ROOT = "/.werf"
 )

--- a/stapel/Dockerfile
+++ b/stapel/Dockerfile
@@ -32,11 +32,14 @@ RUN apk add --no-cache --virtual .build-deps \
   automake \
   libtool
 
+# rsync 3.1.x routes every chmod through lchmod() when configure finds it, and musl's
+# lchmod always fails with EOPNOTSUPP on a symlink, which breaks --keep-dirlinks imports.
+# Upstream stopped using lchmod on Linux in 3.2.4; the glibc stapel build never linked it.
 RUN cd /tmp && \
   wget https://github.com/RsyncProject/rsync/archive/v3.1.2.tar.gz && \
   tar xzf v3.1.2.tar.gz && \
   cd rsync-3.1.2 && \
-  ./configure --prefix=/usr && \
+  ./configure --prefix=/usr ac_cv_func_lchmod=no && \
   make && \
   make install && \
   cd / && \


### PR DESCRIPTION
## Summary

Importing into a symlinked directory (`import: add: /out, to: /` where the base image has `/usr/sbin` as a usrmerge symlink) fails on the v3 stapel image with `rsync: failed to set permissions on "/usr/sbin": Not supported (95)` and exit code 23. Building stapel's rsync with `ac_cv_func_lchmod=no` restores the behaviour of the previous glibc-based stapel image.

## Key changes

- `stapel/Dockerfile`: configure rsync 3.1.2 with `ac_cv_func_lchmod=no`, so `do_chmod()` compiles down to `chmod()` instead of `lchmod()`.
- `pkg/stapel/stapel.go`: `VERSION` `0.7.1` → `0.7.2`; the image is already published as a multi-platform manifest (`linux/amd64`, `linux/arm64`).

## Why

`--keep-dirlinks` (added in #7545 to stop imports from silently destroying symlinked directories) makes rsync apply the source directory's permissions to the symlink path itself. rsync 3.1.x routes every chmod through `lchmod()` whenever configure detects it, and with `-p` a failure there is fatal.

The old stapel image (`0.6.2`, ubuntu/LFS glibc) never linked `lchmod` — its rsync imports plain `chmod`, which is why v2 is unaffected even though it carries the same `--keep-dirlinks` code. The alpine/musl rewrite (#7403) does link it, and musl's `lchmod` is `fchmodat(AT_SYMLINK_NOFOLLOW)`, which always returns `EOPNOTSUPP` on a symlink. Upstream rsync stopped using `lchmod` on Linux in 3.2.4.

## Review focus / risks

- The source directory's mode is now applied to the symlink *target* (`/usr/bin` gets the mode of `/out/usr/sbin`) instead of aborting. This is not new behaviour: stapel `0.6.2` does exactly the same, so this is parity with v2, not a new semantic.
- Permissions of regular directories and files are still transferred — verified explicitly.
- `VERSION` bump requires the published `registry.werf.io/werf/stapel:0.7.2`; it is pushed, so `task build` / `stapel:embed` resolve it.

### Verification

Real `werf build` on a repro project (artifact ships `/out/usr/sbin` as a real `0700` dir, base image has `/usr/sbin -> bin`):

| stapel | linux/amd64 | linux/arm64 |
| --- | --- | --- |
| `0.7.1` | FAILED, code 23 | FAILED, code 23 |
| `0.7.2` | ok | ok |

Resulting image with `0.7.2`: `/usr/sbin -> bin` preserved, `cat /usr/sbin/f` works (physically `/usr/bin/f`), `/usr/bin` is `drwx------` — byte-for-byte the outcome of stapel `0.6.2`.
