### PR TITLE
docs(dev): restore skill rules dropped when porting from upstream

### DIFF
--- a/.agents/skills/git-conventions/SKILL.md
+++ b/.agents/skills/git-conventions/SKILL.md
@@ -39,6 +39,7 @@ Types and scopes are defined in `CONTRIBUTING.md#conventions` — that file is t
 
 - ALWAYS check the current branch (`git branch --show-current`) — a stale local `main` or someone else's WIP branch is easy to miss.
 - NEVER push to a release branch (`main`, `3`, `2`, `1.2`) directly — branch from the current `origin/<base>` and open a PR.
+- When a commit carries recorded fixtures or logs, scrub every class of identifier — uuids, numeric ids, initials, avatar urls — not just names and emails. A name-only pass leaves pseudonymous ids that map back to people through internal tables, and rewriting history afterwards is the expensive path.
 - If a push is rejected, don't retry with force. Find out why the ref diverged first: `--force-with-lease` is also rejected as `stale info` when there is no remote-tracking ref for the branch (e.g. after pushing by URL) — that is a missing lease baseline, not a diverged history, and the fix is `--force-with-lease=<ref>:<sha>`.
 
 ## Output

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -21,7 +21,15 @@ description: Generates Pull Request titles and descriptions according to werf co
 
 ## Description
 
