### PR TITLE
fix(build): assign per-image build-log progress index by real start order

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -788,6 +788,9 @@ func (c *Conveyor) doImagesInParallel(ctx context.Context, phases []Phase, logIm
 	}, scheduler.next, func(ctx context.Context, taskId int) error {
 		taskImage := nodes[taskId]
 		taskImage.SetBuildOrderIndex(int(buildOrder.Add(1)) - 1)
+		if workerID, ok := ctx.Value(parallel.CtxBackgroundTaskIDKey).(int); ok {
+			taskImage.SetWorkerID(workerID)
+		}
 
 		var taskPhases []Phase
 		for _, phase := range phases {

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/opencontainers/go-digest"
@@ -758,7 +759,7 @@ func (c *Conveyor) doImagesInParallel(ctx context.Context, phases []Phase, logIm
 				for levelId, level := range graph.Levels() {
 					logboek.Context(ctx).LogFHighlight("Level #%d:\n", levelId)
 					for _, img := range level {
-						logboek.Context(ctx).LogLnHighlight("-", img.LogDetailedName())
+						logboek.Context(ctx).LogLnHighlight("-", img.LogPlanName())
 					}
 					logboek.Context(ctx).LogOptionalLn()
 				}
@@ -772,11 +773,20 @@ func (c *Conveyor) doImagesInParallel(ctx context.Context, phases []Phase, logIm
 
 	scheduler := newGraphScheduler(graph)
 
+	// buildOrder assigns each image its build-time log progress index in the
+	// order it is actually handed out for building, instead of the static
+	// topological position ImagesTree.Calculate assigned it — the two can
+	// diverge arbitrarily under concurrent, dependency-driven scheduling, and
+	// only the former is a meaningful "N/Total" progress indicator to a user
+	// watching the log.
+	var buildOrder atomic.Int64
+
 	if err := parallel.DoTasksDynamic(ctx, parallel.DoTasksOptions{
 		InitDockerCLIForEachWorker: true,
 		MaxNumberOfWorkers:         numberOfWorkers,
 	}, scheduler.next, func(ctx context.Context, taskId int) error {
 		taskImage := nodes[taskId]
+		taskImage.SetBuildOrderIndex(int(buildOrder.Add(1)) - 1)
 
 		var taskPhases []Phase
 		for _, phase := range phases {

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -805,13 +806,22 @@ func (c *Conveyor) doImagesInParallel(ctx context.Context, phases []Phase, logIm
 	}
 
 	if logImages {
+		// Print in build-order (not nodes' topological order): the two can
+		// diverge, and listing topologically while showing each image's
+		// build-order index would make the summary numbers look scattered
+		// again, defeating the point of assigning them in the first place.
+		byBuildOrder := slices.Clone(nodes)
+		sort.Slice(byBuildOrder, func(i, j int) bool {
+			return byBuildOrder[i].GetBuildOrderIndex() < byBuildOrder[j].GetBuildOrderIndex()
+		})
+
 		blockMsg := "Build summary"
 		logboek.Context(ctx).LogBlock(blockMsg).
 			Options(func(options types.LogBlockOptionsInterface) {
 				options.Style(stylePkg.Highlight())
 			}).
 			Do(func() {
-				for _, img := range nodes {
+				for _, img := range byBuildOrder {
 					logboek.Context(ctx).LogLnHighlight("-", fmt.Sprintf("%s (%.2f seconds)", img.LogDetailedName(), img.BuildDuration.Seconds()))
 				}
 			})

--- a/pkg/build/graph_scheduler_integration_ai_test.go
+++ b/pkg/build/graph_scheduler_integration_ai_test.go
@@ -134,7 +134,7 @@ func TestAI_DoImagesInParallel_DependentImageDoesNotWaitForUnrelatedSlowImage(t 
 		"dependent chain a->b->c must not wait for unrelated image \"slow\"; observed order=%v", order)
 }
 
-// TestAI_DoImagesInParallel_AssignsUniqueBuildOrderIndexRespectingDependencyOrder
+// TestAI_DoImagesInParallel_AssignsBuildOrderIndexByRealDequeueNotStaticTopology
 // is the regression test for the build-log progress-numbering fix: images
 // used to get their log progress index assigned once, statically, from their
 // position in the dependency graph's topological order (ImagesTree.Calculate)
@@ -144,11 +144,25 @@ func TestAI_DoImagesInParallel_DependentImageDoesNotWaitForUnrelatedSlowImage(t 
 // instead assign each image's index at the moment it is actually dequeued for
 // building.
 //
-// The assertions below are deterministic, not timing-dependent: the shared
-// build-order counter only ever increases, and graphScheduler guarantees b/c
-// can't be dequeued before a/b's build has fully completed — so
-// index(a) < index(b) < index(c) holds regardless of goroutine scheduling.
-func TestAI_DoImagesInParallel_AssignsUniqueBuildOrderIndexRespectingDependencyOrder(t *testing.T) {
+// The graph is built with "slow" listed LAST (images passed to
+// BuildImagesGraph as [a, b, c, slow]), which — because "slow" has no
+// dependencies and is a DFS leaf reachable only after a/b/c in that input
+// order — places it LAST (index 3) in the graph's static topological order
+// (graph.Nodes()). If build-order numbering regressed back to that static
+// position, "slow" would get index 3. But "slow" has no dependencies, so the
+// real scheduler makes it ready to build from the very start, alongside "a"
+// — it must get an early real build-order index (0 or 1), not the late
+// static one. This is what actually distinguishes "assigned by real dequeue
+// order" from "assigned by static topological position": a graph where a
+// dependency-free image's real-time readiness and its topological-sort
+// position disagree.
+//
+// The a < b < c assertion is a separate, always-true invariant (the shared
+// build-order counter only increases, and graphScheduler guarantees b/c
+// can't be dequeued before a/b's build has fully completed) kept here as a
+// basic sanity check, not the core regression signal — a purely topological
+// assignment would also happen to satisfy it for a simple chain.
+func TestAI_DoImagesInParallel_AssignsBuildOrderIndexByRealDequeueNotStaticTopology(t *testing.T) {
 	require.NoError(t, werf.Init(t.TempDir(), ""))
 
 	newImg := func(name string) *image.Image {
@@ -164,7 +178,8 @@ func TestAI_DoImagesInParallel_AssignsUniqueBuildOrderIndexRespectingDependencyO
 	b.AddDependencyName("a")
 	c.AddDependencyName("b")
 
-	graph, err := image.BuildImagesGraph([]*image.Image{slow, a, b, c})
+	// "slow" listed last on purpose — see the doc comment above.
+	graph, err := image.BuildImagesGraph([]*image.Image{a, b, c, slow})
 	require.NoError(t, err)
 
 	tree := &image.ImagesTree{}
@@ -214,4 +229,12 @@ func TestAI_DoImagesInParallel_AssignsUniqueBuildOrderIndexRespectingDependencyO
 
 	require.Less(t, a.GetBuildOrderIndex(), b.GetBuildOrderIndex(), "a must be assigned a build-order index before its dependent b")
 	require.Less(t, b.GetBuildOrderIndex(), c.GetBuildOrderIndex(), "b must be assigned a build-order index before its dependent c")
+
+	// The core regression signal: "slow" has no dependencies and is ready to
+	// build from the very start (same as "a"), so it must get an early
+	// build-order index. Under the old, reverted-to bug (static topological
+	// index), "slow" would instead get index 3 — the last position, because
+	// it was listed last in the input passed to BuildImagesGraph above.
+	require.LessOrEqual(t, slow.GetBuildOrderIndex(), 1,
+		"\"slow\" has no dependencies and must be dequeued near the start (index 0 or 1), not assigned the static topological tail position (3) it would get under the old bug; got %d", slow.GetBuildOrderIndex())
 }

--- a/pkg/build/graph_scheduler_integration_ai_test.go
+++ b/pkg/build/graph_scheduler_integration_ai_test.go
@@ -238,3 +238,69 @@ func TestAI_DoImagesInParallel_AssignsBuildOrderIndexByRealDequeueNotStaticTopol
 	require.LessOrEqual(t, slow.GetBuildOrderIndex(), 1,
 		"\"slow\" has no dependencies and must be dequeued near the start (index 0 or 1), not assigned the static topological tail position (3) it would get under the old bug; got %d", slow.GetBuildOrderIndex())
 }
+
+// TestAI_DoImagesInParallel_AnnotatesEachImageWithARealWorkerID is the
+// end-to-end test for the worker-ID log annotation: it exercises the real
+// path — parallel.DoTasksDynamic stashing the worker ID into the task
+// context, Conveyor.doImagesInParallel reading it back out via
+// ctx.Value(parallel.CtxBackgroundTaskIDKey) and calling
+// Image.SetWorkerID — rather than only unit-testing the string formatting
+// in isolation (pkg/logging/image_ai_test.go). With 4 independent images
+// and exactly 2 workers, both worker IDs must actually get used (not just
+// a default/zero value), and every image must end up with a worker ID set.
+func TestAI_DoImagesInParallel_AnnotatesEachImageWithARealWorkerID(t *testing.T) {
+	require.NoError(t, werf.Init(t.TempDir(), ""))
+
+	newImg := func(name string) *image.Image {
+		img := &image.Image{Name: name, TargetPlatform: "linux/amd64"}
+		img.ForceTargetPlatformLogging = true
+		return img
+	}
+
+	images := []*image.Image{newImg("w1"), newImg("w2"), newImg("w3"), newImg("w4")}
+
+	graph, err := image.BuildImagesGraph([]*image.Image{images[0], images[1], images[2], images[3]})
+	require.NoError(t, err)
+
+	tree := &image.ImagesTree{}
+	tree.SetImagesGraphForTests(graph)
+
+	conveyor := &Conveyor{
+		ConveyorOptions: ConveyorOptions{
+			Parallel:           true,
+			ParallelTasksLimit: 2,
+		},
+		imagesTree:       tree,
+		stageImages:      make(map[string]*stage.StageImage),
+		serviceRWMutex:   map[string]*sync.RWMutex{},
+		stageDigestMutex: map[string]*sync.Mutex{},
+	}
+
+	var mu sync.Mutex
+	var order []string
+	phase := &recordingPhase{
+		mu:    &mu,
+		order: &order,
+		delays: map[string]time.Duration{
+			"w1": 20 * time.Millisecond,
+			"w2": 20 * time.Millisecond,
+			"w3": 20 * time.Millisecond,
+			"w4": 20 * time.Millisecond,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, conveyor.doImages(ctx, []Phase{phase}, false))
+
+	seenWorkers := map[int]bool{}
+	for _, img := range images {
+		workerID, ok := img.GetWorkerID()
+		require.True(t, ok, "image %q must have a worker ID set by the real doImagesInParallel path", img.Name)
+		require.True(t, workerID == 0 || workerID == 1, "worker ID for %q must be 0 or 1 (ParallelTasksLimit=2), got %d", img.Name, workerID)
+		seenWorkers[workerID] = true
+	}
+
+	require.Len(t, seenWorkers, 2, "both workers must actually have been used across 4 images with ParallelTasksLimit=2, not just one")
+}

--- a/pkg/build/graph_scheduler_integration_ai_test.go
+++ b/pkg/build/graph_scheduler_integration_ai_test.go
@@ -22,22 +22,12 @@ type recordingPhase struct {
 	mu     *sync.Mutex
 	order  *[]string
 	delays map[string]time.Duration
-
-	// startOrder, when non-nil, records the order in which images actually
-	// begin building (BeforeImageStages runs before any artificial delay),
-	// as opposed to order, which records completion order.
-	startOrder *[]string
 }
 
 func (p *recordingPhase) Name() string                       { return "recording" }
 func (p *recordingPhase) BeforeImages(context.Context) error { return nil }
 func (p *recordingPhase) AfterImages(context.Context) error  { return nil }
-func (p *recordingPhase) BeforeImageStages(_ context.Context, img *image.Image) (func(), error) {
-	if p.startOrder != nil {
-		p.mu.Lock()
-		*p.startOrder = append(*p.startOrder, img.Name)
-		p.mu.Unlock()
-	}
+func (p *recordingPhase) BeforeImageStages(context.Context, *image.Image) (func(), error) {
 	return nil, nil
 }
 
@@ -144,17 +134,21 @@ func TestAI_DoImagesInParallel_DependentImageDoesNotWaitForUnrelatedSlowImage(t 
 		"dependent chain a->b->c must not wait for unrelated image \"slow\"; observed order=%v", order)
 }
 
-// TestAI_DoImagesInParallel_AssignsBuildOrderIndexMatchingActualStartOrder is
-// the regression test for the build-log progress-numbering fix: images used
-// to get their log progress index assigned once, statically, from their
+// TestAI_DoImagesInParallel_AssignsUniqueBuildOrderIndexRespectingDependencyOrder
+// is the regression test for the build-log progress-numbering fix: images
+// used to get their log progress index assigned once, statically, from their
 // position in the dependency graph's topological order (ImagesTree.Calculate)
-// — a position that has no relation to the real, concurrent, dependency-
-// driven order images actually start building in, producing confusingly
+// — a position with no relation to the real, concurrent, dependency-driven
+// order images actually start building in, producing confusingly
 // out-of-order "(N/Total)" numbers in the build log. doImagesInParallel must
 // instead assign each image's index at the moment it is actually dequeued for
-// building, so the numbers form a 0..N-1 permutation matching real start
-// order.
-func TestAI_DoImagesInParallel_AssignsBuildOrderIndexMatchingActualStartOrder(t *testing.T) {
+// building.
+//
+// The assertions below are deterministic, not timing-dependent: the shared
+// build-order counter only ever increases, and graphScheduler guarantees b/c
+// can't be dequeued before a/b's build has fully completed — so
+// index(a) < index(b) < index(c) holds regardless of goroutine scheduling.
+func TestAI_DoImagesInParallel_AssignsUniqueBuildOrderIndexRespectingDependencyOrder(t *testing.T) {
 	require.NoError(t, werf.Init(t.TempDir(), ""))
 
 	newImg := func(name string) *image.Image {
@@ -163,9 +157,6 @@ func TestAI_DoImagesInParallel_AssignsBuildOrderIndexMatchingActualStartOrder(t 
 		return img
 	}
 
-	// Same shape as the test above: an independent slow image plus a fast
-	// a -> b -> c chain, so the real dequeue order is very unlikely to match
-	// whatever static topological order ImagesTree.Calculate would assign.
 	slow := newImg("slow")
 	a := newImg("a")
 	b := newImg("b")
@@ -191,13 +182,12 @@ func TestAI_DoImagesInParallel_AssignsBuildOrderIndexMatchingActualStartOrder(t 
 	}
 
 	var mu sync.Mutex
-	var order, startOrder []string
+	var order []string
 	phase := &recordingPhase{
-		mu:         &mu,
-		order:      &order,
-		startOrder: &startOrder,
+		mu:    &mu,
+		order: &order,
 		delays: map[string]time.Duration{
-			"slow": 150 * time.Millisecond,
+			"slow": 10 * time.Millisecond,
 			"a":    10 * time.Millisecond,
 			"b":    10 * time.Millisecond,
 			"c":    10 * time.Millisecond,
@@ -208,18 +198,20 @@ func TestAI_DoImagesInParallel_AssignsBuildOrderIndexMatchingActualStartOrder(t 
 	defer cancel()
 
 	require.NoError(t, conveyor.doImages(ctx, []Phase{phase}, false))
-	require.Len(t, startOrder, 4)
 
-	byName := map[string]*image.Image{"slow": slow, "a": a, "b": b, "c": c}
-	seenIndex := map[int]string{}
-	for wantIdx, name := range startOrder {
-		img := byName[name]
-		gotIdx := img.GetBuildOrderIndex()
-		require.Equal(t, wantIdx, gotIdx, "image %q build-order index must match its real start position; startOrder=%v", name, startOrder)
+	images := []*image.Image{slow, a, b, c}
+	seen := make(map[int]string, len(images))
+	for _, img := range images {
+		idx := img.GetBuildOrderIndex()
+		require.GreaterOrEqual(t, idx, 0)
+		require.Less(t, idx, len(images))
 
-		if other, dup := seenIndex[gotIdx]; dup {
-			t.Fatalf("build-order index %d assigned to both %q and %q", gotIdx, other, name)
+		if other, dup := seen[idx]; dup {
+			t.Fatalf("build-order index %d assigned to both %q and %q", idx, other, img.Name)
 		}
-		seenIndex[gotIdx] = name
+		seen[idx] = img.Name
 	}
+
+	require.Less(t, a.GetBuildOrderIndex(), b.GetBuildOrderIndex(), "a must be assigned a build-order index before its dependent b")
+	require.Less(t, b.GetBuildOrderIndex(), c.GetBuildOrderIndex(), "b must be assigned a build-order index before its dependent c")
 }

--- a/pkg/build/graph_scheduler_integration_ai_test.go
+++ b/pkg/build/graph_scheduler_integration_ai_test.go
@@ -22,12 +22,22 @@ type recordingPhase struct {
 	mu     *sync.Mutex
 	order  *[]string
 	delays map[string]time.Duration
+
+	// startOrder, when non-nil, records the order in which images actually
+	// begin building (BeforeImageStages runs before any artificial delay),
+	// as opposed to order, which records completion order.
+	startOrder *[]string
 }
 
 func (p *recordingPhase) Name() string                       { return "recording" }
 func (p *recordingPhase) BeforeImages(context.Context) error { return nil }
 func (p *recordingPhase) AfterImages(context.Context) error  { return nil }
-func (p *recordingPhase) BeforeImageStages(context.Context, *image.Image) (func(), error) {
+func (p *recordingPhase) BeforeImageStages(_ context.Context, img *image.Image) (func(), error) {
+	if p.startOrder != nil {
+		p.mu.Lock()
+		*p.startOrder = append(*p.startOrder, img.Name)
+		p.mu.Unlock()
+	}
 	return nil, nil
 }
 
@@ -132,4 +142,84 @@ func TestAI_DoImagesInParallel_DependentImageDoesNotWaitForUnrelatedSlowImage(t 
 	// 10ms on a/b/c, both b and c finish well before "slow" does.
 	require.Less(t, indexOf("c"), indexOf("slow"),
 		"dependent chain a->b->c must not wait for unrelated image \"slow\"; observed order=%v", order)
+}
+
+// TestAI_DoImagesInParallel_AssignsBuildOrderIndexMatchingActualStartOrder is
+// the regression test for the build-log progress-numbering fix: images used
+// to get their log progress index assigned once, statically, from their
+// position in the dependency graph's topological order (ImagesTree.Calculate)
+// — a position that has no relation to the real, concurrent, dependency-
+// driven order images actually start building in, producing confusingly
+// out-of-order "(N/Total)" numbers in the build log. doImagesInParallel must
+// instead assign each image's index at the moment it is actually dequeued for
+// building, so the numbers form a 0..N-1 permutation matching real start
+// order.
+func TestAI_DoImagesInParallel_AssignsBuildOrderIndexMatchingActualStartOrder(t *testing.T) {
+	require.NoError(t, werf.Init(t.TempDir(), ""))
+
+	newImg := func(name string) *image.Image {
+		img := &image.Image{Name: name, TargetPlatform: "linux/amd64"}
+		img.ForceTargetPlatformLogging = true
+		return img
+	}
+
+	// Same shape as the test above: an independent slow image plus a fast
+	// a -> b -> c chain, so the real dequeue order is very unlikely to match
+	// whatever static topological order ImagesTree.Calculate would assign.
+	slow := newImg("slow")
+	a := newImg("a")
+	b := newImg("b")
+	c := newImg("c")
+	b.AddDependencyName("a")
+	c.AddDependencyName("b")
+
+	graph, err := image.BuildImagesGraph([]*image.Image{slow, a, b, c})
+	require.NoError(t, err)
+
+	tree := &image.ImagesTree{}
+	tree.SetImagesGraphForTests(graph)
+
+	conveyor := &Conveyor{
+		ConveyorOptions: ConveyorOptions{
+			Parallel:           true,
+			ParallelTasksLimit: -1,
+		},
+		imagesTree:       tree,
+		stageImages:      make(map[string]*stage.StageImage),
+		serviceRWMutex:   map[string]*sync.RWMutex{},
+		stageDigestMutex: map[string]*sync.Mutex{},
+	}
+
+	var mu sync.Mutex
+	var order, startOrder []string
+	phase := &recordingPhase{
+		mu:         &mu,
+		order:      &order,
+		startOrder: &startOrder,
+		delays: map[string]time.Duration{
+			"slow": 150 * time.Millisecond,
+			"a":    10 * time.Millisecond,
+			"b":    10 * time.Millisecond,
+			"c":    10 * time.Millisecond,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, conveyor.doImages(ctx, []Phase{phase}, false))
+	require.Len(t, startOrder, 4)
+
+	byName := map[string]*image.Image{"slow": slow, "a": a, "b": b, "c": c}
+	seenIndex := map[int]string{}
+	for wantIdx, name := range startOrder {
+		img := byName[name]
+		gotIdx := img.GetBuildOrderIndex()
+		require.Equal(t, wantIdx, gotIdx, "image %q build-order index must match its real start position; startOrder=%v", name, startOrder)
+
+		if other, dup := seenIndex[gotIdx]; dup {
+			t.Fatalf("build-order index %d assigned to both %q and %q", gotIdx, other, name)
+		}
+		seenIndex[gotIdx] = name
+	}
 }

--- a/pkg/build/image/image.go
+++ b/pkg/build/image/image.go
@@ -173,6 +173,34 @@ func (i *Image) LogDetailedName() string {
 	return logging.ImageLogProcessName(i.Name, i.IsFinal, targetPlatformForLog, logging.WithProgress(i.logImageIndex+1, i.logTotalImages))
 }
 
+// LogPlanName is like LogDetailedName but without a progress number: it is
+// meant for pre-build listings (e.g. a "concurrent build plan" preview)
+// where no build-order index is known yet, unlike LogDetailedName which is
+// used for real build-time log lines.
+func (i *Image) LogPlanName() string {
+	var targetPlatformForLog string
+	if i.ShouldLogPlatform() {
+		targetPlatformForLog = i.TargetPlatform
+	}
+	return logging.ImageLogProcessName(i.Name, i.IsFinal, targetPlatformForLog)
+}
+
+// SetBuildOrderIndex overrides the image's log progress index (see
+// LogDetailedName). ImagesTree.Calculate assigns a static index reflecting
+// each image's position in the dependency graph's topological order, which
+// is only a meaningful "build progress" indicator for the sequential build
+// path. The parallel build scheduler calls this to reassign the index to
+// reflect the image's actual position in real build-start order instead.
+func (i *Image) SetBuildOrderIndex(index int) {
+	i.logImageIndex = index
+}
+
+// GetBuildOrderIndex returns the image's current log progress index (see
+// SetBuildOrderIndex).
+func (i *Image) GetBuildOrderIndex() int {
+	return i.logImageIndex
+}
+
 func (i *Image) LogProcessStyle() color.Style {
 	return ImageLogProcessStyle(i.IsFinal)
 }

--- a/pkg/build/image/image.go
+++ b/pkg/build/image/image.go
@@ -133,6 +133,9 @@ type Image struct {
 	logImageIndex  int
 	logTotalImages int
 
+	hasWorkerID bool
+	workerID    int
+
 	// dependencyNames holds the names (same TargetPlatform) of the images this
 	// image must be fully built after: base image (fromImage), import/artifact
 	// sources, explicit `dependencies:`, and — for staged Dockerfile images —
@@ -170,7 +173,13 @@ func (i *Image) LogDetailedName() string {
 	if i.ShouldLogPlatform() {
 		targetPlatformForLog = i.TargetPlatform
 	}
-	return logging.ImageLogProcessName(i.Name, i.IsFinal, targetPlatformForLog, logging.WithProgress(i.logImageIndex+1, i.logTotalImages))
+
+	opts := []logging.Option{logging.WithProgress(i.logImageIndex+1, i.logTotalImages)}
+	if i.hasWorkerID {
+		opts = append(opts, logging.WithWorker(i.workerID))
+	}
+
+	return logging.ImageLogProcessName(i.Name, i.IsFinal, targetPlatformForLog, opts...)
 }
 
 // LogPlanName is like LogDetailedName but without a progress number: it is
@@ -199,6 +208,23 @@ func (i *Image) SetBuildOrderIndex(index int) {
 // SetBuildOrderIndex).
 func (i *Image) GetBuildOrderIndex() int {
 	return i.logImageIndex
+}
+
+// SetWorkerID annotates the image's log lines (see LogDetailedName) with
+// the parallel worker that is building it, so a jump in the build-order
+// index between consecutive log lines can be told apart from a worker
+// change (parallel.Printer prints one worker's whole output before moving
+// to the next) rather than looking like a scrambled sequence.
+func (i *Image) SetWorkerID(id int) {
+	i.hasWorkerID = true
+	i.workerID = id
+}
+
+// GetWorkerID returns the worker ID set via SetWorkerID and whether one was
+// ever set (false for images built via the sequential path, which has no
+// concept of parallel workers).
+func (i *Image) GetWorkerID() (int, bool) {
+	return i.workerID, i.hasWorkerID
 }
 
 func (i *Image) LogProcessStyle() color.Style {

--- a/pkg/logging/image.go
+++ b/pkg/logging/image.go
@@ -26,10 +26,27 @@ func WithProgress(index, total int) Option {
 	}
 }
 
+// WithWorker annotates the log line with the parallel worker that processed
+// it. Under a dynamic scheduler a single worker can process many images
+// back to back, and the terminal printer drains one worker's output in
+// full before moving to the next (see parallel.Printer) — so a jump in the
+// progress index between two consecutive lines is expected whenever the
+// worker number also changes, and this annotation makes that visible
+// instead of just looking like a scrambled sequence.
+func WithWorker(id int) Option {
+	return func(o *Options) {
+		o.hasWorker = true
+		o.worker = id
+	}
+}
+
 type Options struct {
 	withProgress bool
 	index        int
 	total        int
+
+	hasWorker bool
+	worker    int
 }
 
 type Option func(*Options)
@@ -45,6 +62,10 @@ func ImageLogProcessName(name string, isFinal bool, targetPlatform string, opts 
 
 	if targetPlatform != "" {
 		res += " [" + targetPlatform + "]"
+	}
+
+	if options.hasWorker {
+		res += fmt.Sprintf(" (worker %d)", options.worker)
 	}
 
 	if options.withProgress {

--- a/pkg/logging/image_ai_test.go
+++ b/pkg/logging/image_ai_test.go
@@ -6,15 +6,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAI_ImageLogProcessName_WithWorker(t *testing.T) {
+// disablePrettyLogForTest calls DisablePrettyLog (which mutates the
+// package-level pretty-print prefixes) and restores the original values on
+// cleanup, so these tests don't leak global state to any test that runs
+// after them in the same process.
+func disablePrettyLogForTest(t *testing.T) {
+	t.Helper()
+
+	prevFinal, prevIntermediate := finalImagePrettyPrefix, intermediateImagePrettyPrefix
+	t.Cleanup(func() {
+		finalImagePrettyPrefix, intermediateImagePrettyPrefix = prevFinal, prevIntermediate
+	})
+
 	DisablePrettyLog()
+}
+
+func TestAI_ImageLogProcessName_WithWorker(t *testing.T) {
+	disablePrettyLogForTest(t)
 
 	got := ImageLogProcessName("app", true, "linux/amd64", WithProgress(2, 6), WithWorker(1))
 	require.Equal(t, "(2/6) image app [linux/amd64] (worker 1)", got)
 }
 
 func TestAI_ImageLogProcessName_WithoutWorker(t *testing.T) {
-	DisablePrettyLog()
+	disablePrettyLogForTest(t)
 
 	got := ImageLogProcessName("app", true, "linux/amd64", WithProgress(2, 6))
 	require.Equal(t, "(2/6) image app [linux/amd64]", got)
@@ -22,7 +37,7 @@ func TestAI_ImageLogProcessName_WithoutWorker(t *testing.T) {
 }
 
 func TestAI_ImageLogProcessName_WorkerWithoutProgress(t *testing.T) {
-	DisablePrettyLog()
+	disablePrettyLogForTest(t)
 
 	got := ImageLogProcessName("app", false, "", WithWorker(0))
 	require.Equal(t, "image app (worker 0)", got)

--- a/pkg/logging/image_ai_test.go
+++ b/pkg/logging/image_ai_test.go
@@ -1,0 +1,29 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAI_ImageLogProcessName_WithWorker(t *testing.T) {
+	DisablePrettyLog()
+
+	got := ImageLogProcessName("app", true, "linux/amd64", WithProgress(2, 6), WithWorker(1))
+	require.Equal(t, "(2/6) image app [linux/amd64] (worker 1)", got)
+}
+
+func TestAI_ImageLogProcessName_WithoutWorker(t *testing.T) {
+	DisablePrettyLog()
+
+	got := ImageLogProcessName("app", true, "linux/amd64", WithProgress(2, 6))
+	require.Equal(t, "(2/6) image app [linux/amd64]", got)
+	require.NotContains(t, got, "worker")
+}
+
+func TestAI_ImageLogProcessName_WorkerWithoutProgress(t *testing.T) {
+	DisablePrettyLog()
+
+	got := ImageLogProcessName("app", false, "", WithWorker(0))
+	require.Equal(t, "image app (worker 0)", got)
+}

--- a/pkg/util/parallel/printer.go
+++ b/pkg/util/parallel/printer.go
@@ -11,6 +11,22 @@ import (
 	"github.com/werf/logboek"
 )
 
+// Printer renders worker output as coherent, uninterrupted per-worker
+// blocks, in worker-ID order (see indexes/Swap/SetMax for how fail-fast
+// reordering changes that order on error) — it fully drains one worker's
+// stream before moving to the next, rather than interleaving concurrent
+// workers' output line by line. This keeps each block readable as a single
+// coherent log (e.g. one image's build steps in sequence) instead of a
+// scrambled interleaving of multiple images' output.
+//
+// Under DoTasksDynamic, a single worker can process many tasks back to
+// back over the run, so its printed block can span several unrelated
+// tasks' output concatenated together. The printed sequence across
+// DIFFERENT workers' blocks therefore reflects worker-ID order, not global
+// chronological (task-start/completion) order — any per-task ordinal a
+// caller embeds in its own output (see Conveyor's build-order index in
+// pkg/build/conveyor.go) can still appear non-contiguous across block
+// boundaries, even though it increases correctly within any single block.
 type Printer struct {
 	workers   []*Worker
 	indexes   []int


### PR DESCRIPTION
## Summary

The build log's per-image "(N/Total)" progress number, introduced by #7688
(graph-based build scheduling), is assigned once and statically from each
image's position in the dependency graph's topological order — a position
unrelated to the real, concurrent order images actually start building in
under `doImagesInParallel`. This PR makes the number reflect real build
start order instead.

## Key changes

- `pkg/build/image/image.go`: add `Image.SetBuildOrderIndex(int)` /
  `GetBuildOrderIndex() int` (override/read the log progress index), and
  `Image.LogPlanName()` — like `LogDetailedName()` but without a progress
  number, for pre-build listings where no such number is meaningful yet.
- `pkg/build/conveyor.go` `doImagesInParallel`:
  - assign each image's build-log index via an `atomic.Int64` counter at
    the moment it is actually dequeued for building (right before
    `c.doImage(...)`), instead of relying on the static index
    `ImagesTree.Calculate` assigned earlier.
  - switch the pre-build "Concurrent build plan" preview to
    `img.LogPlanName()` (no progress number) since that listing runs
    before anything starts building and its per-image number never
    corresponded to actual progress.
  - "Build summary" now prints a copy of the image list sorted by the
    assigned build-order index (not the graph's topological order), so its
    numbers read 1..N top to bottom instead of scattered.
- Test (`pkg/build/graph_scheduler_integration_ai_test.go`):
  `TestAI_DoImagesInParallel_AssignsUniqueBuildOrderIndexRespectingDependencyOrder`
  drives the real `Conveyor.doImages`/`doImagesInParallel` path and asserts
  the assigned indices form a 0..N-1 permutation, with
  `index(a) < index(b) < index(c)` for a dependency chain — a deterministic
  invariant (the shared counter only increases, and the scheduler can't
  dequeue a dependent before its dependency completes), not a
  timing-dependent race. Verified with `-race -count=10` and by manually
  reverting/hardcoding the index assignment to confirm the test fails.

## Why

Real user feedback building Deckhouse (1275 images) on v3.0.1
(https://loop.flant.ru/flant/pl/ca5xs5qkgf8azxrw6wgybzjhmr):

> Лог сборки стал менее внятный - оно начало собирать с образа номер 485,
> потом 497, 885, 1112, затем скакнуло к 77.

> Просто раньше номера в логе отражали прогресс - если образ 1200/1275, то
> мы близки к завершению сборки. А сейчас это не так, и это КМК неудобно

The same static index also made the pre-build "Concurrent build plan"
preview look broken — a single level would list images numbered e.g.
1, 3, 10, 12, 76, 432, ..., 1220, reading as scrambled rather than grouped.

## Review focus / risks

- `atomic.Int64` build-order counter in `doImagesInParallel`: each `*Image`
  is only ever handed to exactly one worker goroutine at a time, and the
  index is written once, immediately before that goroutine's own call to
  `c.doImage`, so there's no data race. `BuildPhase`, the only other
  consumer of `logImageIndex`/`LogDetailedName()`, is invoked synchronously
  from within `doImage` by that same goroutine.
- The sequential (non-parallel) build path is untouched — its static index
  from `ImagesTree.Calculate` already equals real build order there.
- `MultiplatformImage` numbering (separate manifest-publish phase,
  `build_phase.go:188`) is untouched — it's a distinct, already-correct,
  static `parallel.DoTasks` over unique image names, unrelated to this bug.
- **Known limitation, deliberately not addressed in this PR**: this fixes
  the *value* assigned to each image's progress number (now a real,
  meaningful, monotonically-issued build-order position instead of an
  arbitrary topological one), but the *terminal print order* is still
  governed by `parallel.Printer`, which drains one worker's entire output
  stream at a time in worker-ID order (`pkg/util/parallel/printer.go`).
  Under `DoTasksDynamic`, a single worker can process many images in a row
  as it keeps pulling ready tasks, so the printed sequence across
  *different* workers' blocks can still show non-contiguous numbers (e.g.
  worker 0's block might print 3, 7, 15, then worker 1's block prints 1,
  2, 4). Within any one worker's own block the numbers are now correctly
  increasing (a real improvement over the old topological numbering, which
  had no such property at all, even locally), but a fully globally
  sequential 1,2,3,4,...N terminal log is not achievable without changing
  how `Printer` interleaves worker output — which risks the deliberate
  "one coherent block per worker, not interleaved line-by-line" readability
  tradeoff that design already makes, and needs a separate, carefully
  scoped change.

## Verification

- `go build ./...`, `go vet ./pkg/build/...`,
  `go test ./pkg/build/... ./pkg/build/image/... ./pkg/config/... ./pkg/util/parallel/...`
  all pass; new test also passes under `-race -count=10`.
- Manually rebuilt `werf` from this branch and ran it (Docker backend,
  macOS) against a test project (independent `slow` image + `a -> b -> c`
  chain, same fixture used in #7688): confirmed the "Concurrent build
  plan" preview no longer shows per-image numbers, and the real build
  headers / "Build summary" now number images 1..4 in actual start order
  (`a`=1, `slow`=2, `b`=3, `c`=4 — `b`/`c` still correctly start well
  before the independent `slow` image finishes; only the *numbering*
  changed, not the scheduling behavior from #7688).
- Independently reviewed with Codex (adversarial second opinion); findings
  incorporated: fixed the "Build summary" ordering mismatch and replaced a
  racy test assertion with a deterministic one. The printer-ordering
  limitation above was raised by that review and is intentionally left as
  a documented follow-up rather than folded into this fix.

---

**Update (2nd Codex review round):** both optional follow-ups applied:
- The build-order test was rebuilt so it actually discriminates real
  dequeue order from static topological order (previously its chain
  assertion could also pass under a reverted-to-the-bug implementation for
  a simple linear chain). Verified the new assertion fails under a
  simulated revert and passes under the fix, plus `-race -count=20`.
- Added a short code comment on `parallel.Printer` documenting that its
  output is a coherent block per worker, not globally chronological across
  workers — the known limitation from the first review round.

---

**Update (worker annotation):** added `(worker N)` to each build-time log
line and to the Build summary, so the printed sequence's block structure is
self-explanatory instead of just looking scrambled when the printer moves
to a different worker's output. Example (`--parallel-tasks-limit=2`, 6
independent images):

```
┌ 🛳️  (1/6) image leaf1 [linux/amd64] (worker 0)
└ 🛳️  (1/6) image leaf1 [linux/amd64] (worker 0) (8.74 seconds)
┌ 🛳️  (3/6) image leaf3 [linux/amd64] (worker 0)
└ 🛳️  (3/6) image leaf3 [linux/amd64] (worker 0) (1.40 seconds)
┌ 🛳️  (5/6) image leaf5 [linux/amd64] (worker 0)
└ 🛳️  (5/6) image leaf5 [linux/amd64] (worker 0) (1.34 seconds)
┌ 🛳️  (2/6) image leaf2 [linux/amd64] (worker 1)
└ 🛳️  (2/6) image leaf2 [linux/amd64] (worker 1) (8.77 seconds)
...
```

Worker 0's block (1, 3, 5) prints in full before worker 1's block (2, 4,
6) starts — each block's own numbers increase correctly, and the worker
tag now makes clear *why* the overall sequence isn't a flat 1..6.

---

**Update (3rd review round: agent-code-review skill + independent Codex pass on the worker-annotation commit).** Both reviews converged on the same actionable points; applied:

- Added an end-to-end test (`TestAI_DoImagesInParallel_AnnotatesEachImageWithARealWorkerID`) exercising the *real* wiring — `parallel.DoTasksDynamic` stashing the worker ID into the task context → `Conveyor` reading it back via `ctx.Value(parallel.CtxBackgroundTaskIDKey)` → `Image.SetWorkerID` — instead of only unit-testing the string formatting. Verified it fails if the `SetWorkerID` call is removed.
- `pkg/logging/image_ai_test.go`'s `DisablePrettyLog()` calls now save/restore the mutated package-level prefix vars via `t.Cleanup`, instead of leaking that global state to whatever runs after in the same test binary.
- Reviewed but intentionally kept as-is: the defensive `if ok` guard around the context-value read (both reviews confirmed it's currently unreachable-false given `parallel.runWorkers`'s wiring — turning it into a hard failure would add error handling for a scenario that can't happen); and the tests staying on `testify`/`testing.T` rather than Ginkgo (an established, already-used parallel convention for `*_ai_test.go` files in this package, e.g. `graph_scheduler_ai_test.go`).

Fresh example output (`--parallel-tasks-limit=2`, 6 independent images, different run — worker/image assignment is nondeterministic across runs by design):

```
┌ 🛳️  (1/6) image leaf1 [linux/amd64] (worker 0)
└ 🛳️  (1/6) image leaf1 [linux/amd64] (worker 0) (8.67 seconds)
┌ 🛳️  (4/6) image leaf4 [linux/amd64] (worker 0)
└ 🛳️  (4/6) image leaf4 [linux/amd64] (worker 0) (1.42 seconds)
┌ 🛳️  (6/6) image leaf6 [linux/amd64] (worker 0)
└ 🛳️  (6/6) image leaf6 [linux/amd64] (worker 0) (1.42 seconds)
┌ 🛳️  (2/6) image leaf2 [linux/amd64] (worker 1)
└ 🛳️  (2/6) image leaf2 [linux/amd64] (worker 1) (8.64 seconds)
┌ 🛳️  (3/6) image leaf3 [linux/amd64] (worker 1)
└ 🛳️  (3/6) image leaf3 [linux/amd64] (worker 1) (1.38 seconds)
┌ 🛳️  (5/6) image leaf5 [linux/amd64] (worker 1)
└ 🛳️  (5/6) image leaf5 [linux/amd64] (worker 1) (1.38 seconds)

┌ Build summary
│ - 🛳️  (1/6) image leaf1 [linux/amd64] (worker 0) (8.67 seconds)
│ - 🛳️  (2/6) image leaf2 [linux/amd64] (worker 1) (8.64 seconds)
│ - 🛳️  (3/6) image leaf3 [linux/amd64] (worker 1) (1.38 seconds)
│ - 🛳️  (4/6) image leaf4 [linux/amd64] (worker 0) (1.42 seconds)
│ - 🛳️  (5/6) image leaf5 [linux/amd64] (worker 1) (1.38 seconds)
│ - 🛳️  (6/6) image leaf6 [linux/amd64] (worker 0) (1.42 seconds)
└ Build summary
Running time 11.79 seconds
```

Worker 0's images (1, 4, 6) and worker 1's images (2, 3, 5) are each internally increasing; the worker tag explains why the interleaved sequence isn't a flat 1..6.
