### PR TITLE
fix(build, stapel, git): remove git commit ancestry check on reuse

### DIFF
--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -231,52 +231,31 @@ func selectStageDescByOldestCreationTs(ctx context.Context, stageDescSet image.S
 	return nil, nil
 }
 
-func (s *BaseStage) selectAncestorStageDescByGitMappings(ctx context.Context, c Conveyor, stageDescSet image.StageDescSet) (*image.StageDesc, error) {
-	var currentCommitsByIndex []string
-	for _, gitMapping := range s.gitMappings {
-		currentCommitInfo, err := gitMapping.GetLatestCommitInfo(ctx, c)
-		if err != nil {
-			return nil, fmt.Errorf("error getting latest commit of git mapping %s: %w", gitMapping.Name, err)
-		}
-
-		currentCommitsByIndex = append(currentCommitsByIndex, currentCommitInfo.Commit)
-	}
-
+// selectStageDescByExistingGitCommits reuses the oldest cached stage whose recorded commit is
+// still reachable in the repo. The commit is not required to be an ancestor of the current one:
+// patches are built from that commit, so it only has to exist.
+func (s *BaseStage) selectStageDescByExistingGitCommits(ctx context.Context, stageDescSet image.StageDescSet) (*image.StageDesc, error) {
 ScanImages:
 	for _, stageDesc := range sortStageDescSetByOldestCreationTs(stageDescSet) {
-		for i, gitMapping := range s.gitMappings {
-			currentCommit := currentCommitsByIndex[i]
-
+		for _, gitMapping := range s.gitMappings {
 			imageCommitInfo, err := gitMapping.GetBuiltImageCommitInfo(stageDesc.Info.Labels)
 			if err != nil {
 				logboek.Context(ctx).Warn().LogF("Ignoring stage %s: unable to get image commit info for git repo %s: %s\n", stageDesc.Info.Name, gitMapping.GitRepo().String(), err)
 				continue ScanImages
 			}
 
-			commitToCheckAncestry := imageCommitInfo.Commit
-
-			exist, err := gitMapping.GitRepo().IsCommitExists(ctx, commitToCheckAncestry)
+			exist, err := gitMapping.GitRepo().IsCommitExists(ctx, imageCommitInfo.Commit)
 			if err != nil {
-				return nil, fmt.Errorf("error checking if commit %s exists: %w", commitToCheckAncestry, err)
+				return nil, fmt.Errorf("error checking if commit %s exists: %w", imageCommitInfo.Commit, err)
 			}
 
 			if !exist {
-				logboek.Context(ctx).Info().LogF("Skipping stage %s: commit %s does not exist in repo %s\n", stageDesc.Info.Name, commitToCheckAncestry, gitMapping.GitRepo().String())
-				continue ScanImages
-			}
-
-			isOurAncestor, err := gitMapping.GitRepo().IsAncestor(ctx, commitToCheckAncestry, currentCommit)
-			if err != nil {
-				return nil, fmt.Errorf("error checking commits ancestry %s<-%s: %w", commitToCheckAncestry, currentCommit, err)
-			}
-
-			if !isOurAncestor {
-				logboek.Context(ctx).Info().LogF("Skipping stage %s: commit %s is not an ancestor of %s in repo %s\n", stageDesc.Info.Name, commitToCheckAncestry, currentCommit, gitMapping.GitRepo().String())
+				logboek.Context(ctx).Info().LogF("Skipping stage %s: commit %s does not exist in repo %s\n", stageDesc.Info.Name, imageCommitInfo.Commit, gitMapping.GitRepo().String())
 				continue ScanImages
 			}
 		}
 
-		logboek.Context(ctx).Info().LogF("Using stage %s (ancestor)\n", stageDesc.Info.Name)
+		logboek.Context(ctx).Info().LogF("Using stage %s\n", stageDesc.Info.Name)
 
 		return stageDesc, nil
 	}

--- a/pkg/build/stage/git.go
+++ b/pkg/build/stage/git.go
@@ -33,6 +33,6 @@ func (s *GitStage) PrepareImage(ctx context.Context, c Conveyor, cb container_ba
 	return s.BaseStage.PrepareImage(ctx, c, cb, prevBuiltImage, stageImage, nil)
 }
 
-func (s *GitStage) SelectSuitableStageDesc(ctx context.Context, c Conveyor, stageDescSet image.StageDescSet) (*image.StageDesc, error) {
-	return s.selectAncestorStageDescByGitMappings(ctx, c, stageDescSet)
+func (s *GitStage) SelectSuitableStageDesc(ctx context.Context, _ Conveyor, stageDescSet image.StageDescSet) (*image.StageDesc, error) {
+	return s.selectStageDescByExistingGitCommits(ctx, stageDescSet)
 }


### PR DESCRIPTION
## Summary

`git commit --amend` (or a rebase, or a branch switch) rebuilds images whose content-based tag is unchanged: the cached stage is found, then discarded. On a ~1300-image monorepo an amend of the tip commit rebuilt 972 images — 3.6 h instead of 21 s.

Repro with any stapel image that has a `git.add` mapping:

```
werf build
git commit --amend --date=now -m second
werf build   # expected: reused by content-based tag; actual: rebuilt
```

## Why

#7615 is titled "remove git commit ancestry check on stage reuse" and the v2→v3 migration guide documents it as removed, but it only dropped the `WERF_DISABLE_GIT_COMMIT_ANCESTRY_CHECK` toggle — the `IsAncestor` call shipped in v3.0.1, so the code contradicts its own guide.

Ancestry was never the requirement: patches are built *from* the commit recorded on the cached stage, so that commit only has to still exist — which `IsCommitExists`, right above, already checks.

The cost propagates. Of those 972, 268 are the `git.add` roots, whose content digest is provably unchanged; the rest are dependents, which take the parent `StageID.String()` — digest *plus* creation timestamp — into their content dependencies, so a fresh timestamp on a root moves every downstream digest.

## Key changes

- Drop the `IsAncestor` branch from git-stage reuse selection, completing what #7615 documented. `IsCommitExists` is kept.
- Rename `selectAncestorStageDescByGitMappings` → `selectStageDescByExistingGitCommits` (and drop the `(ancestor)` log suffix): it no longer selects by ancestry.

No docs change — the guide already describes the post-fix behavior.

## Verification

Hand-run on the repro, Docker backend, local stages storage: after `--amend` the image is reused in 0.30 s where it was rebuilt before; no-change rebuild and switching back to a branch with identical content also reuse.

Checked that reuse did not become too eager: with a file actually added, the image rebuilds and `werf run <img> -- cat /installed.txt` lists the new file, so no stale layer is served.

No new tests, hence no mutation run. The amend case is not among the `test/e2e/build` content-tag entries and was checked by hand.

## Review focus / risks

- Reuse now accepts a stage built on an abandoned line of history as long as the object still exists — the intent of #7615, still gated by the content digest, but a real widening of "suitable stage".
- `IsCommitExists` is evaluated locally, so a commit that was never pushed can end up recorded on a reused stage; a fresh clone lacking that object falls back to a rebuild rather than failing.
- Not addressed: `creationTs` leaking into content identity via `StageID.String()` (`pkg/build/stage/dependencies.go`, `from.go`). This removes the trigger, not the amplifier — a legitimate rebuild of a root still invalidates its dependents. Fixing it invalidates every existing cache once, so it belongs in its own change.