### PR TITLE
fix(dev): warm a persistent dev-index so --dev stops re-reading unchanged files

### DIFF
--- a/pkg/true_git/helpers_test.go
+++ b/pkg/true_git/helpers_test.go
@@ -6,9 +6,15 @@ import (
 	"github.com/werf/werf/v2/test/pkg/utils"
 )
 
-// gitCommitSucceed commits with signing disabled. Without that these tests inherit a
-// developer's global commit.gpgsign and start depending on a working gpg-agent, which
-// intermittently fails to sign under Ginkgo's parallel procs.
+// gitCommitSucceed pins identity and disables signing so commits do not depend on ambient
+// global git config: a developer's commit.gpgsign needs a working gpg-agent, which
+// intermittently fails under Ginkgo's parallel procs, and specs that isolate themselves via
+// GIT_CONFIG_GLOBAL lose the only user.name/user.email the CI runner has.
 func gitCommitSucceed(ctx context.Context, workTreeDir string, args ...string) {
-	utils.RunSucceedCommand(ctx, workTreeDir, "git", append([]string{"-c", "commit.gpgsign=false", "commit"}, args...)...)
+	utils.RunSucceedCommand(ctx, workTreeDir, "git", append([]string{
+		"-c", "commit.gpgsign=false",
+		"-c", "user.email=werf@werf.io",
+		"-c", "user.name=werf",
+		"commit",
+	}, args...)...)
 }

--- a/pkg/true_git/service_branch.go
+++ b/pkg/true_git/service_branch.go
@@ -77,14 +77,19 @@ func syncWorktreeWithServiceWorktreeBranch(ctx context.Context, sourceWorktreeDi
 		return "", fmt.Errorf("unable to compute conversion config signature: %w", err)
 	}
 
-	treeSHA, err := prepareDevIndexAndWriteTree(ctx, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, sourceCommit, serviceBranchHeadCommit, conversionSignature, globExcludeList)
+	treeSHA, seeded, err := prepareDevIndexAndWriteTree(ctx, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, sourceCommit, serviceBranchHeadCommit, conversionSignature, globExcludeList)
 	if err != nil {
-		// The persistent index may be corrupt or left inconsistent by an interrupted run;
-		// discard it and rebuild once from a clean read-tree seed before surfacing the error.
+		// A reused (warm) index may be corrupt or left inconsistent by an interrupted run; discard
+		// it and rebuild once from a clean read-tree seed. When the attempt already ran from a
+		// fresh seed the failure is deterministic (broken clean filter, disk full, ...), so retrying
+		// would only double a potentially multi-minute run — surface it instead.
+		if seeded {
+			return "", fmt.Errorf("unable to prepare dev-index: %w", err)
+		}
 		if rmErr := removeDevIndexFiles(worktreeCacheDir); rmErr != nil {
 			return "", fmt.Errorf("unable to discard dev-index after failure (%v): %w", err, rmErr)
 		}
-		treeSHA, err = prepareDevIndexAndWriteTree(ctx, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, sourceCommit, serviceBranchHeadCommit, conversionSignature, globExcludeList)
+		treeSHA, _, err = prepareDevIndexAndWriteTree(ctx, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, sourceCommit, serviceBranchHeadCommit, conversionSignature, globExcludeList)
 		if err != nil {
 			return "", fmt.Errorf("unable to rebuild dev-index after failure: %w", err)
 		}
@@ -155,34 +160,34 @@ func devIndexBaseMatches(worktreeCacheDir, expected string) bool {
 // its base marker is absent/mismatched (e.g. the service-branch head moved or the add-time
 // conversion config changed), so unchanged files keep matching the source worktree's stat cache
 // and are not re-read or re-hashed.
-func prepareDevIndexAndWriteTree(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, sourceCommit, serviceBranchHeadCommit, conversionSignature string, globExcludeList []string) (string, error) {
+func prepareDevIndexAndWriteTree(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, sourceCommit, serviceBranchHeadCommit, conversionSignature string, globExcludeList []string) (string, bool, error) {
 	devIndexFile := devIndexFilePath(worktreeCacheDir)
 	expectedBase := devIndexBaseSignature(serviceBranchHeadCommit, conversionSignature)
 
-	needSeed := true
+	seeded := true
 	if _, err := os.Stat(devIndexFile); err == nil && devIndexBaseMatches(worktreeCacheDir, expectedBase) {
-		needSeed = false
+		seeded = false
 	}
-	if needSeed {
+	if seeded {
 		if err := seedDevIndex(ctx, serviceWorktreeDir, devIndexFile, serviceBranchHeadCommit); err != nil {
-			return "", fmt.Errorf("unable to seed dev-index from %s: %w", serviceBranchHeadCommit, err)
+			return "", seeded, fmt.Errorf("unable to seed dev-index from %s: %w", serviceBranchHeadCommit, err)
 		}
 	}
 
 	if err := revertExcludedChangesInDevIndex(ctx, serviceWorktreeDir, devIndexFile, sourceCommit, serviceBranchHeadCommit, globExcludeList); err != nil {
-		return "", fmt.Errorf("unable to revert excluded changes in dev-index: %w", err)
+		return "", seeded, fmt.Errorf("unable to revert excluded changes in dev-index: %w", err)
 	}
 
 	if err := runGitAddCmd(ctx, sourceWorktreeDir, serviceWorktreeDir, devIndexFile, globExcludeList); err != nil {
-		return "", fmt.Errorf("unable to add source worktree changes to dev-index: %w", err)
+		return "", seeded, fmt.Errorf("unable to add source worktree changes to dev-index: %w", err)
 	}
 
 	treeSHA, err := writeDevIndexTree(ctx, serviceWorktreeDir, devIndexFile)
 	if err != nil {
-		return "", fmt.Errorf("unable to write tree from dev-index: %w", err)
+		return "", seeded, fmt.Errorf("unable to write tree from dev-index: %w", err)
 	}
 
-	return treeSHA, nil
+	return treeSHA, seeded, nil
 }
 
 func seedDevIndex(ctx context.Context, serviceWorktreeDir, devIndexFile, serviceBranchHeadCommit string) error {
@@ -222,7 +227,7 @@ func computeConversionConfigSignature(ctx context.Context, sourceWorktreeDir str
 	}
 	fmt.Fprintf(h, "filter-config\x00%s\x00", filterConfig)
 
-	attrFiles, err := trackedGitattributesFiles(ctx, sourceWorktreeDir)
+	attrFiles, err := worktreeGitattributesFiles(ctx, sourceWorktreeDir)
 	if err != nil {
 		return "", err
 	}
@@ -265,16 +270,27 @@ func gitConfigFilterValues(ctx context.Context, repoDir string) (string, error) 
 	return configCmd.OutBuf.String(), nil
 }
 
-func trackedGitattributesFiles(ctx context.Context, sourceWorktreeDir string) ([]string, error) {
-	lsCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "ls-files", "-z", "--", ".gitattributes", ":(glob)**/.gitattributes")
+// worktreeGitattributesFiles lists every .gitattributes in the worktree, tracked AND untracked:
+// git add applies attributes from an untracked .gitattributes too, so a signature keyed only on
+// index-tracked files would miss `git lfs track`-style changes and leave a stale blob in the warm
+// index. --exclude-standard is deliberately NOT passed: a gitignored .gitattributes still governs
+// conversion of non-ignored files.
+func worktreeGitattributesFiles(ctx context.Context, sourceWorktreeDir string) ([]string, error) {
+	lsCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "ls-files", "-z", "--cached", "--others", "--", ".gitattributes", ":(glob)**/.gitattributes")
 	if err := lsCmd.Run(ctx); err != nil {
 		return nil, fmt.Errorf("git ls-files command failed: %w", err)
 	}
+	seen := make(map[string]struct{})
 	var files []string
 	for _, p := range strings.Split(lsCmd.OutBuf.String(), "\x00") {
-		if p != "" {
-			files = append(files, p)
+		if p == "" {
+			continue
 		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		files = append(files, p)
 	}
 	sort.Strings(files)
 	return files, nil
@@ -298,12 +314,26 @@ func extraAttributesFilePaths(ctx context.Context, sourceWorktreeDir string) []s
 		if p := strings.TrimSpace(attrFileCmd.OutBuf.String()); p != "" {
 			paths = append(paths, expandTilde(p))
 		}
+	} else if p := defaultGlobalAttributesFile(); p != "" {
+		paths = append(paths, p)
 	}
 
 	return paths
 }
 
+func defaultGlobalAttributesFile() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "git", "attributes")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".config", "git", "attributes")
+	}
+	return ""
+}
+
 func expandTilde(path string) string {
+	// ponytail: only ~ and ~/ are expanded; git's ~user/ form is left as-is (rare, and a
+	// stable literal still yields a stable signature — over-hashing at worst, never a miss).
 	if path == "~" || strings.HasPrefix(path, "~/") {
 		if home, err := os.UserHomeDir(); err == nil {
 			return filepath.Join(home, strings.TrimPrefix(path[1:], "/"))

--- a/pkg/true_git/service_branch.go
+++ b/pkg/true_git/service_branch.go
@@ -128,11 +128,18 @@ func devIndexBaseFilePath(worktreeCacheDir string) string {
 }
 
 func removeDevIndexFiles(worktreeCacheDir string) error {
-	if err := os.RemoveAll(devIndexFilePath(worktreeCacheDir)); err != nil {
-		return fmt.Errorf("unable to remove %s: %w", devIndexFilePath(worktreeCacheDir), err)
-	}
-	if err := os.RemoveAll(devIndexBaseFilePath(worktreeCacheDir)); err != nil {
-		return fmt.Errorf("unable to remove %s: %w", devIndexBaseFilePath(worktreeCacheDir), err)
+	// Also drop a stale <dev_index>.lock: git leaves it behind when a command through the
+	// dev-index is SIGKILLed (werf's WaitDelay escalates SIGTERM to SIGKILL after 5m), and every
+	// later read-tree/add/write-tree would then fail to lock. Safe to remove here because the
+	// whole flow runs under withWorkTreeCacheLock, so no live git legitimately holds it.
+	for _, path := range []string{
+		devIndexFilePath(worktreeCacheDir),
+		devIndexFilePath(worktreeCacheDir) + ".lock",
+		devIndexBaseFilePath(worktreeCacheDir),
+	} {
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("unable to remove %s: %w", path, err)
+		}
 	}
 	return nil
 }
@@ -275,6 +282,9 @@ func gitConfigFilterValues(ctx context.Context, repoDir string) (string, error) 
 // index-tracked files would miss `git lfs track`-style changes and leave a stale blob in the warm
 // index. --exclude-standard is deliberately NOT passed: a gitignored .gitattributes still governs
 // conversion of non-ignored files.
+// ponytail: omitting --exclude-standard makes --others walk fully-ignored trees (node_modules,
+// build output) on every sync; readdir/lstat-only (no content reads, so #4754 stays fixed), but
+// revisit with a smarter enumeration if a repo with a huge ignored tree reports latency here.
 func worktreeGitattributesFiles(ctx context.Context, sourceWorktreeDir string) ([]string, error) {
 	lsCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "ls-files", "-z", "--cached", "--others", "--", ".gitattributes", ":(glob)**/.gitattributes")
 	if err := lsCmd.Run(ctx); err != nil {
@@ -309,26 +319,42 @@ func extraAttributesFilePaths(ctx context.Context, sourceWorktreeDir string) []s
 		}
 	}
 
+	return append(paths, globalAndSystemAttributesFilePaths(ctx, sourceWorktreeDir)...)
+}
+
+// globalAndSystemAttributesFilePaths returns the per-user and system-wide gitattributes files that
+// git consults during `git add`. git 2.43+ exposes their resolved locations via `git var`
+// (honoring GIT_ATTR_NOSYSTEM and the compiled-in/runtime prefix); on older git the system path is
+// undiscoverable, so fall back to core.attributesFile / the XDG default for the per-user file only.
+func globalAndSystemAttributesFilePaths(ctx context.Context, sourceWorktreeDir string) []string {
+	if !gitVersion.LessThan(semver.MustParse("2.43.0")) {
+		var paths []string
+		for _, v := range []string{"GIT_ATTR_SYSTEM", "GIT_ATTR_GLOBAL"} {
+			varCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "var", v)
+			if err := varCmd.Run(ctx); err == nil {
+				if p := strings.TrimSpace(varCmd.OutBuf.String()); p != "" {
+					paths = append(paths, p)
+				}
+			}
+		}
+		return paths
+	}
+
 	attrFileCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "config", "--get", "core.attributesFile")
 	if err := attrFileCmd.Run(ctx); err == nil {
 		if p := strings.TrimSpace(attrFileCmd.OutBuf.String()); p != "" {
-			paths = append(paths, expandTilde(p))
+			return []string{expandTilde(p)}
 		}
-	} else if p := defaultGlobalAttributesFile(); p != "" {
-		paths = append(paths, p)
 	}
