### PR TITLE
chore(release): limit build concurrency and restore binary compression

### DIFF
--- a/trdl.yaml
+++ b/trdl.yaml
@@ -1,5 +1,6 @@
 docker_image: registry.werf.io/werf/builder:dd0d768103857f81c7e652cb2457e0bad53c82ba@sha256:97a3c1030c5822a4a45f783da0b1ffd6fb19fdc9f1c89a9514210a46a2cea65b
 commands:
-  - TASK_X_REMOTE_TASKFILES=1 task --yes build:dist:all version={{ .Tag }}
+  - TASK_X_REMOTE_TASKFILES=1 task --yes -C 2 -o group build:dist:all version={{ .Tag }}
   - TASK_X_REMOTE_TASKFILES=1 task --yes verify:binaries:dist:all version={{ .Tag }}
+  - TASK_X_REMOTE_TASKFILES=1 task --yes compress:binaries:dist:all version={{ .Tag }}
   - cp -a ./dist/{{ .Tag }}/* /result


### PR DESCRIPTION
## Summary

Release builds via trdl now run at most two of the five dist target builds concurrently and upx-compress the published linux and windows binaries again. Only the release pipeline changes; werf behavior is untouched.

## What

- `build:dist:all` inside the trdl build container runs under `task -C 2`: at most two target builds are in flight instead of all five at once.
- #7745 ("build binaries sequentially") only dropped `-p`, which never bounded `deps` — all five builds still ran concurrently; `-C 2` is what actually bounds them.
- Concurrent build logs are grouped per task again (`-o group`), not interleaved.
- Published linux-amd64, linux-arm64 and windows-amd64 binaries are upx-compressed again (`compress:binaries:dist:all`, disabled in #7744); darwin binaries stay uncompressed as before.
- UNVERIFIED: that `-C 2` keeps the 8 GB release builder from exhausting memory during links — settled by the next release run, or by the same commands under `docker run -m 8g`.

## Why

`build:dist:all` fans its five target builds out as task `deps`, whose concurrency go-task does not bound; on the release builder (8 cores / 8 GB) five concurrent builds, two of them statically linked cgo targets, can exhaust memory. `-C 2` bounds executor-wide concurrency while still overlapping one build's serial link phase with another's compilation — serializing fully was rejected because it leaves cores idle during those phases. Shipping uncompressed binaries meanwhile costs users several times larger downloads.
