### PR TITLE
fix(dev): self-heal a stale worktree index.lock left by a killed run

### DIFF
--- a/pkg/true_git/work_tree.go
+++ b/pkg/true_git/work_tree.go
@@ -208,6 +208,26 @@ func prepareWorkTree(ctx context.Context, repoDir, workTreeCacheDir, commit stri
 	return workTreeDir, nil
 }
 
+func removeStaleIndexLock(ctx context.Context, workTreeDir string) error {
+	gitPathCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "rev-parse", "--git-path", "index.lock")
+	if err := gitPathCmd.Run(ctx); err != nil {
+		return fmt.Errorf("git rev-parse git-path command failed: %w", err)
+	}
+
+	lockPath := strings.TrimSpace(gitPathCmd.OutBuf.String())
+	if lockPath == "" {
+		return nil
+	}
+	if !filepath.IsAbs(lockPath) {
+		lockPath = filepath.Join(workTreeDir, lockPath)
+	}
+
+	if err := os.RemoveAll(lockPath); err != nil {
+		return fmt.Errorf("unable to remove stale index lock %s: %w", lockPath, err)
+	}
+	return nil
+}
+
 func verifyWorkTreeConsistency(ctx context.Context, repoDir, workTreeDir string) (bool, error) {
 	dotGitFilePath := filepath.Join(workTreeDir, ".git")
 
@@ -271,6 +291,14 @@ func switchWorkTree(ctx context.Context, repoDir, workTreeDir, commit string, wi
 	case err != nil:
 		return fmt.Errorf("error accessing %s: %w", workTreeDir, err)
 	default:
+		// A SIGKILLed git (werf escalates SIGTERM to SIGKILL after WaitDelay) can leave a stale
+		// index.lock in the cached worktree, which would fail every subsequent checkout/reset.
+		// Drop it before reusing the worktree; safe because the whole flow runs under
+		// withWorkTreeCacheLock, so no live git legitimately holds it.
+		if err = removeStaleIndexLock(ctx, workTreeDir); err != nil {
+			return err
+		}
+
 		checkoutCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "checkout", "--force", "--detach", commit)
 		if err = checkoutCmd.Run(ctx); err != nil {
 			return fmt.Errorf("git checkout command failed: %w", err)

--- a/pkg/true_git/work_tree_test.go
+++ b/pkg/true_git/work_tree_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -66,6 +67,33 @@ var _ = Describe("Work tree helpers", func() {
 
 				Expect(switchWorkTree(ctx, mainWtDir, sideWtDir, commit, false)).To(Succeed())
 			})
+		})
+	})
+
+	When("a stale index.lock is left in a cached worktree", func() {
+		var mainWtDir, sideWtDir string
+
+		BeforeEach(func(ctx SpecContext) {
+			mainWtDir = filepath.Join(SuiteData.TestDirPath, "main-wt")
+			sideWtDir = filepath.Join(SuiteData.TestDirPath, "side-wt")
+
+			Expect(os.MkdirAll(mainWtDir, os.ModePerm)).To(Succeed())
+			utils.RunSucceedCommand(ctx, mainWtDir, "git", "-c", "init.defaultBranch=main", "init")
+			utils.RunSucceedCommand(ctx, mainWtDir, "git", "checkout", "-b", "main")
+			gitCommitSucceed(ctx, mainWtDir, "--allow-empty", "-m", "Initial commit")
+			utils.RunSucceedCommand(ctx, mainWtDir, "git", "worktree", "add", "--detach", sideWtDir)
+		})
+
+		It("self-heals and switches the worktree", func(ctx SpecContext) {
+			commit := getHeadCommit(ctx, mainWtDir)
+
+			lockPath := strings.TrimSpace(utils.SucceedCommandOutputString(ctx, sideWtDir, "git", "rev-parse", "--git-path", "index.lock"))
+			if !filepath.IsAbs(lockPath) {
+				lockPath = filepath.Join(sideWtDir, lockPath)
+			}
+			Expect(os.WriteFile(lockPath, []byte("stale"), 0o644)).To(Succeed())
+
+			Expect(switchWorkTree(ctx, mainWtDir, sideWtDir, commit, false)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
## What

Self-heal a stale `index.lock` left in a cached service worktree by a killed run.

## Why

`switchWorkTree` reuses a cached worktree via `git checkout --force --detach` + `git reset --hard`, both of which take the worktree's `index.lock`. git does **not** clean that lock on `SIGKILL`, and werf escalates `SIGTERM` → `SIGKILL` after its 5-minute `WaitDelay` (`pkg/werf/exec/cancel.go`). So a run interrupted during checkout/reset (e.g. a user Ctrl-C on a slow build) leaves a stale `index.lock`, and every subsequent run then fails at checkout with no recovery path — the user has to manually delete a file inside werf's internal cache dir.

This is the same failure class as the dev-index lock self-heal; this PR covers the pre-existing exposure on the ordinary cached-worktree path.

## How

Before reusing an existing cached worktree, remove a stale `index.lock` (resolved via `git rev-parse --git-path index.lock`). Safe because the whole flow runs under `withWorkTreeCacheLock`, so no live git legitimately holds that lock across werf runs. No behavior change on the happy path.

## Tests

New Ginkgo spec in `pkg/true_git/work_tree_test.go`: plant a stale `index.lock` in a cached worktree, then assert `switchWorkTree` succeeds. Confirmed to fail against the pre-change code and pass with the fix. `task build`, `task lint:golangci-lint` (0 issues), `task test:unit` (52/52) pass.