-
-	return paths
-}
-
-func defaultGlobalAttributesFile() string {
+	// ponytail: on git <2.43 the system gitattributes path is undiscoverable, so it is not
+	// hashed — an extremely rare, unmanaged file; revisit only if reported.
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-		return filepath.Join(xdg, "git", "attributes")
+		return []string{filepath.Join(xdg, "git", "attributes")}
 	}
 	if home, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(home, ".config", "git", "attributes")
+		return []string{filepath.Join(home, ".config", "git", "attributes")}
 	}
-	return ""
+	return nil
 }
 
 func expandTilde(path string) string {

--- a/pkg/true_git/service_branch.go
+++ b/pkg/true_git/service_branch.go
@@ -72,7 +72,7 @@ func syncWorktreeWithServiceWorktreeBranch(ctx context.Context, sourceWorktreeDi
 		return "", fmt.Errorf("unable to get service worktree commit SHA: %w", err)
 	}
 
-	conversionSignature, err := computeConversionConfigSignature(ctx, sourceWorktreeDir)
+	conversionSignature, err := computeConversionConfigSignature(ctx, sourceWorktreeDir, serviceWorktreeDir)
 	if err != nil {
 		return "", fmt.Errorf("unable to compute conversion config signature: %w", err)
 	}
@@ -171,6 +171,13 @@ func prepareDevIndexAndWriteTree(ctx context.Context, sourceWorktreeDir, service
 	devIndexFile := devIndexFilePath(worktreeCacheDir)
 	expectedBase := devIndexBaseSignature(serviceBranchHeadCommit, conversionSignature)
 
+	// Always drop a stale <dev_index>.lock up front: a SIGKILLed run (werf escalates SIGTERM to
+	// SIGKILL after WaitDelay) leaves it behind, and it would otherwise wedge even the cold seed
+	// (read-tree) path where the retry-with-rebuild does not run. Safe under withWorkTreeCacheLock.
+	if err := os.RemoveAll(devIndexFile + ".lock"); err != nil {
+		return "", false, fmt.Errorf("unable to remove stale dev-index lock: %w", err)
+	}
+
 	seeded := true
 	if _, err := os.Stat(devIndexFile); err == nil && devIndexBaseMatches(worktreeCacheDir, expectedBase) {
 		seeded = false
@@ -223,12 +230,15 @@ func resolveTreeSHA(ctx context.Context, serviceWorktreeDir, commit string) (str
 
 // computeConversionConfigSignature captures everything that affects how `git add` converts working
 // tree content into blobs, so a change forces a full reseed instead of silently keeping stale blobs
-// for files whose own content and stat did not change. Read from git in the source worktree's own
-// config context so global filters (e.g. git-lfs's ~/.gitconfig filter.lfs) are included.
-func computeConversionConfigSignature(ctx context.Context, sourceWorktreeDir string) (string, error) {
+// for files whose own content and stat did not change. Config-dependent inputs (filter.*, the
+// global/system attributes locations) are read from serviceWorktreeDir — the same git config
+// context the real `git add` runs in — so a worktree-specific config change cannot slip past the
+// signature; the attribute FILES are enumerated from sourceWorktreeDir, where the working tree and
+// its .gitattributes actually live.
+func computeConversionConfigSignature(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir string) (string, error) {
 	h := sha256.New()
 
-	filterConfig, err := gitConfigFilterValues(ctx, sourceWorktreeDir)
+	filterConfig, err := gitConfigFilterValues(ctx, serviceWorktreeDir)
 	if err != nil {
 		return "", err
 	}
@@ -250,7 +260,7 @@ func computeConversionConfigSignature(ctx context.Context, sourceWorktreeDir str
 		h.Write(content)
 	}
 
-	for _, extra := range extraAttributesFilePaths(ctx, sourceWorktreeDir) {
+	for _, extra := range extraAttributesFilePaths(ctx, sourceWorktreeDir, serviceWorktreeDir) {
 		content, err := os.ReadFile(extra)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
@@ -306,7 +316,7 @@ func worktreeGitattributesFiles(ctx context.Context, sourceWorktreeDir string) (
 	return files, nil
 }
 
-func extraAttributesFilePaths(ctx context.Context, sourceWorktreeDir string) []string {
+func extraAttributesFilePaths(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir string) []string {
 	var paths []string
 
 	gitPathCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "rev-parse", "--git-path", "info/attributes")
@@ -319,18 +329,19 @@ func extraAttributesFilePaths(ctx context.Context, sourceWorktreeDir string) []s
 		}
 	}
 
-	return append(paths, globalAndSystemAttributesFilePaths(ctx, sourceWorktreeDir)...)
+	return append(paths, globalAndSystemAttributesFilePaths(ctx, serviceWorktreeDir)...)
 }
 
 // globalAndSystemAttributesFilePaths returns the per-user and system-wide gitattributes files that
-// git consults during `git add`. git 2.43+ exposes their resolved locations via `git var`
-// (honoring GIT_ATTR_NOSYSTEM and the compiled-in/runtime prefix); on older git the system path is
-// undiscoverable, so fall back to core.attributesFile / the XDG default for the per-user file only.
-func globalAndSystemAttributesFilePaths(ctx context.Context, sourceWorktreeDir string) []string {
+// git consults during `git add`, resolved in the same config context as the real add. git 2.43+
+// exposes their locations via `git var` (honoring GIT_ATTR_NOSYSTEM and the compiled-in/runtime
+// prefix); on older git the system path is undiscoverable, so fall back to core.attributesFile /
+// the XDG default for the per-user file only.
+func globalAndSystemAttributesFilePaths(ctx context.Context, repoDir string) []string {
 	if !gitVersion.LessThan(semver.MustParse("2.43.0")) {
 		var paths []string
 		for _, v := range []string{"GIT_ATTR_SYSTEM", "GIT_ATTR_GLOBAL"} {
-			varCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "var", v)
+			varCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "var", v)
 			if err := varCmd.Run(ctx); err == nil {
 				if p := strings.TrimSpace(varCmd.OutBuf.String()); p != "" {
 					paths = append(paths, p)
@@ -340,7 +351,7 @@ func globalAndSystemAttributesFilePaths(ctx context.Context, sourceWorktreeDir s
 		return paths
 	}
 
-	attrFileCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "config", "--get", "core.attributesFile")
+	attrFileCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "config", "--get", "core.attributesFile")
 	if err := attrFileCmd.Run(ctx); err == nil {
 		if p := strings.TrimSpace(attrFileCmd.OutBuf.String()); p != "" {
 			return []string{expandTilde(p)}

--- a/pkg/true_git/service_branch.go
+++ b/pkg/true_git/service_branch.go
@@ -3,15 +3,23 @@ package true_git
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
+)
 
-	"github.com/werf/common-go/pkg/util"
+const (
+	devIndexFileName     = "dev_index"
+	devIndexBaseFileName = "dev_index_base"
 )
 
 type SyncSourceWorktreeWithServiceBranchOptions struct {
@@ -41,7 +49,7 @@ func SyncSourceWorktreeWithServiceBranch(ctx context.Context, gitDir, sourceWork
 			return fmt.Errorf("unable to remove %s: %w", currentCommitPath, err)
 		}
 
-		resultCommit, err = syncWorktreeWithServiceWorktreeBranch(ctx, sourceWorktreeDir, serviceWorktreeDir, commit, opts.ServiceBranch, opts.GlobExcludeList)
+		resultCommit, err = syncWorktreeWithServiceWorktreeBranch(ctx, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, commit, opts.ServiceBranch, opts.GlobExcludeList)
 		if err != nil {
 			return fmt.Errorf("unable to sync worktree with service branch %q: %w", opts.ServiceBranch, err)
 		}
@@ -54,7 +62,7 @@ func SyncSourceWorktreeWithServiceBranch(ctx context.Context, gitDir, sourceWork
 	return resultCommit, nil
 }
 
-func syncWorktreeWithServiceWorktreeBranch(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir, sourceCommit, branchName string, globExcludeList []string) (string, error) {
+func syncWorktreeWithServiceWorktreeBranch(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, sourceCommit, branchName string, globExcludeList []string) (string, error) {
 	if err := prepareAndCheckoutServiceBranch(ctx, serviceWorktreeDir, sourceCommit, branchName); err != nil {
 		return "", fmt.Errorf("unable to get or prepare service branch head commit: %w", err)
 	}
@@ -64,30 +72,244 @@ func syncWorktreeWithServiceWorktreeBranch(ctx context.Context, sourceWorktreeDi
 		return "", fmt.Errorf("unable to get service worktree commit SHA: %w", err)
 	}
 
-	revertedChangesExist, err := revertExcludedChangesInServiceWorktreeIndex(ctx, sourceWorktreeDir, serviceWorktreeDir, sourceCommit, serviceBranchHeadCommit, globExcludeList)
+	conversionSignature, err := computeConversionConfigSignature(ctx, sourceWorktreeDir)
 	if err != nil {
-		return "", fmt.Errorf("unable to revert excluded changes in service worktree index: %w", err)
+		return "", fmt.Errorf("unable to compute conversion config signature: %w", err)
 	}
 
-	newChangesExist, err := checkNewChangesInSourceWorktreeDir(ctx, sourceWorktreeDir, serviceWorktreeDir, globExcludeList)
+	treeSHA, err := prepareDevIndexAndWriteTree(ctx, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, sourceCommit, serviceBranchHeadCommit, conversionSignature, globExcludeList)
 	if err != nil {
-		return "", fmt.Errorf("unable to check new changes in source worktree: %w", err)
+		// The persistent index may be corrupt or left inconsistent by an interrupted run;
+		// discard it and rebuild once from a clean read-tree seed before surfacing the error.
+		if rmErr := removeDevIndexFiles(worktreeCacheDir); rmErr != nil {
+			return "", fmt.Errorf("unable to discard dev-index after failure (%v): %w", err, rmErr)
+		}
+		treeSHA, err = prepareDevIndexAndWriteTree(ctx, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, sourceCommit, serviceBranchHeadCommit, conversionSignature, globExcludeList)
+		if err != nil {
+			return "", fmt.Errorf("unable to rebuild dev-index after failure: %w", err)
+		}
 	}
 
-	if !revertedChangesExist && !newChangesExist {
+	serviceBranchHeadTree, err := resolveTreeSHA(ctx, serviceWorktreeDir, serviceBranchHeadCommit)
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve service branch head tree: %w", err)
+	}
+
+	if treeSHA == serviceBranchHeadTree {
+		if err := writeDevIndexBase(worktreeCacheDir, serviceBranchHeadCommit, conversionSignature); err != nil {
+			return "", fmt.Errorf("unable to write dev-index base marker: %w", err)
+		}
 		return serviceBranchHeadCommit, nil
 	}
 
-	if err = addNewChangesInServiceWorktreeDir(ctx, sourceWorktreeDir, serviceWorktreeDir, globExcludeList); err != nil {
-		return "", fmt.Errorf("unable to add new changes in service worktree: %w", err)
-	}
-
-	newCommit, err := commitNewChangesInServiceBranch(ctx, serviceWorktreeDir, branchName)
+	newCommit, err := commitTreeToServiceBranch(ctx, serviceWorktreeDir, branchName, treeSHA, serviceBranchHeadCommit)
 	if err != nil {
 		return "", fmt.Errorf("unable to commit new changes in service branch: %w", err)
 	}
 
+	if err := writeDevIndexBase(worktreeCacheDir, newCommit, conversionSignature); err != nil {
+		return "", fmt.Errorf("unable to write dev-index base marker: %w", err)
+	}
+
 	return newCommit, nil
+}
+
+func devIndexFilePath(worktreeCacheDir string) string {
+	return filepath.Join(worktreeCacheDir, devIndexFileName)
+}
+
+func devIndexBaseFilePath(worktreeCacheDir string) string {
+	return filepath.Join(worktreeCacheDir, devIndexBaseFileName)
+}
+
+func removeDevIndexFiles(worktreeCacheDir string) error {
+	if err := os.RemoveAll(devIndexFilePath(worktreeCacheDir)); err != nil {
+		return fmt.Errorf("unable to remove %s: %w", devIndexFilePath(worktreeCacheDir), err)
+	}
+	if err := os.RemoveAll(devIndexBaseFilePath(worktreeCacheDir)); err != nil {
+		return fmt.Errorf("unable to remove %s: %w", devIndexBaseFilePath(worktreeCacheDir), err)
+	}
+	return nil
+}
+
+func devIndexBaseSignature(serviceBranchHeadCommit, conversionSignature string) string {
+	sum := sha256.Sum256([]byte(serviceBranchHeadCommit + "\n" + conversionSignature))
+	return hex.EncodeToString(sum[:])
+}
+
+func writeDevIndexBase(worktreeCacheDir, serviceBranchHeadCommit, conversionSignature string) error {
+	sig := devIndexBaseSignature(serviceBranchHeadCommit, conversionSignature)
+	return os.WriteFile(devIndexBaseFilePath(worktreeCacheDir), []byte(sig+"\n"), 0o644)
+}
+
+func devIndexBaseMatches(worktreeCacheDir, expected string) bool {
+	data, err := os.ReadFile(devIndexBaseFilePath(worktreeCacheDir))
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == expected
+}
+
+// prepareDevIndexAndWriteTree captures the source worktree into the persistent dev-index and
+// returns the resulting tree SHA. The index is (re)seeded from serviceBranchHeadCommit only when
+// its base marker is absent/mismatched (e.g. the service-branch head moved or the add-time
+// conversion config changed), so unchanged files keep matching the source worktree's stat cache
+// and are not re-read or re-hashed.
+func prepareDevIndexAndWriteTree(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir, worktreeCacheDir, sourceCommit, serviceBranchHeadCommit, conversionSignature string, globExcludeList []string) (string, error) {
+	devIndexFile := devIndexFilePath(worktreeCacheDir)
+	expectedBase := devIndexBaseSignature(serviceBranchHeadCommit, conversionSignature)
+
+	needSeed := true
+	if _, err := os.Stat(devIndexFile); err == nil && devIndexBaseMatches(worktreeCacheDir, expectedBase) {
+		needSeed = false
+	}
+	if needSeed {
+		if err := seedDevIndex(ctx, serviceWorktreeDir, devIndexFile, serviceBranchHeadCommit); err != nil {
+			return "", fmt.Errorf("unable to seed dev-index from %s: %w", serviceBranchHeadCommit, err)
+		}
+	}
+
+	if err := revertExcludedChangesInDevIndex(ctx, serviceWorktreeDir, devIndexFile, sourceCommit, serviceBranchHeadCommit, globExcludeList); err != nil {
+		return "", fmt.Errorf("unable to revert excluded changes in dev-index: %w", err)
+	}
+
+	if err := runGitAddCmd(ctx, sourceWorktreeDir, serviceWorktreeDir, devIndexFile, globExcludeList); err != nil {
+		return "", fmt.Errorf("unable to add source worktree changes to dev-index: %w", err)
+	}
+
+	treeSHA, err := writeDevIndexTree(ctx, serviceWorktreeDir, devIndexFile)
+	if err != nil {
+		return "", fmt.Errorf("unable to write tree from dev-index: %w", err)
+	}
+
+	return treeSHA, nil
+}
+
+func seedDevIndex(ctx context.Context, serviceWorktreeDir, devIndexFile, serviceBranchHeadCommit string) error {
+	readTreeCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir, Env: []string{"GIT_INDEX_FILE=" + devIndexFile}}, "read-tree", serviceBranchHeadCommit)
+	if err := readTreeCmd.Run(ctx); err != nil {
+		return fmt.Errorf("git read-tree command failed: %w", err)
+	}
+	return nil
+}
+
+func writeDevIndexTree(ctx context.Context, serviceWorktreeDir, devIndexFile string) (string, error) {
+	writeTreeCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir, Env: []string{"GIT_INDEX_FILE=" + devIndexFile}}, "write-tree")
+	if err := writeTreeCmd.Run(ctx); err != nil {
+		return "", fmt.Errorf("git write-tree command failed: %w", err)
+	}
+	return strings.TrimSpace(writeTreeCmd.OutBuf.String()), nil
+}
+
+func resolveTreeSHA(ctx context.Context, serviceWorktreeDir, commit string) (string, error) {
+	revParseCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir}, "rev-parse", commit+"^{tree}")
+	if err := revParseCmd.Run(ctx); err != nil {
+		return "", fmt.Errorf("git rev-parse tree command failed: %w", err)
+	}
+	return strings.TrimSpace(revParseCmd.OutBuf.String()), nil
+}
+
+// computeConversionConfigSignature captures everything that affects how `git add` converts working
+// tree content into blobs, so a change forces a full reseed instead of silently keeping stale blobs
+// for files whose own content and stat did not change. Read from git in the source worktree's own
+// config context so global filters (e.g. git-lfs's ~/.gitconfig filter.lfs) are included.
+func computeConversionConfigSignature(ctx context.Context, sourceWorktreeDir string) (string, error) {
+	h := sha256.New()
+
+	filterConfig, err := gitConfigFilterValues(ctx, sourceWorktreeDir)
+	if err != nil {
+		return "", err
+	}
+	fmt.Fprintf(h, "filter-config\x00%s\x00", filterConfig)
+
+	attrFiles, err := trackedGitattributesFiles(ctx, sourceWorktreeDir)
+	if err != nil {
+		return "", err
+	}
+	for _, rel := range attrFiles {
+		content, err := os.ReadFile(filepath.Join(sourceWorktreeDir, rel))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return "", fmt.Errorf("unable to read %s: %w", rel, err)
+		}
+		fmt.Fprintf(h, "attr\x00%s\x00", rel)
+		h.Write(content)
+	}
+
+	for _, extra := range extraAttributesFilePaths(ctx, sourceWorktreeDir) {
+		content, err := os.ReadFile(extra)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return "", fmt.Errorf("unable to read %s: %w", extra, err)
+		}
+		fmt.Fprintf(h, "extra-attr\x00%s\x00", extra)
+		h.Write(content)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func gitConfigFilterValues(ctx context.Context, repoDir string) (string, error) {
+	configCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "config", "--get-regexp", "^filter\\.")
+	if err := configCmd.Run(ctx); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return "", nil
+		}
+		return "", fmt.Errorf("git config command failed: %w", err)
+	}
+	return configCmd.OutBuf.String(), nil
+}
+
+func trackedGitattributesFiles(ctx context.Context, sourceWorktreeDir string) ([]string, error) {
+	lsCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "ls-files", "-z", "--", ".gitattributes", ":(glob)**/.gitattributes")
+	if err := lsCmd.Run(ctx); err != nil {
+		return nil, fmt.Errorf("git ls-files command failed: %w", err)
+	}
+	var files []string
+	for _, p := range strings.Split(lsCmd.OutBuf.String(), "\x00") {
+		if p != "" {
+			files = append(files, p)
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func extraAttributesFilePaths(ctx context.Context, sourceWorktreeDir string) []string {
+	var paths []string
+
+	gitPathCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "rev-parse", "--git-path", "info/attributes")
+	if err := gitPathCmd.Run(ctx); err == nil {
+		if p := strings.TrimSpace(gitPathCmd.OutBuf.String()); p != "" {
+			if !filepath.IsAbs(p) {
+				p = filepath.Join(sourceWorktreeDir, p)
+			}
+			paths = append(paths, p)
+		}
+	}
+
+	attrFileCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: sourceWorktreeDir}, "config", "--get", "core.attributesFile")
+	if err := attrFileCmd.Run(ctx); err == nil {
+		if p := strings.TrimSpace(attrFileCmd.OutBuf.String()); p != "" {
+			paths = append(paths, expandTilde(p))
+		}
+	}
+
+	return paths
+}
+
+func expandTilde(path string) string {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, strings.TrimPrefix(path[1:], "/"))
+		}
+	}
+	return path
 }
 
 func prepareAndCheckoutServiceBranch(ctx context.Context, serviceWorktreeDir, sourceCommit, branchName string) error {
@@ -130,9 +352,9 @@ func prepareAndCheckoutServiceBranch(ctx context.Context, serviceWorktreeDir, so
 	return nil
 }
 
-func revertExcludedChangesInServiceWorktreeIndex(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir, sourceCommit, serviceBranchHeadCommit string, globExcludeList []string) (bool, error) {
+func revertExcludedChangesInDevIndex(ctx context.Context, serviceWorktreeDir, devIndexFile, sourceCommit, serviceBranchHeadCommit string, globExcludeList []string) error {
 	if len(globExcludeList) == 0 || serviceBranchHeadCommit == sourceCommit {
-		return false, nil
+		return nil
 	}
 
 	gitDiffArgs := []string{
@@ -147,45 +369,27 @@ func revertExcludedChangesInServiceWorktreeIndex(ctx context.Context, sourceWork
 
 	diffCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir}, gitDiffArgs...)
 	if err := diffCmd.Run(ctx); err != nil {
-		return false, fmt.Errorf("git diff command failed: %w", err)
+		return fmt.Errorf("git diff command failed: %w", err)
 	}
 
 	if diffCmd.OutBuf.Len() == 0 {
-		return false, nil
+		return nil
 	}
 
-	applyCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir}, "apply", "--binary", "--index")
+	applyCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir, Env: []string{"GIT_INDEX_FILE=" + devIndexFile}}, "apply", "--binary", "--cached")
 	applyCmd.Stdin = diffCmd.OutBuf
 	if err := applyCmd.Run(ctx); err != nil {
-		return false, fmt.Errorf("git apply command failed: %w", err)
+		return fmt.Errorf("git apply command failed: %w", err)
 	}
 
