### PR TITLE
chore(dev): extract test-the-tests skill, flag self-review limits in review

### DIFF
--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -7,6 +7,10 @@ description: Code review of a pull request, branch, or diff. Covers technical, p
 
 Evidence-based and blunt. Every finding references a specific `file:line`, function, or component. NEVER sugarcoat, NEVER pad with praise, NEVER report a concern that is not grounded in the diff or the codebase. Style preferences are not defects — but a violation of `AGENTS.md` or `CODESTYLE.md` is a convention finding, not a preference.
 
+## If you are the diff's author
+
+If you wrote the diff you are reviewing now, say so explicitly in the report's Verdict, and treat this pass as necessary but insufficient. Self-review — even done adversarially, even after mutating your own tests — inherits your own design assumptions: it reliably catches localized bugs and weak tests, but is a poor substitute for a second opinion on whether the overall approach is sound. For anything beyond a mechanical or low-risk change, recommend an independently invoked reviewer (a fresh session/agent with no memory of your rationale, or an external tool) before merge, and say so in the report rather than treating your own pass as the final word.
+
 ## Before reviewing
 
 1. Ask the user for numbered acceptance criteria (DoD). If there are none, derive them from the PR description or the linked issue, mark them `(inferred)`, and proceed — do not stall, and do not invent criteria silently.
@@ -30,16 +34,7 @@ Cover the ones the diff actually touches; stay silent about the rest.
 
 ## Tests as evidence
 
-Passing tests, high coverage, and the author's confidence are not evidence of correctness, whoever wrote the diff. Ask what evidence would fail if the implementation were wrong.
-
-Would each load-bearing test fail if:
-
-- the core behavior were removed;
-- a condition were inverted;
-- the return value were a constant;
-- a side effect happened zero or two times?
-
-Name the smallest mutation that should be tried. A suite that cannot detect a plausible fault is weak even when green.
+Passing tests, high coverage, and the author's confidence are not evidence of correctness, whoever wrote the diff. Read `test-the-tests/SKILL.md` and apply it to every load-bearing test: verify by mutating the implementation and confirming the test fails, not by reading the assertions and trusting they'd catch a regression.
 
 High risk by default:
 

--- a/.agents/skills/test-the-tests/SKILL.md
+++ b/.agents/skills/test-the-tests/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: test-the-tests
+description: Verify a test actually falsifies the behavior it claims to cover, via real mutation. Use right after writing or changing a test, when auditing an existing suite's real coverage, or as a step inside a code review.
+---
+
+# Test the Tests
+
+Passing and high coverage are not evidence, whoever wrote the test — including you, just
+now. A test proves it runs; it does not prove it discriminates correct from incorrect
+behavior. Ask:
+
+> What fault would this test fail to catch?
+
+## The mutation loop
+
+For each test that carries real weight (guards a fix, a regression, an invariant — not a
+trivial getter):
+
+1. Pick the smallest plausible fault: invert a condition, change `<` to `<=`, remove a
+   validation, suppress an error, skip a side effect, hardcode a return value, revert to
+   the prior (buggy) behavior.
+2. Apply it to the implementation, run the test, confirm it fails for the right reason —
+   not an unrelated crash.
+3. Revert immediately, confirm the tree is clean (`git status`/`git diff`), confirm the
+   suite passes again. NEVER leave mutated code in the repository between steps.
+
+If running the mutation isn't practical, name the smallest mutation that should be tried
+instead of skipping the exercise — that name is itself the finding.
+
+## Common ways a test looks strong but isn't
+
+- **The assertion holds under the bug too.** A chain assertion like
+  `index(a) < index(b) < index(c)` can pass under both the fix and the regression it's
+  meant to catch if the scenario doesn't force them to disagree. Reshape the scenario (add
+  a case whose correct answer differs from what the bug would produce) instead of trusting
+  a single run.
+- **It re-asserts a second recording of the same event** instead of a property true by
+  construction — comparing two independently-recorded orderings is racier and weaker than
+  asserting a monotonic counter or a guaranteed dependency order.
+- **It exercises the unit in isolation**, never the real wiring a regression would actually
+  break. Prefer driving the real entry point end-to-end when the risk is in the wiring.
+- **It asserts implementation trivia** (mock called N times, internal helper ran) instead
+  of externally observable behavior.
+
+## Output
+
+For each test verified this way: the fault tried, whether it failed as expected, and if
+not, the smallest change that would make it discriminate. For tests not mutated, name the
+smallest fault that should be tried next — don't assert confidence without it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,13 +13,13 @@ werf is a CNCF Sandbox CLI tool to implement full-cycle CI/CD to Kubernetes. wer
 - `pkg/deploy` — bundles and Helm chart extenders; the deployment itself is driven by nelm.
 - `pkg/config`, `pkg/giterminism_manager`, `pkg/git_repo`, `pkg/true_git` — `werf.yaml` parsing, giterminism, git access.
 - `test/e2e` — e2e suites, `test/legacy_e2e` — what `task test:integration` runs, `test/pkg` — shared test helpers.
