### PR TITLE
fix(build): stop re-fetching submodules the checkout already has

### DIFF
--- a/pkg/true_git/helpers_ai_test.go
+++ b/pkg/true_git/helpers_ai_test.go
@@ -1,6 +1,7 @@
 package true_git
 
 import (
+	"os"
 	"os/exec"
 	"testing"
 
@@ -13,6 +14,15 @@ func runGitAI(t *testing.T, dir string, args ...string) string {
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git %v: %s", args, out)
 	return string(out)
+}
+
+// isolateGitConfigAI detaches the test from the developer's global/system git config, so an ambient
+// setting (notably protocol.file.allow=always) cannot mask a missing production option.
+func isolateGitConfigAI(t *testing.T) {
+	t.Helper()
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	t.Setenv("GIT_TERMINAL_PROMPT", "0")
 }
 
 func initGitRepoAI(t *testing.T, dir string) {

--- a/pkg/true_git/helpers_ai_test.go
+++ b/pkg/true_git/helpers_ai_test.go
@@ -1,7 +1,6 @@
 package true_git
 
 import (
-	"os"
 	"os/exec"
 	"testing"
 
@@ -14,15 +13,6 @@ func runGitAI(t *testing.T, dir string, args ...string) string {
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git %v: %s", args, out)
 	return string(out)
-}
-
-// isolateGitConfigAI detaches the test from the developer's global/system git config, so an ambient
-// setting (notably protocol.file.allow=always) cannot mask a missing production option.
-func isolateGitConfigAI(t *testing.T) {
-	t.Helper()
-	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
-	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
-	t.Setenv("GIT_TERMINAL_PROMPT", "0")
 }
 
 func initGitRepoAI(t *testing.T, dir string) {

--- a/pkg/true_git/helpers_test.go
+++ b/pkg/true_git/helpers_test.go
@@ -2,6 +2,12 @@ package true_git
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/werf/werf/v2/test/pkg/utils"
 )
@@ -17,4 +23,69 @@ func gitCommitSucceed(ctx context.Context, workTreeDir string, args ...string) {
 		"-c", "user.name=werf",
 		"commit",
 	}, args...)...)
+}
+
+func gitSucceed(ctx context.Context, dir string, args ...string) string {
+	return utils.SucceedCommandOutputString(ctx, dir, "git", append([]string{
+		"-c", "commit.gpgsign=false",
+		"-c", "user.email=werf@werf.io",
+		"-c", "user.name=werf",
+	}, args...)...)
+}
+
+func gitSucceedTrimmed(ctx context.Context, dir string, args ...string) string {
+	return strings.TrimSpace(gitSucceed(ctx, dir, args...))
+}
+
+func gitSucceedWithStdin(ctx context.Context, dir, stdin string, args ...string) string {
+	out, err := utils.RunCommandWithOptions(ctx, dir, "git", args, utils.RunCommandOptions{
+		ToStdin:       stdin,
+		ShouldSucceed: true,
+		NoStderr:      true,
+	})
+	Expect(err).ToNot(HaveOccurred())
+	return strings.TrimSpace(string(out))
+}
+
+func gitInitRepo(ctx context.Context, dir string) {
+	utils.MkdirAll(dir)
+	gitSucceed(ctx, dir, "-c", "init.defaultBranch=main", "init")
+	gitSucceed(ctx, dir, "commit", "--allow-empty", "-m", "init")
+}
+
+// setEnvForSpec sets an environment variable for the duration of the current spec. Specs of one
+// Ginkgo process run serially, so a process-wide variable restored on teardown stays contained.
+func setEnvForSpec(key, value string) {
+	previous, had := os.LookupEnv(key)
+	Expect(os.Setenv(key, value)).To(Succeed())
+	DeferCleanup(func() {
+		if had {
+			Expect(os.Setenv(key, previous)).To(Succeed())
+			return
+		}
+		Expect(os.Unsetenv(key)).To(Succeed())
+	})
+}
+
+// isolateGitConfig detaches the spec from the developer's global and system git config, so an
+// ambient setting (notably protocol.file.allow=always) cannot mask a missing production option.
+func isolateGitConfig() {
+	setEnvForSpec("GIT_CONFIG_GLOBAL", os.DevNull)
+	setEnvForSpec("GIT_CONFIG_SYSTEM", os.DevNull)
+	setEnvForSpec("GIT_TERMINAL_PROMPT", "0")
+}
+
+func gitAddSubmoduleSucceed(ctx context.Context, superRepoDir, url, path string) {
+	gitSucceed(ctx, superRepoDir, "-c", "protocol.file.allow=always", "submodule", "add", url, path)
+}
+
+func gitUpdateSubmodulesSucceed(ctx context.Context, repoDir string, args ...string) {
+	gitSucceed(ctx, repoDir, append([]string{"-c", "protocol.file.allow=always", "submodule", "update"}, args...)...)
+}
+
+func gitInitRepoWithFile(ctx context.Context, dir, fileName, content string) {
+	gitInitRepo(ctx, dir)
+	Expect(os.WriteFile(filepath.Join(dir, fileName), []byte(content), 0o644)).To(Succeed())
+	gitSucceed(ctx, dir, "add", ".")
+	gitSucceed(ctx, dir, "commit", "-m", "content")
 }

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -147,6 +147,11 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 			return nil, nil, err
 		}
 		if fetchURL == "" {
+			blockers = append(blockers, fmt.Sprintf("%s (submodule has no remote URL to redirect)", node.displayPath))
+			continue
+		}
+		// An earlier run already recorded the store as the remote, so the fetch is local as is.
+		if fetchURL == node.moduleDir {
 			continue
 		}
 		if _, ok := seenURL[fetchURL]; ok {
@@ -155,6 +160,16 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 		}
 		seenURL[fetchURL] = struct{}{}
 		fetchURLs[node.displayPath] = fetchURL
+	}
+
+	// insteadOf matches by prefix, so a remote URL that prefixes one of the store paths would also
+	// rewrite the store URL the clone path relies on.
+	for _, fetchURL := range fetchURLs {
+		for _, node := range nodes {
+			if strings.HasPrefix(node.moduleDir, fetchURL) {
+				blockers = append(blockers, fmt.Sprintf("%s (remote URL prefixes the local object store path)", node.displayPath))
+			}
+		}
 	}
 
 	if len(blockers) > 0 {
@@ -222,9 +237,14 @@ func walkSubmodule(ctx context.Context, parentModuleDir, parentWorktreeModuleDir
 		return nil
 	}
 
-	worktreeModuleDir := filepath.Join(parentWorktreeModuleDir, "modules", name)
-	if _, err := os.Stat(worktreeModuleDir); err != nil {
-		worktreeModuleDir = ""
+	// Absent parent means the whole subtree is unpopulated in the service worktree; keep the empty
+	// marker instead of joining onto it, which would yield a relative path probed against the CWD.
+	var worktreeModuleDir string
+	if parentWorktreeModuleDir != "" {
+		candidate := filepath.Join(parentWorktreeModuleDir, "modules", name)
+		if _, err := os.Stat(candidate); err == nil {
+			worktreeModuleDir = candidate
+		}
 	}
 
 	*nodes = append(*nodes, submoduleNode{

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -37,14 +37,14 @@ func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 			return err
 		}
 
-		localURLOpts, remoteOnly, err := submoduleLocalURLOverrides(ctx, workTreeDir)
+		localURLOpts, blockers, err := submoduleLocalURLOverrides(ctx, workTreeDir)
 		if err != nil {
 			return err
 		}
-		if len(remoteOnly) > 0 {
+		if len(blockers) > 0 {
 			logboek.Context(ctx).Warn().LogF(
-				"WARNING: submodules %s are not present in the local object store and will be fetched from their remotes (credentials may be requested).\nRun `git submodule update --init --recursive` in your working tree beforehand so werf reuses the local objects and touches no network.\n",
-				strings.Join(remoteOnly, ", "),
+				"WARNING: unable to reuse local git objects for submodules: %s.\nAll submodules will be checked out from their remotes, which may request credentials. Run `git submodule update --init --recursive` in your working tree beforehand to let werf reuse the local objects instead.\n",
+				strings.Join(blockers, ", "),
 			)
 		}
 
@@ -53,6 +53,8 @@ func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 		if len(localURLOpts) > 0 {
 			// The overrides point submodule URLs at the on-disk module store, which git clones over
 			// the file transport — blocked by the default protocol.file.allow=user for submodules.
+			// Safe only because overrides are all-or-nothing: every URL used by this invocation is
+			// then a path werf computed itself, never one taken from committed .gitmodules.
 			updateArgs = append(updateArgs, "-c", "protocol.file.allow=always")
 			updateArgs = append(updateArgs, localURLOpts...)
 		}
@@ -73,18 +75,21 @@ type submoduleNode struct {
 	moduleDir   string
 }
 
-// submoduleLocalURLOverrides walks the superproject's submodules recursively and, for those whose
-// pinned commit is already present in the local module store (<parent-module-dir>/modules/<name>,
-// rooted at <git-common-dir>), returns `-c submodule.<name>.url=<local-path>` overrides so
-// `git submodule update --recursive` clones them from those local objects instead of their remotes
-// — no network, no credentials. These -c options propagate to the nested update invocations via
-// GIT_CONFIG_PARAMETERS, so nested submodules are covered too. Submodules missing locally keep
-// their remote URL and are returned in remoteOnly so the caller can warn they will be fetched.
+// submoduleLocalURLOverrides walks the superproject's submodules recursively and, when EVERY
+// submodule's pinned commit is already present in the local module store
+// (<parent-module-dir>/modules/<name>, rooted at <git-common-dir>), returns
+// `-c submodule.<name>.url=<local-path>` overrides so `git submodule update --recursive` checks them
+// all out from those local objects instead of their remotes — no network, no credentials. These -c
+// options propagate into the nested update invocations via GIT_CONFIG_PARAMETERS.
 //
-// A submodule.<name>.url override is global to the git process, so when the same submodule name
-// occurs more than once at different module dirs it cannot be expressed unambiguously; such names
-// are dropped from the overrides and fall back to their remotes instead of risking a wrong source.
-func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overrides, remoteOnly []string, err error) {
+// The overrides are deliberately all-or-nothing: whatever cannot be served locally is reported in
+// blockers and NO override is emitted, leaving the plain remote update werf has always done. Partial
+// reuse is unsafe because `submodule.<name>.url` is global to the git process, so an override for one
+// submodule also redirects a same-named submodule elsewhere in the tree — and a subtree that is not
+// available locally cannot be enumerated at all, so such a collision could not even be detected.
+// All-or-nothing additionally keeps `protocol.file.allow=always`, which the local paths require, from
+// ever applying to a URL werf did not compute itself.
+func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overrides, blockers []string, err error) {
 	names, paths, err := parseGitmodulesPaths(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "config", "-f", ".gitmodules")
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to list submodules: %w", err)
@@ -98,46 +103,68 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 		return nil, nil, err
 	}
 
-	var localNodes []submoduleNode
+	var nodes []submoduleNode
 	for i, name := range names {
 		pinnedCommit, err := lsTreeGitlink(ctx, workTreeDir, "HEAD", paths[i])
 		if err != nil {
 			return nil, nil, err
 		}
-		if err := walkSubmodule(ctx, commonDir, name, paths[i], pinnedCommit, &localNodes, &remoteOnly); err != nil {
+		if err := walkSubmodule(ctx, commonDir, name, paths[i], pinnedCommit, &nodes, &blockers); err != nil {
 			return nil, nil, err
 		}
 	}
 
-	nameCount := make(map[string]int, len(localNodes))
-	for _, node := range localNodes {
-		nameCount[node.name]++
-	}
-	for _, node := range localNodes {
-		if nameCount[node.name] == 1 {
-			overrides = append(overrides, "-c", "submodule."+node.name+".url="+node.moduleDir)
-		} else {
-			remoteOnly = append(remoteOnly, node.displayPath)
+	seen := make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		if _, ok := seen[node.name]; ok {
+			blockers = append(blockers, fmt.Sprintf("%s (submodule name %q is used more than once)", node.displayPath, node.name))
 		}
+		seen[node.name] = struct{}{}
 	}
 
-	return overrides, remoteOnly, nil
+	if len(blockers) > 0 {
+		return nil, blockers, nil
+	}
+
+	for _, node := range nodes {
+		overrides = append(overrides, "-c", "submodule."+node.name+".url="+node.moduleDir)
+	}
+
+	return overrides, nil, nil
 }
 
 // walkSubmodule resolves one submodule against the local module store and recurses into its nested
 // submodules, reading their definitions from the module store at the pinned commit (no checkout
 // needed). parentModuleDir is the git dir whose modules/<name> hosts this submodule's store.
-func walkSubmodule(ctx context.Context, parentModuleDir, name, displayPath, pinnedCommit string, localNodes *[]submoduleNode, remoteOnly *[]string) error {
+func walkSubmodule(ctx context.Context, parentModuleDir, name, displayPath, pinnedCommit string, nodes *[]submoduleNode, blockers *[]string) error {
+	// A .gitmodules entry without a gitlink in the tree is not checked out by git either.
 	if pinnedCommit == "" {
+		return nil
+	}
+
+	if submoduleNameUnsafe(name) {
+		*blockers = append(*blockers, fmt.Sprintf("%s (unsupported submodule name %q)", displayPath, name))
 		return nil
 	}
 
 	moduleDir := filepath.Join(parentModuleDir, "modules", name)
 	if !moduleStoreHasCommit(ctx, moduleDir, pinnedCommit) {
-		*remoteOnly = append(*remoteOnly, displayPath)
+		*blockers = append(*blockers, fmt.Sprintf("%s (not initialized locally)", displayPath))
 		return nil
 	}
-	*localNodes = append(*localNodes, submoduleNode{name: name, displayPath: displayPath, moduleDir: moduleDir})
+
+	// A partial clone can hold the commit while its blobs still live on the promisor remote, so
+	// cloning from it would fail or need the network — exactly what reuse is meant to avoid.
+	isPartial, err := moduleStoreIsPartial(ctx, moduleDir)
+	if err != nil {
+		return err
+	}
+	if isPartial {
+		*blockers = append(*blockers, fmt.Sprintf("%s (local clone is partial)", displayPath))
+		return nil
+	}
+
+	*nodes = append(*nodes, submoduleNode{name: name, displayPath: displayPath, moduleDir: moduleDir})
 
 	nestedNames, nestedPaths, err := parseGitmodulesPaths(ctx, &GitCmdOptions{RepoDir: moduleDir}, "config", "--blob", pinnedCommit+":.gitmodules")
 	if err != nil {
@@ -148,12 +175,35 @@ func walkSubmodule(ctx context.Context, parentModuleDir, name, displayPath, pinn
 		if err != nil {
 			return err
 		}
-		if err := walkSubmodule(ctx, moduleDir, nestedName, displayPath+"/"+nestedPaths[i], nestedPin, localNodes, remoteOnly); err != nil {
+		if err := walkSubmodule(ctx, moduleDir, nestedName, displayPath+"/"+nestedPaths[i], nestedPin, nodes, blockers); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// submoduleNameUnsafe rejects names that cannot be expressed safely as a `-c submodule.<name>.url`
+// option or that would resolve outside the module store: `=` terminates the config key early and
+// would set an unrelated option, and separators or `.`/`..` components would move the resolved path.
+// .gitmodules is repo-controlled and `git config -f` does not reject these itself.
+func submoduleNameUnsafe(name string) bool {
+	if strings.ContainsAny(name, "=\n/\\") {
+		return true
+	}
+	return name == "." || name == ".."
+}
+
+func moduleStoreIsPartial(ctx context.Context, moduleDir string) (bool, error) {
+	configCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: moduleDir}, "config", "--get-regexp", "^(extensions\\.partialclone|remote\\..*\\.(promisor|partialclonefilter))$")
+	if err := configCmd.Run(ctx); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("git config command failed: %w", err)
+	}
+	return configCmd.OutBuf.Len() > 0, nil
 }
 
 // parseGitmodulesPaths runs a `git config ... -z --get-regexp \.path$` over a .gitmodules source
@@ -192,7 +242,7 @@ func parseGitmodulesPaths(ctx context.Context, opts *GitCmdOptions, configArgs .
 }
 
 func lsTreeGitlink(ctx context.Context, repoDir, treeish, submodulePath string) (string, error) {
-	lsTreeCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "ls-tree", treeish, "--", submodulePath)
+	lsTreeCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "ls-tree", treeish, "--", ":(literal)"+submodulePath)
 	if err := lsTreeCmd.Run(ctx); err != nil {
 		return "", fmt.Errorf("git ls-tree command failed: %w", err)
 	}
@@ -208,7 +258,8 @@ func moduleStoreHasCommit(ctx context.Context, moduleDir, commit string) bool {
 	if _, err := os.Stat(moduleDir); err != nil {
 		return false
 	}
-	catFileCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: moduleDir}, "cat-file", "-e", commit+"^{commit}")
+	// GIT_NO_LAZY_FETCH keeps the probe itself from reaching out to a promisor remote (git 2.41+).
+	catFileCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: moduleDir, Env: []string{"GIT_NO_LAZY_FETCH=1"}}, "cat-file", "-e", commit+"^{commit}")
 	return catFileCmd.Run(ctx) == nil
 }
 

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
+	"github.com/werf/common-go/pkg/util"
 	"github.com/werf/logboek"
 )
 