-	return true, nil
+	return nil
 }
 
-func checkNewChangesInSourceWorktreeDir(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir string, globExcludeList []string) (bool, error) {
-	output, err := runGitAddCmd(ctx, sourceWorktreeDir, serviceWorktreeDir, globExcludeList, true)
-	if err != nil {
-		return false, err
-	}
-
-	return len(output.Bytes()) != 0, nil
-}
-
-func addNewChangesInServiceWorktreeDir(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir string, globExcludeList []string) error {
-	_, err := runGitAddCmd(ctx, sourceWorktreeDir, serviceWorktreeDir, globExcludeList, false)
-	return err
-}
-
-func runGitAddCmd(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir string, globExcludeList []string, dryRun bool) (*util.GoroutineSafeBuffer, error) {
+func runGitAddCmd(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir, devIndexFile string, globExcludeList []string) error {
 	gitAddArgs := []string{
 		"--work-tree",
 		sourceWorktreeDir,
 		"add",
-	}
-
-	if dryRun {
-		gitAddArgs = append(gitAddArgs, "--dry-run", "--ignore-missing")
 	}
 
 	var pathSpecList []string
@@ -205,29 +409,35 @@ func runGitAddCmd(ctx context.Context, sourceWorktreeDir, serviceWorktreeDir str
 		pathSpecFileBuf = bytes.NewBufferString(strings.Join(pathSpecList, "\000"))
 	}
 
-	addCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir}, gitAddArgs...)
+	addCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir, Env: []string{"GIT_INDEX_FILE=" + devIndexFile}}, gitAddArgs...)
 	if pathSpecFileBuf != nil {
 		addCmd.Stdin = pathSpecFileBuf
 	}
 	if err := addCmd.Run(ctx); err != nil {
-		return nil, err
+		return err
 	}
 