-- `.agents/skills` — mandatory agent skills: branch and commit conventions, PR format, code review. `.claude/skills` is a symlink to it.
+- `.agents/skills` — mandatory agent skills: branch and commit conventions, PR format, code review, test verification. `.claude/skills` is a symlink to it.
 
 ## Highest-priority rule (MANDATORY)
 
 - NEVER add comments unless they document a non-obvious public API or explain genuinely non-obvious logic. NEVER add comments that restate what the code does, repeat the field/function name, describe obvious error handling, or act as section separators. When in doubt, don't comment.
 - ALWAYS use `task` commands for build/test/lint/format — NEVER raw `go build`, `go test`, `go vet`, `go fmt`, or `golangci-lint` directly.
-- ALWAYS read the matching skill in `.agents/skills/` BEFORE the action it governs and follow it verbatim: `git-conventions/SKILL.md` before naming a branch or writing a commit message, `pull-request/SKILL.md` before creating or updating a PR (title, description, draft by default), `review/SKILL.md` before reviewing code. These files are the source of truth and are NOT duplicated here.
+- ALWAYS read the matching skill in `.agents/skills/` BEFORE the action it governs and follow it verbatim: `git-conventions/SKILL.md` before naming a branch or writing a commit message, `pull-request/SKILL.md` before creating or updating a PR (title, description, draft by default), `review/SKILL.md` before reviewing code, `test-the-tests/SKILL.md` before considering a new or changed test done. These files are the source of truth and are NOT duplicated here.
 - ALWAYS verify, don't assume — check the actual state before making changes.
 - ALWAYS start with the simplest possible solution. If it works, stop. Add complexity only when justified by a concrete, current requirement — NEVER for hypothetical future needs.
 - NEVER leave TODOs, stubs, or partial implementations.


### PR DESCRIPTION
## Summary

Extracts the mutation-testing checklist out of `review/SKILL.md` into its own standalone `.agents/skills/test-the-tests/SKILL.md`, and adds an explicit "if you are the diff's author" section to `review/SKILL.md` about the limits of self-review.

## Key changes

- New `.agents/skills/test-the-tests/SKILL.md`: verify a test actually falsifies the behavior it claims to cover by mutating the implementation and confirming the test fails — usable on its own right after writing/changing a test, not only as a step inside a full PR review. Includes a "common ways a test looks strong but isn't" section (a chain assertion also satisfied by the bug it's meant to catch; comparing two independently-recorded event lists instead of a property true by construction; unit-testing in isolation instead of driving the real wiring a regression would break).
- `review/SKILL.md` "Tests as evidence" now points to the new skill instead of duplicating its checklist.
- `review/SKILL.md`: new "If you are the diff's author" section — self-review (even adversarial, even with mutation testing) inherits the author's own design assumptions; recommend escalating anything beyond a mechanical change to an independently invoked reviewer before merge, and say so explicitly in the report.
- `AGENTS.md`: updated the two bullets that enumerate `.agents/skills/` to mention the new skill.

## Why

Both changes came out of actually using `review/SKILL.md` repeatedly across a real multi-round review of the same PR (werf#7703): one self-review pass (`agent-code-review`), then two independent Codex passes. The mutation checklist turned out to be useful as its own discipline right after writing tests, separate from a full PR review context. And the single most valuable finding across all rounds — an architectural issue in how `parallel.Printer` orders output across workers — came from the independent Codex pass, not from any amount of self-review, which is exactly the gap the new section names.

## Review focus / risks

- Pure documentation/skill-file change — no code, no build/test impact.
- `test-the-tests/SKILL.md` intentionally keeps the exact same mutation-testing content that was in `review/SKILL.md` (just centralized), so `review/SKILL.md`'s behavior when followed doesn't change, only where the instructions live.
- Wording in `review/SKILL.md`'s new self-review section says to flag this in the report's Verdict rather than changing the Output template's fixed structure — open to making it a dedicated template field instead if preferred.

## Verification

Docs-only change (no Go code touched): `git diff` reviewed by hand; confirmed no other file references the old inline mutation-testing checklist text that would now be stale, and that `AGENTS.md`'s two `.agents/skills` mentions stay consistent with the new directory.