@@ -39,13 +42,19 @@ func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 
 		localURLOpts, blockers, err := submoduleLocalURLOverrides(ctx, workTreeDir)
 		if err != nil {
-			return err
+			// Reuse is an optimization, so a failure to even determine whether it applies must cost a
+			// slower build rather than a failed one, exactly like a store that cannot serve the checkout.
+			localURLOpts, blockers = nil, []string{fmt.Sprintf("unable to inspect the local object store: %s", err)}
 		}
 		if len(blockers) > 0 {
-			logboek.Context(ctx).Warn().LogF(
-				"WARNING: unable to reuse local git objects for submodules: %s.\nAll submodules will be checked out from their remotes, which may request credentials. Run `git submodule update --init --recursive` in your working tree beforehand to let werf reuse the local objects instead.\n",
-				strings.Join(blockers, ", "),
-			)
+			// The blockers describe the user's checkout, not this worktree switch, so warning on every
+			// switch of every worktree in a build would repeat the same text many times.
+			submoduleReuseWarnOnce.Do(func() {
+				logboek.Context(ctx).Warn().LogF(
+					"WARNING: unable to reuse local git objects for submodules: %s.\nAll submodules will be checked out from their remotes, which may request credentials. Run `git submodule update --init --recursive` in your working tree beforehand to let werf reuse the local objects instead.\n",
+					strings.Join(blockers, ", "),
+				)
+			})
 		}
 
 		runUpdate := func(reuseOpts []string) error {
@@ -54,9 +63,9 @@ func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 			if len(reuseOpts) > 0 {
 				// The redirects point submodule URLs at the on-disk module store, which git reaches
 				// over the file transport — blocked by the default protocol.file.allow=user for
-				// submodules. Safe only because reuse is all-or-nothing: every URL used by this
-				// invocation is then a path werf computed itself, never one from committed
-				// .gitmodules.
+				// submodules. Safe only because reuse is all-or-nothing: no URL read from committed
+				// .gitmodules is then used while the transport is relaxed (CVE-2022-39253 class).
+				// Ambient trusted configuration may still rewrite the store paths werf computes.
 				updateArgs = append(updateArgs, "-c", "protocol.file.allow=always")
 				updateArgs = append(updateArgs, reuseOpts...)
 			}
@@ -89,6 +98,8 @@ func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 	})
 }
 
+var submoduleReuseWarnOnce sync.Once
+
 type submoduleNode struct {
 	name string
 	// displayPath is the slash-joined path through the tree, used only for messages.
@@ -99,6 +110,8 @@ type submoduleNode struct {
 	// separate from moduleDir, which is exactly why an already-populated submodule fetches instead
 	// of reusing what the superproject already has.
 	worktreeModuleDir string
+	// fetchURL is the remote recorded in worktreeModuleDir, empty when there is nothing to redirect.
+	fetchURL string
 }
 
 // submoduleLocalURLOverrides walks the superproject's submodules recursively and, when EVERY
@@ -114,8 +127,8 @@ type submoduleNode struct {
 // submodule also redirects a same-named submodule elsewhere in the tree — and a subtree that is not
 // available locally cannot be enumerated at all, so such a collision could not even be detected.
 // All-or-nothing additionally keeps `protocol.file.allow=always`, which the local paths require, from
-// ever applying to a URL werf did not compute itself.
-func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overrides, blockers []string, err error) {
+// ever applying to a URL read from committed .gitmodules.
+func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) ([]string, []string, error) {
 	names, paths, err := parseGitmodulesPaths(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "config", "-f", ".gitmodules")
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to list submodules: %w", err)
@@ -124,17 +137,13 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 		return nil, nil, nil
 	}
 
-	commonDir, err := gitCommonDir(ctx, workTreeDir)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	worktreeGitDir, err := gitAbsoluteGitDir(ctx, workTreeDir)
+	worktreeGitDir, commonDir, err := resolveWorkTreeGitDirs(ctx, workTreeDir)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var nodes []submoduleNode
+	var blockers []string
 	for i, name := range names {
 		pinnedCommit, err := lsTreeGitlink(ctx, workTreeDir, "HEAD", paths[i])
 		if err != nil {
@@ -156,9 +165,9 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 	// An already-populated submodule is not re-cloned, so submodule.<name>.url does not reach it:
 	// git fetches the moved gitlink from the URL recorded in the service worktree's own submodule
 	// git dir. Rewriting that URL to the superproject store keeps such a fetch local too.
-	fetchURLs := make(map[string]string, len(nodes))
 	seenURL := make(map[string]struct{}, len(nodes))
-	for _, node := range nodes {
+	for i := range nodes {
+		node := &nodes[i]
 		if node.worktreeModuleDir == "" {
 			continue
 		}
@@ -181,18 +190,17 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 			continue
 		}
 		seenURL[fetchURL] = struct{}{}
-		fetchURLs[node.displayPath] = fetchURL
+		node.fetchURL = fetchURL
 	}
 
 	// insteadOf matches by prefix, so a remote URL that prefixes one of the store paths would also
 	// rewrite the store URL the clone path relies on.
 	for _, owner := range nodes {
-		fetchURL, ok := fetchURLs[owner.displayPath]
-		if !ok {
+		if owner.fetchURL == "" {
 			continue
 		}
 		for _, node := range nodes {
-			if strings.HasPrefix(node.moduleDir, fetchURL) {
+			if strings.HasPrefix(node.moduleDir, owner.fetchURL) {
 				blockers = append(blockers, fmt.Sprintf("%s (its remote URL prefixes the object store path of %s)", owner.displayPath, node.displayPath))
 			}
 		}
@@ -202,10 +210,11 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 		return nil, blockers, nil
 	}
 
+	var overrides []string
 	for _, node := range nodes {
 		overrides = append(overrides, "-c", "submodule."+node.name+".url="+node.moduleDir)
-		if fetchURL, ok := fetchURLs[node.displayPath]; ok {
-			overrides = append(overrides, "-c", "url."+node.moduleDir+".insteadOf="+fetchURL)
+		if node.fetchURL != "" {
+			overrides = append(overrides, "-c", "url."+node.moduleDir+".insteadOf="+node.fetchURL)
 		}
 	}
 
@@ -221,17 +230,11 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 // the repository-wide submodule store, and removing it would destroy the user's own submodule data.
 // Refuse in that case rather than trust the caller.
 func discardWorktreeSubmoduleGitDirs(ctx context.Context, workTreeDir string) error {
-	worktreeGitDir, err := gitAbsoluteGitDir(ctx, workTreeDir)
+	worktreeGitDir, commonDir, err := resolveWorkTreeGitDirs(ctx, workTreeDir)
 	if err != nil {
 		return err
 	}
-	commonDir, err := gitCommonDir(ctx, workTreeDir)
-	if err != nil {
-		return err
-	}
-	// The two are compared through EvalSymlinks because they are produced differently: git resolves
-	// the one, werf joins the other onto a caller-supplied path that may still hold a symlink.
-	if resolvePathForCompare(worktreeGitDir) == resolvePathForCompare(commonDir) {
+	if !util.IsSubpathOfBasePath(filepath.Join(commonDir, "worktrees"), worktreeGitDir) {
 		return fmt.Errorf("refusing to discard submodule git dirs of %s: not a linked work tree", workTreeDir)
 	}
 
@@ -267,19 +270,45 @@ func discardWorktreeSubmoduleGitDirs(ctx context.Context, workTreeDir string) er
 	return nil
 }
 
-func resolvePathForCompare(path string) string {
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		return resolved
+// resolveWorkTreeGitDirs returns the git dir of workTreeDir and the repository's common dir, read
+// from disk rather than from `git rev-parse`: an inherited GIT_DIR or GIT_COMMON_DIR redirects
+// rev-parse at an unrelated repository, and both the store paths werf injects and the discard's
+// os.RemoveAll are derived from these. The .git pointer of the very work tree being operated on is
+// immune to that.
+func resolveWorkTreeGitDirs(ctx context.Context, workTreeDir string) (string, string, error) {
+	dotGitPath := filepath.Join(workTreeDir, ".git")
+	info, err := os.Stat(dotGitPath)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to access %s: %w", dotGitPath, err)
 	}
-	return filepath.Clean(path)
-}
+	if info.IsDir() {
+		return dotGitPath, dotGitPath, nil
+	}
 
-func gitAbsoluteGitDir(ctx context.Context, workTreeDir string) (string, error) {
-	revParseCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "rev-parse", "--absolute-git-dir")
-	if err := revParseCmd.Run(ctx); err != nil {
-		return "", fmt.Errorf("git rev-parse --absolute-git-dir command failed: %w", err)
+	gitDir, err := resolveDotGitFile(ctx, dotGitPath)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to resolve dot-git file %q: %w", dotGitPath, err)
 	}
-	return strings.TrimSpace(revParseCmd.OutBuf.String()), nil
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(workTreeDir, gitDir)
+	}
+	gitDir = filepath.Clean(gitDir)
+
+	commonDirPath := filepath.Join(gitDir, "commondir")
+	data, err := os.ReadFile(commonDirPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return gitDir, gitDir, nil
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("error reading %q: %w", commonDirPath, err)
+	}
+
+	commonDir := strings.TrimSpace(string(data))
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(gitDir, commonDir)
+	}
+
+	return gitDir, filepath.Clean(commonDir), nil
 }
 
 func gitConfigValue(ctx context.Context, repoDir, key string) (string, error) {
@@ -309,19 +338,38 @@ func walkSubmodule(ctx context.Context, parentModuleDir, parentWorktreeModuleDir
 	}
 
 	moduleDir := filepath.Join(parentModuleDir, "modules", name)
-	if !moduleStoreHasCommit(ctx, moduleDir, pinnedCommit) {
+	// The store path lands in the key of `-c url.<path>.insteadOf`, which git rejects outright when
+	// the path itself carries a `=` or a newline.
+	if strings.ContainsAny(moduleDir, "=\n") {
+		*blockers = append(*blockers, fmt.Sprintf("%s (object store path %q cannot be expressed as a git config key)", displayPath, moduleDir))
+		return nil
+	}
+	if _, err := os.Stat(moduleDir); err != nil {
 		*blockers = append(*blockers, fmt.Sprintf("%s (not initialized locally)", displayPath))
 		return nil
 	}
 
 	// A partial clone can hold the commit while its blobs still live on the promisor remote, so
-	// cloning from it would fail or need the network — exactly what reuse is meant to avoid.
+	// cloning from it would fail or need the network — exactly what reuse is meant to avoid. This runs
+	// before any object is looked up, because GIT_NO_LAZY_FETCH is honored only from git 2.45 and werf
+	// supports older git: on those the lookup itself could reach the promisor remote.
 	isPartial, err := moduleStoreIsPartial(ctx, moduleDir)
 	if err != nil {
 		return err
 	}
 	if isPartial {
 		*blockers = append(*blockers, fmt.Sprintf("%s (local clone is partial)", displayPath))
+		return nil
+	}
+
+	// Peeling to the tree covers both the commit and the tree werf enumerates nested submodules from,
+	// so a store holding the commit alone is not mistaken for a serviceable one.
+	hasPinnedTree, err := gitObjectExists(ctx, moduleDir, pinnedCommit+"^{tree}")
+	if err != nil {
+		return err
+	}
+	if !hasPinnedTree {
+		*blockers = append(*blockers, fmt.Sprintf("%s (not initialized locally)", displayPath))
 		return nil
 	}
 
@@ -342,6 +390,16 @@ func walkSubmodule(ctx context.Context, parentModuleDir, parentWorktreeModuleDir
 		worktreeModuleDir: worktreeModuleDir,
 	})
 
+	// `git config --blob` of a missing blob writes an error to stderr, which every leaf submodule
+	// would otherwise produce on the happy path.
+	hasGitmodules, err := gitObjectExists(ctx, moduleDir, pinnedCommit+":.gitmodules")
+	if err != nil {
+		return err
+	}
+	if !hasGitmodules {
+		return nil
+	}
+
 	nestedNames, nestedPaths, err := parseGitmodulesPaths(ctx, &GitCmdOptions{RepoDir: moduleDir}, "config", "--blob", pinnedCommit+":.gitmodules")
 	if err != nil {
 		return err
@@ -359,9 +417,10 @@ func walkSubmodule(ctx context.Context, parentModuleDir, parentWorktreeModuleDir
 	return nil
 }
 
-// submoduleNameUnsafe rejects names that cannot be expressed safely as a `-c submodule.<name>.url`
-// option or that would resolve outside the module store: `=` terminates the config key early and
-// would set an unrelated option, and separators or `.`/`..` components would move the resolved path.
+// submoduleNameUnsafe rejects a repo-controlled name that cannot be carried safely by a
+// `-c submodule.<name>.url` option: `=` ends the config key early, so the rest of the name becomes
+// part of the URL value git uses, and a separator or a `.`/`..` component moves the store path the
+// name is joined into. The fixed `submodule.` prefix keeps such a name out of unrelated config keys.
 // .gitmodules is repo-controlled and `git config -f` does not reject these itself.
 func submoduleNameUnsafe(name string) bool {
 	if strings.ContainsAny(name, "=\n/\\") {
@@ -382,13 +441,14 @@ func moduleStoreIsPartial(ctx context.Context, moduleDir string) (bool, error) {
 	return configCmd.OutBuf.Len() > 0, nil
 }
 
-// parseGitmodulesPaths runs a `git config ... -z --get-regexp \.path$` over a .gitmodules source
-// (a working-tree file via -f, or a tree blob via --blob) and returns the submodule names and
-// paths. A missing source or no matches (git exit code 1) yields empty slices, not an error.
-func parseGitmodulesPaths(ctx context.Context, opts *GitCmdOptions, configArgs ...string) (names, paths []string, err error) {
+// parseGitmodulesPaths runs a `git config ... -z --get-regexp ^submodule\..*\.path$` over a
+// .gitmodules source (a working-tree file via -f, or a tree blob via --blob) and returns the
+// submodule names and paths. A missing source or no matches (git exit code 1) yields empty slices,
+// not an error.
+func parseGitmodulesPaths(ctx context.Context, opts *GitCmdOptions, configArgs ...string) ([]string, []string, error) {
 	args := make([]string, 0, len(configArgs)+3)
 	args = append(args, configArgs...)
-	args = append(args, "-z", "--get-regexp", "\\.path$")
+	args = append(args, "-z", "--get-regexp", "^submodule\\..*\\.path$")
 	configCmd := NewGitCmd(ctx, opts, args...)
 	if err := configCmd.Run(ctx); err != nil {
 		var exitErr *exec.ExitError
@@ -398,6 +458,7 @@ func parseGitmodulesPaths(ctx context.Context, opts *GitCmdOptions, configArgs .
 		return nil, nil, fmt.Errorf("git config command failed: %w", err)
 	}
 
+	var names, paths []string
 	for _, entry := range strings.Split(configCmd.OutBuf.String(), "\x00") {
 		if entry == "" {
 			continue
@@ -418,6 +479,12 @@ func parseGitmodulesPaths(ctx context.Context, opts *GitCmdOptions, configArgs .
 }
 
 func lsTreeGitlink(ctx context.Context, repoDir, treeish, submodulePath string) (string, error) {
+	// An absolute or ".." path from committed .gitmodules, which git validates in no way, makes the
+	// pathspec below fail the whole command. git checks out no submodule at such a path either.
+	if !filepath.IsLocal(submodulePath) {
+		return "", nil
+	}
+
 	lsTreeCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "ls-tree", treeish, "--", ":(literal)"+submodulePath)
 	if err := lsTreeCmd.Run(ctx); err != nil {
 		return "", fmt.Errorf("git ls-tree command failed: %w", err)
@@ -430,23 +497,17 @@ func lsTreeGitlink(ctx context.Context, repoDir, treeish, submodulePath string) 
 	return fields[2], nil
 }
 
-func moduleStoreHasCommit(ctx context.Context, moduleDir, commit string) bool {
-	if _, err := os.Stat(moduleDir); err != nil {
-		return false
-	}
-	// GIT_NO_LAZY_FETCH keeps the probe itself from reaching out to a promisor remote (git 2.41+).
-	catFileCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: moduleDir, Env: []string{"GIT_NO_LAZY_FETCH=1"}}, "cat-file", "-e", commit+"^{commit}")
-	return catFileCmd.Run(ctx) == nil
-}
-
-func gitCommonDir(ctx context.Context, workTreeDir string) (string, error) {
-	revParseCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "rev-parse", "--git-common-dir")
+// gitObjectExists reports whether rev resolves to an object present in repoDir, quietly: --verify
+// --quiet exits 1 without writing to stderr. GIT_NO_LAZY_FETCH keeps the lookup from reaching a
+// promisor remote on git 2.45+; on older git the partial-store blocker is what covers that.
+func gitObjectExists(ctx context.Context, repoDir, rev string) (bool, error) {
+	revParseCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir, Env: []string{"GIT_NO_LAZY_FETCH=1"}}, "rev-parse", "--verify", "--quiet", rev)
 	if err := revParseCmd.Run(ctx); err != nil {
-		return "", fmt.Errorf("git rev-parse --git-common-dir command failed: %w", err)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("git rev-parse command failed: %w", err)
 	}
-	commonDir := strings.TrimSpace(revParseCmd.OutBuf.String())
-	if !filepath.IsAbs(commonDir) {
-		commonDir = filepath.Join(workTreeDir, commonDir)
-	}
-	return commonDir, nil
+	return true, nil
 }

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -70,9 +70,15 @@ func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 }
 
 type submoduleNode struct {
-	name        string
+	name string
+	// displayPath is the slash-joined path through the tree, used only for messages.
 	displayPath string
-	moduleDir   string
+	// moduleDir is the superproject-side store the objects are reused from.
+	moduleDir string
+	// worktreeModuleDir is where git keeps this submodule's git dir for the service worktree. It is
+	// separate from moduleDir, which is exactly why an already-populated submodule fetches instead
+	// of reusing what the superproject already has.
+	worktreeModuleDir string
 }
 
 // submoduleLocalURLOverrides walks the superproject's submodules recursively and, when EVERY
@@ -103,23 +109,52 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 		return nil, nil, err
 	}
 
+	worktreeGitDir, err := gitAbsoluteGitDir(ctx, workTreeDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var nodes []submoduleNode
 	for i, name := range names {
 		pinnedCommit, err := lsTreeGitlink(ctx, workTreeDir, "HEAD", paths[i])
 		if err != nil {
 			return nil, nil, err
 		}
-		if err := walkSubmodule(ctx, commonDir, name, paths[i], pinnedCommit, &nodes, &blockers); err != nil {
+		if err := walkSubmodule(ctx, commonDir, worktreeGitDir, name, paths[i], pinnedCommit, &nodes, &blockers); err != nil {
 			return nil, nil, err
 		}
 	}
 
-	seen := make(map[string]struct{}, len(nodes))
+	seenName := make(map[string]struct{}, len(nodes))
 	for _, node := range nodes {
-		if _, ok := seen[node.name]; ok {
+		if _, ok := seenName[node.name]; ok {
 			blockers = append(blockers, fmt.Sprintf("%s (submodule name %q is used more than once)", node.displayPath, node.name))
 		}
-		seen[node.name] = struct{}{}
+		seenName[node.name] = struct{}{}
+	}
+
+	// An already-populated submodule is not re-cloned, so submodule.<name>.url does not reach it:
+	// git fetches the moved gitlink from the URL recorded in the service worktree's own submodule
+	// git dir. Rewriting that URL to the superproject store keeps such a fetch local too.
+	fetchURLs := make(map[string]string, len(nodes))
+	seenURL := make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		if node.worktreeModuleDir == "" {
+			continue
+		}
+		fetchURL, err := gitConfigValue(ctx, node.worktreeModuleDir, "remote.origin.url")
+		if err != nil {
+			return nil, nil, err
+		}
+		if fetchURL == "" {
+			continue
+		}
+		if _, ok := seenURL[fetchURL]; ok {
+			blockers = append(blockers, fmt.Sprintf("%s (remote URL is shared with another submodule)", node.displayPath))
+			continue
+		}
+		seenURL[fetchURL] = struct{}{}
+		fetchURLs[node.displayPath] = fetchURL
 	}
 
 	if len(blockers) > 0 {
@@ -128,15 +163,38 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 
 	for _, node := range nodes {
 		overrides = append(overrides, "-c", "submodule."+node.name+".url="+node.moduleDir)
+		if fetchURL, ok := fetchURLs[node.displayPath]; ok {
+			overrides = append(overrides, "-c", "url."+node.moduleDir+".insteadOf="+fetchURL)
+		}
 	}
 
 	return overrides, nil, nil
 }
 
+func gitAbsoluteGitDir(ctx context.Context, workTreeDir string) (string, error) {
+	revParseCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "rev-parse", "--absolute-git-dir")
+	if err := revParseCmd.Run(ctx); err != nil {
+		return "", fmt.Errorf("git rev-parse --absolute-git-dir command failed: %w", err)
+	}
+	return strings.TrimSpace(revParseCmd.OutBuf.String()), nil
+}
+
+func gitConfigValue(ctx context.Context, repoDir, key string) (string, error) {
+	configCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "config", "--get", key)
+	if err := configCmd.Run(ctx); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return "", nil
+		}
+		return "", fmt.Errorf("git config command failed: %w", err)
+	}
+	return strings.TrimSpace(configCmd.OutBuf.String()), nil
+}
+
 // walkSubmodule resolves one submodule against the local module store and recurses into its nested
 // submodules, reading their definitions from the module store at the pinned commit (no checkout
 // needed). parentModuleDir is the git dir whose modules/<name> hosts this submodule's store.
-func walkSubmodule(ctx context.Context, parentModuleDir, name, displayPath, pinnedCommit string, nodes *[]submoduleNode, blockers *[]string) error {
+func walkSubmodule(ctx context.Context, parentModuleDir, parentWorktreeModuleDir, name, displayPath, pinnedCommit string, nodes *[]submoduleNode, blockers *[]string) error {
 	// A .gitmodules entry without a gitlink in the tree is not checked out by git either.
 	if pinnedCommit == "" {
 		return nil
@@ -164,7 +222,17 @@ func walkSubmodule(ctx context.Context, parentModuleDir, name, displayPath, pinn
 		return nil
 	}
 
-	*nodes = append(*nodes, submoduleNode{name: name, displayPath: displayPath, moduleDir: moduleDir})
+	worktreeModuleDir := filepath.Join(parentWorktreeModuleDir, "modules", name)
+	if _, err := os.Stat(worktreeModuleDir); err != nil {
+		worktreeModuleDir = ""
+	}
+
+	*nodes = append(*nodes, submoduleNode{
+		name:              name,
+		displayPath:       displayPath,
+		moduleDir:         moduleDir,
+		worktreeModuleDir: worktreeModuleDir,
+	})
 
 	nestedNames, nestedPaths, err := parseGitmodulesPaths(ctx, &GitCmdOptions{RepoDir: moduleDir}, "config", "--blob", pinnedCommit+":.gitmodules")
 	if err != nil {
@@ -175,7 +243,7 @@ func walkSubmodule(ctx context.Context, parentModuleDir, name, displayPath, pinn
 		if err != nil {
 			return err
 		}
-		if err := walkSubmodule(ctx, moduleDir, nestedName, displayPath+"/"+nestedPaths[i], nestedPin, nodes, blockers); err != nil {
+		if err := walkSubmodule(ctx, moduleDir, worktreeModuleDir, nestedName, displayPath+"/"+nestedPaths[i], nestedPin, nodes, blockers); err != nil {
 			return err
 		}
 	}

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -48,21 +48,41 @@ func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 			)
 		}
 
-		updateArgs := make([]string, 0, len(includePathOpts)+len(localURLOpts)+8)
-		updateArgs = append(updateArgs, includePathOpts...)
-		if len(localURLOpts) > 0 {
-			// The overrides point submodule URLs at the on-disk module store, which git clones over
-			// the file transport — blocked by the default protocol.file.allow=user for submodules.
-			// Safe only because overrides are all-or-nothing: every URL used by this invocation is
-			// then a path werf computed itself, never one taken from committed .gitmodules.
-			updateArgs = append(updateArgs, "-c", "protocol.file.allow=always")
-			updateArgs = append(updateArgs, localURLOpts...)
-		}
-		updateArgs = append(updateArgs, "submodule", "update", "--checkout", "--force", "--init", "--recursive")
+		runUpdate := func(reuseOpts []string) error {
+			updateArgs := make([]string, 0, len(includePathOpts)+len(reuseOpts)+8)
+			updateArgs = append(updateArgs, includePathOpts...)
+			if len(reuseOpts) > 0 {
+				// The redirects point submodule URLs at the on-disk module store, which git reaches
+				// over the file transport — blocked by the default protocol.file.allow=user for
+				// submodules. Safe only because reuse is all-or-nothing: every URL used by this
+				// invocation is then a path werf computed itself, never one from committed
+				// .gitmodules.
+				updateArgs = append(updateArgs, "-c", "protocol.file.allow=always")
+				updateArgs = append(updateArgs, reuseOpts...)
+			}
+			updateArgs = append(updateArgs, "submodule", "update", "--checkout", "--force", "--init", "--recursive")
 
-		submUpdateCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, updateArgs...)
-		if err := submUpdateCmd.Run(ctx); err != nil {
-			return fmt.Errorf("submodule update command failed: %w", err)
+			submUpdateCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, updateArgs...)
+			return submUpdateCmd.Run(ctx)
+		}
+
+		if err := runUpdate(localURLOpts); err != nil {
+			// Reuse rests on where git keeps submodule git dirs and on -c reaching nested updates,
+			// neither of which git promises. Anything unanticipated there must cost a slower build,
+			// not a broken one, so fall back to the plain remote update this has always been.
+			if len(localURLOpts) == 0 {
+				return fmt.Errorf("submodule update command failed: %w", err)
+			}
+			logboek.Context(ctx).Warn().LogF("WARNING: unable to check out submodules from the local object store (%s), retrying from their remotes, which may request credentials.\n", err)
+			// The failed attempt leaves the service worktree's own submodule git dirs pointing at the
+			// store, and an initialized submodule is never re-cloned, so the retry would inherit the
+			// very state that just failed. Discard them; they belong to this worktree alone.
+			if err := discardWorktreeSubmoduleGitDirs(ctx, workTreeDir); err != nil {
+				return err
+			}
+			if err := runUpdate(nil); err != nil {
+				return fmt.Errorf("submodule update command failed: %w", err)
+			}
 		}
 
 		return nil
@@ -184,6 +204,31 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 	}
 
 	return overrides, nil, nil
+}
+
+// discardWorktreeSubmoduleGitDirs drops everything the service worktree holds for its submodules,
+// so the next update clones them afresh. Submodule working directories are tracked gitlinks, which
+// git clean leaves alone, and a leftover .git file there would outlive its discarded git dir.
+func discardWorktreeSubmoduleGitDirs(ctx context.Context, workTreeDir string) error {
+	worktreeGitDir, err := gitAbsoluteGitDir(ctx, workTreeDir)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(filepath.Join(worktreeGitDir, "modules")); err != nil {
+		return fmt.Errorf("unable to discard submodule git dirs of work tree %s: %w", workTreeDir, err)
+	}
+
+	_, paths, err := parseGitmodulesPaths(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "config", "-f", ".gitmodules")
+	if err != nil {
+		return err
+	}
+	for _, path := range paths {
+		if err := os.RemoveAll(filepath.Join(workTreeDir, path)); err != nil {
+			return fmt.Errorf("unable to discard submodule work tree %s: %w", path, err)
+		}
+	}
+
+	return nil
 }
 
 func gitAbsoluteGitDir(ctx context.Context, workTreeDir string) (string, error) {

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -2,7 +2,12 @@ package true_git
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/werf/logboek"
 )
@@ -32,11 +37,189 @@ func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 			return err
 		}
 
-		submUpdateCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, append(includePathOpts, "submodule", "update", "--checkout", "--force", "--init", "--recursive")...)
+		localURLOpts, remoteOnly, err := submoduleLocalURLOverrides(ctx, workTreeDir)
+		if err != nil {
+			return err
+		}
+		if len(remoteOnly) > 0 {
+			logboek.Context(ctx).Warn().LogF(
+				"WARNING: submodules %s are not present in the local object store and will be fetched from their remotes (credentials may be requested).\nRun `git submodule update --init --recursive` in your working tree beforehand so werf reuses the local objects and touches no network.\n",
+				strings.Join(remoteOnly, ", "),
+			)
+		}
+
+		updateArgs := make([]string, 0, len(includePathOpts)+len(localURLOpts)+8)
+		updateArgs = append(updateArgs, includePathOpts...)
+		if len(localURLOpts) > 0 {
+			// The overrides point submodule URLs at the on-disk module store, which git clones over
+			// the file transport — blocked by the default protocol.file.allow=user for submodules.
+			updateArgs = append(updateArgs, "-c", "protocol.file.allow=always")
+			updateArgs = append(updateArgs, localURLOpts...)
+		}
+		updateArgs = append(updateArgs, "submodule", "update", "--checkout", "--force", "--init", "--recursive")
+
+		submUpdateCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, updateArgs...)
 		if err := submUpdateCmd.Run(ctx); err != nil {
 			return fmt.Errorf("submodule update command failed: %w", err)
 		}
 
 		return nil
 	})