-	return addCmd.OutBuf, nil
+	return nil
 }
 
-func commitNewChangesInServiceBranch(ctx context.Context, serviceWorktreeDir, branchName string) (string, error) {
-	commitCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir}, "-c", "user.email=werf@werf.io", "-c", "user.name=werf", "commit", "--no-verify", "-m", time.Now().String())
-	if err := commitCmd.Run(ctx); err != nil {
-		return "", fmt.Errorf("git commit command failed: %w", err)
+// commitTreeToServiceBranch creates the service commit with plumbing (commit-tree + update-ref)
+// rather than `git commit`: `git commit` would refresh the index against the service worktree,
+// poisoning the source-worktree stat cache the dev-index relies on, and could run repo hooks.
+func commitTreeToServiceBranch(ctx context.Context, serviceWorktreeDir, branchName, treeSHA, parentCommit string) (string, error) {
+	commitTreeCmd := NewGitCmd(
+		ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir},
+		"-c", "user.email=werf@werf.io", "-c", "user.name=werf",
+		"commit-tree", treeSHA, "-p", parentCommit, "-m", time.Now().String(),
+	)
+	if err := commitTreeCmd.Run(ctx); err != nil {
+		return "", fmt.Errorf("git commit-tree command failed: %w", err)
 	}
+	serviceNewCommit := strings.TrimSpace(commitTreeCmd.OutBuf.String())
 
-	revParseCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir}, "rev-parse", branchName)
-	if err := revParseCmd.Run(ctx); err != nil {
-		return "", fmt.Errorf("git rev parse branch command failed: %w", err)
+	updateRefCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir}, "update-ref", "refs/heads/"+branchName, serviceNewCommit)
+	if err := updateRefCmd.Run(ctx); err != nil {
+		return "", fmt.Errorf("git update-ref command failed: %w", err)
 	}
