### PR TITLE
test(dev): disable git signing in true_git tests

### DIFF
--- a/pkg/true_git/git_cmd_test.go
+++ b/pkg/true_git/git_cmd_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Git command", func() {
 
 		utils.RunSucceedCommand(ctx, gitRepoPath, "git", "checkout", "-b", "main")
 
-		utils.RunSucceedCommand(ctx, gitRepoPath, "git", "commit", "--allow-empty", "-m", "Initial commit")
+		gitCommitSucceed(ctx, gitRepoPath, "--allow-empty", "-m", "Initial commit")
 
 		Expect(Init(ctx, Options{})).Should(Succeed())
 	})

--- a/pkg/true_git/helpers_ai_test.go
+++ b/pkg/true_git/helpers_ai_test.go
@@ -9,7 +9,7 @@ import (
 
 func runGitAI(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd := exec.Command("git", append([]string{"-C", dir, "-c", "commit.gpgsign=false"}, args...)...)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git %v: %s", args, out)
 	return string(out)

--- a/pkg/true_git/helpers_test.go
+++ b/pkg/true_git/helpers_test.go
@@ -1,0 +1,14 @@
+package true_git
+
+import (
+	"context"
+
+	"github.com/werf/werf/v2/test/pkg/utils"
+)
+
+// gitCommitSucceed commits with signing disabled. Without that these tests inherit a
+// developer's global commit.gpgsign and start depending on a working gpg-agent, which
+// intermittently fails to sign under Ginkgo's parallel procs.
+func gitCommitSucceed(ctx context.Context, workTreeDir string, args ...string) {
+	utils.RunSucceedCommand(ctx, workTreeDir, "git", append([]string{"-c", "commit.gpgsign=false", "commit"}, args...)...)
+}

--- a/pkg/true_git/service_branch_test.go
+++ b/pkg/true_git/service_branch_test.go
@@ -32,7 +32,7 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 
 		gitDir = filepath.Join(sourceWorkTreeDir, ".git")
 
-		utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "--allow-empty", "-m", "Initial commit")
+		gitCommitSucceed(ctx, sourceWorkTreeDir, "--allow-empty", "-m", "Initial commit")
 
 		sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
 
@@ -308,7 +308,7 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 				)
 				Expect(err).Should(Succeed())
 
-				utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "-m", "1")
+				gitCommitSucceed(ctx, sourceWorkTreeDir, "-m", "1")
 				sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
 
 				_, err = SyncSourceWorktreeWithServiceBranch(
@@ -328,7 +328,7 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 				ctx = logging.WithLogger(ctx)
 
 				utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "add", ".")
-				utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "-m", "1")
+				gitCommitSucceed(ctx, sourceWorkTreeDir, "-m", "1")
 				sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
 
 				_, err := SyncSourceWorktreeWithServiceBranch(
@@ -361,7 +361,7 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 
 				utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "mv", trackedFilePath, trackedFilePathMoved)
 				utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "add", ".")
-				utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "-m", "2")
+				gitCommitSucceed(ctx, sourceWorkTreeDir, "-m", "2")
 				sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
 
 				_, err = SyncSourceWorktreeWithServiceBranch(

--- a/pkg/true_git/work_tree_test.go
+++ b/pkg/true_git/work_tree_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Work tree helpers", func() {
 
 				utils.RunSucceedCommand(ctx, mainWtDir, "git", "checkout", "-b", "main")
 
-				utils.RunSucceedCommand(ctx, mainWtDir, "git", "commit", "--allow-empty", "-m", "Initial commit")
+				gitCommitSucceed(ctx, mainWtDir, "--allow-empty", "-m", "Initial commit")
 
 				utils.RunSucceedCommand(ctx, mainWtDir, "git", "worktree", "add", sideWtDir)
 
@@ -81,7 +81,7 @@ var _ = Describe("Work tree helpers", func() {
 
 			utils.RunSucceedCommand(ctx, mainWtDir, "git", "checkout", "-b", "main")
 
-			utils.RunSucceedCommand(ctx, mainWtDir, "git", "commit", "--allow-empty", "-m", "Initial commit")
+			gitCommitSucceed(ctx, mainWtDir, "--allow-empty", "-m", "Initial commit")
 
 			utils.RunSucceedCommand(ctx, mainWtDir, "git", "worktree", "add", sideWtDir)
 		})


### PR DESCRIPTION
## Summary

The `pkg/true_git` suite failed locally roughly one run in five, always inside a `BeforeEach`:

```
error: gpg failed to sign the data:
gpg: signing failed: Cannot allocate memory
fatal: failed to write commit object
[FAILED] git commit --allow-empty -m Initial commit
```

The suite's `git commit` calls inherited the developer's global `commit.gpgsign`, so every test commit went through gpg-agent; under Ginkgo's 11 parallel procs pinentry intermittently failed. CI never saw this because no signing key is configured on the runners, which is why it looked like a mystery flake.

## Key changes

- `gitCommitSucceed` helper in `helpers_test.go` passing `-c commit.gpgsign=false`, used by the commit sites in `service_branch_test.go`, `work_tree_test.go` and `git_cmd_test.go`. This matches what `shallow_test.go` and `git_repo/remote_shallow_test.go` already do, and the production service args in `true_git/common.go`.
- Same flag in `runGitAI` (`helpers_ai_test.go`). Those are plain `testing` tests rather than Ginkgo specs, so when they failed the spec report still said `51/51 SUCCESS` and only the suite exit code went non-zero — worth knowing when reading such a failure.

## Why

A flake that only bites developers with commit signing enabled is a flake that gets ignored locally and erodes trust in `task test:unit`. The tests have no reason to consult gpg at all.

## Verification

- Causal, not statistical: with `GIT_CONFIG_GLOBAL` pointing at a config containing `commit.gpgsign = true`, `tag.gpgsign = true` and `gpg.program = /bin/false`, `./pkg/true_git/...` now passes. Before this change it failed under the same conditions. The developer's real global config was not touched.
- 24 consecutive green suite executions (8 × `--repeat=3`) in the normal environment, against ~1-in-5 failures before.
- `task format`, `task build`, `task lint:golangci-lint golangciPaths="./pkg/true_git/..."` (0 issues).

## Review focus / risks

- Deliberately not fixed here, since it is a different problem and much wider: `test/pkg/utils/git.go: SetGitRepoState` and the `test/legacy_e2e` suites commit without the same guard. They do not flake on CI for the same reason (no signing configured), but a developer running them locally would hit this. A hermetic alternative worth considering instead of guarding every call site: set `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to an empty file for the whole test process and provide the identity via `GIT_AUTHOR_*`/`GIT_COMMITTER_*`.
- Unrelated pre-existing failure spotted while verifying, not touched: `pkg/werf/exec` `detach should start new detached process from binary` fails deterministically, in isolation, on a clean `3` as well.