+}
+
+type submoduleNode struct {
+	name        string
+	displayPath string
+	moduleDir   string
+}
+
+// submoduleLocalURLOverrides walks the superproject's submodules recursively and, for those whose
+// pinned commit is already present in the local module store (<parent-module-dir>/modules/<name>,
+// rooted at <git-common-dir>), returns `-c submodule.<name>.url=<local-path>` overrides so
+// `git submodule update --recursive` clones them from those local objects instead of their remotes
+// — no network, no credentials. These -c options propagate to the nested update invocations via
+// GIT_CONFIG_PARAMETERS, so nested submodules are covered too. Submodules missing locally keep
+// their remote URL and are returned in remoteOnly so the caller can warn they will be fetched.
+//
+// A submodule.<name>.url override is global to the git process, so when the same submodule name
+// occurs more than once at different module dirs it cannot be expressed unambiguously; such names
+// are dropped from the overrides and fall back to their remotes instead of risking a wrong source.
+func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overrides, remoteOnly []string, err error) {
+	names, paths, err := parseGitmodulesPaths(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "config", "-f", ".gitmodules")
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to list submodules: %w", err)
+	}
+	if len(names) == 0 {
+		return nil, nil, nil
+	}
+
+	commonDir, err := gitCommonDir(ctx, workTreeDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var localNodes []submoduleNode
+	for i, name := range names {
+		pinnedCommit, err := lsTreeGitlink(ctx, workTreeDir, "HEAD", paths[i])
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := walkSubmodule(ctx, commonDir, name, paths[i], pinnedCommit, &localNodes, &remoteOnly); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	nameCount := make(map[string]int, len(localNodes))
+	for _, node := range localNodes {
+		nameCount[node.name]++
+	}
+	for _, node := range localNodes {
+		if nameCount[node.name] == 1 {
+			overrides = append(overrides, "-c", "submodule."+node.name+".url="+node.moduleDir)
+		} else {
+			remoteOnly = append(remoteOnly, node.displayPath)
+		}
+	}
+
+	return overrides, remoteOnly, nil
+}
+
+// walkSubmodule resolves one submodule against the local module store and recurses into its nested
+// submodules, reading their definitions from the module store at the pinned commit (no checkout
+// needed). parentModuleDir is the git dir whose modules/<name> hosts this submodule's store.
+func walkSubmodule(ctx context.Context, parentModuleDir, name, displayPath, pinnedCommit string, localNodes *[]submoduleNode, remoteOnly *[]string) error {
+	if pinnedCommit == "" {
+		return nil
+	}
+
+	moduleDir := filepath.Join(parentModuleDir, "modules", name)
+	if !moduleStoreHasCommit(ctx, moduleDir, pinnedCommit) {
+		*remoteOnly = append(*remoteOnly, displayPath)
+		return nil
+	}
+	*localNodes = append(*localNodes, submoduleNode{name: name, displayPath: displayPath, moduleDir: moduleDir})
+
+	nestedNames, nestedPaths, err := parseGitmodulesPaths(ctx, &GitCmdOptions{RepoDir: moduleDir}, "config", "--blob", pinnedCommit+":.gitmodules")
+	if err != nil {
+		return err
+	}
+	for i, nestedName := range nestedNames {
+		nestedPin, err := lsTreeGitlink(ctx, moduleDir, pinnedCommit, nestedPaths[i])
+		if err != nil {
+			return err
+		}
+		if err := walkSubmodule(ctx, moduleDir, nestedName, displayPath+"/"+nestedPaths[i], nestedPin, localNodes, remoteOnly); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// parseGitmodulesPaths runs a `git config ... -z --get-regexp \.path$` over a .gitmodules source
+// (a working-tree file via -f, or a tree blob via --blob) and returns the submodule names and
+// paths. A missing source or no matches (git exit code 1) yields empty slices, not an error.
+func parseGitmodulesPaths(ctx context.Context, opts *GitCmdOptions, configArgs ...string) (names, paths []string, err error) {
+	args := make([]string, 0, len(configArgs)+3)
+	args = append(args, configArgs...)
+	args = append(args, "-z", "--get-regexp", "\\.path$")
+	configCmd := NewGitCmd(ctx, opts, args...)
+	if err := configCmd.Run(ctx); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("git config command failed: %w", err)
+	}
+
+	for _, entry := range strings.Split(configCmd.OutBuf.String(), "\x00") {
+		if entry == "" {
+			continue
+		}
+		key, value, found := strings.Cut(entry, "\n")
+		if !found {
+			continue
+		}
+		name := strings.TrimSuffix(strings.TrimPrefix(key, "submodule."), ".path")
+		if name == "" || value == "" {
+			continue
+		}
+		names = append(names, name)
+		paths = append(paths, value)
+	}
+
+	return names, paths, nil
+}
+
+func lsTreeGitlink(ctx context.Context, repoDir, treeish, submodulePath string) (string, error) {
+	lsTreeCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: repoDir}, "ls-tree", treeish, "--", submodulePath)
+	if err := lsTreeCmd.Run(ctx); err != nil {
+		return "", fmt.Errorf("git ls-tree command failed: %w", err)
+	}
+
+	fields := strings.Fields(lsTreeCmd.OutBuf.String())
+	if len(fields) < 3 || fields[1] != "commit" {
+		return "", nil
+	}
+	return fields[2], nil
+}
+
+func moduleStoreHasCommit(ctx context.Context, moduleDir, commit string) bool {
+	if _, err := os.Stat(moduleDir); err != nil {
+		return false
+	}
+	catFileCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: moduleDir}, "cat-file", "-e", commit+"^{commit}")
+	return catFileCmd.Run(ctx) == nil
+}
+
+func gitCommonDir(ctx context.Context, workTreeDir string) (string, error) {
+	revParseCmd := NewGitCmd(ctx, &GitCmdOptions{RepoDir: workTreeDir}, "rev-parse", "--git-common-dir")
+	if err := revParseCmd.Run(ctx); err != nil {
+		return "", fmt.Errorf("git rev-parse --git-common-dir command failed: %w", err)
+	}
+	commonDir := strings.TrimSpace(revParseCmd.OutBuf.String())
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(workTreeDir, commonDir)
+	}
+	return commonDir, nil
 }

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -77,11 +77,11 @@ func updateSubmodules(ctx context.Context, repoDir, workTreeDir string) error {
 			// The failed attempt leaves the service worktree's own submodule git dirs pointing at the
 			// store, and an initialized submodule is never re-cloned, so the retry would inherit the
 			// very state that just failed. Discard them; they belong to this worktree alone.
-			if err := discardWorktreeSubmoduleGitDirs(ctx, workTreeDir); err != nil {
-				return err
+			if discardErr := discardWorktreeSubmoduleGitDirs(ctx, workTreeDir); discardErr != nil {
+				return fmt.Errorf("submodule update command failed: %w (unable to discard the failed attempt: %s)", err, discardErr)
 			}
-			if err := runUpdate(nil); err != nil {
-				return fmt.Errorf("submodule update command failed: %w", err)
+			if retryErr := runUpdate(nil); retryErr != nil {
+				return fmt.Errorf("submodule update command failed: %w (local object store reuse had failed with: %s)", retryErr, err)
 			}
 		}
 
@@ -170,7 +170,9 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 			blockers = append(blockers, fmt.Sprintf("%s (submodule has no remote URL to redirect)", node.displayPath))
 			continue
 		}
-		// An earlier run already recorded the store as the remote, so the fetch is local as is.
+		// Nothing to redirect when the recorded remote is the store itself, and skipping it also
+		// keeps the store-prefix blocker below from matching this URL against its own store and
+		// disabling reuse outright.
 		if fetchURL == node.moduleDir {
 			continue
 		}
@@ -184,10 +186,14 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 
 	// insteadOf matches by prefix, so a remote URL that prefixes one of the store paths would also
 	// rewrite the store URL the clone path relies on.
-	for _, fetchURL := range fetchURLs {
+	for _, owner := range nodes {
+		fetchURL, ok := fetchURLs[owner.displayPath]
+		if !ok {
+			continue
+		}
 		for _, node := range nodes {
 			if strings.HasPrefix(node.moduleDir, fetchURL) {
-				blockers = append(blockers, fmt.Sprintf("%s (remote URL prefixes the local object store path)", node.displayPath))
+				blockers = append(blockers, fmt.Sprintf("%s (its remote URL prefixes the object store path of %s)", owner.displayPath, node.displayPath))
 			}
 		}
 	}
@@ -209,11 +215,26 @@ func submoduleLocalURLOverrides(ctx context.Context, workTreeDir string) (overri
 // discardWorktreeSubmoduleGitDirs drops everything the service worktree holds for its submodules,
 // so the next update clones them afresh. Submodule working directories are tracked gitlinks, which
 // git clean leaves alone, and a leftover .git file there would outlive its discarded git dir.
+//
+// Everything removed here must belong to the service worktree alone. A linked worktree has its own
+// git dir, so its modules/ holds only its submodule git dirs; in a main worktree that same path is
+// the repository-wide submodule store, and removing it would destroy the user's own submodule data.
+// Refuse in that case rather than trust the caller.
 func discardWorktreeSubmoduleGitDirs(ctx context.Context, workTreeDir string) error {
 	worktreeGitDir, err := gitAbsoluteGitDir(ctx, workTreeDir)
 	if err != nil {
 		return err
 	}
+	commonDir, err := gitCommonDir(ctx, workTreeDir)
+	if err != nil {
+		return err
+	}
+	// The two are compared through EvalSymlinks because they are produced differently: git resolves
+	// the one, werf joins the other onto a caller-supplied path that may still hold a symlink.
+	if resolvePathForCompare(worktreeGitDir) == resolvePathForCompare(commonDir) {
+		return fmt.Errorf("refusing to discard submodule git dirs of %s: not a linked work tree", workTreeDir)
+	}
+
 	if err := os.RemoveAll(filepath.Join(worktreeGitDir, "modules")); err != nil {
 		return fmt.Errorf("unable to discard submodule git dirs of work tree %s: %w", workTreeDir, err)
 	}
@@ -223,12 +244,34 @@ func discardWorktreeSubmoduleGitDirs(ctx context.Context, workTreeDir string) er
 		return err
 	}
 	for _, path := range paths {
+		// .gitmodules is repo-controlled and git validates none of it, so two things must hold before
+		// a path reaches RemoveAll. It has to be work-tree local, which rules out an absolute or
+		// ".." path git would anyway refuse as a pathspec; and HEAD has to record it as a gitlink,
+		// which rules out a symlinked component RemoveAll would follow out of the work tree, since
+		// every component leading to a gitlink is itself a tree.
+		if !filepath.IsLocal(path) {
+			continue
+		}
+		gitlink, err := lsTreeGitlink(ctx, workTreeDir, "HEAD", path)
+		if err != nil {
+			return err
+		}
+		if gitlink == "" {
+			continue
+		}
 		if err := os.RemoveAll(filepath.Join(workTreeDir, path)); err != nil {
 			return fmt.Errorf("unable to discard submodule work tree %s: %w", path, err)
 		}
 	}
 
 	return nil
+}
+
+func resolvePathForCompare(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
 }
 
 func gitAbsoluteGitDir(ctx context.Context, workTreeDir string) (string, error) {

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -230,6 +230,45 @@ func TestAI_UpdateSubmodulesReusesLocalObjectsAfterNestedGitlinkMovedInWarmWorkT
 	require.Equal(t, "second", string(content))
 }
 
+// Reuse rests on git behavior that is not promised, so a store that passes every check and still
+// cannot serve the checkout must cost a slower build, not a failed one.
+func TestAI_UpdateSubmodulesFallsBackToRemoteWhenLocalStoreCannotServe(t *testing.T) {
+	ctx := context.Background()
+	isolateGitConfigAI(t)
+	// The retry deliberately drops the transport allowance that only the local store needs, so this
+	// stand-in for an https remote has to be reachable some other way.
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
+
+	subRemote := t.TempDir()
+	initGitRepoAI(t, subRemote)
+	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("hello"), 0o644))
+	runGitAI(t, subRemote, "add", ".")
+	runGitAI(t, subRemote, "commit", "-m", "content")
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "sub")
+	runGitAI(t, superRepo, "commit", "-m", "add submodule")
+	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+
+	// Drop the blob from the store while leaving the pinned commit reachable: the probe still
+	// succeeds, and nothing marks the store as partial, so only the checkout can discover this.
+	subSHA := strings.Fields(runGitAI(t, superRepo, "ls-tree", "HEAD", "--", "sub"))[2]
+	storeDir := filepath.Join(superRepo, ".git", "modules", "sub")
+	blobSHA := strings.TrimSpace(runGitAI(t, storeDir, "rev-parse", subSHA+":file.txt"))
+	require.NoError(t, os.Remove(filepath.Join(storeDir, "objects", blobSHA[:2], blobSHA[2:])))
+
+	gitDir := filepath.Join(superRepo, ".git")
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
+	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
+	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
+
+	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(content))
+}
+
 // GitLab CI clones submodules shallow for GIT_SUBMODULE_DEPTH. A shallow store is not a partial
 // one — it has every object of the commits it holds — so it must stay eligible for reuse.
 func TestAI_UpdateSubmodulesReusesLocalObjectsFromShallowSubmoduleStore(t *testing.T) {

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -64,6 +64,7 @@ func TestAI_UpdateSubmodulesForwardsIncludePath(t *testing.T) {
 
 func TestAI_UpdateSubmodulesReusesLocalObjectsWithoutRemote(t *testing.T) {
 	ctx := context.Background()
+	isolateGitConfigAI(t)
 
 	subRemote := t.TempDir()
 	initGitRepoAI(t, subRemote)
@@ -94,6 +95,7 @@ func TestAI_UpdateSubmodulesReusesLocalObjectsWithoutRemote(t *testing.T) {
 
 func TestAI_UpdateSubmodulesReusesLocalObjectsForNestedWithoutRemote(t *testing.T) {
 	ctx := context.Background()
+	isolateGitConfigAI(t)
 
 	leafRemote := t.TempDir()
 	initGitRepoAI(t, leafRemote)
@@ -127,6 +129,104 @@ func TestAI_UpdateSubmodulesReusesLocalObjectsForNestedWithoutRemote(t *testing.
 	content, err := os.ReadFile(filepath.Join(workTreeDir, "mid", "leaf", "leaf.txt"))
 	require.NoError(t, err)
 	require.Equal(t, "LEAF", string(content))
+}
+
+// A submodule name reused at another nesting level cannot be expressed as a process-global
+// submodule.<name>.url, so no override may be emitted: an override for the top-level copy would
+// otherwise hijack the nested clone and fail the whole update.
+func TestAI_UpdateSubmodulesSkipsOverridesOnDuplicateSubmoduleName(t *testing.T) {
+	ctx := context.Background()
+	isolateGitConfigAI(t)
+
+	newLib := func(marker string) string {
+		dir := t.TempDir()
+		initGitRepoAI(t, dir)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "who.txt"), []byte(marker), 0o644))
+		runGitAI(t, dir, "add", ".")
+		runGitAI(t, dir, "commit", "-m", "lib "+marker)
+		return dir
+	}
+	libA := newLib("A")
+	libB := newLib("B")
+
+	// mid carries a DIFFERENT repo under the same submodule name "lib".
+	midRemote := t.TempDir()
+	initGitRepoAI(t, midRemote)
+	runGitAI(t, midRemote, "-c", "protocol.file.allow=always", "submodule", "add", libB, "lib")
+	runGitAI(t, midRemote, "commit", "-m", "add lib B")
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", libA, "lib")
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", midRemote, "mid")
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
+	runGitAI(t, superRepo, "commit", "-m", "add lib A and mid")
+	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+
+	overrides, blockers, err := submoduleLocalURLOverrides(ctx, superRepo)
+	require.NoError(t, err)
+	require.Empty(t, overrides, "no override may be emitted for a duplicated submodule name")
+	require.NotEmpty(t, blockers)
+
+	// Remotes stay reachable here, so the plain remote update must still produce correct content for
+	// BOTH same-named submodules. These test "remotes" are local paths, hence the explicit transport
+	// allowance that a real https remote would not need.
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
+	require.NoError(t, updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
+
+	topWho, err := os.ReadFile(filepath.Join(workTreeDir, "lib", "who.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "A", string(topWho))
+	nestedWho, err := os.ReadFile(filepath.Join(workTreeDir, "mid", "lib", "who.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "B", string(nestedWho))
+}
+
+// protocol.file.allow=always is only safe while every URL of the invocation is one werf computed,
+// so a submodule that cannot be served locally must suppress the overrides entirely — otherwise the
+// relaxed transport would also un-block a file:// URL taken from committed .gitmodules
+// (CVE-2022-39253 class).
+func TestAI_UpdateSubmodulesKeepsFileTransportBlockedForNonLocalSubmodule(t *testing.T) {
+	ctx := context.Background()
+	isolateGitConfigAI(t)
+
+	okRemote := t.TempDir()
+	initGitRepoAI(t, okRemote)
+	require.NoError(t, os.WriteFile(filepath.Join(okRemote, "ok.txt"), []byte("OK"), 0o644))
+	runGitAI(t, okRemote, "add", ".")
+	runGitAI(t, okRemote, "commit", "-m", "ok content")
+
+	evilRemote := t.TempDir()
+	initGitRepoAI(t, evilRemote)
+	require.NoError(t, os.WriteFile(filepath.Join(evilRemote, "evil.txt"), []byte("EVIL"), 0o644))
+	runGitAI(t, evilRemote, "add", ".")
+	runGitAI(t, evilRemote, "commit", "-m", "evil content")
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", okRemote, "ok")
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", "file://"+evilRemote, "evil")
+	runGitAI(t, superRepo, "commit", "-m", "add submodules")
+	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+
+	// Only "ok" is available locally: deinit "evil" so its module store no longer holds the pin.
+	runGitAI(t, superRepo, "submodule", "deinit", "-f", "evil")
+	require.NoError(t, os.RemoveAll(filepath.Join(superRepo, ".git", "modules", "evil")))
+
+	overrides, blockers, err := submoduleLocalURLOverrides(ctx, superRepo)
+	require.NoError(t, err)
+	require.Empty(t, overrides, "a non-local submodule must suppress all overrides")
+	require.NotEmpty(t, blockers)
+
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
+
+	err = updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir)
+	require.Error(t, err, "git must still refuse the file:// submodule")
+	require.Contains(t, err.Error(), "transport 'file' not allowed")
+	require.NoFileExists(t, filepath.Join(workTreeDir, "evil", "evil.txt"))
 }
 
 func TestAI_SwitchWorkTreeNonSubmodulesUnaffectedByIncludePath(t *testing.T) {

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,462 +64,6 @@ func TestAI_UpdateSubmodulesForwardsIncludePath(t *testing.T) {
 	require.Contains(t, err.Error(), "werf-test-marker")
 }
 
-func TestAI_UpdateSubmodulesReusesLocalObjectsWithoutRemote(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-
-	subRemote := t.TempDir()
-	initGitRepoAI(t, subRemote)
-	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("hello"), 0o644))
-	runGitAI(t, subRemote, "add", ".")
-	runGitAI(t, subRemote, "commit", "-m", "sub content")
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "sub")
-	runGitAI(t, superRepo, "commit", "-m", "add submodule")
-	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-
-	// `submodule add` already populated superRepo/.git/modules/sub; drop the remote to prove the
-	// checkout into a fresh worktree reuses those local objects and touches no network.
-	require.NoError(t, os.RemoveAll(subRemote))
-
-	workTreeDir := filepath.Join(t.TempDir(), "worktree")
-	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
-
-	require.NoError(t, syncSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
-	require.NoError(t, updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
-
-	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
-	require.NoError(t, err)
-	require.Equal(t, "hello", string(content))
-}
-
-func TestAI_UpdateSubmodulesReusesLocalObjectsForNestedWithoutRemote(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-
-	leafRemote := t.TempDir()
-	initGitRepoAI(t, leafRemote)
-	require.NoError(t, os.WriteFile(filepath.Join(leafRemote, "leaf.txt"), []byte("LEAF"), 0o644))
-	runGitAI(t, leafRemote, "add", ".")
-	runGitAI(t, leafRemote, "commit", "-m", "leaf content")
-
-	midRemote := t.TempDir()
-	initGitRepoAI(t, midRemote)
-	runGitAI(t, midRemote, "-c", "protocol.file.allow=always", "submodule", "add", leafRemote, "leaf")
-	runGitAI(t, midRemote, "commit", "-m", "add leaf")
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", midRemote, "mid")
-	// `submodule add` populates only the top module store; recurse once to fill mid/modules/leaf.
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
-	runGitAI(t, superRepo, "commit", "-m", "add mid")
-	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-
-	// Drop every remote to prove both levels are checked out from the local object store alone.
-	require.NoError(t, os.RemoveAll(leafRemote))
-	require.NoError(t, os.RemoveAll(midRemote))
-
-	workTreeDir := filepath.Join(t.TempDir(), "worktree")
-	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
-
-	require.NoError(t, syncSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
-	require.NoError(t, updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
-
-	content, err := os.ReadFile(filepath.Join(workTreeDir, "mid", "leaf", "leaf.txt"))
-	require.NoError(t, err)
-	require.Equal(t, "LEAF", string(content))
-}
-
-// An already-populated submodule is not re-cloned, so it is fetched from the URL recorded in the
-// service worktree's own submodule git dir. Moving the gitlink must therefore still resolve from
-// the superproject store rather than from the remote.
-func TestAI_UpdateSubmodulesReusesLocalObjectsAfterGitlinkMovedInWarmWorkTree(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-
-	subRemote := t.TempDir()
-	initGitRepoAI(t, subRemote)
-	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("first"), 0o644))
-	runGitAI(t, subRemote, "add", ".")
-	runGitAI(t, subRemote, "commit", "-m", "first")
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "sub")
-	runGitAI(t, superRepo, "commit", "-m", "add submodule")
-	firstSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-
-	// Warm the service worktree on the first gitlink, exactly as an earlier werf run would — sync
-	// included, since it rewrites the submodule remote from .gitmodules on every run.
-	gitDir := filepath.Join(superRepo, ".git")
-	workTreeDir := filepath.Join(t.TempDir(), "worktree")
-	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, firstSHA)
-	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
-	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
-
-	// Move the gitlink, and let the superproject store learn the new commit the way CI would.
-	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("second"), 0o644))
-	runGitAI(t, subRemote, "commit", "-am", "second")
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "sub")
-	runGitAI(t, superRepo, "commit", "-am", "bump submodule")
-	secondSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init")
-
-	// Only now drop the remote: the moved commit exists locally, so no fetch may be needed.
-	require.NoError(t, os.RemoveAll(subRemote))
-
-	runGitAI(t, workTreeDir, "checkout", "--force", "--detach", secondSHA)
-	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
-	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
-
-	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
-	require.NoError(t, err)
-	require.Equal(t, "second", string(content))
-}
-
-// The fetch redirect must reach nested levels too: their git dirs are per-worktree just like the
-// top-level one, so a moved nested gitlink is fetched, not re-cloned.
-func TestAI_UpdateSubmodulesReusesLocalObjectsAfterNestedGitlinkMovedInWarmWorkTree(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-
-	leafRemote := t.TempDir()
-	initGitRepoAI(t, leafRemote)
-	require.NoError(t, os.WriteFile(filepath.Join(leafRemote, "leaf.txt"), []byte("first"), 0o644))
-	runGitAI(t, leafRemote, "add", ".")
-	runGitAI(t, leafRemote, "commit", "-m", "first")
-
-	midRemote := t.TempDir()
-	initGitRepoAI(t, midRemote)
-	runGitAI(t, midRemote, "-c", "protocol.file.allow=always", "submodule", "add", leafRemote, "leaf")
-	runGitAI(t, midRemote, "commit", "-m", "add leaf")
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", midRemote, "mid")
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
-	runGitAI(t, superRepo, "commit", "-m", "add mid")
-	firstSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-
-	gitDir := filepath.Join(superRepo, ".git")
-	workTreeDir := filepath.Join(t.TempDir(), "worktree")
-	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, firstSHA)
-	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
-	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
-
-	// Move the NESTED gitlink and let the superproject stores learn the new commits.
-	require.NoError(t, os.WriteFile(filepath.Join(leafRemote, "leaf.txt"), []byte("second"), 0o644))
-	runGitAI(t, leafRemote, "commit", "-am", "second")
-	runGitAI(t, midRemote, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "leaf")
-	runGitAI(t, midRemote, "commit", "-am", "bump leaf")
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "mid")
-	runGitAI(t, superRepo, "commit", "-am", "bump mid")
-	secondSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
-
-	require.NoError(t, os.RemoveAll(leafRemote))
-	require.NoError(t, os.RemoveAll(midRemote))
-
-	runGitAI(t, workTreeDir, "checkout", "--force", "--detach", secondSHA)
-	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
-	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
-
-	content, err := os.ReadFile(filepath.Join(workTreeDir, "mid", "leaf", "leaf.txt"))
-	require.NoError(t, err)
-	require.Equal(t, "second", string(content))
-}
-
-// The fallback discards the service worktree's submodule state, and in a main work tree that same
-// path is the repository-wide submodule store. It must refuse rather than destroy the user's data.
-func TestAI_DiscardWorktreeSubmoduleGitDirsRefusesMainWorkTree(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-
-	subRemote := t.TempDir()
-	initGitRepoAI(t, subRemote)
-	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("hello"), 0o644))
-	runGitAI(t, subRemote, "add", ".")
-	runGitAI(t, subRemote, "commit", "-m", "content")
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "sub")
-	runGitAI(t, superRepo, "commit", "-m", "add submodule")
-
-	sharedStore := filepath.Join(superRepo, ".git", "modules", "sub")
-	require.DirExists(t, sharedStore)
-
-	err := discardWorktreeSubmoduleGitDirs(ctx, superRepo)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not a linked work tree")
-	require.DirExists(t, sharedStore, "the repository-wide submodule store must survive")
-	require.FileExists(t, filepath.Join(superRepo, "sub", "file.txt"))
-}
-
-// .gitmodules is committed content, and git does not validate its paths, so the discard must not
-// delete at a path HEAD does not record as a gitlink.
-func TestAI_DiscardWorktreeSubmoduleGitDirsIgnoresPathsWithoutGitlink(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-
-	outside := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(outside, "inner"), 0o755))
-	victim := filepath.Join(outside, "inner", "data.txt")
-	require.NoError(t, os.WriteFile(victim, []byte("precious"), 0o644))
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	escape, err := filepath.Rel(superRepo, outside)
-	require.NoError(t, err)
-	gitmodules := "[submodule \"escape\"]\n\tpath = " + escape + "\n\turl = https://werf-test-nonexistent.invalid/x.git\n"
-	require.NoError(t, os.WriteFile(filepath.Join(superRepo, ".gitmodules"), []byte(gitmodules), 0o644))
-	runGitAI(t, superRepo, "add", ".gitmodules")
-	runGitAI(t, superRepo, "commit", "-m", "gitmodules entry without a gitlink")
-
-	// The second variant reaches outside through a committed symlink used as an intermediate path
-	// component, so it looks work-tree local and only the gitlink check rejects it. RemoveAll would
-	// follow it, unlike a symlink in the final position, which it would merely unlink.
-	require.NoError(t, os.Symlink(outside, filepath.Join(superRepo, "link")))
-	gitmodules += "[submodule \"vialink\"]\n\tpath = link/inner\n\turl = https://werf-test-nonexistent.invalid/y.git\n"
-	require.NoError(t, os.WriteFile(filepath.Join(superRepo, ".gitmodules"), []byte(gitmodules), 0o644))
-	runGitAI(t, superRepo, "add", ".gitmodules", "link")
-	runGitAI(t, superRepo, "commit", "-m", "symlinked gitmodules path")
-
-	workTreeDir := filepath.Join(t.TempDir(), "worktree")
-	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD")))
-
-	require.NoError(t, discardWorktreeSubmoduleGitDirs(ctx, workTreeDir))
-	require.FileExists(t, victim, "a path outside the work tree must never be removed")
-}
-
-// Reuse rests on git behavior that is not promised, so a store that passes every check and still
-// cannot serve the checkout must cost a slower build, not a failed one.
-func TestAI_UpdateSubmodulesFallsBackToRemoteWhenLocalStoreCannotServe(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-	// The retry deliberately drops the transport allowance that only the local store needs, so this
-	// stand-in for an https remote has to be reachable some other way.
-	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
-
-	subRemote := t.TempDir()
-	initGitRepoAI(t, subRemote)
-	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("hello"), 0o644))
-	runGitAI(t, subRemote, "add", ".")
-	runGitAI(t, subRemote, "commit", "-m", "content")
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "sub")
-	runGitAI(t, superRepo, "commit", "-m", "add submodule")
-	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-
-	// Drop the blob from the store while leaving the pinned commit reachable: the probe still
-	// succeeds, and nothing marks the store as partial, so only the checkout can discover this.
-	subSHA := strings.Fields(runGitAI(t, superRepo, "ls-tree", "HEAD", "--", "sub"))[2]
-	storeDir := filepath.Join(superRepo, ".git", "modules", "sub")
-	blobSHA := strings.TrimSpace(runGitAI(t, storeDir, "rev-parse", subSHA+":file.txt"))
-	require.NoError(t, os.Remove(filepath.Join(storeDir, "objects", blobSHA[:2], blobSHA[2:])))
-
-	gitDir := filepath.Join(superRepo, ".git")
-	workTreeDir := filepath.Join(t.TempDir(), "worktree")
-	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
-	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
-
-	// Pins that the broken store is still reuse-eligible. Without this the test would keep passing
-	// through the ordinary remote path if the store ever stopped qualifying, and would no longer
-	// exercise the retry it is named for.
-	overrides, blockers, err := submoduleLocalURLOverrides(ctx, workTreeDir)
-	require.NoError(t, err)
-	require.Empty(t, blockers, "a missing blob is undetectable up front, so nothing may block reuse")
-	require.NotEmpty(t, overrides)
-
-	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
-
-	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
-	require.NoError(t, err)
-	require.Equal(t, "hello", string(content))
-
-	// The submodule ends up served by the retry, so it records the real remote rather than the store.
-	worktreeGitDir := strings.TrimSpace(runGitAI(t, workTreeDir, "rev-parse", "--absolute-git-dir"))
-	servedFrom := strings.TrimSpace(runGitAI(t, filepath.Join(worktreeGitDir, "modules", "sub"), "config", "--get", "remote.origin.url"))
-	require.Equal(t, subRemote, servedFrom)
-}
-
-// GitLab CI clones submodules shallow for GIT_SUBMODULE_DEPTH. A shallow store is not a partial
-// one — it has every object of the commits it holds — so it must stay eligible for reuse.
-func TestAI_UpdateSubmodulesReusesLocalObjectsFromShallowSubmoduleStore(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-
-	subRemote := t.TempDir()
-	initGitRepoAI(t, subRemote)
-	for _, marker := range []string{"first", "second"} {
-		require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte(marker), 0o644))
-		runGitAI(t, subRemote, "add", ".")
-		runGitAI(t, subRemote, "commit", "-m", marker)
-	}
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	// A depth-limited clone is only honored over file://, not over a plain local path.
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", "file://"+subRemote, "sub")
-	runGitAI(t, superRepo, "commit", "-m", "add submodule")
-	runGitAI(t, superRepo, "submodule", "deinit", "-f", "sub")
-	require.NoError(t, os.RemoveAll(filepath.Join(superRepo, ".git", "modules", "sub")))
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--depth=1")
-	require.FileExists(t, filepath.Join(superRepo, ".git", "modules", "sub", "shallow"))
-	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-
-	require.NoError(t, os.RemoveAll(subRemote))
-
-	gitDir := filepath.Join(superRepo, ".git")
-	workTreeDir := filepath.Join(t.TempDir(), "worktree")
-	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
-	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
-	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
-
-	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
-	require.NoError(t, err)
-	require.Equal(t, "second", string(content))
-}
-
-// GIT_SUBMODULE_FORCE_HTTPS makes GitLab CI install its own broad insteadOf prefix rewrite. Ours is
-// keyed on the full submodule URL, and git resolves insteadOf by longest match, so reuse must win.
-func TestAI_UpdateSubmodulesReusesLocalObjectsDespiteExistingInsteadOfRule(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-
-	subRemote := t.TempDir()
-	initGitRepoAI(t, subRemote)
-	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("hello"), 0o644))
-	runGitAI(t, subRemote, "add", ".")
-	runGitAI(t, subRemote, "commit", "-m", "content")
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "sub")
-	runGitAI(t, superRepo, "commit", "-m", "add submodule")
-	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-
-	// Redirect the remote's parent prefix at a path that does not exist, standing in for the CI's
-	// token rewrite: reuse must not depend on where that rule points.
-	runGitAI(t, superRepo, "config", "url."+filepath.Join(t.TempDir(), "tokenized")+"/.insteadOf", filepath.Dir(subRemote)+"/")
-	require.NoError(t, os.RemoveAll(subRemote))
-
-	gitDir := filepath.Join(superRepo, ".git")
-	workTreeDir := filepath.Join(t.TempDir(), "worktree")
-	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
-	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
-	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
-
-	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
-	require.NoError(t, err)
-	require.Equal(t, "hello", string(content))
-}
-
-// A submodule name reused at another nesting level cannot be expressed as a process-global
-// submodule.<name>.url, so no override may be emitted: an override for the top-level copy would
-// otherwise hijack the nested clone and fail the whole update.
-func TestAI_UpdateSubmodulesSkipsOverridesOnDuplicateSubmoduleName(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-
-	newLib := func(marker string) string {
-		dir := t.TempDir()
-		initGitRepoAI(t, dir)
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "who.txt"), []byte(marker), 0o644))
-		runGitAI(t, dir, "add", ".")
-		runGitAI(t, dir, "commit", "-m", "lib "+marker)
-		return dir
-	}
-	libA := newLib("A")
-	libB := newLib("B")
-
-	// mid carries a DIFFERENT repo under the same submodule name "lib".
-	midRemote := t.TempDir()
-	initGitRepoAI(t, midRemote)
-	runGitAI(t, midRemote, "-c", "protocol.file.allow=always", "submodule", "add", libB, "lib")
-	runGitAI(t, midRemote, "commit", "-m", "add lib B")
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", libA, "lib")
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", midRemote, "mid")
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
-	runGitAI(t, superRepo, "commit", "-m", "add lib A and mid")
-	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-
-	overrides, blockers, err := submoduleLocalURLOverrides(ctx, superRepo)
-	require.NoError(t, err)
-	require.Empty(t, overrides, "no override may be emitted for a duplicated submodule name")
-	require.NotEmpty(t, blockers)
-
-	// Remotes stay reachable here, so the plain remote update must still produce correct content for
-	// BOTH same-named submodules. These test "remotes" are local paths, hence the explicit transport
-	// allowance that a real https remote would not need.
-	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
-	workTreeDir := filepath.Join(t.TempDir(), "worktree")
-	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
-	require.NoError(t, syncSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
-	require.NoError(t, updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
-
-	topWho, err := os.ReadFile(filepath.Join(workTreeDir, "lib", "who.txt"))
-	require.NoError(t, err)
-	require.Equal(t, "A", string(topWho))
-	nestedWho, err := os.ReadFile(filepath.Join(workTreeDir, "mid", "lib", "who.txt"))
-	require.NoError(t, err)
-	require.Equal(t, "B", string(nestedWho))
-}
-
-// protocol.file.allow=always is only safe while every URL of the invocation is one werf computed,
-// so a submodule that cannot be served locally must suppress the overrides entirely — otherwise the
-// relaxed transport would also un-block a file:// URL taken from committed .gitmodules
-// (CVE-2022-39253 class).
-func TestAI_UpdateSubmodulesKeepsFileTransportBlockedForNonLocalSubmodule(t *testing.T) {
-	ctx := context.Background()
-	isolateGitConfigAI(t)
-
-	okRemote := t.TempDir()
-	initGitRepoAI(t, okRemote)
-	require.NoError(t, os.WriteFile(filepath.Join(okRemote, "ok.txt"), []byte("OK"), 0o644))
-	runGitAI(t, okRemote, "add", ".")
-	runGitAI(t, okRemote, "commit", "-m", "ok content")
-
-	evilRemote := t.TempDir()
-	initGitRepoAI(t, evilRemote)
-	require.NoError(t, os.WriteFile(filepath.Join(evilRemote, "evil.txt"), []byte("EVIL"), 0o644))
-	runGitAI(t, evilRemote, "add", ".")
-	runGitAI(t, evilRemote, "commit", "-m", "evil content")
-
-	superRepo := t.TempDir()
-	initGitRepoAI(t, superRepo)
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", okRemote, "ok")
-	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", "file://"+evilRemote, "evil")
-	runGitAI(t, superRepo, "commit", "-m", "add submodules")
-	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
-
-	// Only "ok" is available locally: deinit "evil" so its module store no longer holds the pin.
-	runGitAI(t, superRepo, "submodule", "deinit", "-f", "evil")
-	require.NoError(t, os.RemoveAll(filepath.Join(superRepo, ".git", "modules", "evil")))
-
-	overrides, blockers, err := submoduleLocalURLOverrides(ctx, superRepo)
-	require.NoError(t, err)
-	require.Empty(t, overrides, "a non-local submodule must suppress all overrides")
-	require.NotEmpty(t, blockers)
-
-	workTreeDir := filepath.Join(t.TempDir(), "worktree")
-	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
-
-	require.NoError(t, syncSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
-	err = updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir)
-	require.Error(t, err, "git must still refuse the file:// submodule")
-	require.Contains(t, err.Error(), "transport 'file' not allowed")
-	require.NoFileExists(t, filepath.Join(workTreeDir, "evil", "evil.txt"))
-}
-
 func TestAI_SwitchWorkTreeNonSubmodulesUnaffectedByIncludePath(t *testing.T) {
 	ctx := context.Background()
 
@@ -534,3 +80,771 @@ func TestAI_SwitchWorkTreeNonSubmodulesUnaffectedByIncludePath(t *testing.T) {
 	err := switchWorkTree(ctx, filepath.Join(repoDir, ".git"), workTreeDir, headSHA, false)
 	require.NoError(t, err)
 }
+
+var _ = Describe("submoduleNameUnsafe", func() {
+	DescribeTable("rejects a name that cannot be carried by -c submodule.<name>.url",
+		func(name string, expectedUnsafe bool) {
+			Expect(submoduleNameUnsafe(name)).To(Equal(expectedUnsafe))
+		},
+		Entry("equals sign ends the config key early", "a=b", true),
+		Entry("newline splits the config key", "a\nb", true),
+		Entry("slash moves the store path", "a/b", true),
+		Entry("backslash moves the store path on windows", "a\\b", true),
+		Entry("single dot resolves to the store parent", ".", true),
+		Entry("double dot escapes the store", "..", true),
+		Entry("plain name", "sub", false),
+		Entry("dash, underscore and dot inside are fine", "my-sub_2.0", false),
+		Entry("a dot-prefixed name is not a dot component", ".sub", false),
+		Entry("a name ending in a dot is not a dot component", "sub.", false),
+		Entry("three dots are not a dot component", "...", false),
+	)
+})
+
+var _ = Describe("submodule local object store reuse", func() {
+	var (
+		baseDir     string
+		superRepo   string
+		superGitDir string
+		workTreeDir string
+	)
+
+	BeforeEach(func() {
+		isolateGitConfig()
+		baseDir = SuiteData.TestDirPath
+		superRepo = filepath.Join(baseDir, "super")
+		superGitDir = filepath.Join(superRepo, ".git")
+		workTreeDir = filepath.Join(baseDir, "worktree")
+	})
+
+	// The test "remotes" here are local paths, which the plain remote update reaches only with the
+	// file transport allowed — a real https remote would need nothing of the sort.
+	allowFileTransport := func() {
+		setEnvForSpec("GIT_ALLOW_PROTOCOL", "file")
+	}
+
+	addWorkTree := func(ctx context.Context, commit string) {
+		gitSucceed(ctx, superRepo, "worktree", "add", "--detach", workTreeDir, commit)
+	}
+
+	headSHA := func(ctx context.Context, dir string) string {
+		return gitSucceedTrimmed(ctx, dir, "rev-parse", "HEAD")
+	}
+
+	expectFileContent := func(path, expected string) {
+		content, err := os.ReadFile(path)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(content)).To(Equal(expected))
+	}
+
+	It("checks a submodule out from the local store when its remote is gone", func(ctx SpecContext) {
+		subRemote := filepath.Join(baseDir, "sub-remote")
+		gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+		gitInitRepo(ctx, superRepo)
+		gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+		gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+		// `submodule add` already populated superRepo/.git/modules/sub; drop the remote to prove the
+		// checkout into a fresh worktree reuses those local objects and touches no network.
+		Expect(os.RemoveAll(subRemote)).To(Succeed())
+
+		addWorkTree(ctx, headSHA(ctx, superRepo))
+
+		Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+		Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+	})
+
+	It("checks a nested submodule out from the local store when every remote is gone", func(ctx SpecContext) {
+		leafRemote := filepath.Join(baseDir, "leaf-remote")
+		gitInitRepoWithFile(ctx, leafRemote, "leaf.txt", "LEAF")
+
+		midRemote := filepath.Join(baseDir, "mid-remote")
+		gitInitRepo(ctx, midRemote)
+		gitAddSubmoduleSucceed(ctx, midRemote, leafRemote, "leaf")
+		gitSucceed(ctx, midRemote, "commit", "-m", "add leaf")
+
+		gitInitRepo(ctx, superRepo)
+		gitAddSubmoduleSucceed(ctx, superRepo, midRemote, "mid")
+		// `submodule add` populates only the top module store; recurse once to fill mid/modules/leaf.
+		gitUpdateSubmodulesSucceed(ctx, superRepo, "--init", "--recursive")
+		gitSucceed(ctx, superRepo, "commit", "-m", "add mid")
+
+		Expect(os.RemoveAll(leafRemote)).To(Succeed())
+		Expect(os.RemoveAll(midRemote)).To(Succeed())
+
+		addWorkTree(ctx, headSHA(ctx, superRepo))
+
+		Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+		Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		expectFileContent(filepath.Join(workTreeDir, "mid", "leaf", "leaf.txt"), "LEAF")
+	})
+
+	// An already-populated submodule is not re-cloned, so it is fetched from the URL recorded in the
+	// service worktree's own submodule git dir. Moving the gitlink must therefore still resolve from
+	// the superproject store rather than from the remote.
+	It("serves a moved gitlink from the local store in an already warm work tree", func(ctx SpecContext) {
+		subRemote := filepath.Join(baseDir, "sub-remote")
+		gitInitRepoWithFile(ctx, subRemote, "file.txt", "first")
+
+		gitInitRepo(ctx, superRepo)
+		gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+		gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+		// Warm the service worktree on the first gitlink, exactly as an earlier werf run would — sync
+		// included, since it rewrites the submodule remote from .gitmodules on every run.
+		addWorkTree(ctx, headSHA(ctx, superRepo))
+		Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+		Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		// Move the gitlink, and let the superproject store learn the new commit the way CI would.
+		Expect(os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("second"), 0o644)).To(Succeed())
+		gitSucceed(ctx, subRemote, "commit", "-am", "second")
+		gitUpdateSubmodulesSucceed(ctx, superRepo, "--remote", "sub")
+		gitSucceed(ctx, superRepo, "commit", "-am", "bump submodule")
+		secondSHA := headSHA(ctx, superRepo)
+		gitUpdateSubmodulesSucceed(ctx, superRepo, "--init")
+
+		// Only now drop the remote: the moved commit exists locally, so no fetch may be needed.
+		Expect(os.RemoveAll(subRemote)).To(Succeed())
+
+		gitSucceed(ctx, workTreeDir, "checkout", "--force", "--detach", secondSHA)
+		Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+		Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "second")
+	})
+
+	// The fetch redirect must reach nested levels too: their git dirs are per-worktree just like the
+	// top-level one, so a moved nested gitlink is fetched, not re-cloned.
+	It("serves a moved nested gitlink from the local store in an already warm work tree", func(ctx SpecContext) {
+		leafRemote := filepath.Join(baseDir, "leaf-remote")
+		gitInitRepoWithFile(ctx, leafRemote, "leaf.txt", "first")
+
+		midRemote := filepath.Join(baseDir, "mid-remote")
+		gitInitRepo(ctx, midRemote)
+		gitAddSubmoduleSucceed(ctx, midRemote, leafRemote, "leaf")
+		gitSucceed(ctx, midRemote, "commit", "-m", "add leaf")
+
+		gitInitRepo(ctx, superRepo)
+		gitAddSubmoduleSucceed(ctx, superRepo, midRemote, "mid")
+		gitUpdateSubmodulesSucceed(ctx, superRepo, "--init", "--recursive")
+		gitSucceed(ctx, superRepo, "commit", "-m", "add mid")
+
+		addWorkTree(ctx, headSHA(ctx, superRepo))
+		Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+		Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		// Move the NESTED gitlink and let the superproject stores learn the new commits.
+		Expect(os.WriteFile(filepath.Join(leafRemote, "leaf.txt"), []byte("second"), 0o644)).To(Succeed())
+		gitSucceed(ctx, leafRemote, "commit", "-am", "second")
+		gitUpdateSubmodulesSucceed(ctx, midRemote, "--remote", "leaf")
+		gitSucceed(ctx, midRemote, "commit", "-am", "bump leaf")
+		gitUpdateSubmodulesSucceed(ctx, superRepo, "--remote", "mid")
+		gitSucceed(ctx, superRepo, "commit", "-am", "bump mid")
+		secondSHA := headSHA(ctx, superRepo)
+		gitUpdateSubmodulesSucceed(ctx, superRepo, "--init", "--recursive")
+
+		Expect(os.RemoveAll(leafRemote)).To(Succeed())
+		Expect(os.RemoveAll(midRemote)).To(Succeed())
+
+		gitSucceed(ctx, workTreeDir, "checkout", "--force", "--detach", secondSHA)
+		Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+		Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		expectFileContent(filepath.Join(workTreeDir, "mid", "leaf", "leaf.txt"), "second")
+	})
+
+	// GitLab CI clones submodules shallow for GIT_SUBMODULE_DEPTH. A shallow store is not a partial
+	// one — it has every object of the commits it holds — so it must stay eligible for reuse.
+	It("reuses a shallow submodule store", func(ctx SpecContext) {
+		subRemote := filepath.Join(baseDir, "sub-remote")
+		gitInitRepo(ctx, subRemote)
+		for _, marker := range []string{"first", "second"} {
+			Expect(os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte(marker), 0o644)).To(Succeed())
+			gitSucceed(ctx, subRemote, "add", ".")
+			gitSucceed(ctx, subRemote, "commit", "-m", marker)
+		}
+
+		gitInitRepo(ctx, superRepo)
+		// A depth-limited clone is only honored over file://, not over a plain local path.
+		gitAddSubmoduleSucceed(ctx, superRepo, "file://"+subRemote, "sub")
+		gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+		gitSucceed(ctx, superRepo, "submodule", "deinit", "-f", "sub")
+		Expect(os.RemoveAll(filepath.Join(superGitDir, "modules", "sub"))).To(Succeed())
+		gitUpdateSubmodulesSucceed(ctx, superRepo, "--init", "--depth=1")
+		Expect(filepath.Join(superGitDir, "modules", "sub", "shallow")).To(BeARegularFile())
+
+		Expect(os.RemoveAll(subRemote)).To(Succeed())
+
+		addWorkTree(ctx, headSHA(ctx, superRepo))
+		Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+		Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "second")
+	})
+
+	// GIT_SUBMODULE_FORCE_HTTPS makes GitLab CI install its own broad insteadOf prefix rewrite. Ours
+	// is keyed on the full submodule URL, and git resolves insteadOf by longest match, so reuse wins.
+	It("reuses the local store despite a broader ambient insteadOf rule", func(ctx SpecContext) {
+		subRemote := filepath.Join(baseDir, "sub-remote")
+		gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+		gitInitRepo(ctx, superRepo)
+		gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+		gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+		// Redirect the remote's parent prefix at a path that does not exist, standing in for the CI's
+		// token rewrite: reuse must not depend on where that rule points.
+		gitSucceed(ctx, superRepo, "config", "url."+filepath.Join(baseDir, "tokenized")+"/.insteadOf", filepath.Dir(subRemote)+"/")
+		Expect(os.RemoveAll(subRemote)).To(Succeed())
+
+		addWorkTree(ctx, headSHA(ctx, superRepo))
+		Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+		Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+	})
+
+	// Reuse rests on git behavior that is not promised, so a store that passes every check and still
+	// cannot serve the checkout must cost a slower build, not a failed one.
+	It("falls back to the remotes when the local store cannot serve the checkout", func(ctx SpecContext) {
+		// The retry deliberately drops the transport allowance that only the local store needs.
+		allowFileTransport()
+
+		subRemote := filepath.Join(baseDir, "sub-remote")
+		gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+		gitInitRepo(ctx, superRepo)
+		gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+		gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+		// Drop the blob from the store while leaving the pinned commit reachable: the probe still
+		// succeeds, and nothing marks the store as partial, so only the checkout can discover this.
+		subSHA := strings.Fields(gitSucceed(ctx, superRepo, "ls-tree", "HEAD", "--", "sub"))[2]
+		storeDir := filepath.Join(superGitDir, "modules", "sub")
+		blobSHA := gitSucceedTrimmed(ctx, storeDir, "rev-parse", subSHA+":file.txt")
+		Expect(os.Remove(filepath.Join(storeDir, "objects", blobSHA[:2], blobSHA[2:]))).To(Succeed())
+
+		addWorkTree(ctx, headSHA(ctx, superRepo))
+		Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		// Pins that the broken store is still reuse-eligible. Without this the spec would keep passing
+		// through the ordinary remote path if the store ever stopped qualifying, and would no longer
+		// exercise the retry it is named for.
+		overrides, blockers, err := submoduleLocalURLOverrides(ctx, workTreeDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(blockers).To(BeEmpty(), "a missing blob is undetectable up front, so nothing may block reuse")
+		Expect(overrides).ToNot(BeEmpty())
+
+		Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+
+		// The submodule ends up served by the retry, so it records the real remote, not the store.
+		worktreeGitDir, _, err := resolveWorkTreeGitDirs(ctx, workTreeDir)
+		Expect(err).ToNot(HaveOccurred())
+		servedFrom := gitSucceedTrimmed(ctx, filepath.Join(worktreeGitDir, "modules", "sub"), "config", "--get", "remote.origin.url")
+		Expect(servedFrom).To(Equal(subRemote))
+	})
+
+	// Determining whether reuse applies is itself an optimization: when the probe cannot even run,
+	// the build must get slower, not fail.
+	It("falls back to the remotes when the local store cannot be inspected at all", func(ctx SpecContext) {
+		allowFileTransport()
+
+		subRemote := filepath.Join(baseDir, "sub-remote")
+		gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+		gitInitRepo(ctx, superRepo)
+		gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+		gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+		addWorkTree(ctx, headSHA(ctx, superRepo))
+
+		// An unreadable config makes every probe of this store fail outright, unlike the blockers,
+		// which are stores werf understands and rejects. A linked worktree keeps its own submodule git
+		// dirs, so the plain remote update never touches this one.
+		storeConfig := filepath.Join(superGitDir, "modules", "sub", "config")
+		Expect(storeConfig).To(BeARegularFile())
+		Expect(os.WriteFile(storeConfig, []byte("[this is not valid git config\n"), 0o644)).To(Succeed())
+
+		_, _, err := submoduleLocalURLOverrides(ctx, workTreeDir)
+		Expect(err).To(HaveOccurred(), "the spec is only meaningful while the probe really fails")
+
+		Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+		Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+		expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+	})
+
+	Describe("blockers that suppress reuse entirely", func() {
+		// Partial reuse is unsafe, so every one of these must leave NO override behind: the plain
+		// remote update werf has always done is the only safe fallback.
+		expectReuseBlocked := func(ctx context.Context, dir, blockerSubstring string) {
+			overrides, blockers, err := submoduleLocalURLOverrides(ctx, dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(overrides).To(BeEmpty(), "a blocked submodule must suppress ALL overrides")
+			Expect(strings.Join(blockers, "\n")).To(ContainSubstring(blockerSubstring))
+		}
+
+		// A submodule name reused at another nesting level cannot be expressed as a process-global
+		// submodule.<name>.url, so no override may be emitted: an override for the top-level copy
+		// would otherwise hijack the nested clone and fail the whole update.
+		It("blocks on a submodule name used at two nesting levels", func(ctx SpecContext) {
+			newLib := func(marker string) string {
+				dir := filepath.Join(baseDir, "lib-"+marker)
+				gitInitRepoWithFile(ctx, dir, "who.txt", marker)
+				return dir
+			}
+			libA := newLib("A")
+			libB := newLib("B")
+
+			// mid carries a DIFFERENT repo under the same submodule name "lib".
+			midRemote := filepath.Join(baseDir, "mid-remote")
+			gitInitRepo(ctx, midRemote)
+			gitAddSubmoduleSucceed(ctx, midRemote, libB, "lib")
+			gitSucceed(ctx, midRemote, "commit", "-m", "add lib B")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, libA, "lib")
+			gitAddSubmoduleSucceed(ctx, superRepo, midRemote, "mid")
+			gitUpdateSubmodulesSucceed(ctx, superRepo, "--init", "--recursive")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add lib A and mid")
+
+			expectReuseBlocked(ctx, superRepo, `is used more than once`)
+
+			// Remotes stay reachable here, so the plain remote update must still produce correct
+			// content for BOTH same-named submodules.
+			allowFileTransport()
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+			expectFileContent(filepath.Join(workTreeDir, "lib", "who.txt"), "A")
+			expectFileContent(filepath.Join(workTreeDir, "mid", "lib", "who.txt"), "B")
+		})
+
+		// The everyday CI shape of an unserviceable store: it exists and is perfectly healthy, it
+		// just predates the gitlink. Only looking the pinned object up can tell.
+		It("blocks when the store exists but predates the pinned commit", func(ctx SpecContext) {
+			subRemote := filepath.Join(baseDir, "sub-remote")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "first")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+			// Move the submodule on in its remote and bump the gitlink to the new commit WITHOUT ever
+			// fetching it into the superproject store.
+			Expect(os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("second"), 0o644)).To(Succeed())
+			gitSucceed(ctx, subRemote, "commit", "-am", "second")
+			unfetchedSHA := headSHA(ctx, subRemote)
+			gitSucceed(ctx, superRepo, "update-index", "--cacheinfo", "160000,"+unfetchedSHA+",sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "bump the gitlink past the store")
+
+			storeDir := filepath.Join(superGitDir, "modules", "sub")
+			Expect(storeDir).To(BeADirectory(), "the store must exist, or a cheaper check would explain the blocker")
+
+			expectReuseBlocked(ctx, superRepo, "not initialized locally")
+
+			// The remote does have the commit, so the plain remote update still completes.
+			allowFileTransport()
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "second")
+		})
+
+		// Reuse enumerates nested submodules out of the pinned TREE, so a store holding the pinned
+		// commit while missing that tree cannot serve the checkout either. Peeling the pin to its
+		// tree is what tells the two apart.
+		It("blocks when the store holds the pinned commit but not its tree", func(ctx SpecContext) {
+			subRemote := filepath.Join(baseDir, "sub-remote")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "first")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+			Expect(os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("second"), 0o644)).To(Succeed())
+			gitSucceed(ctx, subRemote, "commit", "-am", "second")
+			unfetchedSHA := headSHA(ctx, subRemote)
+			gitSucceed(ctx, superRepo, "update-index", "--cacheinfo", "160000,"+unfetchedSHA+",sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "bump the gitlink past the store")
+
+			// Plant the pinned COMMIT object alone into the store: a commit object names its tree but
+			// does not carry it, so writing it back verbatim leaves the tree missing.
+			storeDir := filepath.Join(superGitDir, "modules", "sub")
+			commitObject := gitSucceed(ctx, subRemote, "cat-file", "commit", unfetchedSHA)
+			planted := gitSucceedWithStdin(ctx, storeDir, commitObject, "hash-object", "-t", "commit", "-w", "--stdin")
+			Expect(planted).To(Equal(unfetchedSHA), "the planted object must be the pin itself")
+
+			hasCommit, err := gitObjectExists(ctx, storeDir, unfetchedSHA+"^{commit}")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasCommit).To(BeTrue(), "a commit-only probe would call this store serviceable")
+
+			expectReuseBlocked(ctx, superRepo, "not initialized locally")
+
+			allowFileTransport()
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "second")
+		})
+
+		// protocol.file.allow=always is only safe while every URL of the invocation is one werf
+		// computed, so a submodule that cannot be served locally must suppress the overrides
+		// entirely — otherwise the relaxed transport would also un-block a file:// URL taken from
+		// committed .gitmodules (CVE-2022-39253 class).
+		It("keeps the file transport blocked for a submodule missing from the store", func(ctx SpecContext) {
+			okRemote := filepath.Join(baseDir, "ok-remote")
+			gitInitRepoWithFile(ctx, okRemote, "ok.txt", "OK")
+
+			evilRemote := filepath.Join(baseDir, "evil-remote")
+			gitInitRepoWithFile(ctx, evilRemote, "evil.txt", "EVIL")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, okRemote, "ok")
+			gitAddSubmoduleSucceed(ctx, superRepo, "file://"+evilRemote, "evil")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodules")
+
+			// Only "ok" is available locally: deinit "evil" so its module store no longer holds the pin.
+			gitSucceed(ctx, superRepo, "submodule", "deinit", "-f", "evil")
+			Expect(os.RemoveAll(filepath.Join(superGitDir, "modules", "evil"))).To(Succeed())
+
+			expectReuseBlocked(ctx, superRepo, "not initialized locally")
+
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			err := updateSubmodules(ctx, superGitDir, workTreeDir)
+			Expect(err).To(HaveOccurred(), "git must still refuse the file:// submodule")
+			Expect(err.Error()).To(ContainSubstring("transport 'file' not allowed"))
+			Expect(filepath.Join(workTreeDir, "evil", "evil.txt")).ToNot(BeAnExistingFile())
+		})
+
+		// A partial clone can hold the pinned commit while its blobs still live on the promisor
+		// remote, so cloning from it would fail or need the very network reuse exists to avoid.
+		DescribeTable("blocks on a partial-clone marker in the store",
+			func(ctx SpecContext, configKey, configValue string) {
+				subRemote := filepath.Join(baseDir, "sub-remote")
+				gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+				gitInitRepo(ctx, superRepo)
+				gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+				gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+				storeDir := filepath.Join(superGitDir, "modules", "sub")
+				gitSucceed(ctx, storeDir, "config", configKey, configValue)
+
+				expectReuseBlocked(ctx, superRepo, "local clone is partial")
+
+				// The store is intact apart from the marker, so the plain remote update still works.
+				allowFileTransport()
+				addWorkTree(ctx, headSHA(ctx, superRepo))
+				Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+				Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+				expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+			},
+			Entry("extensions.partialclone", "extensions.partialclone", "origin"),
+			Entry("remote.<name>.promisor", "remote.origin.promisor", "true"),
+			Entry("remote.<name>.partialclonefilter", "remote.origin.partialclonefilter", "blob:none"),
+		)
+
+		// url.<store>.insteadOf=<remote> is keyed on the remote URL, so one URL shared by two
+		// submodules would need two different stores behind the same key.
+		It("blocks when two submodules share one remote URL", func(ctx SpecContext) {
+			subRemote := filepath.Join(baseDir, "sub-remote")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "a")
+			gitSucceed(ctx, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", "--name", "b", subRemote, "b")
+			gitSucceed(ctx, superRepo, "commit", "-m", "two submodules, one remote URL")
+
+			// The shared URL is only reachable once the service worktree has its own submodule git
+			// dirs, which is what records a remote to redirect: warm it, then let sync put the real
+			// remote back the way every werf run does.
+			allowFileTransport()
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+			expectReuseBlocked(ctx, workTreeDir, "remote URL is shared with another submodule")
+
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			expectFileContent(filepath.Join(workTreeDir, "a", "file.txt"), "hello")
+			expectFileContent(filepath.Join(workTreeDir, "b", "file.txt"), "hello")
+		})
+
+		// insteadOf matches by prefix, so a remote URL that prefixes a store path would rewrite that
+		// store URL too, and the clone would be pointed somewhere else entirely.
+		It("blocks when a remote URL prefixes another submodule's store path", func(ctx SpecContext) {
+			// The store path is <superRepo>/.git/modules/<name>, so a remote at <superRepo> minus its
+			// suffix is a literal string prefix of it.
+			superRepo = filepath.Join(baseDir, "pfx-super")
+			superGitDir = filepath.Join(superRepo, ".git")
+			subRemote := filepath.Join(baseDir, "pfx")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+			allowFileTransport()
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+			storeDir := filepath.Join(superGitDir, "modules", "sub")
+			Expect(storeDir).To(HavePrefix(subRemote), "the spec is only meaningful while the URL really prefixes the store path")
+			expectReuseBlocked(ctx, workTreeDir, "prefixes the object store path of")
+
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+		})
+
+		// Without a recorded remote there is nothing for url.<store>.insteadOf to key on, so the
+		// already-populated submodule would keep fetching from wherever git resolves it.
+		It("blocks when a populated submodule records no remote URL", func(ctx SpecContext) {
+			subRemote := filepath.Join(baseDir, "sub-remote")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+			allowFileTransport()
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+
+			worktreeGitDir, _, err := resolveWorkTreeGitDirs(ctx, workTreeDir)
+			Expect(err).ToNot(HaveOccurred())
+			worktreeModuleDir := filepath.Join(worktreeGitDir, "modules", "sub")
+			Expect(worktreeModuleDir).To(BeADirectory())
+			gitSucceed(ctx, worktreeModuleDir, "config", "--unset", "remote.origin.url")
+
+			expectReuseBlocked(ctx, workTreeDir, "has no remote URL to redirect")
+
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+		})
+
+		// The store path lands in the KEY of -c url.<path>.insteadOf, and git rejects a key carrying
+		// an `=`. Reuse must notice that before handing such an option to git.
+		It("blocks when the store path cannot be expressed as a git config key", func(ctx SpecContext) {
+			superRepo = filepath.Join(baseDir, "super=eq")
+			superGitDir = filepath.Join(superRepo, ".git")
+
+			subRemote := filepath.Join(baseDir, "sub-remote")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+			expectReuseBlocked(ctx, superRepo, "cannot be expressed as a git config key")
+
+			allowFileTransport()
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+		})
+
+		// A repo-controlled name carrying an `=` would end the -c submodule.<name>.url key early, so
+		// the store path would land in an unrelated option's value instead.
+		It("blocks on a submodule whose committed name carries an equals sign", func(ctx SpecContext) {
+			subRemote := filepath.Join(baseDir, "sub-remote")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+			// git offers no way to commit such a name, so write .gitmodules directly. The store the
+			// legitimate `submodule add` produced stays in place, so nothing else can block reuse.
+			gitmodules := "[submodule \"ev=il\"]\n\tpath = sub\n\turl = " + subRemote + "\n"
+			Expect(os.WriteFile(filepath.Join(superRepo, ".gitmodules"), []byte(gitmodules), 0o644)).To(Succeed())
+			gitSucceed(ctx, superRepo, "add", ".gitmodules")
+			gitSucceed(ctx, superRepo, "commit", "-m", "rename the submodule to a hostile name")
+
+			expectReuseBlocked(ctx, superRepo, `unsupported submodule name "ev=il"`)
+
+			allowFileTransport()
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+		})
+	})
+
+	// .gitmodules is committed content git validates in no way. Both of these must be ignored the
+	// way git itself ignores them, and neither may cost the whole repository its reuse.
+	Describe("hostile .gitmodules content that must not disable reuse", func() {
+		// Reuse must come out of these unharmed: exactly the one real submodule redirected, and nothing
+		// blocked. The store here is the main work tree's own, which is also the remote it records, so
+		// only the submodule.<name>.url override applies.
+		expectOnlySubIsRedirected := func(ctx context.Context) {
+			overrides, blockers, err := submoduleLocalURLOverrides(ctx, superRepo)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(blockers).To(BeEmpty())
+			storeDir := filepath.Join(superGitDir, "modules", "sub")
+			Expect(overrides).To(Equal([]string{
+				"-c", "submodule.sub.url=" + storeDir,
+				"-c", "url." + storeDir + ".insteadOf=" + filepath.Join(baseDir, "sub-remote"),
+			}))
+		}
+
+		It("ignores an [include] section rather than reading it as a submodule", func(ctx SpecContext) {
+			subRemote := filepath.Join(baseDir, "sub-remote")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+			// `include.path` also ends in `.path`, so an unanchored key regex reads it as a submodule
+			// named "include". Pointing it at the real submodule's path gives that phantom a gitlink,
+			// which is what makes the misreading observable at all.
+			gitmodules := gitSucceed(ctx, superRepo, "show", "HEAD:.gitmodules") + "[include]\n\tpath = sub\n"
+			Expect(os.WriteFile(filepath.Join(superRepo, ".gitmodules"), []byte(gitmodules), 0o644)).To(Succeed())
+			gitSucceed(ctx, superRepo, "add", ".gitmodules")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add an include section")
+
+			expectOnlySubIsRedirected(ctx)
+
+			Expect(os.RemoveAll(subRemote)).To(Succeed())
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+		})
+
+		It("ignores an absolute and a .. submodule path rather than failing the update", func(ctx SpecContext) {
+			subRemote := filepath.Join(baseDir, "sub-remote")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+			// git refuses to add these itself; a repository can still ship them. As a pathspec each
+			// would fail the ls-tree of the whole update, while git checks out no submodule there.
+			gitmodules := gitSucceed(ctx, superRepo, "show", "HEAD:.gitmodules") +
+				"[submodule \"abs\"]\n\tpath = " + filepath.Join(baseDir, "absolute-victim") + "\n\turl = https://werf-test-nonexistent.invalid/a.git\n" +
+				"[submodule \"up\"]\n\tpath = ../escape\n\turl = https://werf-test-nonexistent.invalid/b.git\n"
+			Expect(os.WriteFile(filepath.Join(superRepo, ".gitmodules"), []byte(gitmodules), 0o644)).To(Succeed())
+			gitSucceed(ctx, superRepo, "add", ".gitmodules")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add non-local submodule paths")
+
+			expectOnlySubIsRedirected(ctx)
+
+			// Dropping the remote also pins that the surviving submodule is served locally: the plain
+			// update this used to fall back to could not reach it any more.
+			Expect(os.RemoveAll(subRemote)).To(Succeed())
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+			Expect(syncSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			Expect(updateSubmodules(ctx, superGitDir, workTreeDir)).To(Succeed())
+			expectFileContent(filepath.Join(workTreeDir, "sub", "file.txt"), "hello")
+		})
+	})
+
+	Describe("discardWorktreeSubmoduleGitDirs", func() {
+		// The fallback discards the service worktree's submodule state, and in a main work tree that
+		// same path is the repository-wide submodule store. It must refuse rather than destroy data.
+		It("refuses a main work tree", func(ctx SpecContext) {
+			subRemote := filepath.Join(baseDir, "sub-remote")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+
+			sharedStore := filepath.Join(superGitDir, "modules", "sub")
+			Expect(sharedStore).To(BeADirectory())
+
+			err := discardWorktreeSubmoduleGitDirs(ctx, superRepo)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a linked work tree"))
+			Expect(sharedStore).To(BeADirectory(), "the repository-wide submodule store must survive")
+			Expect(filepath.Join(superRepo, "sub", "file.txt")).To(BeARegularFile())
+		})
+
+		// .gitmodules is committed content, and git does not validate its paths, so the discard must
+		// not delete at a path HEAD does not record as a gitlink.
+		It("ignores a .gitmodules path without a gitlink", func(ctx SpecContext) {
+			outside := filepath.Join(baseDir, "outside")
+			Expect(os.MkdirAll(filepath.Join(outside, "inner"), 0o755)).To(Succeed())
+			victim := filepath.Join(outside, "inner", "data.txt")
+			Expect(os.WriteFile(victim, []byte("precious"), 0o644)).To(Succeed())
+
+			gitInitRepo(ctx, superRepo)
+			escape, err := filepath.Rel(superRepo, outside)
+			Expect(err).ToNot(HaveOccurred())
+			gitmodules := "[submodule \"escape\"]\n\tpath = " + escape + "\n\turl = https://werf-test-nonexistent.invalid/x.git\n"
+			Expect(os.WriteFile(filepath.Join(superRepo, ".gitmodules"), []byte(gitmodules), 0o644)).To(Succeed())
+			gitSucceed(ctx, superRepo, "add", ".gitmodules")
+			gitSucceed(ctx, superRepo, "commit", "-m", "gitmodules entry without a gitlink")
+
+			// The second variant reaches outside through a committed symlink used as an intermediate
+			// path component, so it looks work-tree local and only the gitlink check rejects it.
+			// RemoveAll would follow it, unlike a symlink in the final position, which it would
+			// merely unlink.
+			Expect(os.Symlink(outside, filepath.Join(superRepo, "link"))).To(Succeed())
+			gitmodules += "[submodule \"vialink\"]\n\tpath = link/inner\n\turl = https://werf-test-nonexistent.invalid/y.git\n"
+			Expect(os.WriteFile(filepath.Join(superRepo, ".gitmodules"), []byte(gitmodules), 0o644)).To(Succeed())
+			gitSucceed(ctx, superRepo, "add", ".gitmodules", "link")
+			gitSucceed(ctx, superRepo, "commit", "-m", "symlinked gitmodules path")
+
+			addWorkTree(ctx, headSHA(ctx, superRepo))
+
+			Expect(discardWorktreeSubmoduleGitDirs(ctx, workTreeDir)).To(Succeed())
+			Expect(victim).To(BeARegularFile(), "a path outside the work tree must never be removed")
+		})
+
+		// The discard resolves what it deletes from the work tree's own .git pointer, not from
+		// `git rev-parse`, which an inherited GIT_DIR silently redirects at another repository.
+		It("removes only the given work tree's submodule git dirs under an inherited GIT_DIR", func(ctx SpecContext) {
+			subRemote := filepath.Join(baseDir, "sub-remote")
+			gitInitRepoWithFile(ctx, subRemote, "file.txt", "hello")
+
+			gitInitRepo(ctx, superRepo)
+			gitAddSubmoduleSucceed(ctx, superRepo, subRemote, "sub")
+			gitSucceed(ctx, superRepo, "commit", "-m", "add submodule")
+			commit := headSHA(ctx, superRepo)
+
+			bystanderWorkTree := filepath.Join(baseDir, "bystander")
+			gitSucceed(ctx, superRepo, "worktree", "add", "--detach", bystanderWorkTree, commit)
+			addWorkTree(ctx, commit)
+			for _, dir := range []string{bystanderWorkTree, workTreeDir} {
+				gitUpdateSubmodulesSucceed(ctx, dir, "--init")
+			}
+
+			targetGitDir, _, err := resolveWorkTreeGitDirs(ctx, workTreeDir)
+			Expect(err).ToNot(HaveOccurred())
+			bystanderGitDir, _, err := resolveWorkTreeGitDirs(ctx, bystanderWorkTree)
+			Expect(err).ToNot(HaveOccurred())
+			bystanderModules := filepath.Join(bystanderGitDir, "modules", "sub")
+			Expect(bystanderModules).To(BeADirectory())
+			Expect(filepath.Join(targetGitDir, "modules", "sub")).To(BeADirectory())
+
+			// This is what defeated the earlier `git rev-parse`-based resolution: every git
+			// invocation, and the discard with it, would have answered for the bystander instead.
+			setEnvForSpec("GIT_DIR", bystanderGitDir)
+
+			Expect(discardWorktreeSubmoduleGitDirs(ctx, workTreeDir)).To(Succeed())
+
+			Expect(bystanderModules).To(BeADirectory(), "another work tree's submodule git dirs must survive")
+			Expect(filepath.Join(bystanderWorkTree, "sub", "file.txt")).To(BeARegularFile())
+			Expect(filepath.Join(targetGitDir, "modules")).ToNot(BeAnExistingFile())
+			Expect(filepath.Join(workTreeDir, "sub")).ToNot(BeAnExistingFile())
+		})
+	})
+})

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -62,6 +62,73 @@ func TestAI_UpdateSubmodulesForwardsIncludePath(t *testing.T) {
 	require.Contains(t, err.Error(), "werf-test-marker")
 }
 
