### PR TITLE
test(dev): use a portable ps format in the detach test

### DIFF
--- a/pkg/werf/exec/detach_test.go
+++ b/pkg/werf/exec/detach_test.go
@@ -77,7 +77,7 @@ func findProcessLineByCommand(ctx context.Context, command string) (string, erro
 	b := backoff.NewConstantBackOff(time.Millisecond * 10)
 
 	operation := func() (string, error) {
-		cmd := exec.CommandContext(ctx, "ps", "-eo", "pid,cmd")
+		cmd := exec.CommandContext(ctx, "ps", "-eo", "pid,command")
 		outBytes, err := cmd.Output()
 		Expect(err).To(Succeed())
 


### PR DESCRIPTION
## Summary

`pkg/werf/exec` `detach should start new detached process from binary` failed deterministically on macOS, in isolation and on a clean `3`:

```
[FAILED] Expected success, but got an error: exit status 1
In [It] at: pkg/werf/exec/detach_test.go:82
```

Line 82 asserts on `ps -eo pid,cmd`. `cmd` is a procps keyword; BSD `ps` answers `ps: cmd: keyword not found` and exits 1:

```
$ ps -eo pid,cmd      ; ps: cmd: keyword not found   (exit 1)
$ ps -eo pid,command  ; PID COMMAND ...              (exit 0)
```

The spec skips only non-Unix systems, so it explicitly claims darwin support and then breaks on a non-portable format keyword. `command` is accepted by both — procps documents it as an alias of `cmd`.

## Why

The suite is red for every developer on macOS, which is where werf development largely happens, so `task test:unit` cannot be trusted end to end locally. CI is on Linux and never noticed.

## Verification

- The spec now passes on macOS: 4/4 specs, 5 consecutive runs.
- Causal check in both directions: reverting the keyword to `pid,cmd` makes the suite fail again, restoring `pid,command` makes it pass.
- `task format`, `task build`, `task lint:golangci-lint golangciPaths="./pkg/werf/exec/..."` (0 issues).

## Review focus / risks

- macOS `ps` can truncate output to terminal width, and the test matches the full binary path with `HasSuffix`. Not an issue here because the output goes to a pipe rather than a tty, and the spec gets far enough to `Kill()` the process it found — but that is the one assumption worth a second look.
- Linux behaviour is unchanged in intent, and `command` is a documented procps alias; the Linux CI run on this PR is what confirms it.