-
-	serviceNewCommit := strings.TrimSpace(revParseCmd.OutBuf.String())
 
 	checkoutCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: serviceWorktreeDir}, "checkout", "--force", "--detach", serviceNewCommit)
 	if err := checkoutCmd.Run(ctx); err != nil {

--- a/pkg/true_git/service_branch_test.go
+++ b/pkg/true_git/service_branch_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -499,8 +500,12 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			Expect(cleanFilterInvocationCount(counterPath)).Should(BeNumerically(">", countAfter1))
 		})
 
-		It("reseeds when filter configuration changes so an unchanged file is re-filtered", func(ctx context.Context) {
+		It("reseeds when an untracked .gitattributes newly filters a stat-unchanged file", func(ctx context.Context) {
 			ctx = logging.WithLogger(ctx)
+
+			// Filter config pre-exists; only an UNTRACKED .gitattributes appears between syncs, so
+			// the reseed must come from hashing worktree (not just index-tracked) .gitattributes.
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "config", "filter.up.clean", "tr 'a-z' 'A-Z'")
 
 			const fRel = "cased_file"
 			fPath := filepath.Join(sourceWorkTreeDir, fRel)
@@ -508,13 +513,15 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "add", fRel)
 			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "-m", "add cased_file")
 			sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
+			past := time.Unix(1, 0)
+			Expect(os.Chtimes(fPath, past, past)).Should(Succeed())
 
 			serviceCommit1, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
 			Expect(err).Should(Succeed())
 			Expect(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "show", serviceCommit1+":"+fRel)).Should(Equal("abc"))
 