+func TestAI_UpdateSubmodulesReusesLocalObjectsWithoutRemote(t *testing.T) {
+	ctx := context.Background()
+
+	subRemote := t.TempDir()
+	initGitRepoAI(t, subRemote)
+	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("hello"), 0o644))
+	runGitAI(t, subRemote, "add", ".")
+	runGitAI(t, subRemote, "commit", "-m", "sub content")
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "sub")
+	runGitAI(t, superRepo, "commit", "-m", "add submodule")
+	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+
+	// `submodule add` already populated superRepo/.git/modules/sub; drop the remote to prove the
+	// checkout into a fresh worktree reuses those local objects and touches no network.
+	require.NoError(t, os.RemoveAll(subRemote))
+
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
+
+	err := updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(content))
+}
+
+func TestAI_UpdateSubmodulesReusesLocalObjectsForNestedWithoutRemote(t *testing.T) {
+	ctx := context.Background()
+
+	leafRemote := t.TempDir()
+	initGitRepoAI(t, leafRemote)
+	require.NoError(t, os.WriteFile(filepath.Join(leafRemote, "leaf.txt"), []byte("LEAF"), 0o644))
+	runGitAI(t, leafRemote, "add", ".")
+	runGitAI(t, leafRemote, "commit", "-m", "leaf content")
+
+	midRemote := t.TempDir()
+	initGitRepoAI(t, midRemote)
+	runGitAI(t, midRemote, "-c", "protocol.file.allow=always", "submodule", "add", leafRemote, "leaf")
+	runGitAI(t, midRemote, "commit", "-m", "add leaf")
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", midRemote, "mid")
+	// `submodule add` populates only the top module store; recurse once to fill mid/modules/leaf.
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
+	runGitAI(t, superRepo, "commit", "-m", "add mid")
+	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+
+	// Drop every remote to prove both levels are checked out from the local object store alone.
+	require.NoError(t, os.RemoveAll(leafRemote))
+	require.NoError(t, os.RemoveAll(midRemote))
+
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
+
+	err := updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(workTreeDir, "mid", "leaf", "leaf.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "LEAF", string(content))
+}
+
 func TestAI_SwitchWorkTreeNonSubmodulesUnaffectedByIncludePath(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -230,6 +230,69 @@ func TestAI_UpdateSubmodulesReusesLocalObjectsAfterNestedGitlinkMovedInWarmWorkT
 	require.Equal(t, "second", string(content))
 }
 
+// The fallback discards the service worktree's submodule state, and in a main work tree that same
+// path is the repository-wide submodule store. It must refuse rather than destroy the user's data.
+func TestAI_DiscardWorktreeSubmoduleGitDirsRefusesMainWorkTree(t *testing.T) {
+	ctx := context.Background()
+	isolateGitConfigAI(t)
+
+	subRemote := t.TempDir()
+	initGitRepoAI(t, subRemote)
+	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("hello"), 0o644))
+	runGitAI(t, subRemote, "add", ".")
+	runGitAI(t, subRemote, "commit", "-m", "content")
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "sub")
+	runGitAI(t, superRepo, "commit", "-m", "add submodule")
+
+	sharedStore := filepath.Join(superRepo, ".git", "modules", "sub")
+	require.DirExists(t, sharedStore)
+
+	err := discardWorktreeSubmoduleGitDirs(ctx, superRepo)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a linked work tree")
+	require.DirExists(t, sharedStore, "the repository-wide submodule store must survive")
+	require.FileExists(t, filepath.Join(superRepo, "sub", "file.txt"))
+}
+
+// .gitmodules is committed content, and git does not validate its paths, so the discard must not
+// delete at a path HEAD does not record as a gitlink.
+func TestAI_DiscardWorktreeSubmoduleGitDirsIgnoresPathsWithoutGitlink(t *testing.T) {
+	ctx := context.Background()
+	isolateGitConfigAI(t)
+
+	outside := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(outside, "inner"), 0o755))
+	victim := filepath.Join(outside, "inner", "data.txt")
+	require.NoError(t, os.WriteFile(victim, []byte("precious"), 0o644))
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	escape, err := filepath.Rel(superRepo, outside)
+	require.NoError(t, err)
+	gitmodules := "[submodule \"escape\"]\n\tpath = " + escape + "\n\turl = https://werf-test-nonexistent.invalid/x.git\n"
+	require.NoError(t, os.WriteFile(filepath.Join(superRepo, ".gitmodules"), []byte(gitmodules), 0o644))
+	runGitAI(t, superRepo, "add", ".gitmodules")
+	runGitAI(t, superRepo, "commit", "-m", "gitmodules entry without a gitlink")
+
+	// The second variant reaches outside through a committed symlink used as an intermediate path
+	// component, so it looks work-tree local and only the gitlink check rejects it. RemoveAll would
+	// follow it, unlike a symlink in the final position, which it would merely unlink.
+	require.NoError(t, os.Symlink(outside, filepath.Join(superRepo, "link")))
+	gitmodules += "[submodule \"vialink\"]\n\tpath = link/inner\n\turl = https://werf-test-nonexistent.invalid/y.git\n"
+	require.NoError(t, os.WriteFile(filepath.Join(superRepo, ".gitmodules"), []byte(gitmodules), 0o644))
+	runGitAI(t, superRepo, "add", ".gitmodules", "link")
+	runGitAI(t, superRepo, "commit", "-m", "symlinked gitmodules path")
+
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD")))
+
+	require.NoError(t, discardWorktreeSubmoduleGitDirs(ctx, workTreeDir))
+	require.FileExists(t, victim, "a path outside the work tree must never be removed")
+}
+
 // Reuse rests on git behavior that is not promised, so a store that passes every check and still
 // cannot serve the checkout must cost a slower build, not a failed one.
 func TestAI_UpdateSubmodulesFallsBackToRemoteWhenLocalStoreCannotServe(t *testing.T) {
@@ -262,11 +325,25 @@ func TestAI_UpdateSubmodulesFallsBackToRemoteWhenLocalStoreCannotServe(t *testin
 	workTreeDir := filepath.Join(t.TempDir(), "worktree")
 	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
 	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
+
+	// Pins that the broken store is still reuse-eligible. Without this the test would keep passing
+	// through the ordinary remote path if the store ever stopped qualifying, and would no longer
+	// exercise the retry it is named for.
+	overrides, blockers, err := submoduleLocalURLOverrides(ctx, workTreeDir)
+	require.NoError(t, err)
+	require.Empty(t, blockers, "a missing blob is undetectable up front, so nothing may block reuse")
+	require.NotEmpty(t, overrides)
+
 	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
 
 	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
 	require.NoError(t, err)
 	require.Equal(t, "hello", string(content))
+
+	// The submodule ends up served by the retry, so it records the real remote rather than the store.
+	worktreeGitDir := strings.TrimSpace(runGitAI(t, workTreeDir, "rev-parse", "--absolute-git-dir"))
+	servedFrom := strings.TrimSpace(runGitAI(t, filepath.Join(worktreeGitDir, "modules", "sub"), "config", "--get", "remote.origin.url"))
+	require.Equal(t, subRemote, servedFrom)
 }
 
 // GitLab CI clones submodules shallow for GIT_SUBMODULE_DEPTH. A shallow store is not a partial

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -230,6 +230,78 @@ func TestAI_UpdateSubmodulesReusesLocalObjectsAfterNestedGitlinkMovedInWarmWorkT
 	require.Equal(t, "second", string(content))
 }
 
