### PR TITLE
docs(dev): write feat/fix subjects from the user's side

### DIFF
--- a/.agents/skills/git-conventions/SKILL.md
+++ b/.agents/skills/git-conventions/SKILL.md
@@ -28,7 +28,8 @@ Types and scopes are defined in `CONTRIBUTING.md#conventions` — that file is t
 - Determine type and scope from `git diff --cached`.
 - **Header:** ≤ 72 characters. Nested scopes are allowed, comma-separated: `fix(build, stapel, import): …`.
 - **Subject:** imperative, lower-case, no trailing period.
-- **Body:** imperative; state the motivation for the change and contrast it with previous behavior.
+- **Subject of a `feat`/`fix`:** the observed outcome, never the mechanism. `CHANGELOG.md` is generated from these subjects verbatim, so the reader is a werf user who has never seen the code: name the symptom that goes away or what becomes possible, and leave function names, internal identifiers and the how to the body. `make service script executable regardless of umask` describes the patch; `stop stapel builds failing with "Permission denied" under a custom umask` describes what the user hit. For `refactor`/`test`/`chore` the reader is a developer and the mechanism is the right subject.
+- **Body:** imperative; state the motivation for the change and contrast it with previous behavior. This is where the mechanism and the root cause go.
 - NEVER include sensitive or customer-identifying details: client/company names, internal hostnames or filesystem paths, private build tags or version suffixes, credentials. Describe environments generically.
 
 ## Before starting work

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -18,6 +18,7 @@ description: Generates Pull Request titles and descriptions according to werf co
 4. Keep the total length ≤ 72 characters.
 5. Nested scopes are allowed and encouraged, comma-separated: `fix(build, stapel, import): …`.
 6. Subject: imperative present tense, no capitalized first letter, no trailing dot.
+7. For a `feat`/`fix`, the subject states the observed outcome and not the mechanism, by the same rule as the commit subject (`git-conventions`) — it ends up in the release notes verbatim.
 
 ## Description
 
@@ -31,7 +32,9 @@ Match the description to what the reviewer cannot infer from the diff. Two tiers
 ## Summary
 
 <1-3 sentence high-level overview of what the PR does. For a `fix`, lead with the
-observed wrong behavior and add a minimal repro (Dockerfile / werf.yaml / command) plus expected vs actual.>
+observed wrong behavior and add a minimal repro (Dockerfile / werf.yaml / command) plus expected vs actual.
+For a `feat`, lead with what the user can now do and the workflow that needed it, then the command or
+werf.yaml snippet that uses it.>
 
 ## Why
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,8 @@ The subject contains a succinct description of the change:
 - use the imperative, present tense: "change" not "changed" nor "changes"
 - don't capitalize the first letter
 - no dot (.) at the end
+- for **feat** and **fix**, describe the change from the user's side — the symptom that goes away, or what becomes possible. Release notes in `CHANGELOG.md` are generated from these subjects verbatim, and their reader has never seen the code, so internal names and the mechanism belong in the **body**. Prefer "importing into symlinked directories no longer silently loses files" over "resolve symlinks in the import target path".
+- for **refactor**, **test** and **chore**, the reader is a developer, so the mechanism is the right subject.
 
 #### Body
 


### PR DESCRIPTION
## Summary

`CHANGELOG.md` is generated from commit subjects verbatim, so a `feat`/`fix` subject is a release note read by someone who has never seen the code. About half of the recent ones describe the patch instead: `make service script executable regardless of umask` (the user saw `bash: /.werf/scripts/<hash>: Permission denied`), `use UUID-based naming for scratch base images to prevent buildah misinterpretation` (the user saw a failing buildah build), `resolve dependency image refs in FROM stage before computing cache digest`. The rule that they should read from the user's side was nowhere written down.

## Why

`CONTRIBUTING.md` already defines `feat`/`fix` as changes that "enhance the user's experience", but says nothing about the text, and the subject rules are purely grammatical (imperative, lower-case, no dot). Nothing pushed back on a mechanism-first subject, so the release notes ended up mixed — the good ones (`importing into symlinked directories no longer silently loses files`, `no more "no match for resource kind" errors`) were down to individual judgement.

## Key changes

- `CONTRIBUTING.md`, *Subject*: for `feat`/`fix`, describe the change from the user's side — the symptom that goes away or what becomes possible — because `CHANGELOG.md` reuses the subject verbatim; internal names and the mechanism go to the body. For `refactor`/`test`/`chore` the reader is a developer, so the mechanism stays the right subject.
- `git-conventions`: the same rule for agents, with the umask commit as a before/after pair, plus a note on *Body* that the mechanism and the root cause belong there.
- `pull-request`: the PR title follows the commit-subject rule (cross-referenced, not restated); a `feat` *Summary* leads with what the user can now do and the workflow that needed it, mirroring the existing `fix` instruction.

## Verification

- Documentation only, nothing to run. The three examples quoted in the new rules are taken from this repo's history (#7720, #7602, #7545).

## Review focus / risks

- Splits the subject rules by type — a mistyped commit (`refactor` for what is really a `fix`) now also gets the wrong subject style. No check enforces the type.
- The `CONTRIBUTING.md` wording is user-facing for external contributors; the skill wording is agent-facing and deliberately longer.
