### PR TITLE
chore(dev): stop the caller's WERF_* leaking into generated CLI docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Follow [Effective Go](https://go.dev/doc/effective_go) and [Go Code Review Comme
 
 - ALWAYS use LSP (`goToDefinition`, `findReferences`, `documentSymbol`, `hover`, `goToImplementation`, call hierarchy) to find definitions, usages, implementations, and callers. `grep` matches strings blindly: it hits comments and unrelated identifiers, and misses interface dispatch and aliased imports.
 - Use `grep` ONLY for literal text — config keys, error message strings, annotation names.
+- ALWAYS use your harness's file-read and search tools instead of `cat`, `sed -n`, `head` or `grep` inside `bash`. They cap what enters the context — byte and match limits, offset windows, long-line truncation — where a shell command dumps the whole file or every hit. Reading an entire file to look at one function is the most expensive habit there is.
 - If your harness has a semantic code-search tool, prefer it over `grep` for intent-based questions ("how does X work"). If it does not, read the code: NEVER substitute keyword grepping for understanding.
 
 ## Commands (MANDATORY)
@@ -81,7 +82,11 @@ After changing Go code, run these in order — `task format` mutates files, so i
 
 NEVER assume a change compiles. While iterating, scope the slow steps (`task lint:golangci-lint golangciPaths="./pkg/foo/..."`, `task test:unit paths="./pkg/foo/..."`), then run them unscoped before handing the work over.
 
-On macOS `task build` produces a **non-CGO** binary — the Buildah backend is only built for linux/amd64 (`task build:dev:linux:amd64:cgo`), so Buildah changes cannot be compiled or exercised locally. Unit tests run anywhere; e2e and integration tests need Linux with Docker and kind (`task test:setup:environment`).
+A green `task test:unit` does NOT prove a command runs. No unit test constructs the storage manager, so a command that dereferences a flag group it never registered dies with a SIGSEGV before doing any work while the whole unit suite stays green. After adding or changing a command, execute it once — via `task test:integration`, or the binary in `./bin/` — before calling it done.
+
+`git diff --check` cannot be a whole-repo gate. The CLI reference generator emits column-aligned help text, so the generated pages under `docs/_includes/reference/cli` and `docs/pages_en/reference/cli` carry trailing whitespace on every branch. Scope the check to authored files.
+
+On macOS `task build` produces a **non-CGO** binary — the Buildah backend is only built for linux/amd64 (`task build:dev:linux:amd64:cgo`), so Buildah changes cannot be compiled or exercised locally. Unit tests run anywhere; e2e and integration tests need Linux with Docker and kind (`task test:setup:environment`). Anything exercising registry deletion additionally needs `REGISTRY_STORAGE_DELETE_ENABLED=true` on that registry: stock `registry:2` answers every DELETE with `UNSUPPORTED: The operation is unsupported`, which reads like a werf bug.
 
 ## Testing (MANDATORY)
 

--- a/scripts/docs/regen.sh
+++ b/scripts/docs/regen.sh
@@ -9,8 +9,16 @@ project_dir="$(dirname $source_path)/../.."
 docs_dir="$project_dir/docs"
 
 function regen() {
+  # Every WERF_* variable in the caller's environment becomes a flag default in the
+  # generated reference, so clear them all instead of the few known offenders.
+  local werf_env_args=()
+  while IFS='=' read -r name _; do
+    werf_env_args+=(-u "$name")
+  done < <(env | grep '^WERF_' || true)
+
   # regen CLI partials, pages and sidebar
-  HOME='~' DOCKER_DEFAULT_PLATFORM='' WERF_PLATFORM='' $arg_werf_bin_path docs --dir="$project_dir" --log-terminal-width=100
+  env "${werf_env_args[@]}" HOME='~' DOCKER_DEFAULT_PLATFORM='' WERF_PLATFORM='' \
+    $arg_werf_bin_path docs --dir="$project_dir" --log-terminal-width=100
 }
 
 function create_documentation_sidebar() {


### PR DESCRIPTION
## Summary

Regenerating the CLI reference no longer picks up flag defaults from whoever runs it. `scripts/docs/regen.sh` already cleared `HOME`, `DOCKER_DEFAULT_PLATFORM` and `WERF_PLATFORM`, but any other `WERF_*` variable in the caller's environment still became a documented default: with `WERF_DISABLE_AUTO_HOST_CLEANUP=1` exported, one `task doc:gen` rewrote `--disable-auto-host-cleanup=true` into twelve unrelated command pages.

```
WERF_DISABLE_AUTO_HOST_CLEANUP=1 task doc:gen && git status --porcelain docs
```

## What

- `task doc:gen` produces identical output regardless of which `WERF_*` variables the caller has exported; previously each one silently became a flag default in every page listing that flag.
- The corruption was indistinguishable from ordinary generator output in review — twelve one-line changes in pages the actual work never touched.
- VERIFIED: reproduced the twelve-file rewrite, applied the fix, reran with the same variable exported for a clean tree, and reran in a clean environment to confirm the generator is still idempotent.
- `AGENTS.md` gains four facts this session had to learn by hitting them: a green `task test:unit` does not prove a command starts, since nothing in the unit suite constructs the storage manager and a command missing a flag group crashes before doing any work; `git diff --check` cannot gate the whole repo, since the reference generator emits column-aligned help and its pages carry trailing whitespace on every branch; e2e against a local registry needs `REGISTRY_STORAGE_DELETE_ENABLED=true`, because stock `registry:2` refuses every DELETE with a message that reads like a werf bug; and file reads and searches belong in the harness tools rather than `cat`, `sed` or `grep` in `bash`.
- No generated page changes in this PR: the fix removes an environment dependency, it does not alter correct output.

## Why

The generator reads flag defaults exactly as the commands do, so the developer's shell is an undeclared input to a committed artifact. Clearing offenders one variable at a time — the previous approach — only holds until someone exports a variable nobody thought of, and the failure is silent: the diff looks like normal regeneration, so it survives review and lands as documentation stating a default werf does not have.

The `AGENTS.md` additions are the session's other dead ends, and each cost real work: two commands shipped unrunnable behind a fully green unit suite, a whitespace gate that could never pass, and a registry rejecting deletes in a way that looked like a product bug.
