### PR TITLE
docs(dev): audit the PR description against review findings

### DIFF
--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -64,6 +64,7 @@ Classify each risk as Technical, Security, UX/Product, or Operational, and repor
 - Persisted formats (stage metadata, bundles, storage records) need backward compatibility.
 - `go.mod` replaces cobra and oras with `werf/3p-*` forks — upstream documentation is not authoritative for them.
 - Build and test only via `task` commands, never raw Go tools.
+- The PR description outlives the review — werf squashes, so it becomes the commit body. Audit its claims against your findings: a safety property asserted there that a finding contradicts is itself a defect, and inline comments anchored to code lines never reach whoever reads it.
 
 ## Output
 


### PR DESCRIPTION
## Summary

`review/SKILL.md` referenced a PR's description only as a source for deriving DoD criteria, so a reviewing agent read it as input and never checked it as an artifact. The skill now states that the description's own claims are subject to review, and why that matters more here than in most repositories.

## What

- The delta in what a reviewing agent produces: a finding is now raised when the PR description asserts a property the review disproves, instead of only when code does. Previously such a contradiction went unreported even with findings that directly refuted it.
- The bullet lands in `## Gotchas`, alongside the other werf-specific traps; no other section changes and no existing bullet is reworded.
- Nothing is added to `pull-request/SKILL.md`: that skill governs *writing* a description and already states the squash-permanence fact. This is the reviewing side, and duplicating the fact would let the two drift.
- `.claude/skills` is a symlink to `.agents/skills`, so the change is visible under both paths with no second edit.

## Why

A four-round review of a submodule-reuse change produced 17 inline comments. Its description asserted three safety properties the findings contradict — a probe that "cannot itself trigger a fetch" (true only on git >= 2.45, while `pkg/true_git/init.go` admits 2.18), a reuse failure that "costs a slower build rather than a broken one" (untrue for probe failures, which return with no fallback), and that every URL used is "a path werf computed itself" (ambient `url.*.insteadOf` can rewrite it). None of that was noticed until the user asked whether the description was still accurate.

Two properties make the omission expensive. werf squashes on merge, so the description becomes the commit body: a wrong safety claim outlives the review in `git log` indefinitely. And inline comments anchor to code lines, so a reader of the description never encounters them — the reviewer can be simultaneously thorough about the code and silent about false claims made on top of it.

Rejected alternative: a CI check comparing description claims against the diff. Claims are prose, and deciding whether one contradicts a finding is the review judgment itself, not something a check can make.
