### PR TITLE
docs(dev): put Why before Key changes in PR descriptions

### DIFF
--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -29,15 +29,15 @@ Use the following structure. *Summary*, *Why* and *Verification* are **mandatory
 <1-3 sentence high-level overview of what the PR does and why it exists. For a `fix`, lead with the
 observed wrong behavior and add a minimal repro (Dockerfile / werf.yaml / command) plus expected vs actual.>
 
+## Why
+
+<Motivation: what problem this solves, what maintenance/UX/perf gain it brings.>
+
 ## Key changes
 
 - <concrete change 1>
 - <concrete change 2>
 - …
-
-## Why
-
-<Motivation: what problem this solves, what maintenance/UX/perf gain it brings.>
 
 ## Verification
 


### PR DESCRIPTION
## Summary

Reorder the PR description template in the `pull-request` skill so *Why* comes right after *Summary*, before *Key changes*.

## Why

A reviewer who already knows why the change exists can judge each change as they read it. With *Why* placed after *Key changes*, the motivation arrived only once the reviewer had inferred it, and the section ended up restating context instead of framing it.

## Key changes

- `.agents/skills/pull-request/SKILL.md`: section order is now Summary → Why → Key changes → Verification → Review focus / risks. Section contents and rules are unchanged.

## Verification

- Docs-only change to an agent skill, no Go code touched — nothing to build or test.
- This PR description itself follows the new order.