### PR TITLE
refactor(host-cleanup): drop host locker dir schema version

### DIFF
--- a/pkg/werf/gc.go
+++ b/pkg/werf/gc.go
@@ -23,18 +23,8 @@ const HostLocksGCMinAge = 24 * time.Hour
 // inode-exhaustion failure mode this addresses.
 const hostLocksAutoGCThreshold = 10000
 
-// hostLockerDirSchemaVersion namespaces the host locker directory so that
-// older werf binaries (which acquire locks without the inode-safe retry
-// against GCLockFileDir) never share a locks directory with a GC-capable
-// werf. Mixing the two on the same host could otherwise let a new process's
-// GC pass unlink a lock file an old process just opened, right before the
-// old process takes its flock — the old acquire path has no way to detect
-// the resulting dead inode. Bump this whenever the locking protocol changes
-// in an incompatible way.
-const hostLockerDirSchemaVersion = "2"
-
 func getHostLockerDir() string {
-	return filepath.Join(GetServiceDir(), "locks", hostLockerDirSchemaVersion)
+	return filepath.Join(GetServiceDir(), "locks")
 }
 
 // GCHostLockerDir removes stale host lock files older than HostLocksGCMinAge.


### PR DESCRIPTION
## Summary

Host locks move back from `$WERF_HOME/service/locks/2` to `$WERF_HOME/service/locks`, dropping the `hostLockerDirSchemaVersion` namespace that came in with the host-lock GC.

## Why

The segment existed so that a GC-capable werf never shares a locks directory with a binary whose acquire path cannot notice a lock file unlinked between `open()` and `flock()`. Only pre-v0.2.0 lockgate binaries lack that check, so the namespace guarded exactly one scenario: werf 2.x using the same `$WERF_HOME`. v3 is experimental and does not support that coexistence, and both the cost and the benefit of the split apply to that same scenario — with it out of scope the segment guards nothing, while leaving behind a directory nothing ever GCs.

Worth recording why the split was not free, since #7686 accepted it as low-risk. v2 and v3 lock the same resources under identical names: cache version constants are unchanged across the branches (`GitReposCacheVersion` 6, `GitWorktreesCacheVersion` 9, `GitArchivesCacheVersion` 7, `GitPatchesCacheVersion` 6, `ManifestCacheVersion` 5, `LRUImagesCacheVersion` 1), lock names are byte-identical (`git_work_tree_cache <dir>`), and `LegacyHashFunction = true` holds on both — only the directory differed. The case that cannot be namespaced at all is the container backend: `LockStageImage` takes an `image.<ref>` lock and `LocalBackendCleaner.isLocked` honours it, but a host has one image store, so with split directories a v3 background `host cleanup` cannot see a v2 build's image lock and deletes a stage image mid-build.

## Verification

- Ran the built binary against a throwaway `$WERF_HOME`: `werf host cleanup --dry-run` creates lock files directly in `service/locks/`, murmur-hashed names, no `2/` segment.
- Not run: nothing platform-specific is touched. The `pkg/werf/exec` detach test fails on macOS for an unrelated reason (`ps -o cmd` is Linux syntax); confirmed it fails identically with this change stashed.

## Review focus / risks

- Accepted limitation: on a shared directory the automatic lock GC can still unlink a file another process has opened but not yet flocked. Harmless among v3 binaries — `fileLocker.tryLock` re-checks `Nlink > 0` and retries on a fresh handle — and only dangerous against pre-v0.2.0 binaries, i.e. the coexistence this PR declares out of scope. Note also that GC never touches a lock that is currently held, since `safeDeleteLockFile` takes `TryLock` first.
- Gating lock GC behind an explicit flag was considered and deliberately deferred. If it is ever wanted, dropping `ShouldRunHostLocksGC` from the auto-cleanup triggers is not sufficient: the auto path detaches `werf host cleanup`, which calls `GCHostLockerDir` unconditionally at `host_cleanup.go:116`.
- Anyone who ran 3.0.0-alpha or 3.0.1 keeps an orphaned `service/locks/2`; only `werf host purge` clears it. Deliberately not migrated.