### PR TITLE
chore(dev): backport global skill rules into .agents/skills

### DIFF
--- a/.agents/skills/agent-code-review/SKILL.md
+++ b/.agents/skills/agent-code-review/SKILL.md
@@ -79,6 +79,17 @@ invoked reviewer before merging — don't treat your own adversarial pass as the
 Say so explicitly in your findings when you are the diff's author and no second reviewer
 has looked yet, so the person deciding whether to merge knows that gap exists.
 
+When that review comes back and you disagree, separate the finding from the fix it
+proposes: a correct finding often ships with a remedy that does not work, and verifying the
+mechanism tells you which half to reject. Say which one you are rejecting and show the
+evidence.
+
+Two failure modes on your side. "It does not reduce the headline risk" is not sufficient
+grounds to decline a cheap fix that closes a silent-failure path — measure the cost, and if
+it is small, take it. And if a reviewer raises the same finding a second time, re-examine
+whether the fix is feasible instead of restating your position; the second request is
+evidence your explanation did not land, not that it needs repeating.
+
 ## Output
 
 Report only actionable findings. Each one: where the problem is visible, what fails and

--- a/.agents/skills/git-conventions/SKILL.md
+++ b/.agents/skills/git-conventions/SKILL.md
@@ -31,9 +31,13 @@ Types and scopes are defined in `CONTRIBUTING.md#conventions` — that file is t
 - **Body:** imperative; state the motivation for the change and contrast it with previous behavior.
 - NEVER include sensitive or customer-identifying details: client/company names, internal hostnames or filesystem paths, private build tags or version suffixes, credentials. Describe environments generically.
 
+## Before starting work
+
+- `git fetch` and compare your base against `origin/<base>` BEFORE writing code, not at push time. A moved base can have refactored the very file you are about to edit, and the whole diff then has to be re-ported by hand during the rebase.
+
 ## Before staging
 
-- Check `git status` for unrelated untracked files before staging. This worktree carries local working files (`.dev/`, scratch notes, orchestrator state), so prefer explicit paths over `git add -A` — a blanket add sweeps them in, and untracking later costs an extra commit.
+- Check `git status` for unrelated untracked files before staging. This worktree carries local working files (`.dev/`, scratch notes, orchestrator state), so prefer explicit paths over `git add -A` — a blanket add sweeps them in, and untracking later costs an extra commit. An orchestrator or helper commit command stages broadly — inspect `git status` BEFORE invoking it, not after.
 
 ## Before pushing
 

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -53,6 +53,10 @@ observed wrong behavior and add a minimal repro (Dockerfile / werf.yaml / comman
 
 - <area or file that deserves careful review>
 - <potential risk or side-effect>
+
+## After merge
+
+- [ ] <action that has to happen outside this PR, and where>
 ```
 
 ### Rules
@@ -69,6 +73,18 @@ observed wrong behavior and add a minimal repro (Dockerfile / werf.yaml / comman
 - The only code block worth its space is a repro the reviewer can paste (Dockerfile, werf.yaml, command). Never paste a terminal transcript of an error that the repro already produces.
 - NEVER speculate in *Review focus / risks*. List what you know. "Probably fine because …" is filler — drop the whole bullet.
 - NEVER include sensitive or customer-identifying details in the title or description: client/company names, internal hostnames or filesystem paths, private build tags or version suffixes, credentials. Describe the environment generically (e.g. "long-lived CI runners sharing WERF_HOME", not a customer's runner path).
+- The description must be repo-scoped: no local paths (`~/...`), no references to artifacts that don't live in the repo (session notes, review matrices). A reviewer sees only the repo — every referenced fact must be visible from it.
+- A `Fixes`/`Closes` reference to an issue in another repository (`werf/nelm`, `werf/3p-helm`, `werf/kubedog`, `werf/common-go`) does not close it — GitHub only auto-closes same-repo issues. Link it, and close it by hand once the change reaches the consumer.
+
+### After merge
+
+Anything the change needs that this PR cannot contain — a version bump in a consumer or in werf, a release note, an issue to file or to close by hand — goes in a final `## After merge` section, written as a GitHub task list so a human or a bot can work through it and see what is left. Add it to a small PR too when it has such an action; it is the one section that does not depend on the diff's size.
+
+- Checkboxes, never prose. The section exists to be worked through, not read once.
+- One action per line, each naming where it happens (`owner/repo`, a file, a command). An item nobody can act on without asking you first is not an action.
+- Mark the ones that must not be skipped. When a release note is the only mitigation for a breaking change, say so on the line — otherwise the whole list reads as optional cleanup.
+- This is the one section where cross-repo references are expected. Name repositories explicitly rather than "the consumer".
+- Omit the section when there is nothing to do. A list padded with speculative or already-done items trains everyone to skip it, which costs you the one item that mattered.
 
 ## Output
 

--- a/.agents/skills/session-retro/SKILL.md
+++ b/.agents/skills/session-retro/SKILL.md
@@ -23,8 +23,13 @@ issue/PR template, or a `docs/` page. Pick the landing spot from the finding, no
 - **Workflow decisions**: the user picked one approach over another ("always do it this way from now on") — a durable preference, not a one-off call.
 - **Friction**: a check that was slow, awkward, or easy to forget, or a step done by hand that a `task` target could do.
 - **Near-misses**: something caught just before landing (wrong branch, guessed path, unverified assumption) — the cheapest lesson, the cost is already paid.
+- **Context waste**: tool calls that cost a lot of context for little return — a whole-file read where a grep would do, the same file read twice, a raw `task build`/`task test` log pasted in full, a subagent spawned for a one-line lookup, or a wide search done inline instead of delegated. A generic `bash` call where a purpose-built tool exists is the expensive one. Each maps to a rule.
+- **Skill usage**: which skills actually fired, and whether it mattered. A skill whose body was never opened during the work it governs guided nothing, however apt its name.
+- **Prompt friction**: the request as posed cost tokens — a file the user already knew and you hunted for, a constraint revealed after you built the wrong thing, work redone that one clarifying question would have prevented. If a question you should have asked would have caught it, that is a rule for you; otherwise it is feedback for the user, not a file.
 
-Ignore one-off task specifics and anything an existing doc, skill, or check already covers.
+Those three are denominated in tokens, so measure them instead of recalling them: per-message usage lives in the session transcript (`~/.pi/agent/sessions/<cwd-slug>/*.jsonl`, or `~/.claude/projects/<cwd-slug>/*.jsonl`). Aggregate inside the analysis script and print only the top consumers — dumping per-message rows into the conversation costs more than the finding is worth. Match skills by **file path** (`skills/<name>/SKILL.md`), never the bare name, and keep frontmatter-only, body-read, and edited apart. With no transcript available, drop these cuts rather than estimating from memory.
+
+Ignore one-off task specifics, anything an existing doc, skill, or check already covers, and raw totals with no attributable cause — a per-tool call-count table is not a finding.
 
 ## 2. Classify each finding
 
@@ -67,4 +72,7 @@ check is worse than none.
 ## 6. Report
 
 List what changed, file by file, and where each finding was routed — including the ones dropped as
-one-off, so nothing is silently omitted.
+one-off, so nothing is silently omitted. Report skill usage as a short table — skill, tier reached,
+body reads, and one line of impact: what it changed, or what it would have prevented. Report
+context-waste and prompt-friction findings with their measured cost and the turn they came from,
+even when they produce no file.

--- a/.agents/skills/test-the-tests/SKILL.md
+++ b/.agents/skills/test-the-tests/SKILL.md
@@ -24,6 +24,10 @@ trivial getter):
 3. Revert immediately, confirm the tree is clean (`git status`/`git diff`), confirm the
    suite passes again. NEVER leave mutated code in the repository between steps.
 
