### PR TITLE
feat: embed kubeconform schemas

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -1183,11 +1183,6 @@ func SetupTrackingFlags(cmdData *CmdData, cmd *cobra.Command) error {
 }
 
 func SetupResourceValidationFlags(cmdData *CmdData, cmd *cobra.Command) error {
-	kubeVersion := os.Getenv("WERF_RESOURCE_VALIDATION_KUBE_VERSION")
-	if kubeVersion == "" {
-		kubeVersion = common.DefaultResourceValidationKubeVersion
-	}
-
 	defaultValidationCacheLifetime := common.DefaultResourceValidationCacheLifetime
 
 	if os.Getenv("WERF_RESOURCE_VALIDATION_CACHE_LIFETIME") != "" {
@@ -1199,17 +1194,10 @@ func SetupResourceValidationFlags(cmdData *CmdData, cmd *cobra.Command) error {
 		}
 	}
 
-	validationSchemas := util.PredefinedValuesByEnvNamePrefix("WERF_RESOURCE_VALIDATION_SCHEMA_")
-	if len(validationSchemas) == 0 {
-		validationSchemas = common.DefaultResourceValidationSchema
-	}
-
 	cmd.Flags().BoolVarP(&cmdData.NoResourceValidation, "no-resource-validation", "", util.GetBoolEnvironmentDefaultFalse("WERF_NO_RESOURCE_VALIDATION"), "Disable resource validation (default $WERF_NO_RESOURCE_VALIDATION)")
-	cmd.Flags().BoolVarP(&cmdData.LocalResourceValidation, "local-resource-validation", "", util.GetBoolEnvironmentDefaultFalse("WERF_LOCAL_RESOURCE_VALIDATION"), "Do not use external json schema sources (default $WERF_LOCAL_RESOURCE_VALIDATION)")
-	cmd.Flags().StringVarP(&cmdData.ValidationKubeVersion, "resource-validation-kube-version", "", kubeVersion, "Kubernetes schemas version to use during resource validation. Also can be defined by $WERF_RESOURCE_VALIDATION_KUBE_VERSION")
+	cmd.Flags().BoolVarP(&cmdData.LocalResourceValidation, "local-resource-validation", "", util.GetBoolEnvironmentDefaultFalse("WERF_LOCAL_RESOURCE_VALIDATION"), "Do not use external json schema sources, validate against the json schemas embedded into the binary instead (default $WERF_LOCAL_RESOURCE_VALIDATION)")
 	cmd.Flags().StringArrayVarP(&cmdData.ValidationSkip, "resource-validation-skip", "", []string{}, "Skip resource validation for resources with specified attributes (can specify multiple). Format: key1=value1,key2=value2. Supported keys: group, version, kind, name, namespace. Example: kind=Deployment,name=my-app. Also, can be defined with $WERF_RESOURCE_VALIDATION_SKIP_* (e.g. $WERF_RESOURCE_VALIDATION_SKIP_1=kind=Deployment,name=my-app)")
-	cmd.Flags().StringArrayVarP(&cmdData.ValidationSchemas, "resource-validation-schema", "", validationSchemas, "Default json schema sources to validate resources. Must be a valid go template defining a http(s) URL, or an absolute path on local file system. Also, can be defined with $WERF_RESOURCE_VALIDATION_SCHEMA_* (eg. $WERF_RESOURCE_VALIDATION_SCHEMA_1='https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json')")
-	cmd.Flags().StringArrayVarP(&cmdData.ValidationExtraSchemas, "resource-validation-extra-schema", "", []string{}, "Extra json schema sources to validate resources (preferred over default sources). Must be a valid go template defining a http(s) URL, or an absolute path on local file system. Also, can be defined with $WERF_RESOURCE_VALIDATION_EXTRA_SCHEMA_* (eg. $WERF_RESOURCE_VALIDATION_EXTRA_SCHEMA_1='https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json')")
+	cmd.Flags().StringArrayVarP(&cmdData.ValidationExtraSchemas, "resource-validation-extra-schema", "", []string{}, "Extra json schema sources to validate resources (preferred over ebedded sources). Must be a valid go template defining a http(s) URL, or an absolute path on local file system. Also, can be defined with $WERF_RESOURCE_VALIDATION_EXTRA_SCHEMA_* (eg. $WERF_RESOURCE_VALIDATION_EXTRA_SCHEMA_1='https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json')")
 	cmd.Flags().DurationVarP(&cmdData.ValidationSchemaCacheLifetime, "resource-validation-cache-lifetime", "", defaultValidationCacheLifetime, "How long local schema cache will be valid. Also can be defined by $WERF_RESOURCE_VALIDATION_CACHE_LIFETIME")
 
 	return nil

--- a/docs/_data/sidebars/documentation.yml
+++ b/docs/_data/sidebars/documentation.yml
@@ -761,9 +761,6 @@ entries:
           - title: werf images
             url: /reference/werf_images.html
 
-          - title: Debug environment variables
-            url: /reference/debug_env_vars.html
-
           - title: Command line interface
             f: *cli
 
@@ -924,9 +921,6 @@ entries:
 
           - title: Образы werf
             url: /reference/werf_images.html
-
-          - title: Переменные окружения для отладки
-            url: /reference/debug_env_vars.html
 
           - title: Интерфейс командной строки
             f: *cli

--- a/docs/_includes/reference/cli/werf_bundle_apply.md
+++ b/docs/_includes/reference/cli/werf_bundle_apply.md
@@ -145,7 +145,8 @@ werf bundle apply [options]
             Path to file with bearer token for authentication in Kubernetes (default                
             $WERF_KUBE_TOKEN_PATH)
       --local-resource-validation=false
-            Do not use external json schema sources (default $WERF_LOCAL_RESOURCE_VALIDATION)
+            Do not use external json schema sources, validate against the json schemas embedded     
+            into the binary instead (default $WERF_LOCAL_RESOURCE_VALIDATION)
       --log-color-mode="auto"
             Set log color mode.
             Supported on, off and auto (based on the stdout’s file descriptor referring to a        
@@ -248,20 +249,11 @@ werf bundle apply [options]
             How long local schema cache will be valid. Also can be defined by                       
             $WERF_RESOURCE_VALIDATION_CACHE_LIFETIME
       --resource-validation-extra-schema=[]
-            Extra json schema sources to validate resources (preferred over default sources). Must  
+            Extra json schema sources to validate resources (preferred over ebedded sources). Must  
             be a valid go template defining a http(s) URL, or an absolute path on local file        
             system. Also, can be defined with $WERF_RESOURCE_VALIDATION_EXTRA_SCHEMA_* (eg. $WERF_RE
             SOURCE_VALIDATION_EXTRA_SCHEMA_1=`https://raw.githubusercontent.com/datreeio/CRDs-catalo
             g/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json`)
-      --resource-validation-kube-version="1.35.0"
-            Kubernetes schemas version to use during resource validation. Also can be defined by    
-            $WERF_RESOURCE_VALIDATION_KUBE_VERSION
-      --resource-validation-schema=[https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json,https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json]
-            Default json schema sources to validate resources. Must be a valid go template defining 
-            a http(s) URL, or an absolute path on local file system. Also, can be defined with      
-            $WERF_RESOURCE_VALIDATION_SCHEMA_* (eg. $WERF_RESOURCE_VALIDATION_SCHEMA_1=`https://raw.
-            githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.Resourc
-            eAPIVersion}}.json`)
       --resource-validation-skip=[]
             Skip resource validation for resources with specified attributes (can specify           
             multiple). Format: key1=value1,key2=value2. Supported keys: group, version, kind, name, 

--- a/docs/_includes/reference/cli/werf_bundle_plan.md
+++ b/docs/_includes/reference/cli/werf_bundle_plan.md
@@ -141,7 +141,8 @@ werf bundle plan [options]
             Path to file with bearer token for authentication in Kubernetes (default                
             $WERF_KUBE_TOKEN_PATH)
       --local-resource-validation=false
-            Do not use external json schema sources (default $WERF_LOCAL_RESOURCE_VALIDATION)
+            Do not use external json schema sources, validate against the json schemas embedded     
+            into the binary instead (default $WERF_LOCAL_RESOURCE_VALIDATION)
       --log-color-mode="auto"
             Set log color mode.
             Supported on, off and auto (based on the stdout’s file descriptor referring to a        
@@ -231,20 +232,11 @@ werf bundle plan [options]
             How long local schema cache will be valid. Also can be defined by                       
             $WERF_RESOURCE_VALIDATION_CACHE_LIFETIME
       --resource-validation-extra-schema=[]
-            Extra json schema sources to validate resources (preferred over default sources). Must  
+            Extra json schema sources to validate resources (preferred over ebedded sources). Must  
             be a valid go template defining a http(s) URL, or an absolute path on local file        
             system. Also, can be defined with $WERF_RESOURCE_VALIDATION_EXTRA_SCHEMA_* (eg. $WERF_RE
             SOURCE_VALIDATION_EXTRA_SCHEMA_1=`https://raw.githubusercontent.com/datreeio/CRDs-catalo
             g/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json`)
-      --resource-validation-kube-version="1.35.0"
-            Kubernetes schemas version to use during resource validation. Also can be defined by    
-            $WERF_RESOURCE_VALIDATION_KUBE_VERSION
-      --resource-validation-schema=[https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json,https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json]
-            Default json schema sources to validate resources. Must be a valid go template defining 
-            a http(s) URL, or an absolute path on local file system. Also, can be defined with      
-            $WERF_RESOURCE_VALIDATION_SCHEMA_* (eg. $WERF_RESOURCE_VALIDATION_SCHEMA_1=`https://raw.
-            githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.Resourc
-            eAPIVersion}}.json`)
       --resource-validation-skip=[]
             Skip resource validation for resources with specified attributes (can specify           
             multiple). Format: key1=value1,key2=value2. Supported keys: group, version, kind, name, 

--- a/docs/_includes/reference/cli/werf_converge.md
+++ b/docs/_includes/reference/cli/werf_converge.md
@@ -294,7 +294,8 @@ werf converge --repo registry.mydomain.com/web --env production
             Path to file with bearer token for authentication in Kubernetes (default                
             $WERF_KUBE_TOKEN_PATH)
       --local-resource-validation=false
-            Do not use external json schema sources (default $WERF_LOCAL_RESOURCE_VALIDATION)
+            Do not use external json schema sources, validate against the json schemas embedded     
+            into the binary instead (default $WERF_LOCAL_RESOURCE_VALIDATION)
       --log-color-mode="auto"
             Set log color mode.
             Supported on, off and auto (based on the stdout’s file descriptor referring to a        
@@ -415,20 +416,11 @@ werf converge --repo registry.mydomain.com/web --env production
             How long local schema cache will be valid. Also can be defined by                       
             $WERF_RESOURCE_VALIDATION_CACHE_LIFETIME
       --resource-validation-extra-schema=[]
-            Extra json schema sources to validate resources (preferred over default sources). Must  
+            Extra json schema sources to validate resources (preferred over ebedded sources). Must  
             be a valid go template defining a http(s) URL, or an absolute path on local file        
             system. Also, can be defined with $WERF_RESOURCE_VALIDATION_EXTRA_SCHEMA_* (eg. $WERF_RE
             SOURCE_VALIDATION_EXTRA_SCHEMA_1=`https://raw.githubusercontent.com/datreeio/CRDs-catalo
             g/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json`)
-      --resource-validation-kube-version="1.35.0"
-            Kubernetes schemas version to use during resource validation. Also can be defined by    
-            $WERF_RESOURCE_VALIDATION_KUBE_VERSION
-      --resource-validation-schema=[https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json,https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json]
-            Default json schema sources to validate resources. Must be a valid go template defining 
-            a http(s) URL, or an absolute path on local file system. Also, can be defined with      
-            $WERF_RESOURCE_VALIDATION_SCHEMA_* (eg. $WERF_RESOURCE_VALIDATION_SCHEMA_1=`https://raw.
-            githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.Resourc
-            eAPIVersion}}.json`)
       --resource-validation-skip=[]
             Skip resource validation for resources with specified attributes (can specify           
             multiple). Format: key1=value1,key2=value2. Supported keys: group, version, kind, name, 

--- a/docs/_includes/reference/cli/werf_lint.md
+++ b/docs/_includes/reference/cli/werf_lint.md
@@ -233,7 +233,8 @@ werf lint [IMAGE_NAME...] [options]
       --kube-version=""
             Set specific Capabilities.KubeVersion (default $WERF_KUBE_VERSION)
       --local-resource-validation=false
-            Do not use external json schema sources (default $WERF_LOCAL_RESOURCE_VALIDATION)
+            Do not use external json schema sources, validate against the json schemas embedded     
+            into the binary instead (default $WERF_LOCAL_RESOURCE_VALIDATION)
       --log-color-mode="auto"
             Set log color mode.
             Supported on, off and auto (based on the stdout’s file descriptor referring to a        
@@ -335,20 +336,11 @@ werf lint [IMAGE_NAME...] [options]
             How long local schema cache will be valid. Also can be defined by                       
             $WERF_RESOURCE_VALIDATION_CACHE_LIFETIME
       --resource-validation-extra-schema=[]
-            Extra json schema sources to validate resources (preferred over default sources). Must  
+            Extra json schema sources to validate resources (preferred over ebedded sources). Must  
             be a valid go template defining a http(s) URL, or an absolute path on local file        
             system. Also, can be defined with $WERF_RESOURCE_VALIDATION_EXTRA_SCHEMA_* (eg. $WERF_RE
             SOURCE_VALIDATION_EXTRA_SCHEMA_1=`https://raw.githubusercontent.com/datreeio/CRDs-catalo
             g/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json`)
-      --resource-validation-kube-version="1.35.0"
-            Kubernetes schemas version to use during resource validation. Also can be defined by    
-            $WERF_RESOURCE_VALIDATION_KUBE_VERSION
-      --resource-validation-schema=[https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json,https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json]
-            Default json schema sources to validate resources. Must be a valid go template defining 
-            a http(s) URL, or an absolute path on local file system. Also, can be defined with      
-            $WERF_RESOURCE_VALIDATION_SCHEMA_* (eg. $WERF_RESOURCE_VALIDATION_SCHEMA_1=`https://raw.
-            githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.Resourc
-            eAPIVersion}}.json`)
       --resource-validation-skip=[]
             Skip resource validation for resources with specified attributes (can specify           
             multiple). Format: key1=value1,key2=value2. Supported keys: group, version, kind, name, 

--- a/docs/_includes/reference/cli/werf_plan.md
+++ b/docs/_includes/reference/cli/werf_plan.md
@@ -288,7 +288,8 @@ werf plan --repo registry.mydomain.com/web --env production
             Path to file with bearer token for authentication in Kubernetes (default                
             $WERF_KUBE_TOKEN_PATH)
       --local-resource-validation=false
-            Do not use external json schema sources (default $WERF_LOCAL_RESOURCE_VALIDATION)
+            Do not use external json schema sources, validate against the json schemas embedded     
+            into the binary instead (default $WERF_LOCAL_RESOURCE_VALIDATION)
       --log-color-mode="auto"
             Set log color mode.
             Supported on, off and auto (based on the stdout’s file descriptor referring to a        
@@ -396,20 +397,11 @@ werf plan --repo registry.mydomain.com/web --env production
             How long local schema cache will be valid. Also can be defined by                       
             $WERF_RESOURCE_VALIDATION_CACHE_LIFETIME
       --resource-validation-extra-schema=[]
-            Extra json schema sources to validate resources (preferred over default sources). Must  
+            Extra json schema sources to validate resources (preferred over ebedded sources). Must  
             be a valid go template defining a http(s) URL, or an absolute path on local file        
             system. Also, can be defined with $WERF_RESOURCE_VALIDATION_EXTRA_SCHEMA_* (eg. $WERF_RE
             SOURCE_VALIDATION_EXTRA_SCHEMA_1=`https://raw.githubusercontent.com/datreeio/CRDs-catalo
             g/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json`)
-      --resource-validation-kube-version="1.35.0"
-            Kubernetes schemas version to use during resource validation. Also can be defined by    
-            $WERF_RESOURCE_VALIDATION_KUBE_VERSION
-      --resource-validation-schema=[https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json,https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json]
-            Default json schema sources to validate resources. Must be a valid go template defining 
-            a http(s) URL, or an absolute path on local file system. Also, can be defined with      
-            $WERF_RESOURCE_VALIDATION_SCHEMA_* (eg. $WERF_RESOURCE_VALIDATION_SCHEMA_1=`https://raw.
-            githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.Resourc
-            eAPIVersion}}.json`)
       --resource-validation-skip=[]
             Skip resource validation for resources with specified attributes (can specify           
             multiple). Format: key1=value1,key2=value2. Supported keys: group, version, kind, name, 

--- a/docs/_includes/reference/cli/werf_rollback.md
+++ b/docs/_includes/reference/cli/werf_rollback.md
@@ -144,7 +144,8 @@ werf rollback --revision 10
             Path to file with bearer token for authentication in Kubernetes (default                
             $WERF_KUBE_TOKEN_PATH)
       --local-resource-validation=false
-            Do not use external json schema sources (default $WERF_LOCAL_RESOURCE_VALIDATION)
+            Do not use external json schema sources, validate against the json schemas embedded     
+            into the binary instead (default $WERF_LOCAL_RESOURCE_VALIDATION)
       --log-color-mode="auto"
             Set log color mode.
             Supported on, off and auto (based on the stdout’s file descriptor referring to a        
@@ -214,20 +215,11 @@ werf rollback --revision 10
             How long local schema cache will be valid. Also can be defined by                       
             $WERF_RESOURCE_VALIDATION_CACHE_LIFETIME
       --resource-validation-extra-schema=[]
-            Extra json schema sources to validate resources (preferred over default sources). Must  
+            Extra json schema sources to validate resources (preferred over ebedded sources). Must  
             be a valid go template defining a http(s) URL, or an absolute path on local file        
             system. Also, can be defined with $WERF_RESOURCE_VALIDATION_EXTRA_SCHEMA_* (eg. $WERF_RE
             SOURCE_VALIDATION_EXTRA_SCHEMA_1=`https://raw.githubusercontent.com/datreeio/CRDs-catalo
             g/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json`)
-      --resource-validation-kube-version="1.35.0"
-            Kubernetes schemas version to use during resource validation. Also can be defined by    
-            $WERF_RESOURCE_VALIDATION_KUBE_VERSION
-      --resource-validation-schema=[https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .NormalizedKubernetesVersion }}-standalone{{ .StrictSuffix }}/{{ .ResourceKind }}{{ .KindSuffix }}.json,https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json]
-            Default json schema sources to validate resources. Must be a valid go template defining 
-            a http(s) URL, or an absolute path on local file system. Also, can be defined with      
-            $WERF_RESOURCE_VALIDATION_SCHEMA_* (eg. $WERF_RESOURCE_VALIDATION_SCHEMA_1=`https://raw.
-            githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.Resourc
-            eAPIVersion}}.json`)
       --resource-validation-skip=[]
             Skip resource validation for resources with specified attributes (can specify           
             multiple). Format: key1=value1,key2=value2. Supported keys: group, version, kind, name, 

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/werf/copy-recurse v0.3.1
 	github.com/werf/lockgate v0.2.0
 	github.com/werf/logboek v0.7.1
-	github.com/werf/nelm v1.26.2-0.20260728083400-0d2b4e06f3a6
+	github.com/werf/nelm v1.26.2-0.20260731110750-f6ce79b3fd4c
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -1048,6 +1048,8 @@ github.com/werf/nelm v1.26.2-0.20260714210400-9241ea8a51d0 h1:GF/D3qu2r19zJcrR+8
 github.com/werf/nelm v1.26.2-0.20260714210400-9241ea8a51d0/go.mod h1:3jr18vadayMPDKQaXzCsc5RFtfPRwnZOxvawwHhm+4M=
 github.com/werf/nelm v1.26.2-0.20260728083400-0d2b4e06f3a6 h1:4XE06yWKh/XgR2AodJnk8LDRsyl6zYcHF0fmcTO4Mi8=
 github.com/werf/nelm v1.26.2-0.20260728083400-0d2b4e06f3a6/go.mod h1:eI4z6u+zG3t+CLdqRvAxNjoLH/5Jq3wStjUILE4HjFc=
+github.com/werf/nelm v1.26.2-0.20260731110750-f6ce79b3fd4c h1:2sxMqBKezwgA5kcmTJ4eR2Fz0U0r4gTZhbqu2GwmuNU=
+github.com/werf/nelm v1.26.2-0.20260731110750-f6ce79b3fd4c/go.mod h1:eI4z6u+zG3t+CLdqRvAxNjoLH/5Jq3wStjUILE4HjFc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=


### PR DESCRIPTION
Resource validation with kubeconform may not depend on network any more. Kubernetes standard resources and CRDs validation schemas are embedded into the binary. This feature become possible because of https://github.com/werf/nelm/pull/673

We do use https://github.com/yannh/kubernetes-json-schema as a source for Kubernetes standard resources and https://github.com/datreeio/CRDs-catalog for the CRDs.