+			// Only create the untracked .gitattributes; do NOT touch fPath or git config.
 			utils.WriteFile(filepath.Join(sourceWorkTreeDir, ".gitattributes"), []byte(bigFileRelPath+" filter=count\n"+fRel+" filter=up\n"))
-			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "config", "filter.up.clean", "tr 'a-z' 'A-Z'")
 
 			serviceCommit2, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
 			Expect(err).Should(Succeed())
@@ -570,6 +577,72 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			serviceCommit, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
 			Expect(err).Should(Succeed())
 			Expect(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "show", serviceCommit+":"+rel)).Should(Equal("content"))
+		})
+	})
+
+	When("the source worktree has a submodule", func() {
+		syncOptions := SyncSourceWorktreeWithServiceBranchOptions{ServiceBranch: "_werf-dev"}
+
+		It("records the submodule gitlink in the service commit", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+
+			subRepoDir := filepath.Join(SuiteData.TestDirPath, "submodule-src")
+			utils.MkdirAll(subRepoDir)
+			utils.RunSucceedCommand(ctx, subRepoDir, "git", "-c", "init.defaultBranch=main", "init")
+			utils.WriteFile(filepath.Join(subRepoDir, "subfile"), []byte("sub"))
+			utils.RunSucceedCommand(ctx, subRepoDir, "git", "add", ".")
+			utils.RunSucceedCommand(ctx, subRepoDir, "git", "commit", "-m", "sub init")
+			subHead := utils.GetHeadCommit(ctx, subRepoDir)
+
+			// git blocks file:// submodule transport by default (CVE-2022-39253). werf's internal
+			// `git submodule update` runs without -c overrides but inherits our env, so allow it via
+			// GIT_CONFIG_* which git applies process-wide including to spawned git.
+			GinkgoT().Setenv("GIT_CONFIG_COUNT", "1")
+			GinkgoT().Setenv("GIT_CONFIG_KEY_0", "protocol.file.allow")
+			GinkgoT().Setenv("GIT_CONFIG_VALUE_0", "always")
+
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "submodule", "add", subRepoDir, "sub")
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "-m", "add submodule")
+			sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
+
+			serviceCommit, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+
+			lsTree := utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "ls-tree", serviceCommit, "sub")
+			Expect(lsTree).Should(ContainSubstring("commit " + subHead))
+		})
+	})
+
+	When("validating the service tree against a full git-add snapshot", func() {
+		syncOptions := SyncSourceWorktreeWithServiceBranchOptions{ServiceBranch: "_werf-dev"}
+
+		It("equals an independent full snapshot even with staged and unstaged changes", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+
+			utils.WriteFile(filepath.Join(sourceWorkTreeDir, "staged_file"), []byte("staged"))
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "add", "staged_file")
+			utils.WriteFile(filepath.Join(sourceWorkTreeDir, "unstaged_file"), []byte("unstaged"))
+
+			serviceCommit, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			serviceTree := utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "rev-parse", serviceCommit+"^{tree}")
+
+			// Build the oracle with a disposable index so the user's real index is untouched.
+			oracleEnv := []string{"GIT_INDEX_FILE=" + filepath.Join(SuiteData.TestDirPath, "oracle_index")}
+			runOracle := func(args ...string) string {
+				res, err := utils.RunCommandWithOptions(ctx, sourceWorkTreeDir, "git", args, utils.RunCommandOptions{ExtraEnv: oracleEnv, ShouldSucceed: true, NoStderr: true})
+				Expect(err).Should(Succeed())
+				return string(res)
+			}
+			runOracle("read-tree", sourceHeadCommit)
+			runOracle("add", "--", ":.")
+			oracleTree := runOracle("write-tree")
+
+			Expect(strings.TrimSpace(serviceTree)).Should(Equal(strings.TrimSpace(oracleTree)))
+
+			// staged content is in the snapshot; the user index still shows staged_file staged.
+			Expect(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "show", serviceCommit+":staged_file")).Should(Equal("staged"))
+			Expect(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "show", serviceCommit+":unstaged_file")).Should(Equal("unstaged"))
 		})
 	})
 })

--- a/pkg/true_git/service_branch_test.go
+++ b/pkg/true_git/service_branch_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -527,6 +528,51 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			Expect(err).Should(Succeed())
 			Expect(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "show", serviceCommit2+":"+fRel)).Should(Equal("ABC"))
 		})
+
+		It("reseeds when the global gitattributes file newly filters a stat-unchanged file", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+
+			// git var GIT_ATTR_GLOBAL honors XDG_CONFIG_HOME (git >= 2.43); on older git the
+			// signature falls back to the same XDG default, so both paths are exercised here.
+			xdg := filepath.Join(SuiteData.TestDirPath, "xdg")
+			globalAttrs := filepath.Join(xdg, "git", "attributes")
+			utils.MkdirAll(filepath.Dir(globalAttrs))
+			utils.WriteFile(globalAttrs, []byte(""))
+			GinkgoT().Setenv("XDG_CONFIG_HOME", xdg)
+
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "config", "filter.up.clean", "tr 'a-z' 'A-Z'")
+
+			const fRel = "global_cased"
+			fPath := filepath.Join(sourceWorkTreeDir, fRel)
+			utils.WriteFile(fPath, []byte("abc"))
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "add", fRel)
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "-m", "add global_cased")
+			sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
+			past := time.Unix(1, 0)
+			Expect(os.Chtimes(fPath, past, past)).Should(Succeed())
+
+			serviceCommit1, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "show", serviceCommit1+":"+fRel)).Should(Equal("abc"))
+
+			// Change ONLY the global attributes file content; repo config and file stat unchanged.
+			utils.WriteFile(globalAttrs, []byte(fRel+" filter=up\n"))
+
+			serviceCommit2, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "show", serviceCommit2+":"+fRel)).Should(Equal("ABC"))
+		})
+
+		It("includes the system gitattributes path in the conversion signature (git >= 2.43)", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+			if gitVersion.LessThan(semver.MustParse("2.43.0")) {
+				Skip("git var GIT_ATTR_SYSTEM requires git >= 2.43")
+			}
+
+			systemPath := strings.TrimSpace(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "var", "GIT_ATTR_SYSTEM"))
+			Expect(systemPath).ShouldNot(BeEmpty())
+			Expect(globalAndSystemAttributesFilePaths(ctx, sourceWorkTreeDir)).Should(ContainElement(systemPath))
+		})
 	})
 
 	When("the persistent dev-index is corrupted", func() {
@@ -540,6 +586,21 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			Expect(err).Should(Succeed())
 
 			utils.WriteFile(filepath.Join(workTreeCacheDir, "dev_index"), []byte("corrupt-not-an-index"))
+
+			serviceCommit2, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(serviceCommit2).Should(Equal(serviceCommit1))
+		})
+
+		It("self-heals past a stale dev_index.lock left by a killed run", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+			utils.WriteFile(filepath.Join(sourceWorkTreeDir, "tracked_file"), []byte("state"))
+
+			serviceCommit1, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+
+			// A SIGKILLed git leaves this behind; every later index op would fail to lock.
+			utils.WriteFile(filepath.Join(workTreeCacheDir, "dev_index.lock"), []byte("stale"))
 
 			serviceCommit2, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
 			Expect(err).Should(Succeed())

--- a/pkg/true_git/service_branch_test.go
+++ b/pkg/true_git/service_branch_test.go
@@ -512,7 +512,7 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			fPath := filepath.Join(sourceWorkTreeDir, fRel)
 			utils.WriteFile(fPath, []byte("abc"))
 			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "add", fRel)
