### PR TITLE
docs(dev): create the topic branch before the first commit

### DIFF
--- a/.agents/skills/git-conventions/SKILL.md
+++ b/.agents/skills/git-conventions/SKILL.md
@@ -33,6 +33,7 @@ Types and scopes are defined in `CONTRIBUTING.md#conventions` — that file is t
 
 ## Before starting work
 
+- Create the topic branch BEFORE the first commit, not before the push. `main`, `3`, `2`, `1.2` are release branches: a commit landed on one has to be moved by hand afterwards and its message amended along with it, and until someone asks for a PR nothing reveals it is on the wrong branch.
 - `git fetch` and compare your base against `origin/<base>` BEFORE writing code, not at push time. A moved base can have refactored the very file you are about to edit, and the whole diff then has to be re-ported by hand during the rebase.
 
 ## Before staging


### PR DESCRIPTION
The skill said to branch from `origin/<base>` rather than a release branch, but only under **Before pushing** — by which point the commit already exists in the wrong place, and moving it costs an amend of a message already written plus a reset of a branch that should never have been touched. Nothing surfaces the mistake either, until someone asks for a PR.

Found the expensive way in this repo: a fix committed straight onto `3`, noticed only when a PR was requested. Now stated under **Before starting work**, where `checkout -b` is still free. Naming rules stay where they were.