-Use the following structure. *Summary*, *Why* and *Verification* are **mandatory**. Omit *Key changes* when it would only restate *Summary*, and *Review focus / risks* when there is genuinely nothing to guide the reviewer to. NEVER rename or substitute the sections.
+Match the description to the size of the diff. Two tiers, nothing in between.
+
+**Small** — one logical change, under ~20 changed lines, no user-visible behavior change (doc or
+skill wording, test fix, typo, dependency bump): no headings at all. One to three sentences — what
+was wrong, what it is now. If the title already says it, one sentence is the whole description.
+
+**Everything else** — the structure below. *Summary*, *Why* and *Verification* are **mandatory**.
+Omit *Key changes* when it would only restate *Summary*, and *Review focus / risks* when there is
+genuinely nothing to guide the reviewer to. NEVER rename or substitute the sections.
 
 ```
 ## Summary
@@ -59,6 +67,7 @@ observed wrong behavior and add a minimal repro (Dockerfile / werf.yaml / comman
 - *Verification*: only the delta over CI — manual runs, hand-run e2e/real-cluster checks, the environment they required, and what could NOT be run. CI builds and runs the whole suite, so `task build`/`task test:unit` are noise unless a scoped local run is itself the point — then name it by its `task` command, never raw `go test`/`go vet`/`gofmt`. Plain list, not checkboxes — the reviewer is not the one ticking them.
 - *Review focus / risks*: guide the reviewer — call out non-obvious consequences, large generated diffs, breaking changes, and any deliberately accepted limitation of the chosen approach.
 - No AI-slop filler ("This PR improves the codebase…"). Every sentence must carry information.
+- Length is a budget, not a target: under ~300 characters for a small PR, under ~1500 for a normal one. Cut any sentence that restates the title, another section, or the diff.
 - NEVER include sensitive or customer-identifying details in the title or description: client/company names, internal hostnames or filesystem paths, private build tags or version suffixes, credentials. Describe the environment generically (e.g. "long-lived CI runners sharing WERF_HOME", not a customer's runner path).
 
 ## Output

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -65,7 +65,8 @@ observed wrong behavior and add a minimal repro (Dockerfile / werf.yaml / comman
 - *Key changes*: group related items by theme, not one bullet per file; use sub-bullets for detail when helpful.
 - *Why*: explain the reason, not what changed (that's *Key changes*).
 - *Verification*: only the delta over CI — manual runs, hand-run e2e/real-cluster checks, the environment they required, and what could NOT be run. CI builds and runs the whole suite, so `task build`/`task test:unit` are noise unless a scoped local run is itself the point — then name it by its `task` command, never raw `go test`/`go vet`/`gofmt`. Plain list, not checkboxes — the reviewer is not the one ticking them.
-- *Review focus / risks*: guide the reviewer — call out non-obvious consequences, large generated diffs, breaking changes, and any deliberately accepted limitation of the chosen approach.
+- *Review focus / risks*: guide the reviewer — call out non-obvious consequences, large generated diffs, breaking changes, and any deliberately accepted limitation of the chosen approach. NEVER speculate there: list what you know, and drop the bullet that would start with "probably fine because…".
+- No terminal transcripts or code blocks beyond the repro a `fix` needs. A reviewer who wants the error runs the command.
 - No AI-slop filler ("This PR improves the codebase…"). Every sentence must carry information.
 - Length is a budget, not a target: under ~300 characters for a small PR, under ~1500 for a normal one. Cut any sentence that restates the title, another section, or the diff.
 - NEVER include sensitive or customer-identifying details in the title or description: client/company names, internal hostnames or filesystem paths, private build tags or version suffixes, credentials. Describe the environment generically (e.g. "long-lived CI runners sharing WERF_HOME", not a customer's runner path).

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -9,7 +9,7 @@ Evidence-based and blunt. Every finding references a specific `file:line`, funct
 
 ## If you are the diff's author
 
-If you wrote the diff you are reviewing now, say so explicitly in the report's Verdict, and treat this pass as necessary but insufficient. Self-review — even done adversarially, even after mutating your own tests — inherits your own design assumptions: it reliably catches localized bugs and weak tests, but is a poor substitute for a second opinion on whether the overall approach is sound. For anything beyond a mechanical or low-risk change, recommend an independently invoked reviewer (a fresh session/agent with no memory of your rationale, or an external tool) before merge, and say so in the report rather than treating your own pass as the final word.
+If you wrote the diff you are reviewing now, say so explicitly in the report's Verdict and treat this pass as necessary but insufficient. `agent-code-review/SKILL.md` covers why self-review inherits your own design assumptions and what to recommend instead — read it, don't re-derive it here.
 
 ## Before reviewing
 
@@ -34,7 +34,7 @@ Cover the ones the diff actually touches; stay silent about the rest.
 
 ## Tests as evidence
 
-Passing tests, high coverage, and the author's confidence are not evidence of correctness, whoever wrote the diff. Read `test-the-tests/SKILL.md` and apply it to every load-bearing test: verify by mutating the implementation and confirming the test fails, not by reading the assertions and trusting they'd catch a regression.
+Passing tests, high coverage, and the author's confidence are not evidence of correctness, whoever wrote the diff. Read `test-the-tests/SKILL.md` and run its mutation loop against every load-bearing test: mutate the implementation and confirm the test fails, rather than reading the assertions and trusting they'd catch a regression. This is not optional — skipping it because the tests "look thorough" is exactly the failure mode it exists to catch.
 
 If the diff's author is an agent, or the diff touches tests or verification infrastructure, also read `agent-code-review/SKILL.md` — it covers check-gaming detection (weakened assertions, quietly skipped tests, mocked-out critical behavior, and more) in one place, so this list doesn't drift from it again.
 
@@ -83,9 +83,9 @@ Print the report. Do not write it into the repository unless the user asks for a
 
 ## DoD Criteria
 
-| Criteria | Met? | Evidence |
-| :--- | :--- | :--- |
-| [criterion] | ✅/⚠️/❌ | file:line |
+| Criteria | Inferred? | Met? | Evidence |
+| :--- | :--- | :--- | :--- |
+| [criterion] | yes/no | ✅/⚠️/❌ | file:line |
 
 ## Issues
 

--- a/.agents/skills/session-retro/SKILL.md
+++ b/.agents/skills/session-retro/SKILL.md
@@ -20,6 +20,7 @@ issue/PR template, or a `docs/` page. Pick the landing spot from the finding, no
 - **Repeated explanations**: anything explained more than once — the current instructions don't cover it.
 - **Discovered conventions**: facts that came from the user or from reading the repo, not from any doc — build quirks, naming schemes, "we always do X here".
 - **Skill bugs found in use**: a skill that gave wrong guidance, missed a step, or referenced a stale path or command.
+- **Workflow decisions**: the user picked one approach over another ("always do it this way from now on") — a durable preference, not a one-off call.
 - **Friction**: a check that was slow, awkward, or easy to forget, or a step done by hand that a `task` target could do.
 - **Near-misses**: something caught just before landing (wrong branch, guessed path, unverified assumption) — the cheapest lesson, the cost is already paid.
 
@@ -49,6 +50,7 @@ file. Extend the closest existing skill or section rather than creating a near-d
 - Match the file's existing tone — `AGENTS.md` and `CODESTYLE.md` are terse, imperative, bulleted.
 - A rule belongs in exactly one place. Cross-reference instead of duplicating; a copied rule drifts.
 - Don't restate in prose what a `task` command or linter already enforces.
+- When a tool has become self-documenting — its own descriptions now carry the contract — TRIM the skill that taught workarounds for it instead of layering notes on top. A skill keeps only what the tool cannot know: local conventions and domain norms.
 
 ## 4. Confirm before applying
 

--- a/.agents/skills/test-the-tests/SKILL.md
+++ b/.agents/skills/test-the-tests/SKILL.md
@@ -27,6 +27,11 @@ trivial getter):
 If running the mutation isn't practical, name the smallest mutation that should be tried
 instead of skipping the exercise — that name is itself the finding.
 
+"Not practical" is a conclusion, not an assumption — establish it as `AGENTS.md` requires
+(is the runtime actually missing, is a Linux host available) before falling back to naming
+the mutation. A "can't run it here" that turns out to be wrong ships tests nobody has ever
+seen fail.
+
 ## Common ways a test looks strong but isn't
 
 - **The assertion holds under the bug too.** A chain assertion like
@@ -41,6 +46,14 @@ instead of skipping the exercise — that name is itself the finding.
   break. Prefer driving the real entry point end-to-end when the risk is in the wiring.
 - **It asserts implementation trivia** (mock called N times, internal helper ran) instead
   of externally observable behavior.
+- **Coverage number, not falsifiability.** A line being executed says nothing about whether
+  a wrong value on that line would be caught.
+- **An extended test quietly drops what the old one proved.** Adding cases to a fixture can
+  remove the conflict that made an earlier property observable. After editing an existing
+  test, re-run the mutations the previous version caught, not only the new ones.
+- **Ordered behavior tested without conflicts.** For precedence lists and fallback chains,
+  a fixture with one candidate per level survives swapping adjacent candidates. Give every
+  level two candidates whose effects differ.
 
 ## Output
 


### PR DESCRIPTION
## Summary

Diff every skill copy in `.agents/skills` against the version it was ported from, and put back the rules the porting dropped. No new rules, no scope changes.

## Why

These copies are deliberate forks — they name `task` commands, werf scopes, werf release branches. But a fork is only reviewable if it differs *only* where it means to. Each copy had also lost content unrelated to werf, so the repo silently ran a weaker version of a skill it believes it follows.

## Key changes

- `session-retro`: a workflow preference the user states once is a finding; a tool that became self-documenting is a reason to trim its skill, not to append to it.
- `pull-request`: description tiers restored — a small diff gets one to three sentences and no headings, plus a length budget; no speculation in *Review focus / risks*; no terminal transcripts beyond the repro a `fix` needs; missing trailing newline.
- `test-the-tests`: "can't run it here" must be established, not assumed (as `AGENTS.md` already requires); coverage is not falsifiability; editing a test can silently drop what the old version proved; ordered behavior needs fixtures that actually conflict.
- `git-conventions`: recorded fixtures and logs need every class of identifier scrubbed, not just names and emails.
- `review`: the mutation loop is mandatory, not a suggestion; the DoD table gets an `Inferred?` column; the self-review paragraph becomes a pointer to `agent-code-review`, which already carries it verbatim.

## Verification

- Docs-only change to the agent harness, no Go code touched — nothing to build or test.
- `diff -rq` against the upstream copies afterwards: `agent-code-review` is identical, the other five differ only in werf-specific scope.