### PR TITLE
docs(build): mention .dockerignore for the Dockerfile builder

### DIFF
--- a/docs/pages_en/usage/build/images.md
+++ b/docs/pages_en/usage/build/images.md
@@ -131,6 +131,25 @@ dockerfile: Dockerfile
 
 In the example above, werf will use the Dockerfile at `docs/Dockerfile` to build the `docs` image and the Dockerfile at `service/Dockerfile` to build the `service` image.
 
+#### Excluding files from the build context
+
+werf honours the `.dockerignore` file. Inside the context directory it looks for `<dockerfile>.dockerignore` first and falls back to `.dockerignore`; only the first file found is used.
+
+```yaml
+project: example
+configVersion: 1
+---
+image: app
+context: app
+dockerfile: Dockerfile
+```
+
+For this configuration werf reads `app/Dockerfile.dockerignore`, or `app/.dockerignore` if the former does not exist.
+
+Excluded files are neither sent to the build context nor taken into account when calculating the image digest, so changing them does not cause a rebuild.
+
+The `.dockerignore` file is a configuration file, so by default it must be committed to Git. To use an uncommitted one, allow it with the `allowUncommittedDockerignoreFiles` directive in [werf-giterminism.yaml]({{"reference/werf_giterminism_yaml.html" | true_relative_url }}).
+
 #### Using build secrets
 
 > **NOTE:** To use secrets in builds, you need to enable them explicitly in the giterminism settings. Learn more ([here]({{ "/usage/project_configuration/giterminism.html#using-build-secrets" | true_relative_url }}))

--- a/docs/pages_ru/usage/build/images.md
+++ b/docs/pages_ru/usage/build/images.md
@@ -131,6 +131,25 @@ dockerfile: Dockerfile
 
 Для образа `docs` будет использоваться Dockerfile по пути `docs/Dockerfile`, а для `service` — `service/Dockerfile`.
 
+#### Исключение файлов из сборочного контекста
+
+werf учитывает файл `.dockerignore`. В директории контекста сначала ищется `<dockerfile>.dockerignore`, затем `.dockerignore`; используется только первый найденный файл.
+
+```yaml
+project: example
+configVersion: 1
+---
+image: app
+context: app
+dockerfile: Dockerfile
+```
+
+Для такой конфигурации werf прочитает `app/Dockerfile.dockerignore`, а если его нет — `app/.dockerignore`.
+
+Исключённые файлы не попадают в сборочный контекст и не учитываются при расчёте дайджеста образа, поэтому их изменение не приводит к пересборке.
+
+Файл `.dockerignore` является конфигурационным, поэтому по умолчанию должен быть закоммичен в Git. Чтобы использовать незакоммиченный файл, разрешите его директивой `allowUncommittedDockerignoreFiles` в [werf-giterminism.yaml]({{ "reference/werf_giterminism_yaml.html" | true_relative_url }}).
+
 #### Использование сборочных секретов
 
 > **ЗАМЕЧАНИЕ:** Чтобы использовать секреты в сборках, их нужно явно разрешить в настройках гитерминизма. Подробнее ([здесь]({{ "/usage/project_configuration/giterminism.html#использование-сборочных-секретов" | true_relative_url }}))


### PR DESCRIPTION
The Dockerfile builder honours `.dockerignore`, but the documentation never said so, nor which of `<dockerfile>.dockerignore` / `.dockerignore` wins, that excluded files also drop out of the image digest, or that the file is subject to giterminism. Added as a section under "Selecting the build context directory" in both languages.

Closes #4044