+// GitLab CI clones submodules shallow for GIT_SUBMODULE_DEPTH. A shallow store is not a partial
+// one — it has every object of the commits it holds — so it must stay eligible for reuse.
+func TestAI_UpdateSubmodulesReusesLocalObjectsFromShallowSubmoduleStore(t *testing.T) {
+	ctx := context.Background()
+	isolateGitConfigAI(t)
+
+	subRemote := t.TempDir()
+	initGitRepoAI(t, subRemote)
+	for _, marker := range []string{"first", "second"} {
+		require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte(marker), 0o644))
+		runGitAI(t, subRemote, "add", ".")
+		runGitAI(t, subRemote, "commit", "-m", marker)
+	}
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	// A depth-limited clone is only honored over file://, not over a plain local path.
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", "file://"+subRemote, "sub")
+	runGitAI(t, superRepo, "commit", "-m", "add submodule")
+	runGitAI(t, superRepo, "submodule", "deinit", "-f", "sub")
+	require.NoError(t, os.RemoveAll(filepath.Join(superRepo, ".git", "modules", "sub")))
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--depth=1")
+	require.FileExists(t, filepath.Join(superRepo, ".git", "modules", "sub", "shallow"))
+	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+
+	require.NoError(t, os.RemoveAll(subRemote))
+
+	gitDir := filepath.Join(superRepo, ".git")
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
+	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
+	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
+
+	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "second", string(content))
+}
+
+// GIT_SUBMODULE_FORCE_HTTPS makes GitLab CI install its own broad insteadOf prefix rewrite. Ours is
+// keyed on the full submodule URL, and git resolves insteadOf by longest match, so reuse must win.
+func TestAI_UpdateSubmodulesReusesLocalObjectsDespiteExistingInsteadOfRule(t *testing.T) {
+	ctx := context.Background()
+	isolateGitConfigAI(t)
+
+	subRemote := t.TempDir()
+	initGitRepoAI(t, subRemote)
+	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("hello"), 0o644))
+	runGitAI(t, subRemote, "add", ".")
+	runGitAI(t, subRemote, "commit", "-m", "content")
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "sub")
+	runGitAI(t, superRepo, "commit", "-m", "add submodule")
+	headSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+
+	// Redirect the remote's parent prefix at a path that does not exist, standing in for the CI's
+	// token rewrite: reuse must not depend on where that rule points.
+	runGitAI(t, superRepo, "config", "url."+filepath.Join(t.TempDir(), "tokenized")+"/.insteadOf", filepath.Dir(subRemote)+"/")
+	require.NoError(t, os.RemoveAll(subRemote))
+
+	gitDir := filepath.Join(superRepo, ".git")
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
+	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
+	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
+
+	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(content))
+}
+
 // A submodule name reused at another nesting level cannot be expressed as a process-global
 // submodule.<name>.url, so no override may be emitted: an override for the top-level copy would
 // otherwise hijack the nested clone and fail the whole update.

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -85,8 +85,8 @@ func TestAI_UpdateSubmodulesReusesLocalObjectsWithoutRemote(t *testing.T) {
 	workTreeDir := filepath.Join(t.TempDir(), "worktree")
 	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
 
-	err := updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir)
-	require.NoError(t, err)
+	require.NoError(t, syncSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
+	require.NoError(t, updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
 
 	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
 	require.NoError(t, err)
@@ -123,8 +123,8 @@ func TestAI_UpdateSubmodulesReusesLocalObjectsForNestedWithoutRemote(t *testing.
 	workTreeDir := filepath.Join(t.TempDir(), "worktree")
 	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
 
-	err := updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir)
-	require.NoError(t, err)
+	require.NoError(t, syncSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
+	require.NoError(t, updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
 
 	content, err := os.ReadFile(filepath.Join(workTreeDir, "mid", "leaf", "leaf.txt"))
 	require.NoError(t, err)
@@ -178,6 +178,58 @@ func TestAI_UpdateSubmodulesReusesLocalObjectsAfterGitlinkMovedInWarmWorkTree(t 
 	require.Equal(t, "second", string(content))
 }
 
+// The fetch redirect must reach nested levels too: their git dirs are per-worktree just like the
+// top-level one, so a moved nested gitlink is fetched, not re-cloned.
+func TestAI_UpdateSubmodulesReusesLocalObjectsAfterNestedGitlinkMovedInWarmWorkTree(t *testing.T) {
+	ctx := context.Background()
+	isolateGitConfigAI(t)
+
+	leafRemote := t.TempDir()
+	initGitRepoAI(t, leafRemote)
+	require.NoError(t, os.WriteFile(filepath.Join(leafRemote, "leaf.txt"), []byte("first"), 0o644))
+	runGitAI(t, leafRemote, "add", ".")
+	runGitAI(t, leafRemote, "commit", "-m", "first")
+
+	midRemote := t.TempDir()
+	initGitRepoAI(t, midRemote)
+	runGitAI(t, midRemote, "-c", "protocol.file.allow=always", "submodule", "add", leafRemote, "leaf")
+	runGitAI(t, midRemote, "commit", "-m", "add leaf")
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", midRemote, "mid")
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
+	runGitAI(t, superRepo, "commit", "-m", "add mid")
+	firstSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+
+	gitDir := filepath.Join(superRepo, ".git")
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, firstSHA)
+	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
+	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
+
+	// Move the NESTED gitlink and let the superproject stores learn the new commits.
+	require.NoError(t, os.WriteFile(filepath.Join(leafRemote, "leaf.txt"), []byte("second"), 0o644))
+	runGitAI(t, leafRemote, "commit", "-am", "second")
+	runGitAI(t, midRemote, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "leaf")
+	runGitAI(t, midRemote, "commit", "-am", "bump leaf")
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "mid")
+	runGitAI(t, superRepo, "commit", "-am", "bump mid")
+	secondSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
+
+	require.NoError(t, os.RemoveAll(leafRemote))
+	require.NoError(t, os.RemoveAll(midRemote))
+
+	runGitAI(t, workTreeDir, "checkout", "--force", "--detach", secondSHA)
+	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
+	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
+
+	content, err := os.ReadFile(filepath.Join(workTreeDir, "mid", "leaf", "leaf.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "second", string(content))
+}
+
 // A submodule name reused at another nesting level cannot be expressed as a process-global
 // submodule.<name>.url, so no override may be emitted: an override for the top-level copy would
 // otherwise hijack the nested clone and fail the whole update.
@@ -221,6 +273,7 @@ func TestAI_UpdateSubmodulesSkipsOverridesOnDuplicateSubmoduleName(t *testing.T)
 	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
 	workTreeDir := filepath.Join(t.TempDir(), "worktree")
 	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
+	require.NoError(t, syncSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
 	require.NoError(t, updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
 
 	topWho, err := os.ReadFile(filepath.Join(workTreeDir, "lib", "who.txt"))
@@ -270,6 +323,7 @@ func TestAI_UpdateSubmodulesKeepsFileTransportBlockedForNonLocalSubmodule(t *tes
 	workTreeDir := filepath.Join(t.TempDir(), "worktree")
 	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, headSHA)
 
+	require.NoError(t, syncSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir))
 	err = updateSubmodules(ctx, filepath.Join(superRepo, ".git"), workTreeDir)
 	require.Error(t, err, "git must still refuse the file:// submodule")
 	require.Contains(t, err.Error(), "transport 'file' not allowed")

--- a/pkg/true_git/submodule_ai_test.go
+++ b/pkg/true_git/submodule_ai_test.go
@@ -131,6 +131,53 @@ func TestAI_UpdateSubmodulesReusesLocalObjectsForNestedWithoutRemote(t *testing.
 	require.Equal(t, "LEAF", string(content))
 }
 
+// An already-populated submodule is not re-cloned, so it is fetched from the URL recorded in the
+// service worktree's own submodule git dir. Moving the gitlink must therefore still resolve from
+// the superproject store rather than from the remote.
+func TestAI_UpdateSubmodulesReusesLocalObjectsAfterGitlinkMovedInWarmWorkTree(t *testing.T) {
+	ctx := context.Background()
+	isolateGitConfigAI(t)
+
+	subRemote := t.TempDir()
+	initGitRepoAI(t, subRemote)
+	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("first"), 0o644))
+	runGitAI(t, subRemote, "add", ".")
+	runGitAI(t, subRemote, "commit", "-m", "first")
+
+	superRepo := t.TempDir()
+	initGitRepoAI(t, superRepo)
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "add", subRemote, "sub")
+	runGitAI(t, superRepo, "commit", "-m", "add submodule")
+	firstSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+
+	// Warm the service worktree on the first gitlink, exactly as an earlier werf run would — sync
+	// included, since it rewrites the submodule remote from .gitmodules on every run.
+	gitDir := filepath.Join(superRepo, ".git")
+	workTreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitAI(t, superRepo, "worktree", "add", "--detach", workTreeDir, firstSHA)
+	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
+	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
+
+	// Move the gitlink, and let the superproject store learn the new commit the way CI would.
+	require.NoError(t, os.WriteFile(filepath.Join(subRemote, "file.txt"), []byte("second"), 0o644))
+	runGitAI(t, subRemote, "commit", "-am", "second")
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--remote", "sub")
+	runGitAI(t, superRepo, "commit", "-am", "bump submodule")
+	secondSHA := strings.TrimSpace(runGitAI(t, superRepo, "rev-parse", "HEAD"))
+	runGitAI(t, superRepo, "-c", "protocol.file.allow=always", "submodule", "update", "--init")
+
+	// Only now drop the remote: the moved commit exists locally, so no fetch may be needed.
+	require.NoError(t, os.RemoveAll(subRemote))
+
+	runGitAI(t, workTreeDir, "checkout", "--force", "--detach", secondSHA)
+	require.NoError(t, syncSubmodules(ctx, gitDir, workTreeDir))
+	require.NoError(t, updateSubmodules(ctx, gitDir, workTreeDir))
+
+	content, err := os.ReadFile(filepath.Join(workTreeDir, "sub", "file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "second", string(content))
+}
+
 // A submodule name reused at another nesting level cannot be expressed as a process-global
 // submodule.<name>.url, so no override may be emitted: an override for the top-level copy would
 // otherwise hijack the nested clone and fail the whole update.


### PR DESCRIPTION
## Summary

werf re-fetched every submodule from its remote inside its own worktree under `$WERF_HOME`, even when the user or CI had already fetched them. Where credentials are injected per command (GitLab CI with `GIT_SUBMODULE_STRATEGY: recursive`), werf's git subprocess has none and the build fails:

```
fatal: could not read Username for 'https://git.example.com'/: No such device or address
Failed to clone '<submodule>'. Retry scheduled
```

This happens on a cold worktree (clone) and again on every commit that moves a submodule gitlink (fetch), so a long-lived worktree cache does not make it go away.

Fixes #2257 — the credential-prompt symptom, confirmed still current on `3`. The original 2020 "cannot chdir" report is not addressed and no longer reproduces: git keeps the submodule git dir per worktree, so werf does not disturb the shared module store.

## What

### Reuse

- When every submodule of the committed tree, nested levels included, has its pinned commit in a complete local store, werf checks them all out from those objects — no network, no credentials. VERIFIED: the #2257 GitLab shape reproduced by hand against credential-less local remotes.
- An already-populated submodule in werf's worktree is served from the local store when its gitlink moves, not only on its first clone.
- A shallow store (`GIT_SUBMODULE_DEPTH`) stays eligible for reuse; a partial or promisor store does not, because a present commit does not imply present blobs.
- An ambient `insteadOf` prefix rewrite (`GIT_SUBMODULE_FORCE_HTTPS`) does not defeat reuse: werf keys its rewrite on the full submodule URL and git resolves `insteadOf` by longest match.
- Nothing changes about which commit a submodule ends up at — objects are content-addressed, so a served checkout cannot differ from what the remote would have produced — and a repository without submodules is unaffected.

### When reuse does not apply

- Reuse is all-or-nothing: a submodule that is missing locally, in a partial clone, duplicated or unsafely named, whose store path contains `=`, or whose remote URL is shared with another submodule or prefixes a store path, suppresses every redirect and keeps the plain remote update.
- The blockers are named in one `WARNING: unable to reuse local git objects for submodules: …`, printed once per process, which tells the user to run `git submodule update --init --recursive` beforehand.
- `GIT_SUBMODULE_STRATEGY: none`, and any strategy that leaves a submodule uninitialized, still clones from the remote and may still request credentials.
- No build that used to work fails because of reuse: a probe that cannot determine eligibility falls back to the plain remote update, and a store that passes every check yet cannot serve the checkout falls back after discarding the failed attempt, since an initialized submodule is never re-cloned. Every fallback is automatic; there is deliberately no user-facing toggle.
- A committed `.gitmodules` `path` that is absolute or contains `..` is ignored instead of aborting the update, exactly as git's own update ignores it. VERIFIED: with server-side `transfer.fsckObjects=true` git rejects `url = -x` but accepts both path shapes, so such an entry can be pushed.

### Safety

- `protocol.file.allow=always` is added only alongside redirects, and all-or-nothing is what keeps it safe: no URL read from committed `.gitmodules` is used while the file transport is relaxed, so a `file://` submodule URL stays blocked (CVE-2022-39253 class). Ambient trusted `url.*.insteadOf` configuration can still rewrite the store paths werf computes — the invariant covers committed content, not every URL being werf's own.
- The eligibility probe cannot reach a promisor remote: a partial store is rejected before any object lookup instead of relying on `GIT_NO_LAZY_FETCH`, which lookups honor only from git 2.45 while werf supports git 2.18.
- The discard before the fallback removes only what werf's own worktree owns: it resolves the git dir from `<worktree>/.git` on disk rather than with `git rev-parse`, so an inherited `GIT_DIR` cannot redirect it at another repository; it refuses a work tree that is not linked; and it removes a submodule directory only at a work-tree-local path that HEAD records as a gitlink.

## Why

git does not reuse the superproject's `<git-common-dir>/modules/<name>` for a linked worktree — it keeps a separate git dir at `<worktree-gitdir>/modules/<name>`. werf therefore cloned from the remote the first time and, because `git submodule sync` rewrites the recorded remote from committed `.gitmodules` before every update, fetched from the remote whenever a gitlink moved. That redoes work the checkout already did, and where credentials are injected per command it cannot be redone at all. Two redirects cover the two paths: `submodule.<name>.url`, documented as user-overridable before `git submodule update`, for the clone, and `url.<store>.insteadOf` for the fetch of an already-populated submodule.

`<git-common-dir>/modules/<name>` is documented in gitsubmodules(7) as the usual, not the guaranteed, location, and `-c` propagation into nested updates rides on the undocumented `GIT_CONFIG_PARAMETERS`. Both fail safe: a wrong guess fails the pinned-object probe, and anything that slips past every probe falls back to the remotes.

Rejected alternatives: `submodule.alternateLocation`, `--reference` and making the service worktree a main worktree — none of them covers this case. Partial reuse, achievable by splitting the update into a pathspec-limited invocation per group, rescues nothing where credentials are missing, since a submodule absent locally still needs the network; it would only save bandwidth where credentials already work.
