### PR TITLE
chore(deps): merge main into 3

### DIFF
--- a/.agents/skills/git-conventions/SKILL.md
+++ b/.agents/skills/git-conventions/SKILL.md
@@ -29,6 +29,7 @@ Types and scopes are defined in `CONTRIBUTING.md#conventions` — that file is t
 - **Header:** ≤ 72 characters. Nested scopes are allowed, comma-separated: `fix(build, stapel, import): …`.
 - **Subject:** imperative, lower-case, no trailing period.
 - **Body:** imperative; state the motivation for the change and contrast it with previous behavior.
+- NEVER include sensitive or customer-identifying details: client/company names, internal hostnames or filesystem paths, private build tags or version suffixes, credentials. Describe environments generically.
 
 ## Output
 

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -58,6 +58,7 @@ observed wrong behavior and add a minimal repro (Dockerfile / werf.yaml / comman
 - *Verification*: only the delta over CI — manual runs, hand-run e2e/real-cluster checks, the environment they required, and what could NOT be run. CI builds and runs the whole suite, so `task build`/`task test:unit` are noise unless a scoped local run is itself the point — then name it by its `task` command, never raw `go test`/`go vet`/`gofmt`. Plain list, not checkboxes — the reviewer is not the one ticking them.
 - *Review focus / risks*: guide the reviewer — call out non-obvious consequences, large generated diffs, breaking changes, and any deliberately accepted limitation of the chosen approach.
 - No AI-slop filler ("This PR improves the codebase…"). Every sentence must carry information.
+- NEVER include sensitive or customer-identifying details in the title or description: client/company names, internal hostnames or filesystem paths, private build tags or version suffixes, credentials. Describe the environment generically (e.g. "long-lived CI runners sharing WERF_HOME", not a customer's runner path).
 
 ## Output
 

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -20,12 +20,13 @@ description: Generates Pull Request titles and descriptions according to werf co
 
 ## Description
 
-Use the following structure. Every section is **mandatory** — omit a section only when it genuinely does not apply (e.g. single-line typo fix may skip *Review focus / risks*).
+Use the following structure. *Summary*, *Why* and *Verification* are **mandatory**. Omit *Key changes* when it would only restate *Summary*, and *Review focus / risks* when there is genuinely nothing to guide the reviewer to. NEVER rename or substitute the sections.
 
 ```
 ## Summary
 
-<1-3 sentence high-level overview of what the PR does and why it exists.>
+<1-3 sentence high-level overview of what the PR does and why it exists. For a `fix`, lead with the
+observed wrong behavior and add a minimal repro (Dockerfile / werf.yaml / command) plus expected vs actual.>
 
 ## Key changes
 
@@ -37,6 +38,11 @@ Use the following structure. Every section is **mandatory** — omit a section o
 
 <Motivation: what problem this solves, what maintenance/UX/perf gain it brings.>
 
+## Verification
+
+- <manual or hand-run e2e check, and the environment it needed>
+- <what could not be run>
+
 ## Review focus / risks
 
 - <area or file that deserves careful review>
@@ -46,10 +52,11 @@ Use the following structure. Every section is **mandatory** — omit a section o
 ### Rules
 
 - Language: English.
-- Be specific: name files, modules, functions — not "updated some code".
-- *Key changes*: group related items; use sub-bullets for detail when helpful.
+- Be specific about behavior, not "updated some code". Lead each bullet with what changed; add a path only when it helps navigation — a new file, a non-obvious location, or when the point is that the change plumbs through several layers. The Files tab already lists paths.
+- *Key changes*: group related items by theme, not one bullet per file; use sub-bullets for detail when helpful.
 - *Why*: explain the reason, not what changed (that's *Key changes*).
-- *Review focus / risks*: guide the reviewer — call out non-obvious consequences, large generated diffs, breaking changes.
+- *Verification*: only the delta over CI — manual runs, hand-run e2e/real-cluster checks, the environment they required, and what could NOT be run. CI builds and runs the whole suite, so `task build`/`task test:unit` are noise unless a scoped local run is itself the point — then name it by its `task` command, never raw `go test`/`go vet`/`gofmt`. Plain list, not checkboxes — the reviewer is not the one ticking them.
+- *Review focus / risks*: guide the reviewer — call out non-obvious consequences, large generated diffs, breaking changes, and any deliberately accepted limitation of the chosen approach.
 - No AI-slop filler ("This PR improves the codebase…"). Every sentence must carry information.
 
 ## Output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ werf is a CNCF Sandbox CLI tool to implement full-cycle CI/CD to Kubernetes. wer
 - When removing content, ALWAYS clean up orphaned structural elements (comment separators, section headers, blank-line groups) that no longer serve a purpose.
 - When renaming a type, function, or constant, ALWAYS rename all related local variables, parameters, and error messages that reference the old name. A rename is not complete until grep for the old name returns zero hits in affected packages.
 - When removing a feature that has documentation in multiple languages (e.g. `pages_en/`, `pages_ru/`), ALWAYS apply the same removal to ALL language versions. NEVER assume English-only cleanup is sufficient.
+- If a package has a doc.go, ALWAYS read it before changing that package or the on-disk data it owns — invariants and compatibility contracts live there (e.g. pkg/git_repo/gitdata owns the shared $WERF_HOME/local_cache).
 
 ## Code style (MANDATORY)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.75.3](https://github.com/werf/werf/compare/v2.75.2...v2.75.3) (2026-07-29)
+
+
+### Bug Fixes
+
+* **host-cleanup:** stop wiping other werf versions' live git cache ([#7699](https://github.com/werf/werf/issues/7699)) ([3e43c28](https://github.com/werf/werf/commit/3e43c28ba80c0cc2d8ea1f52e5e2fb314977b6f1))
+
 ## [2.75.2](https://github.com/werf/werf/compare/v2.75.1...v2.75.2) (2026-07-27)
 
 

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -13,7 +13,11 @@ import (
 	"github.com/werf/werf/v2/pkg/werf"
 )
 
-const GitReposCacheVersion = "6"
+// Before changing: read the local_cache contract in the package doc of pkg/git_repo/gitdata.
+const GitReposCacheVersion = "5"
+
+// Before changing: read the local_cache contract in the package doc of pkg/git_repo/gitdata.
+const GitMirrorsCacheVersion = "1"
 
 type (
 	PatchOptions    true_git.PatchOptions
@@ -111,4 +115,8 @@ type Archive interface {
 
 func GetGitRepoCacheDir() string {
 	return filepath.Join(werf.GetLocalCacheDir(), "git_repos", GitReposCacheVersion)
+}
+
+func GetGitMirrorsCacheDir() string {
+	return filepath.Join(werf.GetLocalCacheDir(), "git_mirrors", GitMirrorsCacheVersion)
 }

--- a/pkg/git_repo/gitdata/doc.go
+++ b/pkg/git_repo/gitdata/doc.go
@@ -1,0 +1,112 @@
+// Package gitdata manages garbage collection of werf's host-local git data
+// under $WERF_HOME/local_cache. It is the only package that performs
+// selective GC of local_cache data; every rule below exists because that
+// directory is shared.
+//
+// # Base invariant
+//
+// local_cache has no per-werf-version path segment (see localCacheDir in
+// pkg/werf): it is shared by ALL werf binaries using the same WERF_HOME,
+// across minor and major versions alike. On CI runners different release
+// branches are routinely built by different werf versions on one host.
+// Therefore any path under local_cache either belongs to the running binary
+// or to another werf version that may be in the middle of a build right now.
+//
+// # Cache roots
+//
+// Each kind of data lives in its own root with a per-root version namespace:
+//
+//	git_repos/<v>      version: git_repo.GitReposCacheVersion      cleaned: wipeCacheDirs + LRU
+//	git_mirrors/<v>    version: git_repo.GitMirrorsCacheVersion    cleaned: wipeCacheDirs + LRU
+//	git_worktrees/<v>  version: git_repo.GitWorktreesCacheVersion  cleaned: wipeCacheDirs + LRU
+//	git_archives/<v>   version: GitArchivesCacheVersion            cleaned: wipeCacheDirs + LRU
+//	git_patches/<v>    version: GitPatchesCacheVersion             cleaned: wipeCacheDirs + LRU
+//	manifests/<v>      version: image.ManifestCacheVersion         cleaned: never
+//	lru_images/<v>     version: lrumeta.LRUImagesCacheVersion      cleaned: never
+//	helm_chart_dependencies/<v>  version: nelm chart loader          cleaned: never
+//
+// Nothing cleans manifests, lru_images and helm_chart_dependencies (the last
+// is owned by the nelm chart loader via loader.SetLocalCacheDir): a version
+// bump there leaks the old data forever but destroys nothing. The whole
+// local_cache is removed only by `werf host purge`.
+//
+// # Bumping a cache version
+//
+// A bump is allowed only when ALL of the following hold:
+//
+//  1. The on-disk format changed incompatibly and the change cannot be made
+//     additive.
+//  2. Every werf version that can share the host has a staleness guard in its
+//     wipe path (see wipeCacheDirs). A bump against releases without the
+//     guard deletes their cache in the middle of a build.
+//  3. The transition cost is accepted: both layouts stay on disk until the
+//     old one goes stale, plus a one-time re-fetch.
+//
+// Never bump "to invalidate the cache" — that is deletion of another
+// version's data. A deliberate bump as a weapon is acceptable only when
+// reusing old data is unsafe (wrong builds, leaked credentials), and then it
+// goes into release notes. If compatibility with already released guard-less
+// versions is needed, use a new root instead of a bump.
+//
+// # Deleting and reading foreign data
+//
+//   - A foreign version directory is deleted only when stale, never
+//     immediately (see wipeCacheDirs for the window).
+//   - Never read or write inside another version's namespace.
+//   - Never put a non-directory directly into a version root: collectors
+//     remove such entries as invalid.
+//
+// # Load-bearing artifacts (backward compatibility)
+//
+// While a version constant is unchanged, its namespace is shared with
+// released werf versions and everything below is load-bearing. Changing any
+// item is an incompatible change: new root or a bump by the rules above.
+//
+// git_repos/<v>/<repoID>:
+//
+//   - <repoID> is util.Sha256Hash of Remote.getFilesystemRelativePathByEndpoint();
+//     the path function must not change.
+//   - <repoID> IS the bare mirror itself, not a container of mirrors: werf
+//     2.74.x os.Stat's it, treats existence as "already cloned" and goes
+//     straight to PlainOpen, so nesting breaks old builds permanently.
+//   - <repoID>/last_access_at in common-go/pkg/util/timestamps format,
+//     updated on every access; an entry with a missing or corrupt timestamp
+//     gets zero last-access time and is evicted first by LRU.
+//   - The mirror carries refs/remotes/origin/* and tags; never rely on a
+//     refspec written into the mirror's config by another version — use
+//     explicit refspecs only (see buildFetchOptions).
+//   - During a clone a sibling <repoID>.<uuid>.tmp dir exists; one abandoned
+//     by a killed process may carry a fresh last_access_at, is not reclaimed
+//     by werf 2.74.x (which only removes its fixed <repoID>.tmp), and is
+//     swept by the next clone of the repo once stale (see
+//     removeStaleCloneTmpDirs).
+//
+// git_mirrors/<v>/<repoID>: shallow/ is a bare shallow mirror with
+// last_access_at inside; requires_full is a marker file (not a mirror) that
+// pins the repo to the full mirror; a repoID dir holding only the marker is
+// valid and kept. The collector removes every other child, including werf's
+// own in-flight shallow.<uuid>.tmp — that is safe only because clone and GC
+// exclude each other via the git_data_manager lock, so every binary sharing
+// this root must share that lock's locker dir (or add an age guard first).
+//
+// git_worktrees/<v>/{local,remote}/<name> with last_access_at inside; for
+// local, <name> is sha256 of the repository's absolute path. The full-mirror
+// worktree dir is the unsuffixed remote/<repoID> so that werf 2.74.x reuses
+// it; the shallow-mirror worktree dir keeps the .shallow suffix. Changing the
+// naming scheme does not break old versions but orphans their entries: cache
+// misses plus garbage until LRU.
+//
+// git_archives/<v>/<repoID>/<2 hex>/<id>.tar plus <id>.meta.json with a
+// LastAccessTimestamp field rewritten on every access. git_patches/<v> is the
+// same plus <id>.patch and <id>.patch.<hash>.paths_list; see the doc comments
+// of GetGitArchivesAndRemoveInvalid and GetGitPatchesAndRemoveInvalid.
+//
+// Additive changes are safe exactly as far as other versions' collectors and
+// readers tolerate them, and tolerance differs per root: the flat git_repos
+// collector turns any extra directory in its version root into an LRU entry
+// and removes non-directories; werf 2.74.x tolerates extra plain files inside
+// a mirror but breaks on nesting; the git_mirrors collector treats <repoID>
+// as a closed set and removes every child other than shallow/ and
+// requires_full. A new kind of artifact gets its own root with its own
+// version, its own wipeCacheDirs call and its own LRU collection.
+package gitdata

--- a/pkg/git_repo/gitdata/gc.go
+++ b/pkg/git_repo/gitdata/gc.go
@@ -2,7 +2,9 @@ package gitdata
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"math"
 	"os"
@@ -22,10 +24,9 @@ import (
 	"github.com/werf/werf/v2/pkg/werf"
 )
 
-const (
-	KeepGitWorkTreeCacheVersionV1_1 = "6"
-	KeepGitRepoCacheVersionV1_1     = "3"
-)
+const cacheVersionStalenessWindow = 3 * 24 * time.Hour
+
+var errFreshFileFound = errors.New("fresh file found")
 
 func ShouldRunAutoGC(ctx context.Context, allowedVolumeUsageBytes uint64) (bool, error) {
 	vu, err := volumeutils.GetVolumeUsageByPath(ctx, werf.GetLocalCacheDir())
@@ -49,31 +50,23 @@ func RunGC(ctx context.Context, options RunGCOptions) error {
 		defer werf.HostLocker().ReleaseLock(lock)
 	}
 
-	keepGitDataV1_1, err := shouldKeepGitDataV1_1(ctx)
-	if err != nil {
-		return fmt.Errorf("unable to check if git data v1.1 should be kept: %w", err)
-	}
-
 	{
-		keepCacheVersions := []string{git_repo.GitReposCacheVersion}
-		if keepGitDataV1_1 {
-			keepCacheVersions = append(keepCacheVersions, KeepGitRepoCacheVersionV1_1)
-		}
-
 		cacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_repos")
-		if err := wipeCacheDirs(ctx, cacheRoot, keepCacheVersions); err != nil {
+		if err := wipeCacheDirs(ctx, cacheRoot, []string{git_repo.GitReposCacheVersion}); err != nil {
 			return fmt.Errorf("unable to wipe old git repos cache dirs in %q: %w", cacheRoot, err)
 		}
 	}
 
 	{
-		keepCacheVersions := []string{git_repo.GitWorktreesCacheVersion}
-		if keepGitDataV1_1 {
-			keepCacheVersions = append(keepCacheVersions, KeepGitWorkTreeCacheVersionV1_1)
+		cacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_mirrors")
+		if err := wipeCacheDirs(ctx, cacheRoot, []string{git_repo.GitMirrorsCacheVersion}); err != nil {
+			return fmt.Errorf("unable to wipe old git mirrors cache dirs in %q: %w", cacheRoot, err)
 		}
+	}
 
+	{
 		cacheRoot := filepath.Join(werf.GetLocalCacheDir(), "git_worktrees")
-		if err := wipeCacheDirs(ctx, cacheRoot, keepCacheVersions); err != nil {
+		if err := wipeCacheDirs(ctx, cacheRoot, []string{git_repo.GitWorktreesCacheVersion}); err != nil {
 			return fmt.Errorf("unable to wipe old git worktrees cache dirs in %q: %w", cacheRoot, err)
 		}
 	}
@@ -126,6 +119,17 @@ func RunGC(ctx context.Context, options RunGCOptions) error {
 		entries, err := GetGitReposAndRemoveInvalid(ctx, cacheVersionRoot)
 		if err != nil {
 			return fmt.Errorf("unable to process git repos from %q: %w", cacheVersionRoot, err)
+		}
+
+		gitDataEntries = append(gitDataEntries, entries...)
+	}
+
+	{
+		cacheVersionRoot := filepath.Join(werf.GetLocalCacheDir(), "git_mirrors", git_repo.GitMirrorsCacheVersion)
+
+		entries, err := GetGitMirrorsAndRemoveInvalid(ctx, cacheVersionRoot)
+		if err != nil {
+			return fmt.Errorf("unable to process git mirrors from %q: %w", cacheVersionRoot, err)
 		}
 
 		gitDataEntries = append(gitDataEntries, entries...)
@@ -226,8 +230,10 @@ func RemovePathWithEmptyParentDirsInsideScope(scopeDir, path string) error {
 	return nil
 }
 
-// wipeCacheDirs removes all subdirectories from the specified cache root directory,
-// except for those listed in keepCacheVersions.
+// wipeCacheDirs removes non-current version dirs from cacheRootDir, but only
+// stale ones: local_cache is shared by all werf versions on the host (see
+// package doc), and a version dir with recent file mtimes belongs to another
+// werf version that may be mid-build right now.
 func wipeCacheDirs(ctx context.Context, cacheRootDir string, keepCacheVersions []string) error {
 	logboek.Context(ctx).Debug().LogF("wipeCacheDirs %q\n", cacheRootDir)
 
@@ -250,6 +256,16 @@ func wipeCacheDirs(ctx context.Context, cacheRootDir string, keepCacheVersions [
 
 		versionedCacheDir := filepath.Join(cacheRootDir, finfo.Name())
 
+		fresh, err := hasFreshFiles(versionedCacheDir)
+		if err != nil {
+			logboek.Context(ctx).Warn().LogF("Keeping %q: unable to check for fresh files: %s\n", versionedCacheDir, err)
+			continue
+		}
+		if fresh {
+			logboek.Context(ctx).Debug().LogF("wipeCacheDirs in %q: keep fresh %q\n", cacheRootDir, finfo.Name())
+			continue
+		}
+
 		if err = os.RemoveAll(versionedCacheDir); err != nil {
 			return fmt.Errorf("unable to remove %q: %w", versionedCacheDir, err)
 		}
@@ -258,17 +274,44 @@ func wipeCacheDirs(ctx context.Context, cacheRootDir string, keepCacheVersions [
 	return nil
 }
 
+func hasFreshFiles(path string) (bool, error) {
+	err := filepath.WalkDir(path, func(_ string, dirEntry fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+
+		if !dirEntry.Type().IsRegular() {
+			return nil
+		}
+
+		info, err := dirEntry.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+
+		if time.Since(info.ModTime()) <= cacheVersionStalenessWindow {
+			return errFreshFileFound
+		}
+
+		return nil
+	})
+	if errors.Is(err, errFreshFileFound) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return false, nil
+}
+
 func lockGC(ctx context.Context, shared bool) (lockgate.LockHandle, error) {
 	_, handle, err := werf.HostLocker().AcquireLock(ctx, "git_data_manager", lockgate.AcquireOptions{Shared: shared})
 	return handle, err
-}
-
-// shouldKeepGitDataV1_1 returns true if the last run of werf v1.1 was within the last 3 days.
-func shouldKeepGitDataV1_1(ctx context.Context) (bool, error) {
-	v1_1LastRunAt, err := werf.GetWerfLastRunAtV1_1(ctx)
-	if err != nil {
-		return false, fmt.Errorf("error getting last run timestamp for werf v1.1: %w", err)
-	}
-
-	return time.Since(v1_1LastRunAt) <= time.Hour*24*3, nil
 }

--- a/pkg/git_repo/gitdata/gc_test.go
+++ b/pkg/git_repo/gitdata/gc_test.go
@@ -1,0 +1,71 @@
+package gitdata
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("wipeCacheDirs", func() {
+	staleTime := time.Now().Add(-cacheVersionStalenessWindow - time.Hour)
+
+	writeFileWithMtime := func(path string, mtime time.Time) {
+		Expect(os.MkdirAll(filepath.Dir(path), 0o755)).To(Succeed())
+		Expect(os.WriteFile(path, []byte("x"), 0o644)).To(Succeed())
+		Expect(os.Chtimes(path, mtime, mtime)).To(Succeed())
+	}
+
+	DescribeTable("removes only stale non-kept children",
+		func(ctx SpecContext, setup func(root string) string, expectRemoved bool) {
+			root := GinkgoT().TempDir()
+			child := setup(root)
+
+			Expect(wipeCacheDirs(ctx, root, []string{"5"})).To(Succeed())
+
+			if expectRemoved {
+				Expect(child).NotTo(BeAnExistingFile())
+			} else {
+				Expect(child).To(BeAnExistingFile())
+			}
+		},
+		Entry("keeps a foreign version dir with a fresh nested file",
+			func(root string) string {
+				dir := filepath.Join(root, "6")
+				writeFileWithMtime(filepath.Join(dir, "repo", "last_access_at"), time.Now())
+				return dir
+			}, false),
+		Entry("removes a foreign version dir with only stale files",
+			func(root string) string {
+				dir := filepath.Join(root, "6")
+				writeFileWithMtime(filepath.Join(dir, "repo", "last_access_at"), staleTime)
+				return dir
+			}, true),
+		Entry("removes an empty foreign version dir",
+			func(root string) string {
+				dir := filepath.Join(root, "6")
+				Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+				return dir
+			}, true),
+		Entry("keeps the current version dir even when stale",
+			func(root string) string {
+				dir := filepath.Join(root, "5")
+				writeFileWithMtime(filepath.Join(dir, "repo", "last_access_at"), staleTime)
+				return dir
+			}, false),
+		Entry("keeps a fresh stray file directly under root",
+			func(root string) string {
+				path := filepath.Join(root, ".DS_Store")
+				writeFileWithMtime(path, time.Now())
+				return path
+			}, false),
+		Entry("removes a stale stray file directly under root",
+			func(root string) string {
+				path := filepath.Join(root, ".DS_Store")
+				writeFileWithMtime(path, staleTime)
+				return path
+			}, true),
+	)
+})

--- a/pkg/git_repo/gitdata/git_data_manager.go
+++ b/pkg/git_repo/gitdata/git_data_manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/werf/werf/v2/pkg/werf"
 )
 
+// Before changing: read the local_cache contract in the package doc of pkg/git_repo/gitdata.
 const (
 	GitArchivesCacheVersion = "7"
 	GitPatchesCacheVersion  = "6"

--- a/pkg/git_repo/gitdata/git_mirror.go
+++ b/pkg/git_repo/gitdata/git_mirror.go
@@ -1,0 +1,125 @@
+package gitdata
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/werf/common-go/pkg/util/timestamps"
+	"github.com/werf/logboek"
+	"github.com/werf/werf/v2/pkg/volumeutils"
+)
+
+// GetGitMirrorsAndRemoveInvalid scans the given cacheVersionRoot directory and
+// returns a list of GitRepoDesc for each valid shallow git mirror found. It
+// removes invalid entries and handles errors appropriately.
+//
+// The directory structure expected is as follows:
+// ├── c447df0d5918decb5d832cb4324e3e2cbe0670eb3fe9301f795be831a9175f47
+// │   ├── shallow/
+// │   │   └── ... (repository files)
+// │   └── requires_full (optional marker file)
+// └── ... (other repositories)
+//
+// Each shallow mirror is an LRU entry with its own last_access_at. The
+// requires_full marker is persistent metadata, not an LRU entry: a repo dir
+// holding only the marker is valid and kept. A repo dir with neither shallow
+// mirror nor marker is removed.
+func GetGitMirrorsAndRemoveInvalid(ctx context.Context, cacheVersionRoot string) ([]GitDataEntry, error) {
+	var res []GitDataEntry
+
+	fileStat, err := os.Stat(cacheVersionRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error accessing dir %q: %w", cacheVersionRoot, err)
+	}
+	if !fileStat.IsDir() {
+		logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: not a directory\n", cacheVersionRoot)
+		if err := os.RemoveAll(cacheVersionRoot); err != nil {
+			return nil, fmt.Errorf("unable to remove %q: %w", cacheVersionRoot, err)
+		}
+		return nil, nil
+	}
+
+	repoDirs, err := ioutil.ReadDir(cacheVersionRoot)
+	if err != nil {
+		return nil, fmt.Errorf("error reading dir %q: %w", cacheVersionRoot, err)
+	}
+
+	for _, repoDirInfo := range repoDirs {
+		repoPath := filepath.Join(cacheVersionRoot, repoDirInfo.Name())
+
+		if !repoDirInfo.IsDir() {
+			logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: not a directory\n", repoPath)
+			if err := os.RemoveAll(repoPath); err != nil {
+				return nil, fmt.Errorf("unable to remove %q: %w", repoPath, err)
+			}
+			continue
+		}
+
+		repoChildren, err := ioutil.ReadDir(repoPath)
+		if err != nil {
+			return nil, fmt.Errorf("error reading dir %q: %w", repoPath, err)
+		}
+
+		var shallowFound, markerFound bool
+
+		for _, childInfo := range repoChildren {
+			childPath := filepath.Join(repoPath, childInfo.Name())
+
+			switch {
+			case childInfo.Name() == "shallow" && childInfo.IsDir():
+				shallowFound = true
+			case childInfo.Name() == "requires_full" && childInfo.Mode().IsRegular():
+				markerFound = true
+			default:
+				logboek.Context(ctx).Warn().LogF("Removing invalid entry %q\n", childPath)
+				if err := os.RemoveAll(childPath); err != nil {
+					return nil, fmt.Errorf("unable to remove %q: %w", childPath, err)
+				}
+			}
+		}
+
+		if !shallowFound && !markerFound {
+			logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: no shallow mirror and no requires_full marker inside\n", repoPath)
+			if err := os.RemoveAll(repoPath); err != nil {
+				return nil, fmt.Errorf("unable to remove %q: %w", repoPath, err)
+			}
+			continue
+		}
+
+		if !shallowFound {
+			continue
+		}
+
+		shallowPath := filepath.Join(repoPath, "shallow")
+
+		size, err := volumeutils.DirSizeBytes(shallowPath)
+		if err != nil {
+			return nil, fmt.Errorf("error getting dir %q size: %w", shallowPath, err)
+		}
+
+		lastAccessAtPath := filepath.Join(shallowPath, "last_access_at")
+		lastAccessAt, err := timestamps.ReadTimestampFile(lastAccessAtPath)
+		if err != nil {
+			logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: error reading last access timestamp file %q: %v\n", shallowPath, lastAccessAtPath, err)
+			if err := os.RemoveAll(shallowPath); err != nil {
+				return nil, fmt.Errorf("unable to remove %q: %w", shallowPath, err)
+			}
+			continue
+		}
+
+		res = append(res, &GitRepoDesc{
+			Path:          shallowPath,
+			Size:          size,
+			LastAccessAt:  lastAccessAt,
+			CacheBasePath: cacheVersionRoot,
+		})
+	}
+
+	return res, nil
+}

--- a/pkg/git_repo/gitdata/git_mirror_test.go
+++ b/pkg/git_repo/gitdata/git_mirror_test.go
@@ -1,0 +1,119 @@
+package gitdata
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetGitMirrorsAndRemoveInvalid", func() {
+	It("returns nil, nil when root does not exist", func(ctx SpecContext) {
+		res, err := GetGitMirrorsAndRemoveInvalid(ctx, filepath.Join(GinkgoT().TempDir(), "missing"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeNil())
+	})
+
+	It("keeps a repo dir holding only the requires_full marker without yielding an entry", func(ctx SpecContext) {
+		root := GinkgoT().TempDir()
+		repo := filepath.Join(root, "abc")
+		Expect(os.MkdirAll(repo, 0o755)).To(Succeed())
+		marker := filepath.Join(repo, "requires_full")
+		Expect(os.WriteFile(marker, nil, 0o644)).To(Succeed())
+
+		res, err := GetGitMirrorsAndRemoveInvalid(ctx, root)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeEmpty())
+		Expect(marker).To(BeARegularFile())
+	})
+
+	It("yields one entry for a shallow-only repo dir", func(ctx SpecContext) {
+		root := GinkgoT().TempDir()
+		now := time.Now().Truncate(time.Second)
+		shallow := writeMirror(filepath.Join(root, "abc", "shallow"), now)
+
+		res, err := GetGitMirrorsAndRemoveInvalid(ctx, root)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0].GetPaths()).To(ConsistOf(shallow))
+		Expect(res[0].GetCacheBasePath()).To(Equal(root))
+		Expect(res[0].GetLastAccessAt().Unix()).To(Equal(now.Unix()))
+	})
+
+	It("yields exactly one entry for marker plus shallow and preserves the marker", func(ctx SpecContext) {
+		root := GinkgoT().TempDir()
+		now := time.Now().Truncate(time.Second)
+		shallow := writeMirror(filepath.Join(root, "abc", "shallow"), now)
+		marker := filepath.Join(root, "abc", "requires_full")
+		Expect(os.WriteFile(marker, nil, 0o644)).To(Succeed())
+
+		res, err := GetGitMirrorsAndRemoveInvalid(ctx, root)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0].GetPaths()).To(ConsistOf(shallow))
+		Expect(marker).To(BeARegularFile())
+	})
+
+	It("removes an empty repo dir", func(ctx SpecContext) {
+		root := GinkgoT().TempDir()
+		repo := filepath.Join(root, "abc")
+		Expect(os.MkdirAll(repo, 0o755)).To(Succeed())
+
+		res, err := GetGitMirrorsAndRemoveInvalid(ctx, root)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeEmpty())
+		Expect(repo).NotTo(BeAnExistingFile())
+	})
+
+	It("removes non-directory entries directly under root", func(ctx SpecContext) {
+		root := GinkgoT().TempDir()
+		stray := filepath.Join(root, "stray")
+		Expect(os.WriteFile(stray, []byte("x"), 0o644)).To(Succeed())
+
+		res, err := GetGitMirrorsAndRemoveInvalid(ctx, root)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeEmpty())
+		Expect(stray).NotTo(BeAnExistingFile())
+	})
+
+	It("removes a malformed shallow that is not a directory, then the repo dir with nothing valid left", func(ctx SpecContext) {
+		root := GinkgoT().TempDir()
+		repo := filepath.Join(root, "abc")
+		Expect(os.MkdirAll(repo, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(repo, "shallow"), []byte("x"), 0o644)).To(Succeed())
+
+		res, err := GetGitMirrorsAndRemoveInvalid(ctx, root)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeEmpty())
+		Expect(repo).NotTo(BeAnExistingFile())
+	})
+
+	It("removes a malformed requires_full that is a directory but keeps the valid shallow sibling", func(ctx SpecContext) {
+		root := GinkgoT().TempDir()
+		now := time.Now().Truncate(time.Second)
+		shallow := writeMirror(filepath.Join(root, "abc", "shallow"), now)
+		malformedMarker := filepath.Join(root, "abc", "requires_full")
+		Expect(os.MkdirAll(malformedMarker, 0o755)).To(Succeed())
+
+		res, err := GetGitMirrorsAndRemoveInvalid(ctx, root)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0].GetPaths()).To(ConsistOf(shallow))
+		Expect(malformedMarker).NotTo(BeAnExistingFile())
+	})
+
+	It("removes unknown children like a leftover marker tmp file", func(ctx SpecContext) {
+		root := GinkgoT().TempDir()
+		now := time.Now().Truncate(time.Second)
+		writeMirror(filepath.Join(root, "abc", "shallow"), now)
+		leftover := filepath.Join(root, "abc", "requires_full.tmp")
+		Expect(os.WriteFile(leftover, nil, 0o644)).To(Succeed())
+
+		res, err := GetGitMirrorsAndRemoveInvalid(ctx, root)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(leftover).NotTo(BeAnExistingFile())
+	})
+})

--- a/pkg/git_repo/gitdata/git_repo.go
+++ b/pkg/git_repo/gitdata/git_repo.go
@@ -42,16 +42,11 @@ func (entry *GitRepoDesc) GetCacheBasePath() string {
 //
 // The directory structure expected is as follows:
 // ├── c447df0d5918decb5d832cb4324e3e2cbe0670eb3fe9301f795be831a9175f47
-// │   ├── full/
-// │   │   └── ... (repository files)
-// │   ├── shallow/
-// │   │   └── ... (repository files)
-// │   └── requires_full (optional marker file)
+// │   └── ... (repository files)
 // └── ... (other repositories)
 //
-// Each full/shallow mirror is an independent LRU entry with its own
-// last_access_at. A repo dir with no mirror subdirs is removed entirely,
-// including the requires_full marker.
+// Each repo dir is itself a bare full mirror and an independent LRU entry
+// with its own last_access_at.
 func GetGitReposAndRemoveInvalid(ctx context.Context, cacheVersionRoot string) ([]GitDataEntry, error) {
 	var res []GitDataEntry
 
@@ -87,58 +82,27 @@ func GetGitReposAndRemoveInvalid(ctx context.Context, cacheVersionRoot string) (
 			continue
 		}
 
-		var mirrorEntries []GitDataEntry
-
-		for _, kind := range []string{"full", "shallow"} {
-			mirrorPath := filepath.Join(repoPath, kind)
-
-			mirrorStat, err := os.Stat(mirrorPath)
-			if os.IsNotExist(err) {
-				continue
-			} else if err != nil {
-				return nil, fmt.Errorf("error accessing dir %q: %w", mirrorPath, err)
-			}
-
-			if !mirrorStat.IsDir() {
-				logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: not a directory\n", mirrorPath)
-				if err := os.RemoveAll(mirrorPath); err != nil {
-					return nil, fmt.Errorf("unable to remove %q: %w", mirrorPath, err)
-				}
-				continue
-			}
-
-			size, err := volumeutils.DirSizeBytes(mirrorPath)
-			if err != nil {
-				return nil, fmt.Errorf("error getting dir %q size: %w", mirrorPath, err)
-			}
-
-			lastAccessAtPath := filepath.Join(mirrorPath, "last_access_at")
-			lastAccessAt, err := timestamps.ReadTimestampFile(lastAccessAtPath)
-			if err != nil {
-				logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: error reading last access timestamp file %q: %v\n", mirrorPath, lastAccessAtPath, err)
-				if err := os.RemoveAll(mirrorPath); err != nil {
-					return nil, fmt.Errorf("unable to remove %q: %w", mirrorPath, err)
-				}
-				continue
-			}
-
-			mirrorEntries = append(mirrorEntries, &GitRepoDesc{
-				Path:          mirrorPath,
-				Size:          size,
-				LastAccessAt:  lastAccessAt,
-				CacheBasePath: cacheVersionRoot,
-			})
+		size, err := volumeutils.DirSizeBytes(repoPath)
+		if err != nil {
+			return nil, fmt.Errorf("error getting dir %q size: %w", repoPath, err)
 		}
 
-		if len(mirrorEntries) == 0 {
-			logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: no valid git mirrors inside\n", repoPath)
+		lastAccessAtPath := filepath.Join(repoPath, "last_access_at")
+		lastAccessAt, err := timestamps.ReadTimestampFile(lastAccessAtPath)
+		if err != nil {
+			logboek.Context(ctx).Warn().LogF("Removing invalid entry %q: error reading last access timestamp file %q: %v\n", repoPath, lastAccessAtPath, err)
 			if err := os.RemoveAll(repoPath); err != nil {
 				return nil, fmt.Errorf("unable to remove %q: %w", repoPath, err)
 			}
 			continue
 		}
 
-		res = append(res, mirrorEntries...)
+		res = append(res, &GitRepoDesc{
+			Path:          repoPath,
+			Size:          size,
+			LastAccessAt:  lastAccessAt,
+			CacheBasePath: cacheVersionRoot,
+		})
 	}
 
 	return res, nil

--- a/pkg/git_repo/gitdata/git_repo_test.go
+++ b/pkg/git_repo/gitdata/git_repo_test.go
@@ -11,11 +11,10 @@ import (
 	"github.com/werf/common-go/pkg/util/timestamps"
 )
 
-func writeMirror(root, hash, kind string, ts time.Time) string {
-	mirror := filepath.Join(root, hash, kind)
-	Expect(os.MkdirAll(mirror, 0o755)).To(Succeed())
-	Expect(timestamps.WriteTimestampFile(filepath.Join(mirror, "last_access_at"), ts)).To(Succeed())
-	return mirror
+func writeMirror(mirrorPath string, ts time.Time) string {
+	Expect(os.MkdirAll(mirrorPath, 0o755)).To(Succeed())
+	Expect(timestamps.WriteTimestampFile(filepath.Join(mirrorPath, "last_access_at"), ts)).To(Succeed())
+	return mirrorPath
 }
 
 var _ = Describe("GetGitReposAndRemoveInvalid", func() {
@@ -46,57 +45,34 @@ var _ = Describe("GetGitReposAndRemoveInvalid", func() {
 		Expect(stray).NotTo(BeAnExistingFile())
 	})
 
-	DescribeTable("mirror subdir combinations",
-		func(ctx SpecContext, kinds []string, expected int) {
-			root := GinkgoT().TempDir()
-			hash := "abc"
-			now := time.Now().Truncate(time.Second)
-
-			var mirrorPaths []string
-			for _, k := range kinds {
-				mirrorPaths = append(mirrorPaths, writeMirror(root, hash, k, now))
-			}
-
-			res, err := GetGitReposAndRemoveInvalid(ctx, root)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res).To(HaveLen(expected))
-
-			paths := make(map[string]GitDataEntry, len(res))
-			for _, e := range res {
-				Expect(e.GetCacheBasePath()).To(Equal(root))
-				Expect(e.GetLastAccessAt().Unix()).To(Equal(now.Unix()))
-				Expect(e.GetPaths()).To(HaveLen(1))
-				paths[e.GetPaths()[0]] = e
-			}
-			for _, mp := range mirrorPaths {
-				Expect(paths).To(HaveKey(mp))
-			}
-		},
-		Entry("only full", []string{"full"}, 1),
-		Entry("only shallow", []string{"shallow"}, 1),
-		Entry("both full and shallow", []string{"full", "shallow"}, 2),
-	)
-
-	It("removes repo dir with neither full nor shallow, even if requires_full marker is present", func(ctx SpecContext) {
+	It("yields one entry per flat repo dir", func(ctx SpecContext) {
 		root := GinkgoT().TempDir()
-		repo := filepath.Join(root, "abc")
-		Expect(os.MkdirAll(repo, 0o755)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(repo, "requires_full"), nil, 0o644)).To(Succeed())
+		now := time.Now().Truncate(time.Second)
+		mirrorA := writeMirror(filepath.Join(root, "aaa"), now)
+		mirrorB := writeMirror(filepath.Join(root, "bbb"), now)
 
 		res, err := GetGitReposAndRemoveInvalid(ctx, root)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res).To(BeEmpty())
-		Expect(repo).NotTo(BeAnExistingFile())
+		Expect(res).To(HaveLen(2))
+
+		paths := make(map[string]GitDataEntry, len(res))
+		for _, e := range res {
+			Expect(e.GetCacheBasePath()).To(Equal(root))
+			Expect(e.GetLastAccessAt().Unix()).To(Equal(now.Unix()))
+			Expect(e.GetPaths()).To(HaveLen(1))
+			paths[e.GetPaths()[0]] = e
+		}
+		Expect(paths).To(HaveKey(mirrorA))
+		Expect(paths).To(HaveKey(mirrorB))
 	})
 
-	DescribeTable("mirror with missing or corrupt last_access_at yields a zero LastAccessAt entry so LRU can prune it",
+	DescribeTable("repo dir with missing or corrupt last_access_at yields a zero LastAccessAt entry so LRU can prune it",
 		func(ctx SpecContext, brokenSetup func(path string)) {
 			root := GinkgoT().TempDir()
-			hash := "abc"
 			now := time.Now().Truncate(time.Second)
-			validMirror := writeMirror(root, hash, "full", now)
+			validMirror := writeMirror(filepath.Join(root, "valid"), now)
 
-			brokenMirror := filepath.Join(root, hash, "shallow")
+			brokenMirror := filepath.Join(root, "broken")
 			Expect(os.MkdirAll(brokenMirror, 0o755)).To(Succeed())
 			brokenSetup(filepath.Join(brokenMirror, "last_access_at"))
 

--- a/pkg/git_repo/remote.go
+++ b/pkg/git_repo/remote.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/google/uuid"
 	"gopkg.in/ini.v1"
 
 	"github.com/werf/common-go/pkg/util"
@@ -103,7 +105,10 @@ func (repo *Remote) GetClonePath() string {
 }
 
 func (repo *Remote) clonePathForKind(kind mirrorKind) string {
-	return filepath.Join(GetGitRepoCacheDir(), repo.getRepoID(), string(kind))
+	if kind == mirrorKindFull {
+		return filepath.Join(GetGitRepoCacheDir(), repo.getRepoID())
+	}
+	return filepath.Join(GetGitMirrorsCacheDir(), repo.getRepoID(), string(kind))
 }
 
 func (repo *Remote) mirrorKind() mirrorKind {
@@ -114,7 +119,7 @@ func (repo *Remote) mirrorKind() mirrorKind {
 }
 
 func (repo *Remote) requiresFullMarkerPath() string {
-	return filepath.Join(GetGitRepoCacheDir(), repo.getRepoID(), "requires_full")
+	return filepath.Join(GetGitMirrorsCacheDir(), repo.getRepoID(), "requires_full")
 }
 
 func (repo *Remote) resolveMirrorKind() (mirrorKind, error) {
@@ -291,12 +296,9 @@ func (repo *Remote) cloneFullCore(ctx context.Context, kind mirrorKind) error {
 		return fmt.Errorf("unable to create dir %s: %w", filepath.Dir(clonePath), err)
 	}
 
-	tmpPath := fmt.Sprintf("%s.tmp", clonePath)
-	// Remove previously created possibly existing dir
-	if err := os.RemoveAll(tmpPath); err != nil {
-		return fmt.Errorf("unable to prepare tmp path %s: failed to remove: %w", tmpPath, err)
-	}
-	// Ensure cleanup on failure
+	removeStaleCloneTmpDirs(ctx, clonePath)
+
+	tmpPath := fmt.Sprintf("%s.%s.tmp", clonePath, uuid.New().String())
 	defer os.RemoveAll(tmpPath)
 
 	cloneOpts := buildCloneOptions(repo.Url, repo.Branch)
@@ -309,15 +311,102 @@ func (repo *Remote) cloneFullCore(ctx context.Context, kind mirrorKind) error {
 		return fmt.Errorf("unable to clone repo: %w", err)
 	}
 
-	if err := repo.updateLastAccessAt(ctx, tmpPath); err != nil {
-		return fmt.Errorf("error updating last access at timestamp: %w", err)
+	if err := timestamps.WriteTimestampFile(filepath.Join(tmpPath, "last_access_at"), time.Now()); err != nil {
+		return fmt.Errorf("error writing last access at timestamp: %w", err)
 	}
 
-	if err := os.Rename(tmpPath, clonePath); err != nil {
-		return fmt.Errorf("rename %s to %s failed: %w", tmpPath, clonePath, err)
+	peerWon, err := renameCloneIntoPlace(tmpPath, clonePath)
+	if err != nil {
+		return err
+	}
+	if peerWon {
+		return repo.fetchOriginFullCore(ctx, kind)
 	}
 
 	return nil
+}
+
+// cloneTmpStalenessWindow encodes the same judgement as gitdata's
+// cacheVersionStalenessWindow: how long a werf process can plausibly still be
+// mid-operation. Tune them together.
+const cloneTmpStalenessWindow = 3 * 24 * time.Hour
+
+// removeStaleCloneTmpDirs reclaims tmp dirs abandoned by SIGKILLed clones. A
+// tmp dir is swept only when nothing in its subtree was written within the
+// window (unlike gitdata's hasFreshFiles, directory mtimes count — keeping is
+// the safe direction here), which makes the sweep safe even against a werf
+// process that does not share our locker dir: a live clone writes
+// continuously.
+func removeStaleCloneTmpDirs(ctx context.Context, clonePath string) {
+	parentDir := filepath.Dir(clonePath)
+
+	entries, err := os.ReadDir(parentDir)
+	if err != nil {
+		logboek.Context(ctx).Warn().LogF("Unable to look up stale tmp dirs of %q: %s\n", clonePath, err)
+		return
+	}
+
+	prefix := filepath.Base(clonePath) + "."
+
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), prefix) || !strings.HasSuffix(entry.Name(), ".tmp") {
+			continue
+		}
+
+		tmpPath := filepath.Join(parentDir, entry.Name())
+		if !isCloneTmpDirAbandoned(tmpPath) {
+			continue
+		}
+
+		if err := os.RemoveAll(tmpPath); err != nil {
+			logboek.Context(ctx).Warn().LogF("Unable to remove stale tmp dir %q: %s\n", tmpPath, err)
+		}
+	}
+}
+
+func isCloneTmpDirAbandoned(tmpPath string) bool {
+	abandoned := true
+
+	err := filepath.WalkDir(tmpPath, func(_ string, dirEntry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		info, err := dirEntry.Info()
+		if err != nil {
+			return err
+		}
+
+		if time.Since(info.ModTime()) <= cloneTmpStalenessWindow {
+			abandoned = false
+			return filepath.SkipAll
+		}
+
+		return nil
+	})
+	if err != nil {
+		return false
+	}
+
+	return abandoned
+}
+
+// renameCloneIntoPlace treats a failed rename as a lost race when the
+// destination already exists: a concurrent werf process (possibly another
+// version sharing WERF_HOME) cloned the same mirror first. The peer's clone
+// may have been made with a different refspec, so callers must fetch their
+// own refs into it instead of treating it as their fresh clone.
+func renameCloneIntoPlace(tmpPath, clonePath string) (bool, error) {
+	renameErr := os.Rename(tmpPath, clonePath)
+	if renameErr == nil {
+		return false, nil
+	}
+
+	if _, err := os.Stat(clonePath); err == nil {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("rename %s to %s failed: %w", tmpPath, clonePath, renameErr)
 }
 
 type Auth struct {
@@ -570,12 +659,26 @@ func (repo *Remote) getRepoID() string {
 }
 
 func (repo *Remote) getWorkTreeCacheDir(repoID string) string {
+	if repo.mirrorKind() == mirrorKindFull {
+		return filepath.Join(GetWorkTreeCacheDir(), "remote", repoID)
+	}
 	return filepath.Join(GetWorkTreeCacheDir(), "remote", fmt.Sprintf("%s.%s", repoID, repo.mirrorKind()))
 }
 
 func (repo *Remote) withMirrorKindLock(ctx context.Context, kind mirrorKind, f func() error) error {
-	lockName := fmt.Sprintf("remote_git.%s.%s", repo.getRepoID(), kind)
-	return werf.HostLocker().WithLock(ctx, lockName, lockgate.AcquireOptions{Timeout: 600 * time.Second}, f)
+	opts := lockgate.AcquireOptions{Timeout: 600 * time.Second}
+	repoIDLockName := fmt.Sprintf("remote_git.%s.%s", repo.getRepoID(), kind)
+
+	if kind == mirrorKindFull {
+		// remote_git_mapping.<name> is the lock name used by released werf 2.74.x
+		// binaries for the shared full-mirror dir; matching it byte-for-byte is
+		// what gives cross-version exclusion on hosts with a shared WERF_HOME.
+		return werf.HostLocker().WithLock(ctx, fmt.Sprintf("remote_git_mapping.%s", repo.Name), opts, func() error {
+			return werf.HostLocker().WithLock(ctx, repoIDLockName, opts, f)
+		})
+	}
+
+	return werf.HostLocker().WithLock(ctx, repoIDLockName, opts, f)
 }
 
 func (repo *Remote) TagsList(_ context.Context) ([]string, error) {

--- a/pkg/git_repo/remote_shallow.go
+++ b/pkg/git_repo/remote_shallow.go
@@ -9,10 +9,13 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/google/uuid"
 
 	"github.com/werf/common-go/pkg/util"
+	"github.com/werf/common-go/pkg/util/timestamps"
 	"github.com/werf/logboek"
 	"github.com/werf/werf/v2/pkg/true_git"
 	"github.com/werf/werf/v2/pkg/werf"
@@ -358,22 +361,23 @@ func (repo *Remote) ensureShallowMirror(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("unable to create dir %s: %w", filepath.Dir(shallowPath), err)
 	}
 
-	tmpPath := fmt.Sprintf("%s.tmp", shallowPath)
-	if err := os.RemoveAll(tmpPath); err != nil {
-		return false, fmt.Errorf("unable to prepare tmp path %s: failed to remove: %w", tmpPath, err)
-	}
+	removeStaleCloneTmpDirs(ctx, shallowPath)
+
+	tmpPath := fmt.Sprintf("%s.%s.tmp", shallowPath, uuid.New().String())
 	defer os.RemoveAll(tmpPath)
 
 	if err := true_git.InitBareRepoWithOrigin(ctx, tmpPath, repo.Url); err != nil {
 		return false, err
 	}
 
-	if err := repo.updateLastAccessAt(ctx, tmpPath); err != nil {
-		return false, fmt.Errorf("error updating last access at timestamp: %w", err)
+	if err := timestamps.WriteTimestampFile(filepath.Join(tmpPath, "last_access_at"), time.Now()); err != nil {
+		return false, fmt.Errorf("error writing last access at timestamp: %w", err)
 	}
 
-	if err := os.Rename(tmpPath, shallowPath); err != nil {
-		return false, fmt.Errorf("rename %s to %s failed: %w", tmpPath, shallowPath, err)
+	// A peer win needs no handling here: returning exists == false already
+	// makes the callers fetch into the peer's mirror.
+	if _, err := renameCloneIntoPlace(tmpPath, shallowPath); err != nil {
+		return false, err
 	}
 
 	return false, nil
@@ -450,6 +454,10 @@ func (repo *Remote) verifyTargetInFullMirror(ctx context.Context, fullPath strin
 
 func (repo *Remote) writeRequiresFullMarker() error {
 	markerPath := repo.requiresFullMarkerPath()
+
+	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
+		return fmt.Errorf("unable to create dir %s: %w", filepath.Dir(markerPath), err)
+	}
 
 	tmpPath := fmt.Sprintf("%s.tmp", markerPath)
 	if err := os.WriteFile(tmpPath, nil, 0o644); err != nil {

--- a/pkg/git_repo/remote_shallow_test.go
+++ b/pkg/git_repo/remote_shallow_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
@@ -83,7 +84,7 @@ var _ = Describe("Remote shallow mirror", func() {
 			repo := openRemote("main", "", "")
 			Expect(repo.CloneAndFetch(ctx)).To(Succeed())
 
-			Expect(repo.GetClonePath()).To(HaveSuffix(string(mirrorKindFull)))
+			Expect(repo.GetClonePath()).To(Equal(filepath.Join(GetGitRepoCacheDir(), repo.getRepoID())))
 			Expect(repo.GetClonePath()).To(BeADirectory())
 
 			headCommit := utils.GetHeadCommit(ctx, sourceDir)
@@ -98,7 +99,7 @@ var _ = Describe("Remote shallow mirror", func() {
 			repo := openRemote("", "", "")
 			Expect(repo.CloneAndFetch(ctx)).To(Succeed())
 
-			Expect(repo.GetClonePath()).To(HaveSuffix(string(mirrorKindFull)))
+			Expect(repo.GetClonePath()).To(Equal(filepath.Join(GetGitRepoCacheDir(), repo.getRepoID())))
 
 			headCommit := utils.GetHeadCommit(ctx, sourceDir)
 			tagCommit, err := repo.TagCommit(ctx, "v1")
@@ -152,7 +153,7 @@ var _ = Describe("Remote shallow mirror", func() {
 
 				repo := openRemote("", tag, "")
 				Expect(repo.CloneAndFetch(ctx)).To(Succeed())
-				Expect(repo.GetClonePath()).To(HaveSuffix(string(mirrorKindShallow)))
+				Expect(repo.GetClonePath()).To(Equal(filepath.Join(GetGitMirrorsCacheDir(), repo.getRepoID(), string(mirrorKindShallow))))
 
 				headCommit := utils.GetHeadCommit(ctx, sourceDir)
 				tagCommit, err := repo.TagCommit(ctx, tag)
@@ -186,7 +187,7 @@ var _ = Describe("Remote shallow mirror", func() {
 
 			repo := openRemote("", "", headCommit)
 			Expect(repo.CloneAndFetch(ctx)).To(Succeed())
-			Expect(repo.GetClonePath()).To(HaveSuffix(string(mirrorKindShallow)))
+			Expect(repo.GetClonePath()).To(Equal(filepath.Join(GetGitMirrorsCacheDir(), repo.getRepoID(), string(mirrorKindShallow))))
 
 			exists, err := repo.IsCommitExists(ctx, headCommit)
 			Expect(err).NotTo(HaveOccurred())
@@ -327,7 +328,7 @@ var _ = Describe("Remote shallow mirror", func() {
 
 			fullRepo := openRemote("", "v2", "")
 			Expect(fullRepo.CloneAndFetch(ctx)).To(Succeed())
-			Expect(fullRepo.GetClonePath()).To(HaveSuffix(string(mirrorKindFull)))
+			Expect(fullRepo.GetClonePath()).To(Equal(filepath.Join(GetGitRepoCacheDir(), fullRepo.getRepoID())))
 			Expect(fullRepo.GetClonePath()).To(BeADirectory())
 			Expect(fullRepo.requiresFullMarkerPath()).To(BeARegularFile())
 			Expect(shallowPath).To(BeADirectory())
@@ -345,7 +346,7 @@ var _ = Describe("Remote shallow mirror", func() {
 
 			nextRepo := openRemote("", "v1", "")
 			Expect(nextRepo.CloneAndFetch(ctx)).To(Succeed())
-			Expect(nextRepo.GetClonePath()).To(HaveSuffix(string(mirrorKindFull)))
+			Expect(nextRepo.GetClonePath()).To(Equal(filepath.Join(GetGitRepoCacheDir(), nextRepo.getRepoID())))
 		})
 
 		It("does not persist marker when remote is unreachable", func(ctx SpecContext) {
@@ -383,6 +384,80 @@ var _ = Describe("Remote shallow mirror", func() {
 			opts := buildFetchOptions("upstream", "")
 			Expect(opts.Tags).To(Equal(git.AllTags))
 			Expect(opts.RefSpecs).To(ConsistOf(gitconfig.RefSpec("+refs/heads/*:refs/remotes/upstream/*")))
+		})
+	})
+
+	Describe("renameCloneIntoPlace", func() {
+		It("reports no race when the rename succeeds", func() {
+			dir := GinkgoT().TempDir()
+			tmpPath := filepath.Join(dir, "clone.tmp")
+			clonePath := filepath.Join(dir, "clone")
+			Expect(os.MkdirAll(tmpPath, 0o755)).To(Succeed())
+
+			peerWon, err := renameCloneIntoPlace(tmpPath, clonePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(peerWon).To(BeFalse())
+			Expect(clonePath).To(BeADirectory())
+		})
+
+		It("reports a peer win when a peer already moved a clone into place", func() {
+			dir := GinkgoT().TempDir()
+			tmpPath := filepath.Join(dir, "clone.tmp")
+			clonePath := filepath.Join(dir, "clone")
+			Expect(os.MkdirAll(tmpPath, 0o755)).To(Succeed())
+			Expect(os.MkdirAll(clonePath, 0o755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(clonePath, "HEAD"), []byte("ref"), 0o644)).To(Succeed())
+
+			peerWon, err := renameCloneIntoPlace(tmpPath, clonePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(peerWon).To(BeTrue())
+		})
+
+		It("returns the rename error when the destination does not appear", func() {
+			dir := GinkgoT().TempDir()
+			tmpPath := filepath.Join(dir, "clone.tmp")
+			Expect(os.MkdirAll(tmpPath, 0o755)).To(Succeed())
+			clonePath := filepath.Join(dir, "missing-parent", "clone")
+
+			peerWon, err := renameCloneIntoPlace(tmpPath, clonePath)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("rename"))
+			Expect(peerWon).To(BeFalse())
+		})
+	})
+
+	Describe("removeStaleCloneTmpDirs", func() {
+		It("removes only stale tmp siblings of the clone path", func(ctx SpecContext) {
+			dir := GinkgoT().TempDir()
+			clonePath := filepath.Join(dir, "abc")
+			staleTmp := clonePath + ".111.tmp"
+			freshTmp := clonePath + ".222.tmp"
+			Expect(os.MkdirAll(clonePath, 0o755)).To(Succeed())
+			Expect(os.MkdirAll(staleTmp, 0o755)).To(Succeed())
+			Expect(os.MkdirAll(freshTmp, 0o755)).To(Succeed())
+			old := time.Now().Add(-cloneTmpStalenessWindow - time.Hour)
+			Expect(os.Chtimes(staleTmp, old, old)).To(Succeed())
+
+			removeStaleCloneTmpDirs(ctx, clonePath)
+
+			Expect(staleTmp).NotTo(BeAnExistingFile())
+			Expect(freshTmp).To(BeADirectory())
+			Expect(clonePath).To(BeADirectory())
+		})
+
+		It("keeps a tmp dir with a stale top level but recent writes inside", func(ctx SpecContext) {
+			dir := GinkgoT().TempDir()
+			clonePath := filepath.Join(dir, "abc")
+			liveTmp := clonePath + ".111.tmp"
+			innerDir := filepath.Join(liveTmp, "objects", "pack")
+			Expect(os.MkdirAll(innerDir, 0o755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(innerDir, "pack-1.pack"), []byte("x"), 0o644)).To(Succeed())
+			old := time.Now().Add(-cloneTmpStalenessWindow - time.Hour)
+			Expect(os.Chtimes(liveTmp, old, old)).To(Succeed())
+
+			removeStaleCloneTmpDirs(ctx, clonePath)
+
+			Expect(liveTmp).To(BeADirectory())
 		})
 	})
 

--- a/pkg/git_repo/work_tree.go
+++ b/pkg/git_repo/work_tree.go
@@ -6,6 +6,7 @@ import (
 	"github.com/werf/werf/v2/pkg/werf"
 )
 
+// Before changing: read the local_cache contract in the package doc of pkg/git_repo/gitdata.
 const GitWorktreesCacheVersion = "9"
 
 func GetWorkTreeCacheDir() string {

--- a/trdl_channels.yaml
+++ b/trdl_channels.yaml
@@ -50,4 +50,4 @@ groups:
   - name: "3"
     channels:
       - name: dev
-        version: 3.0.0-alpha.2
+        version: 3.0.1

--- a/trdl_channels.yaml
+++ b/trdl_channels.yaml
@@ -38,11 +38,11 @@ groups:
   - name: "2"
     channels:
       - name: alpha
-        version: 2.75.2
+        version: 2.75.3
       - name: beta
-        version: 2.75.2
+        version: 2.75.3
       - name: ea
-        version: 2.75.1
+        version: 2.75.3
       - name: stable
         version: 2.74.0
       - name: rock-solid

--- a/trdl_channels.yaml
+++ b/trdl_channels.yaml
@@ -50,4 +50,4 @@ groups:
   - name: "3"
     channels:
       - name: dev
-        version: 3.0.0-alpha.1
+        version: 3.0.0-alpha.2


### PR DESCRIPTION
## Summary

Merge `origin/main` (6 commits, up to `286f5924`) into `3`. Brings the host-cleanup fix that stopped werf from wiping other werf versions live git cache (#7699), the `pkg/git_repo/gitdata` doc.go/refactor that came with it, agent-skill doc updates and release-channel bumps.

## Key changes

- Code merged cleanly, no manual resolution needed (`pkg/git_repo/gitdata/gc.go` auto-merged on top of the `3`-only host locker dir schema version removal).
- `AGENTS.md`: kept both sides — `3` LSP/out-of-scope rules plus main new doc.go rule.
- `CHANGELOG.md`: kept the `3` side; the `2.75.3` entry belongs to main release-please track.

## Why

Keep `3` in sync with `main` so v3 carries the same bug fixes and does not drift.

## Verification

- `task build` and `task test:unit paths="./pkg/git_repo/..."` on the merge commit — pass.
- Nothing Buildah/linux-specific was touched, so no linux/cgo run.

## Review focus / risks

- `CHANGELOG.md` conflict resolution — confirm the `2.75.3` section is intentionally not carried into `3`.
- `trdl_channels.yaml` release-channel bumps came from main as-is.