### PR TITLE
docs(dev): document three agent rules for PR review and doc:gen

### DIFF
--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -15,9 +15,10 @@ If you wrote the diff you are reviewing now, say so explicitly in the report's V
 
 1. Ask the user for numbered acceptance criteria (DoD). If there are none, derive them from the PR description or the linked issue, mark them `(inferred)`, and proceed — do not stall, and do not invent criteria silently.
 2. Resolve the base first: `git fetch`, then diff against the branch the PR actually targets. werf maintains release branches (`1.2`, `2.63`, `3`, …), so `main` is the wrong base for a backport. State the resolved base in the report. For uncommitted work, review `git diff` / `git diff --cached` instead.
-3. Read every changed file. Then trace callers of the changed exported symbols whose signature or behavior changed, and of anything crossing a persistence boundary — via LSP call hierarchy and references, not grep.
-4. For 10+ changed files, split the reading by area (e.g. new files, storage/cleanup, build pipeline) across subagents if your harness has them, and synthesize the findings yourself.
-5. If the worktree holds the branch and `task` works, run `task build` and `task test:unit` — a review that never compiled the change is an opinion. NEVER run `task format`: it would rewrite the diff under review.
+3. If the PR head is not checked out, take every `file:line` from that commit's blob (`git show <head>:<path>`), never from the worktree. The worktree sits on the base, so any file the PR itself changed has different line numbers there, and a comment anchored on a worktree line number lands on the wrong line — or is rejected outright.
+4. Read every changed file. Then trace callers of the changed exported symbols whose signature or behavior changed, and of anything crossing a persistence boundary — via LSP call hierarchy and references, not grep. LSP indexes the worktree, so when the head is not checked out it answers about the base: add a worktree at the head first, or read blobs and say in the report that call tracing was limited.
+5. For 10+ changed files, split the reading by area (e.g. new files, storage/cleanup, build pipeline) across subagents if your harness has them, and synthesize the findings yourself.
+6. If the worktree holds the branch and `task` works, run `task build` and `task test:unit` — a review that never compiled the change is an opinion. NEVER run `task format`: it would rewrite the diff under review.
 
 ## Technical perspective
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Follow [Effective Go](https://go.dev/doc/effective_go) and [Go Code Review Comme
 - ALWAYS use LSP (`goToDefinition`, `findReferences`, `documentSymbol`, `hover`, `goToImplementation`, call hierarchy) to find definitions, usages, implementations, and callers. `grep` matches strings blindly: it hits comments and unrelated identifiers, and misses interface dispatch and aliased imports.
 - Use `grep` ONLY for literal text — config keys, error message strings, annotation names.
 - If your harness has a semantic code-search tool, prefer it over `grep` for intent-based questions ("how does X work"). If it does not, read the code: NEVER substitute keyword grepping for understanding.
+- LSP indexes the worktree, so it answers about whatever is checked out. When the code you are reading lives in a commit that is NOT checked out — reviewing an unfetched PR head, for instance — LSP and a bare `grep` both silently describe the base instead. Read the blob (`git show <ref>:<path>`) or add a worktree at that commit; a plain worktree grep that finds nothing there proves nothing.
 
 ## Commands (MANDATORY)
 
@@ -68,7 +69,7 @@ ALWAYS use these `task` commands. NEVER use raw `go build`, `go test`, `go fmt`,
 - `task enum:generate` — run enum generators.
 - `task mock:generate` — run mock generators.
 - `task mock:check` — verify generated mocks are up to date (runs `go generate -run mockgen` and diffs).
-- `task doc:gen` — regenerate CLI reference docs. ALWAYS run after changing command descriptions, flags, or help text in Go source.
+- `task doc:gen` — regenerate CLI reference docs. ALWAYS run after changing command descriptions, flags, or help text in Go source. It renders each flag's default from the CURRENT environment, so run it with the `WERF_*` variables unset and review the diff for flags you never touched — one exported `WERF_*` rewrites that flag's documented default across every command page.
 
 `format` and `lint*` come from a remote taskfile ([werf/common-ci](https://github.com/werf/common-ci)), so they need `TASK_X_REMOTE_TASKFILES=1` and network access.
 


### PR DESCRIPTION
## Summary

Three rules an agent needs when reviewing a pull request whose head is not checked out, and when regenerating the CLI reference. Each one was written after an agent broke it during the review of #7737 and produced a wrong artifact — a comment anchored on the wrong line, a false finding, a documentation diff that changed twelve pages nobody touched.

## What

- A review of a PR head that is not checked out now reads every `file:line` from that commit's blob, so a posted line comment lands on the line the finding is about. Previously the numbers came from the worktree, which sits on the base: `SetupMetaRepo` was quoted at `common.go:480` while the PR head has it at `:572`.
- The review skill now states that LSP indexes the worktree and therefore answers about the base when the head is not checked out. A review in that situation either adds a worktree at the head or records in *Not verified* that call tracing was limited, instead of reporting untraced callers as if they had been traced.
- `AGENTS.md`'s code-navigation section, which mandates LSP and forbids grep for definitions, now names the one case where LSP cannot work at all. It also warns that a plain worktree grep for the reviewed commit's identifiers returns nothing and resembles a finding — the failure that produced a false "these constants are unused" claim.
- `task doc:gen` is now documented as rendering flag defaults from the current environment, with the instruction to unset `WERF_*` first and to check the diff for untouched flags. An exported `WERF_DISABLE_AUTO_HOST_CLEANUP` rewrote the documented default of `--disable-auto-host-cleanup` in twelve command pages, a diff that looked like ordinary drift.
- Deliberately unchanged: the review skill's *Output* section keeps its single rule — print the report, do not write it into the repository. A harness that wants a review file adapts to that, it does not override it.
- Deliberately unchanged: no rule tells an agent to skip LSP or prefer grep. The navigation mandate stands; only the case where the tool is structurally blind is now named.

## Why

Every one of these was reachable because the existing documents are written for the ordinary case — a checked-out branch and a clean shell — and say nothing about the two situations an agent hits constantly: reviewing a commit it has not checked out, and running a generator whose output depends on the environment it inherits.

That gap is expensive in a specific way. Each failure produces output that looks correct: a line number is a line number, an empty grep looks like an absent symbol, and a `doc:gen` diff looks like drift the agent is supposed to commit. None of them announce themselves, so they survive review unless a rule names them in advance.

The alternative was to leave these in a session retro, which is where they started. A retro is not read before the next review; `AGENTS.md` and the skills are, and they are the documents the harness already loads.