### PR TITLE
fix(build, stapel): make service script executable regardless of umask

### DIFF
--- a/pkg/stapel/create_script_ai_test.go
+++ b/pkg/stapel/create_script_ai_test.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package stapel
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CreateScript", func() {
+	It("creates an executable script under a umask that strips the executable bit", func() {
+		previousUmask := syscall.Umask(0o001)
+		defer syscall.Umask(previousUmask)
+
+		scriptPath := filepath.Join(GinkgoT().TempDir(), "scripts", "script")
+		Expect(CreateScript(scriptPath, []string{"echo hello"})).To(Succeed())
+
+		info, err := os.Stat(scriptPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o755)))
+	})
+})

--- a/pkg/stapel/stapel.go
+++ b/pkg/stapel/stapel.go
@@ -235,5 +235,15 @@ func CreateScript(path string, lines []string) error {
 	scriptLines = append(scriptLines, lines...)
 	scriptData := []byte(strings.Join(scriptLines, "\n") + "\n")
 
-	return os.WriteFile(path, scriptData, os.FileMode(0o667))
+	if err := os.WriteFile(path, scriptData, 0o755); err != nil {
+		return fmt.Errorf("write script %s: %w", path, err)
+	}
+
+	// os.WriteFile applies the process umask, which can leave the script without any
+	// executable bit, and then even root cannot run it.
+	if err := os.Chmod(path, 0o755); err != nil {
+		return fmt.Errorf("chmod script %s: %w", path, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary

With a non-default umask a stapel build fails with `bash: /.werf/scripts/<hash>: Permission denied`. The service script is written with mode `0667` — its only executable bit is the one for others — and `os.WriteFile` applies the umask, so `umask 001` (as reported), `005`, `007` or `077` leave the file with no executable bit at all. `execve` needs at least one, so this fails for root too. The mode is now set explicitly after writing.

```
umask 001 && werf build   # any werf.yaml with a stapel image
```

## Why

The old mode worked only by luck: the common umasks 022 and 002 don't touch the last digit, which is where the single executable bit sat. Setting the mode after the write takes the umask out of the equation, and `0755` also drops world-write from a file that is executed inside the build container.

## Verification

- `task test:unit paths="./pkg/stapel/..."` — new spec sets `umask 001` and asserts the resulting mode is exactly `0755`. Mutation-checked twice: restoring `WriteFile(0o667)` yields `0666`, and keeping `WriteFile(0o755)` without the `Chmod` yields `0754` — the spec fails in both cases.
- Not run: an actual stapel build under a non-default umask needs Linux with a container backend.

## Review focus / risks

- `os.MkdirAll(dirPath, os.ModePerm)` in the same function and the `/.werf` tmp dir in `pkg/build/conveyor.go` are umask-dependent too, but directory traversal is bypassed for root, which is who runs the stapel service commands. Left alone deliberately.

Closes #2339
