### PR TITLE
docs(dev): correct where e2e tests can run, add pre-staging and pre-push checks

### DIFF
--- a/.agents/skills/git-conventions/SKILL.md
+++ b/.agents/skills/git-conventions/SKILL.md
@@ -31,6 +31,16 @@ Types and scopes are defined in `CONTRIBUTING.md#conventions` — that file is t
 - **Body:** imperative; state the motivation for the change and contrast it with previous behavior.
 - NEVER include sensitive or customer-identifying details: client/company names, internal hostnames or filesystem paths, private build tags or version suffixes, credentials. Describe environments generically.
 
+## Before staging
+
+- Check `git status` for unrelated untracked files before staging. This worktree carries local working files (`.dev/`, scratch notes, orchestrator state), so prefer explicit paths over `git add -A` — a blanket add sweeps them in, and untracking later costs an extra commit.
+
+## Before pushing
+
+- ALWAYS check the current branch (`git branch --show-current`) — a stale local `main` or someone else's WIP branch is easy to miss.
+- NEVER push to a release branch (`main`, `3`, `2`, `1.2`) directly — branch from the current `origin/<base>` and open a PR.
+- If a push is rejected, don't retry with force. Find out why the ref diverged first: `--force-with-lease` is also rejected as `stale info` when there is no remote-tracking ref for the branch (e.g. after pushing by URL) — that is a missing lease baseline, not a diverged history, and the fix is `--force-with-lease=<ref>:<sha>`.
+
 ## Output
 
 Output ONLY the branch name or the commit message, with no additional text, quotes, or formatting.

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -8,6 +8,7 @@ description: Generates Pull Request titles and descriptions according to werf co
 ## Defaults
 
 - Always create PRs as draft (`gh pr create --draft`). The author marks it ready for review manually.
+- When a pushed commit changes what the PR does, update the title and description in the same step. A description that describes an earlier state of the branch is what the reviewer reads.
 
 ## Title
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ werf is a CNCF Sandbox CLI tool to implement full-cycle CI/CD to Kubernetes. wer
 - NEVER add comments unless they document a non-obvious public API or explain genuinely non-obvious logic. NEVER add comments that restate what the code does, repeat the field/function name, describe obvious error handling, or act as section separators. When in doubt, don't comment.
 - ALWAYS use `task` commands for build/test/lint/format — NEVER raw `go build`, `go test`, `go vet`, `go fmt`, or `golangci-lint` directly.
 - ALWAYS read the matching skill in `.agents/skills/` BEFORE the action it governs and follow it verbatim: `git-conventions/SKILL.md` before naming a branch or writing a commit message, `pull-request/SKILL.md` before creating or updating a PR (title, description, draft by default), `review/SKILL.md` before reviewing code, `test-the-tests/SKILL.md` before considering a new or changed test done, `agent-code-review/SKILL.md` in addition to `review/SKILL.md` when the diff's author is an agent or the diff touches tests/verification infrastructure. These files are the source of truth and are NOT duplicated here.
-- ALWAYS verify, don't assume — check the actual state before making changes.
+- ALWAYS verify, don't assume — check the actual state before making changes. Before concluding that a check cannot run here, establish it: whether a runtime is actually missing, and whether a remote host is available.
 - ALWAYS start with the simplest possible solution. If it works, stop. Add complexity only when justified by a concrete, current requirement — NEVER for hypothetical future needs.
 - NEVER leave TODOs, stubs, or partial implementations.
 - ALWAYS stay within the scope of what was asked. When asked to update a plan — only update the plan, don't change code. When asked to brainstorm/discuss — only discuss, don't write code. When asked to do X — do X and nothing else. NEVER make unsolicited changes.
@@ -83,7 +83,7 @@ After changing Go code, run these in order — `task format` mutates files, so i
 
 NEVER assume a change compiles. While iterating, scope the slow steps (`task lint:golangci-lint golangciPaths="./pkg/foo/..."`, `task test:unit paths="./pkg/foo/..."`), then run them unscoped before handing the work over.
 
-On macOS `task build` produces a **non-CGO** binary — the Buildah backend is only built for linux/amd64 (`task build:dev:linux:amd64:cgo`), so Buildah changes cannot be compiled or exercised locally. Unit tests run anywhere; e2e and integration tests need Linux with Docker and kind (`task test:setup:environment`).
+On macOS `task build` produces a **non-CGO** binary — the Buildah backend is only built for linux/amd64 (`task build:dev:linux:amd64:cgo`), so Buildah changes cannot be compiled or exercised locally. Unit tests run anywhere. The Docker-backend entries of the e2e suites also run on macOS with Docker Desktop — `task test:e2e paths="./test/e2e/build" labelFilter="..." parallel=1`, with `WERF_TEST_K8S_DOCKER_REGISTRY` set even when the entries need no registry. Buildah entries, and any suite that needs kind, require Linux (`task test:setup:environment`).
 
 ## Testing (MANDATORY)
 


### PR DESCRIPTION
## Summary

Two corrections to the agent-facing docs, both paid for in one session.

`AGENTS.md` said "e2e and integration tests need Linux with Docker and kind". Read as a blanket statement it means "not verifiable on macOS", and that is how it was used: an e2e test was written, declared unrunnable locally, and pushed without ever being executed — on a machine that had Docker Desktop the whole time. The Docker-backend entries of the build suite run there fine; only Buildah entries and kind-dependent suites need Linux.

The `git-conventions` skill covered how to name a branch and word a commit, but nothing about the two steps around them, so both went wrong: `git add -A` in a worktree that carries local working files, and a force-push retried against a rejection nobody had diagnosed.

## Key changes

- `AGENTS.md`: state that the Docker-backend e2e entries run on macOS, with the exact invocation (`labelFilter`, `parallel=1`, `WERF_TEST_K8S_DOCKER_REGISTRY` required even when unused), and keep Linux for Buildah and kind.
- `AGENTS.md`: extend the verify-don't-assume rule to environment limits — establish that a check cannot run here instead of assuming it.
- `.agents/skills/git-conventions`: what to check before staging (untracked local files, explicit paths over `git add -A`) and before pushing (current branch, no direct pushes to a release branch, diagnose a rejection instead of forcing — including the `stale info` case, where `--force-with-lease` fails for lack of a lease baseline rather than a diverged history).
- `.agents/skills/pull-request`: a commit that changes what the PR does updates the title and description in the same step.

## Why

Every one of these was an unverified assumption: about the environment, about what a staging command would sweep in, about what a rejected push meant. Each is one command to check and a redo to skip.

## Verification

Documentation only, no code paths touched. The e2e claim was established by running `task test:e2e paths="./test/e2e/build" labelFilter="dockerfile-outside-context" parallel=1` on macOS with Docker 27.4.0, and the same suite for the Buildah entry on a Linux host, in the session that produced #7722.
