### PR TITLE
fix(host): keep git caches of other werf versions until disk pressure

### DIFF
--- a/pkg/git_repo/gitdata/gc.go
+++ b/pkg/git_repo/gitdata/gc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/werf/common-go/pkg/util"
+	"github.com/werf/common-go/pkg/util/timestamps"
 	"github.com/werf/kubedog/pkg/utils"
 	"github.com/werf/lockgate"
 	"github.com/werf/logboek"
@@ -49,49 +50,6 @@ func RunGC(ctx context.Context, options RunGCOptions) error {
 		defer werf.HostLocker().ReleaseLock(lock)
 	}
 
-	keepGitDataV1_1, err := shouldKeepGitDataV1_1(ctx)
-	if err != nil {
-		return fmt.Errorf("unable to check if git data v1.1 should be kept: %w", err)
-	}
-
-	{
-		keepCacheVersions := []string{git_repo.GitReposCacheVersion}
-		if keepGitDataV1_1 {
-			keepCacheVersions = append(keepCacheVersions, KeepGitRepoCacheVersionV1_1)
-		}
-
-		cacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_repos")
-		if err := wipeCacheDirs(ctx, cacheRoot, keepCacheVersions); err != nil {
-			return fmt.Errorf("unable to wipe old git repos cache dirs in %q: %w", cacheRoot, err)
-		}
-	}
-
-	{
-		keepCacheVersions := []string{git_repo.GitWorktreesCacheVersion}
-		if keepGitDataV1_1 {
-			keepCacheVersions = append(keepCacheVersions, KeepGitWorkTreeCacheVersionV1_1)
-		}
-
-		cacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_worktrees")
-		if err := wipeCacheDirs(ctx, cacheRoot, keepCacheVersions); err != nil {
-			return fmt.Errorf("unable to wipe old git worktrees cache dirs in %q: %w", cacheRoot, err)
-		}
-	}
-
-	{
-		cacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_archives")
-		if err := wipeCacheDirs(ctx, cacheRoot, []string{GitArchivesCacheVersion}); err != nil {
-			return fmt.Errorf("unable to wipe old git archives cache dirs in %q: %w", cacheRoot, err)
-		}
-	}
-
-	{
-		cacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_patches")
-		if err := wipeCacheDirs(ctx, cacheRoot, []string{GitPatchesCacheVersion}); err != nil {
-			return fmt.Errorf("unable to wipe old git patches cache dirs in %q: %w", cacheRoot, err)
-		}
-	}
-
 	vu, err := volumeutils.GetVolumeUsageByPath(ctx, werf.GetLocalCacheDir())
 	if err != nil {
 		return fmt.Errorf("error getting volume usage by path %q: %w", werf.GetLocalCacheDir(), err)
@@ -119,6 +77,11 @@ func RunGC(ctx context.Context, options RunGCOptions) error {
 	})
 
 	var gitDataEntries []GitDataEntry
