### PR TITLE
docs(dev): verify cgo code in a container, script rebases by sha

### DIFF
--- a/.agents/skills/git-conventions/SKILL.md
+++ b/.agents/skills/git-conventions/SKILL.md
@@ -41,6 +41,12 @@ Types and scopes are defined in `CONTRIBUTING.md#conventions` — that file is t
 
 - Check `git status` for unrelated untracked files before staging. This worktree carries local working files (`.dev/`, scratch notes, orchestrator state), so prefer explicit paths over `git add -A` — a blanket add sweeps them in, and untracking later costs an extra commit. An orchestrator or helper commit command stages broadly — inspect `git status` BEFORE invoking it, not after.
 
+## Rebasing
+
+- Predict conflicts against the merge base, never with a two-dot diff: compare `git diff --name-only $(git merge-base HEAD origin/<base>)..origin/<base>` with the same for `..HEAD`. Plain `git diff HEAD..origin/<base>` lists every file the branch itself touched, so it always reports an overlap and the prediction is worthless.
+- Scripting a non-interactive `reword` or `fixup`: match the todo line on the sha alone. `rebase.instructionFormat` can insert a `#` before the subject, and a `sed` keyed on `pick <sha> <subject>` then silently matches nothing — the rebase reports success with nothing reworded. Dump the todo first when unsure: `GIT_SEQUENCE_EDITOR='cp "$1" /tmp/todo; false' git rebase -i --autosquash origin/<base>`.
+- Commit a correction as `fixup! <target subject>` BEFORE the rebase, so one `--autosquash` pass carries both it and any reword and the branch is rewritten once.
+
 ## Before pushing
 
 - ALWAYS check the current branch (`git branch --show-current`) — a stale local `main` or someone else's WIP branch is easy to miss.

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -73,7 +73,11 @@ someone would argue for — "a repo-wide marker instead of a per-project one" is
 Before handing the PR over to the user, map it both ways:
 
 - every behavior-changing hunk lands on a claim in *What*, and a supporting hunk (test, doc, error wrapping, refactor) lands on the claim it serves — an unmapped hunk is scope creep or a missing claim;