-			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "-m", "add cased_file")
+			gitCommitSucceed(ctx, sourceWorkTreeDir, "-m", "add cased_file")
 			sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
 			past := time.Unix(1, 0)
 			Expect(os.Chtimes(fPath, past, past)).Should(Succeed())
@@ -551,7 +551,7 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			fPath := filepath.Join(sourceWorkTreeDir, fRel)
 			utils.WriteFile(fPath, []byte("abc"))
 			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "add", fRel)
-			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "-m", "add global_cased")
+			gitCommitSucceed(ctx, sourceWorkTreeDir, "-m", "add global_cased")
 			sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
 			past := time.Unix(1, 0)
 			Expect(os.Chtimes(fPath, past, past)).Should(Succeed())
@@ -672,7 +672,7 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			utils.RunSucceedCommand(ctx, subRepoDir, "git", "-c", "init.defaultBranch=main", "init")
 			utils.WriteFile(filepath.Join(subRepoDir, "subfile"), []byte("sub"))
 			utils.RunSucceedCommand(ctx, subRepoDir, "git", "add", ".")
-			utils.RunSucceedCommand(ctx, subRepoDir, "git", "commit", "-m", "sub init")
+			gitCommitSucceed(ctx, subRepoDir, "-m", "sub init")
 			subHead := utils.GetHeadCommit(ctx, subRepoDir)
 
 			// git blocks file:// submodule transport by default (CVE-2022-39253). werf's internal
@@ -683,7 +683,7 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			GinkgoT().Setenv("GIT_CONFIG_VALUE_0", "always")
 
 			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "submodule", "add", subRepoDir, "sub")
-			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "-m", "add submodule")
+			gitCommitSucceed(ctx, sourceWorkTreeDir, "-m", "add submodule")
 			sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
 
 			serviceCommit, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)

--- a/pkg/true_git/service_branch_test.go
+++ b/pkg/true_git/service_branch_test.go
@@ -534,11 +534,16 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 
 			// git var GIT_ATTR_GLOBAL honors XDG_CONFIG_HOME (git >= 2.43); on older git the
 			// signature falls back to the same XDG default, so both paths are exercised here.
+			// Isolate from the host's real global config, which could set core.attributesFile and
+			// redirect GIT_ATTR_GLOBAL away from our XDG file.
 			xdg := filepath.Join(SuiteData.TestDirPath, "xdg")
 			globalAttrs := filepath.Join(xdg, "git", "attributes")
 			utils.MkdirAll(filepath.Dir(globalAttrs))
 			utils.WriteFile(globalAttrs, []byte(""))
 			GinkgoT().Setenv("XDG_CONFIG_HOME", xdg)
+			emptyGlobalConfig := filepath.Join(SuiteData.TestDirPath, "empty_global_gitconfig")
+			utils.WriteFile(emptyGlobalConfig, []byte(""))
+			GinkgoT().Setenv("GIT_CONFIG_GLOBAL", emptyGlobalConfig)
 
 			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "config", "filter.up.clean", "tr 'a-z' 'A-Z'")
 
@@ -570,7 +575,9 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			}
 
 			systemPath := strings.TrimSpace(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "var", "GIT_ATTR_SYSTEM"))
-			Expect(systemPath).ShouldNot(BeEmpty())
+			if systemPath == "" {
+				Skip("system gitattributes disabled (GIT_ATTR_NOSYSTEM)")
+			}
 			Expect(globalAndSystemAttributesFilePaths(ctx, sourceWorkTreeDir)).Should(ContainElement(systemPath))
 		})
 	})
@@ -605,6 +612,19 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 			serviceCommit2, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
 			Expect(err).Should(Succeed())
 			Expect(serviceCommit2).Should(Equal(serviceCommit1))
+		})
+
+		It("self-heals past a stale dev_index.lock left by a killed COLD run", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+			utils.WriteFile(filepath.Join(sourceWorkTreeDir, "tracked_file"), []byte("state"))
+
+			// No prior successful sync: marker absent ⇒ next sync takes the cold seed path, where
+			// the warm retry-with-rebuild does not run. A stale lock here must still be cleared.
+			utils.WriteFile(filepath.Join(workTreeCacheDir, "dev_index.lock"), []byte("stale"))
+
+			serviceCommit, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(serviceCommit).ShouldNot(Equal(sourceHeadCommit))
 		})
 	})
 

--- a/pkg/true_git/service_branch_test.go
+++ b/pkg/true_git/service_branch_test.go
@@ -3,7 +3,9 @@ package true_git
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -12,6 +14,14 @@ import (
 	"github.com/werf/werf/v2/pkg/werf"
 	"github.com/werf/werf/v2/test/pkg/utils"
 )
+
+func cleanFilterInvocationCount(counterPath string) int {
+	data, err := os.ReadFile(counterPath)
+	if err != nil {
+		return 0
+	}
+	return len(data)
+}
 
 var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 	var sourceWorkTreeDir string