+
+	keepGitDataV1_1, err := shouldKeepGitDataV1_1(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to check if git data v1.1 should be kept: %w", err)
+	}
 
 	{
 		cacheVersionRoot := filepath.Join(werf.GetLocalCacheDir(), "git_repos", git_repo.GitReposCacheVersion)
@@ -164,6 +127,23 @@ func RunGC(ctx context.Context, options RunGCOptions) error {
 		gitDataEntries = append(gitDataEntries, entries...)
 	}
 
+	for _, foreignVersionsDesc := range []struct {
+		cacheRoot    string
+		keepVersions []string
+	}{
+		{filepath.Join(werf.GetLocalCacheDir(), "git_repos"), lo.Ternary(keepGitDataV1_1, []string{git_repo.GitReposCacheVersion, KeepGitRepoCacheVersionV1_1}, []string{git_repo.GitReposCacheVersion})},
+		{filepath.Join(werf.GetLocalCacheDir(), "git_worktrees"), lo.Ternary(keepGitDataV1_1, []string{git_repo.GitWorktreesCacheVersion, KeepGitWorkTreeCacheVersionV1_1}, []string{git_repo.GitWorktreesCacheVersion})},
+		{filepath.Join(werf.GetLocalCacheDir(), "git_archives"), []string{GitArchivesCacheVersion}},
+		{filepath.Join(werf.GetLocalCacheDir(), "git_patches"), []string{GitPatchesCacheVersion}},
+	} {
+		entries, err := getForeignCacheVersionEntries(foreignVersionsDesc.cacheRoot, foreignVersionsDesc.keepVersions)
+		if err != nil {
+			return fmt.Errorf("unable to process foreign cache versions in %q: %w", foreignVersionsDesc.cacheRoot, err)
+		}
+
+		gitDataEntries = append(gitDataEntries, entries...)
+	}
+
 	gitDataEntries = keepGitDataByLru(gitDataEntries)
 
 	var freedBytes uint64
@@ -196,8 +176,15 @@ func RemovePathWithEmptyParentDirsInsideScope(scopeDir, path string) error {
 		return nil
 	}
 
-	if err := os.RemoveAll(path); err != nil {
-		return fmt.Errorf("unable to remove %q: %w", path, err)
+	// Rename before removal so that concurrent readers see the path disappear atomically
+	// instead of observing a partially deleted directory.
+	removePath := fmt.Sprintf("%s.removing.%d", path, time.Now().UnixNano())
+	if err := os.Rename(path, removePath); err != nil {
+		removePath = path
+	}
+
+	if err := os.RemoveAll(removePath); err != nil {
+		return fmt.Errorf("unable to remove %q: %w", removePath, err)
 	}
 
 	dir := filepath.Dir(path)
@@ -226,36 +213,107 @@ func RemovePathWithEmptyParentDirsInsideScope(scopeDir, path string) error {
 	return nil
 }
 
-// wipeCacheDirs removes all subdirectories from the specified cache root directory,
-// except for those listed in keepCacheVersions.
-func wipeCacheDirs(ctx context.Context, cacheRootDir string, keepCacheVersions []string) error {
-	logboek.Context(ctx).Debug().LogF("wipeCacheDirs %q\n", cacheRootDir)
+type foreignCacheVersionDesc struct {
+	Path          string
+	LastAccessAt  time.Time
+	Size          uint64
+	CacheBasePath string
+}
 
-	if _, err := os.Stat(cacheRootDir); os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("error accessing %q: %w", cacheRootDir, err)
-	}
+var _ GitDataEntry = (*foreignCacheVersionDesc)(nil)
 
+func (entry *foreignCacheVersionDesc) GetPaths() []string {
+	return []string{entry.Path}
+}
+
+func (entry *foreignCacheVersionDesc) GetSize() uint64 {
+	return entry.Size
+}
+
+func (entry *foreignCacheVersionDesc) GetLastAccessAt() time.Time {
+	return entry.LastAccessAt
+}
+
+func (entry *foreignCacheVersionDesc) GetCacheBasePath() string {
+	return entry.CacheBasePath
+}
+
+// getForeignCacheVersionEntries returns LRU entries for cache version dirs maintained by other
+// werf versions running on the same host. Each foreign version dir is a single entry: its layout
+// is unknown to the current werf version, so it is only measured, never validated or modified.
+// Last access time is the newest last_access_at timestamp found near the top of the dir, falling
+// back to the dir modification time.
+func getForeignCacheVersionEntries(cacheRootDir string, keepVersions []string) ([]GitDataEntry, error) {
 	dirs, err := ioutil.ReadDir(cacheRootDir)
-	if err != nil {
-		return fmt.Errorf("error reading dir %q: %w", cacheRootDir, err)
+	if os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("error reading dir %q: %w", cacheRootDir, err)
 	}
 
-	for _, finfo := range dirs {
-		if slices.Contains(keepCacheVersions, finfo.Name()) {
-			logboek.Context(ctx).Debug().LogF("wipeCacheDirs in %q: keep cache version %q\n", cacheRootDir, finfo.Name())
+	var res []GitDataEntry
+
+	for _, versionDirInfo := range dirs {
+		if !versionDirInfo.IsDir() || slices.Contains(keepVersions, versionDirInfo.Name()) {
 			continue
 		}
 
-		versionedCacheDir := filepath.Join(cacheRootDir, finfo.Name())
+		versionDir := filepath.Join(cacheRootDir, versionDirInfo.Name())
 
-		if err = os.RemoveAll(versionedCacheDir); err != nil {
-			return fmt.Errorf("unable to remove %q: %w", versionedCacheDir, err)
+		size, err := volumeutils.DirSizeBytes(versionDir)
+		if err != nil {
+			return nil, fmt.Errorf("error getting dir %q size: %w", versionDir, err)
+		}
+
+		lastAccessAt, found := findMaxLastAccessAt(versionDir, 2)
+		if !found {
+			lastAccessAt = versionDirInfo.ModTime()
+		}
+
+		res = append(res, &foreignCacheVersionDesc{
+			Path:          versionDir,
+			LastAccessAt:  lastAccessAt,
+			Size:          size,
+			CacheBasePath: cacheRootDir,
+		})
+	}
+
+	return res, nil
+}
+
+func findMaxLastAccessAt(dir string, depth int) (time.Time, bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	var res time.Time
+	var found bool
+
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+
+		if entry.IsDir() {
+			if depth > 0 {
+				if t, ok := findMaxLastAccessAt(path, depth-1); ok && t.After(res) {
+					res = t
+					found = true
+				}
+			}
+			continue
+		}
+
+		if entry.Name() != "last_access_at" {
+			continue
+		}
+
+		if t, err := timestamps.ReadTimestampFile(path); err == nil && t.After(res) {
+			res = t
+			found = true
 		}
 	}
 
-	return nil
+	return res, found
 }
 
 func lockGC(ctx context.Context, shared bool) (lockgate.LockHandle, error) {

--- a/pkg/git_repo/gitdata/gc_test.go
+++ b/pkg/git_repo/gitdata/gc_test.go
@@ -1,0 +1,115 @@
+package gitdata
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/common-go/pkg/util/timestamps"
+)
+
+var _ = Describe("getForeignCacheVersionEntries", func() {
+	It("returns nil, nil when cache root does not exist", func() {
+		res, err := getForeignCacheVersionEntries(filepath.Join(GinkgoT().TempDir(), "missing"), []string{"6"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeNil())
+	})
+
+	It("skips kept versions and non-directories", func() {
+		root := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(root, "6"), 0o755)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(root, "3"), 0o755)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(root, "5"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(root, "stray"), []byte("x"), 0o644)).To(Succeed())
+
+		res, err := getForeignCacheVersionEntries(root, []string{"6", "3"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0].GetPaths()).To(Equal([]string{filepath.Join(root, "5")}))
+		Expect(res[0].GetCacheBasePath()).To(Equal(root))
+	})
+
+	It("uses the newest last_access_at found in old flat layout", func() {
+		root := GinkgoT().TempDir()
+		older := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+		newer := time.Now().Add(-1 * time.Hour).Truncate(time.Second)
+
+		for i, ts := range []time.Time{older, newer} {
+			repoDir := filepath.Join(root, "5", fmt.Sprintf("repo%d", i))
+			Expect(os.MkdirAll(repoDir, 0o755)).To(Succeed())
+			Expect(timestamps.WriteTimestampFile(filepath.Join(repoDir, "last_access_at"), ts)).To(Succeed())
+		}
+
+		res, err := getForeignCacheVersionEntries(root, []string{"6"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0].GetLastAccessAt().Unix()).To(Equal(newer.Unix()))
+	})
+
+	It("uses the newest last_access_at found in mirror layout", func() {
+		root := GinkgoT().TempDir()
+		ts := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+
+		mirrorDir := filepath.Join(root, "7", "repohash", "full")
+		Expect(os.MkdirAll(mirrorDir, 0o755)).To(Succeed())
+		Expect(timestamps.WriteTimestampFile(filepath.Join(mirrorDir, "last_access_at"), ts)).To(Succeed())
+
+		res, err := getForeignCacheVersionEntries(root, []string{"6"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0].GetLastAccessAt().Unix()).To(Equal(ts.Unix()))
+	})
+
+	It("falls back to dir mtime when no last_access_at is found", func() {
+		root := GinkgoT().TempDir()
+		versionDir := filepath.Join(root, "5")
+		Expect(os.MkdirAll(versionDir, 0o755)).To(Succeed())
+
+		res, err := getForeignCacheVersionEntries(root, []string{"6"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0].GetLastAccessAt()).To(BeTemporally("~", time.Now(), time.Minute))
+	})
+})
+
+var _ = Describe("RemovePathWithEmptyParentDirsInsideScope", func() {
+	It("removes target and cleans up empty parents up to scope", func() {
+		scope := GinkgoT().TempDir()
+		target := filepath.Join(scope, "a", "b", "c")
+		Expect(os.MkdirAll(target, 0o755)).To(Succeed())
+
+		Expect(RemovePathWithEmptyParentDirsInsideScope(scope, target)).To(Succeed())
+		Expect(filepath.Join(scope, "a")).NotTo(BeADirectory())
+		Expect(scope).To(BeADirectory())
+	})
+
+	It("keeps non-empty parents", func() {
+		scope := GinkgoT().TempDir()
+		target := filepath.Join(scope, "a", "b")
+		Expect(os.MkdirAll(target, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(scope, "a", "keep"), []byte("x"), 0o644)).To(Succeed())
+
+		Expect(RemovePathWithEmptyParentDirsInsideScope(scope, target)).To(Succeed())
+		Expect(target).NotTo(BeADirectory())
+		Expect(filepath.Join(scope, "a", "keep")).To(BeAnExistingFile())
+	})
+
+	It("does nothing for paths outside the scope", func() {
+		scope := GinkgoT().TempDir()
+		outside := GinkgoT().TempDir()
+		target := filepath.Join(outside, "dir")
+		Expect(os.MkdirAll(target, 0o755)).To(Succeed())
+
+		Expect(RemovePathWithEmptyParentDirsInsideScope(scope, target)).To(Succeed())
+		Expect(target).To(BeADirectory())
+	})
+
+	It("succeeds when target does not exist", func() {
+		scope := GinkgoT().TempDir()
+		Expect(RemovePathWithEmptyParentDirsInsideScope(scope, filepath.Join(scope, "missing"))).To(Succeed())
+	})
+})


### PR DESCRIPTION
Stop wiping foreign git cache version dirs (git_repos, git_worktrees, git_archives, git_patches) unconditionally on every GC run. On shared hosts several werf versions run side by side, and after a cache version bump every run of the newer werf deleted the cache of the older one, breaking its in-flight builds with errors like "cannot open git work tree: repository does not exist".

Treat each foreign cache version dir as an LRU entry instead: measure its size, derive last access time from the newest last_access_at marker inside (works for both the old flat and the current mirror layouts, falling back to dir mtime), and delete it only under disk pressure, oldest first. Data of werf v1.1 is still kept while v1.1 is in use, as before.

Also rename paths into a unique trash name before removal so concurrent processes see cache entries disappear atomically instead of observing a partially deleted repository.