-- every claim lands on code — a claim with nothing behind it is unfinished work. For a documentation change this map runs against the existing code that makes each claim true.
+- every claim lands on code — a claim with nothing behind it is unfinished work. For a documentation change this map runs against the existing code that makes each claim true;
+- the comment holds only the delta over CI — a green-run recital, a `task build`/`task test:unit` transcript, or the story of a re-run flaky job is noise, however true;
+- no sentence appears in both the description and the comment — the claim carries the `VERIFIED:`/`UNVERIFIED:` attestation, the comment carries the mechanics, and neither restates the other.
+
+Run this map after the last push, against the text as published: the rules above are easiest to break while editing an already-good description.
 
 A branch too large to walk hunk by hunk is mapped commit by commit, and the comment says so.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Follow [Effective Go](https://go.dev/doc/effective_go) and [Go Code Review Comme
 - ALWAYS use LSP (`goToDefinition`, `findReferences`, `documentSymbol`, `hover`, `goToImplementation`, call hierarchy) to find definitions, usages, implementations, and callers. `grep` matches strings blindly: it hits comments and unrelated identifiers, and misses interface dispatch and aliased imports.
 - Use `grep` ONLY for literal text — config keys, error message strings, annotation names.
 - If your harness has a semantic code-search tool, prefer it over `grep` for intent-based questions ("how does X work"). If it does not, read the code: NEVER substitute keyword grepping for understanding.
+- A blast-radius tool that expands a diff into symbols lists every symbol in every touched file, not the impacted ones — thousands of tokens that say less than `git diff --stat` plus `lsp findReferences` on the symbols you actually changed. Reach for it on a wide or unfamiliar diff, never on a handful of files.
 
 ## Commands (MANDATORY)
 
@@ -61,7 +62,7 @@ ALWAYS use these `task` commands. NEVER use raw `go build`, `go test`, `go fmt`,
 - NEVER `go test` → ALWAYS `task test:unit`. Accepts `paths="./pkg/..."`.
 - NEVER `go test` (e2e) → ALWAYS `task test:e2e` with `paths="./pkg/..."` and `labelFilter="..."` (Ginkgo label filter) to target specific tests.
 - NEVER `go test` (integration) → ALWAYS `task test:integration`. Legacy e2e tests.
-- NEVER `go vet` → ALWAYS `task lint:golangci-lint`. golangci-lint includes vet checks. Accepts `golangciPaths="./pkg/..."`.
+- NEVER `go vet` → ALWAYS `task lint:golangci-lint`. golangci-lint includes vet checks. Accepts `golangciPaths="./pkg/..."`. That target runs only its `:go` variant, so it never lints linux/cgo-gated code (`pkg/buildah`, any `*_linux.go`) — for those use `task lint:golangci-lint:cgo`, which needs Linux.
 - NEVER `go fmt`/`gofmt` → ALWAYS `task format`. Accepts `paths="pkg/foo"` — plain directories only; the `./pkg/foo/...` wildcard the test and lint tasks take makes the formatters fail.
 - NEVER `golangci-lint` → ALWAYS `task lint:golangci-lint`. Accepts `golangciPaths="./pkg/..."`.
 - `task lint` — run all linters in parallel.
@@ -83,7 +84,7 @@ After changing Go code, run these in order — `task format` mutates files, so i
 
 NEVER assume a change compiles. While iterating, scope the slow steps (`task lint:golangci-lint golangciPaths="./pkg/foo/..."`, `task test:unit paths="./pkg/foo/..."`), then run them unscoped before handing the work over.
 
-On macOS `task build` produces a **non-CGO** binary — the Buildah backend is only built for linux/amd64 (`task build:dev:linux:amd64:cgo`), so Buildah changes cannot be compiled or exercised locally. Unit tests run anywhere. The Docker-backend entries of the e2e suites also run on macOS with Docker Desktop — `task test:e2e paths="./test/e2e/build" labelFilter="..." parallel=1`, with `WERF_TEST_K8S_DOCKER_REGISTRY` set even when the entries need no registry. Buildah entries, and any suite that needs kind, require Linux (`task test:setup:environment`).
+On macOS `task build` produces a **non-CGO** binary — the Buildah backend is only built for linux/amd64 (`task build:dev:linux:amd64:cgo`), so Buildah changes do not compile on the host. They DO compile, unit-test and lint inside a linux container running this repo's own `task` targets: `golang:<go.mod version>` plus `apt-get install libbtrfs-dev`, then `task test:unit paths="./pkg/buildah/..."` and `task lint:golangci-lint:cgo`. Move `bin/golangci-lint-*` aside first — the host binary is a darwin build and dies with `exec format error`. Establish this before reporting a Buildah check as unrunnable. Unit tests run anywhere. The Docker-backend entries of the e2e suites also run on macOS with Docker Desktop — `task test:e2e paths="./test/e2e/build" labelFilter="..." parallel=1`, with `WERF_TEST_K8S_DOCKER_REGISTRY` set even when the entries need no registry. Buildah entries, and any suite that needs kind, require Linux (`task test:setup:environment`).
 
 ## Testing (MANDATORY)
 


### PR DESCRIPTION
## Summary

Agent instructions claimed Buildah changes cannot be compiled or exercised on a macOS host, so a
session would hand over `pkg/buildah` edits with no compile evidence. They compile in a linux
container running this repo's own `task` targets. Three more rules come from the same session, each
from a mistake that reached a PR or a rebase before being caught.

## What

- `AGENTS.md` no longer tells an agent that Buildah changes "cannot be compiled or exercised
  locally". It names the container recipe instead — `golang:<go.mod version>` plus `libbtrfs-dev`,
  then `task test:unit paths="./pkg/buildah/..."` and `task lint:golangci-lint:cgo` — and the
  `bin/golangci-lint-*` darwin binary that fails with `exec format error` inside it. VERIFIED: both
  targets were run that way on a macOS arm64 host, 39/39 specs and 0 lint issues; the previous
  wording had already caused one session to consider reporting the check as unrunnable.
- `AGENTS.md` states that the scoped `task lint:golangci-lint` runs only its `:go` variant and so
  never lints `pkg/buildah` or any `*_linux.go`, and points at `task lint:golangci-lint:cgo`. An
  agent following the old line believed it had linted files golangci-lint never opened.
- `AGENTS.md` code-navigation gains one line: expanding a diff into symbols returns every symbol in
  every touched file, so on a small diff it costs thousands of tokens and says less than
  `git diff --stat` plus `lsp findReferences`. Measured at ~7.4k tokens for a 15-file diff in the
  session that prompted this.
- `git-conventions` gains a *Rebasing* section: predict conflicts against the merge base, because a
  two-dot `git diff HEAD..origin/<base>` lists the branch's own files and always reports an overlap;
  match a scripted `reword` on the sha alone, because `rebase.instructionFormat` can prefix the
  subject with `#` and a subject-keyed `sed` then rewords nothing while the rebase reports success;
  commit a correction as `fixup!` before the rebase so one `--autosquash` pass rewrites the branch
  once. All three were hit in one session.
- `pull-request`'s self-check gains the two comment rules the same session broke after reading the
  skill: only the delta over CI, and no sentence in both the description and the comment. They are
  stated as a check to run against the published text, since editing an already-good description is
  when they break.
- No `task` target, linter rule or CI check changes. The container recipe is deliberately prose, not
  a target, because it needs a verified run before it becomes tooling.

## Why

These are harness rules, and every one of them is a mistake that was already paid for once: a wrong
claim about what can be verified on macOS, a lint target that quietly skips its own subject, a
conflict prediction that cannot fail, a rebase that reports success without rewording, and two PR
description rules that survived a reading of the skill. Left in place, each recurs in the next
session at full cost. Encoding them as a `task` target or a linter rule would be better than prose
for the first two, and that is deliberately not attempted here: an unverified check is worse than
none, so the tooling version needs its own run and its own PR.
