### PR TITLE
docs(dev): add Inferred? column to review's DoD Criteria table

### DIFF
--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -83,9 +83,9 @@ Print the report. Do not write it into the repository unless the user asks for a
 
 ## DoD Criteria
 
-| Criteria | Met? | Evidence |
-| :--- | :--- | :--- |
-| [criterion] | ✅/⚠️/❌ | file:line |
+| Criteria | Inferred? | Met? | Evidence |
+| :--- | :--- | :--- | :--- |
+| [criterion] | yes/no | ✅/⚠️/❌ | file:line |
 
 ## Issues
 


### PR DESCRIPTION
## Summary

`review/SKILL.md` says derived DoD criteria should be marked `(inferred)`, but the Output template's DoD table had no column for it — the flag had nowhere to go once the report was actually filled in.

## Key changes

- Added an `Inferred?` column (`yes`/`no`) to the DoD Criteria table in the Output template.

## Why

Without the column, a reviewer following the template literally either drops the inferred marker or bolts it onto the `Criteria` cell inconsistently. A dedicated column makes it unambiguous.

## Verification

Docs-only change: re-read the Output template after editing to confirm the table still renders correctly and the added column doesn't break the surrounding markdown.