@@ -447,6 +457,119 @@ var _ = Describe("SyncSourceWorktreeWithServiceBranch", func() {
 
 			output := string(bytes)
 			Expect(output).Should(ContainSubstring(fmt.Sprintf("'%s' exists on disk, but not in '%s'", untrackedFileRelPath, serviceCommit)))
+		})
+	})
+
+	When("a clean filter is configured", func() {
+		const bigFileRelPath = "bigfile"
+		var counterPath string
+		syncOptions := SyncSourceWorktreeWithServiceBranchOptions{ServiceBranch: "_werf-dev"}
+
+		BeforeEach(func(ctx SpecContext) {
+			counterPath = filepath.Join(SuiteData.TestDirPath, "clean_count")
+			utils.WriteFile(filepath.Join(sourceWorkTreeDir, ".gitattributes"), []byte(bigFileRelPath+" filter=count\n"))
+			bigFilePath := filepath.Join(sourceWorkTreeDir, bigFileRelPath)
+			utils.WriteFile(bigFilePath, []byte("payload"))
+			// Push mtime into the past so the first sync's index is not "racily clean":
+			// git re-hashes entries whose mtime is not older than the index timestamp, which
+			// would otherwise re-invoke the clean filter on the unchanged second sync.
+			past := time.Unix(1, 0)
+			Expect(os.Chtimes(bigFilePath, past, past)).Should(Succeed())
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "config", "filter.count.clean", fmt.Sprintf("printf x >> '%s'; cat", counterPath))
+		})
+
+		It("does not re-run the clean filter on an unchanged second sync (#4754)", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+
+			serviceCommit1, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			countAfter1 := cleanFilterInvocationCount(counterPath)
+			Expect(countAfter1).Should(BeNumerically(">", 0))
+
+			serviceCommit2, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(serviceCommit2).Should(Equal(serviceCommit1))
+			Expect(cleanFilterInvocationCount(counterPath)).Should(Equal(countAfter1))
+
+			utils.WriteFile(filepath.Join(sourceWorkTreeDir, bigFileRelPath), []byte("payload-modified"))
+
+			serviceCommit3, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(serviceCommit3).ShouldNot(Equal(serviceCommit1))
+			Expect(cleanFilterInvocationCount(counterPath)).Should(BeNumerically(">", countAfter1))
+		})
+
+		It("reseeds when filter configuration changes so an unchanged file is re-filtered", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+
+			const fRel = "cased_file"
+			fPath := filepath.Join(sourceWorkTreeDir, fRel)
+			utils.WriteFile(fPath, []byte("abc"))
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "add", fRel)
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "commit", "-m", "add cased_file")
+			sourceHeadCommit = utils.GetHeadCommit(ctx, sourceWorkTreeDir)
+
+			serviceCommit1, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "show", serviceCommit1+":"+fRel)).Should(Equal("abc"))
+
+			utils.WriteFile(filepath.Join(sourceWorkTreeDir, ".gitattributes"), []byte(bigFileRelPath+" filter=count\n"+fRel+" filter=up\n"))
+			utils.RunSucceedCommand(ctx, sourceWorkTreeDir, "git", "config", "filter.up.clean", "tr 'a-z' 'A-Z'")
+
+			serviceCommit2, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "show", serviceCommit2+":"+fRel)).Should(Equal("ABC"))
+		})
+	})
+
+	When("the persistent dev-index is corrupted", func() {
+		syncOptions := SyncSourceWorktreeWithServiceBranchOptions{ServiceBranch: "_werf-dev"}
+
+		It("self-heals and produces the same commit", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+			utils.WriteFile(filepath.Join(sourceWorkTreeDir, "tracked_file"), []byte("state"))
+
+			serviceCommit1, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+
+			utils.WriteFile(filepath.Join(workTreeCacheDir, "dev_index"), []byte("corrupt-not-an-index"))
+
+			serviceCommit2, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(serviceCommit2).Should(Equal(serviceCommit1))
+		})
+	})
+
+	When("a failing repository pre-commit hook is installed", func() {
+		syncOptions := SyncSourceWorktreeWithServiceBranchOptions{ServiceBranch: "_werf-dev"}
+
+		It("does not run the hook during sync", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+			utils.MkdirAll(filepath.Join(gitDir, "hooks"))
+			hookPath := filepath.Join(gitDir, "hooks", "pre-commit")
+			utils.WriteFile(hookPath, []byte("#!/bin/sh\nexit 1\n"))
+			Expect(os.Chmod(hookPath, 0o755)).Should(Succeed())
+
+			utils.WriteFile(filepath.Join(sourceWorkTreeDir, "tracked_file"), []byte("state"))
+
+			serviceCommit, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(serviceCommit).ShouldNot(Equal(sourceHeadCommit))
+		})
+	})
+
+	When("paths contain spaces and unicode", func() {
+		syncOptions := SyncSourceWorktreeWithServiceBranchOptions{ServiceBranch: "_werf-dev"}
+
+		It("captures them into the service commit", func(ctx context.Context) {
+			ctx = logging.WithLogger(ctx)
+			const rel = "dir with space/файл.txt"
+			utils.MkdirAll(filepath.Join(sourceWorkTreeDir, "dir with space"))
+			utils.WriteFile(filepath.Join(sourceWorkTreeDir, rel), []byte("content"))
+
+			serviceCommit, err := SyncSourceWorktreeWithServiceBranch(ctx, gitDir, sourceWorkTreeDir, workTreeCacheDir, sourceHeadCommit, syncOptions)
+			Expect(err).Should(Succeed())
+			Expect(utils.SucceedCommandOutputString(ctx, sourceWorkTreeDir, "git", "show", serviceCommit+":"+rel)).Should(Equal("content"))
 		})
 	})
 })


### PR DESCRIPTION
## What

Fixes [#4754](https://github.com/werf/werf/issues/4754): `werf build --dev` (and other `--dev` commands) is unusably slow on large working trees — minutes spent "doing nothing" on every run even when nothing changed, dramatically worse with git-lfs (reporter: 30GB re-read → 5 min).

## Why

Dev mode snapshots the working tree into a synthetic "service branch" commit. To do so it ran `git add` against the **service worktree's** index, whose stat-cache was captured on a *different physical worktree* than the user's. Git's `ce_match_stat` therefore flagged **every** file as possibly-changed and re-read/re-hashed the whole tree on every run; with git-lfs each file was also pushed through the `git-lfs clean` filter (full-content read). Cost scaled with total worktree size, not with what actually changed — and the closing `git checkout --force --detach` reset the index straight back, so the next run was just as slow.

## How

Capture the working tree through a **persistent, cache-owned dedicated index** (`dev_index` under the worktree cache dir, passed via `GIT_INDEX_FILE`):

- Seeded once from the service-branch head via `git read-tree`, then kept warm across runs so unchanged files stat-match the user worktree and are **never re-read / re-cleaned / re-hashed**.
- Change detection is a single real `git add` + `git write-tree` compared against the service-branch-head tree (the old `--dry-run` detection is removed — a dry-run add does not persist refreshed stat data).
- Commits are built by plumbing (`git commit-tree` + `update-ref`) rather than `git commit`, which would re-stat the index against the service worktree and poison the warm cache (and could run hooks).
- The index is reseeded when the service-branch head moves **or** the effective add-time conversion config changes — `filter.*` plus the worktree / `info/attributes` / per-user / system `.gitattributes` (resolved via `git var GIT_ATTR_SYSTEM`/`GIT_ATTR_GLOBAL` on git ≥ 2.43, with a `core.attributesFile`/XDG fallback below). Config-dependent inputs are read in the same git context `git add` uses.
- Self-heals: a corrupt index or a stale `dev_index.lock` left by a SIGKILLed run (werf escalates SIGTERM→SIGKILL after its 5-minute `WaitDelay`) is discarded and rebuilt rather than wedging dev mode.

The resulting service-commit **tree** stays byte-identical to today's full-`git add` snapshot for the same working-tree state; the first run is still a full hash, the win is on subsequent runs. No user-facing behavior, CLI flags, or the `OpenLocalRepo` contract change. `--dev-ignore` glob excludes, submodules, giterminism, and precommit-hook bypass are preserved.

## Tests

New Ginkgo specs in `pkg/true_git/service_branch_test.go`:

- **#4754 regression**: a counting clean filter proves an unchanged second sync invokes the filter **zero** times (and a real change invokes it again). Confirmed to fail against the pre-change implementation.
- Invalidation: reseed when an untracked `.gitattributes`, the global attributes file, or (asserted directly) the system attributes path changes.
- Self-heal: corrupt index; stale `dev_index.lock` on both the warm and the cold/seed path.
- Correctness: submodule gitlink; a disposable-index full-`git add` tree oracle for staged+unstaged state; plumbing commit runs no repo hook; unicode/space paths.

`task build`, `task lint:golangci-lint`, and `task test:unit` (62/62) pass.

## Notes

- The git < 2.25 positional-pathspec fallback in `runGitAddCmd` is preserved verbatim (only the dry-run sub-branch removed) but is not separately exercised in CI (CI git ≥ 2.25).
- The pre-existing service-worktree default `index.lock` has the same theoretical stale-lock exposure and is out of scope here — worth a follow-up.