+Copy the file before mutating it (`cp f f.bak`) and restore from the copy. NEVER restore with
+`git checkout`/`git restore` while the work under test is still uncommitted — those discard the
+work along with the mutation. Commit first, or use the copy.
+
 If running the mutation isn't practical, name the smallest mutation that should be tried
 instead of skipping the exercise — that name is itself the finding.
 


### PR DESCRIPTION
## Summary

Five skills under `.agents/skills` had drifted behind their global counterparts, each missing a rule that was learned and written down elsewhere. This ports those rules in, keeping the werf-specific wording of each skill.

## Why

The werf copies are a deliberate fork — they name `task` commands, release branches and this repo's layout — so they don't get global updates automatically. The gap accumulated silently: two of the missing rules (`git restore` destroying uncommitted work during a mutation run, a helper commit command staging unrelated files) describe damage already done once, and nothing in this repo would have prevented a repeat.

## Key changes

- `git-conventions`: compare the base against `origin/<base>` before writing code, not at push time — a moved base forces a hand re-port during the rebase. Also: an orchestrator or helper commit command stages broadly, so inspect `git status` before invoking it.
- `test-the-tests`: copy the file before mutating it and restore from the copy. `git checkout`/`git restore` discards the work under test along with the mutation while it is still uncommitted.
- `pull-request`: an `## After merge` task list for actions the PR cannot contain (version bumps in `werf/nelm`, `werf/3p-helm`, `werf/kubedog`, `werf/common-go`, release notes, issues to close by hand); a `Fixes` reference to another repository does not auto-close it; the description must be repo-scoped.
- `session-retro`: scan the session for context waste, skill usage and prompt friction, measured from the transcript rather than recalled, and report them with their cost.
- `agent-code-review`: when a review finding is correct but its proposed fix is not, say which half is being rejected; a cheap fix that closes a silent-failure path is not declined for missing the headline risk.

## Review focus / risks

- Documentation only, no Go code and no user-facing behavior — but `.agents/skills` is what drives agent work in this repo, so a wrong rule here propagates into future diffs.
- The `session-retro` addition names transcript paths of specific harnesses (`~/.pi/agent/sessions`, `~/.claude/projects`); they degrade gracefully — the skill says to drop those cuts when no transcript is available.
