### PR TITLE
fix(build, buildah): stop imports failing on symlinked paths like /bin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -189,7 +189,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f // indirect
-	github.com/cyphar/filepath-securejoin v0.2.5 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/daviddengcn/go-colortext v1.0.0 // indirect
 	github.com/disiqueira/gotree/v3 v3.0.2 // indirect

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -392,6 +392,14 @@ func (backend *BuildahBackend) CalculateDependencyImportChecksum(ctx context.Con
 		return "", err
 	}
 
+	return calculateDependencyImportChecksum(ctx, fromPath, dependencyImport)
+}
+
+// calculateDependencyImportChecksum hashes the files under fromPath (the already resolved
+// on-disk location of dependencyImport.FromPath), keying every entry by the configured
+// FromPath so the checksum does not depend on where the container root is mounted or on
+// symlink resolution of the parent directories.
+func calculateDependencyImportChecksum(ctx context.Context, fromPath string, dependencyImport DependencyImportSpec) (string, error) {
 	pathMatcher := path_matcher.NewPathMatcher(path_matcher.PathMatcherOptions{
 		BasePath:     fromPath,
 		IncludeGlobs: dependencyImport.IncludePaths,
@@ -400,7 +408,7 @@ func (backend *BuildahBackend) CalculateDependencyImportChecksum(ctx context.Con
 
 	var files []string
 
-	err = filepath.Walk(fromPath, func(path string, f os.FileInfo, err error) error {
+	err := filepath.Walk(fromPath, func(path string, f os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("error accessing %s: %w", path, err)
 		}

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/containers/storage/types"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/google/uuid"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
@@ -249,6 +250,17 @@ func (backend *BuildahBackend) unmountContainers(ctx context.Context, containers
 	return nil
 }
 
+// resolveContainerRootPath resolves containerPath inside the mounted container root,
+// following symlinks relative to rootMount instead of the host root: a naive
+// filepath.Join would resolve absolute symlinks like /bin -> /usr/bin against the host.
+func resolveContainerRootPath(rootMount, containerPath string) (string, error) {
+	resolvedPath, err := securejoin.SecureJoin(rootMount, containerPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve path %q in container root %q: %w", containerPath, rootMount, err)
+	}
+	return resolvedPath, nil
+}
+
 func makeScript(commands []string, verbose bool) []byte {
 	var scriptCommands []string
 	for _, c := range commands {
@@ -363,7 +375,10 @@ func (backend *BuildahBackend) CalculateDependencyImportChecksum(ctx context.Con
 		}
 	}()
 
-	fromPath := filepath.Join(container.RootMount, dependencyImport.FromPath)
+	fromPath, err := resolveContainerRootPath(container.RootMount, dependencyImport.FromPath)
+	if err != nil {
+		return "", err
+	}
 
 	pathMatcher := path_matcher.NewPathMatcher(path_matcher.PathMatcherOptions{
 		BasePath:     fromPath,
@@ -373,7 +388,7 @@ func (backend *BuildahBackend) CalculateDependencyImportChecksum(ctx context.Con
 
 	var files []string
 
-	err := filepath.Walk(fromPath, func(path string, f os.FileInfo, err error) error {
+	err = filepath.Walk(fromPath, func(path string, f os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("error accessing %s: %w", path, err)
 		}
@@ -438,7 +453,7 @@ func (backend *BuildahBackend) CalculateDependencyImportChecksum(ctx context.Con
 			}
 		}
 
-		if _, err := fmt.Fprintf(hash, "%x  %s\n", fileHash.Sum(nil), filepath.Join("/", util.GetRelativeToBaseFilepath(container.RootMount, path))); err != nil {
+		if _, err := fmt.Fprintf(hash, "%x  %s\n", fileHash.Sum(nil), filepath.Join("/", dependencyImport.FromPath, util.GetRelativeToBaseFilepath(fromPath, path))); err != nil {
 			return "", fmt.Errorf("error calculating file %q checksum: %w", path, err)
 		}
 	}
@@ -448,7 +463,10 @@ func (backend *BuildahBackend) CalculateDependencyImportChecksum(ctx context.Con
 
 func (backend *BuildahBackend) applyDataArchives(ctx context.Context, container *containerDesc, dataArchives []DataArchiveSpec) error {
 	for _, archive := range dataArchives {
-		destPath := filepath.Join(container.RootMount, archive.To)
+		destPath, err := resolveContainerRootPath(container.RootMount, archive.To)
+		if err != nil {
+			return err
+		}
 
 		var extractDestPath string
 		switch archive.Type {
@@ -499,21 +517,30 @@ func (backend *BuildahBackend) applyRemoveData(ctx context.Context, container *c
 		switch spec.Type {
 		case RemoveExactPath:
 			for _, path := range spec.Paths {
-				destPath := filepath.Join(container.RootMount, path)
+				destPath, err := resolveContainerRootPath(container.RootMount, path)
+				if err != nil {
+					return err
+				}
 				if err := removeExactPath(ctx, destPath); err != nil {
 					return fmt.Errorf("unable to remove %q: %w", path, err)
 				}
 			}
 		case RemoveExactPathWithEmptyParentDirs:
 			for _, path := range spec.Paths {
-				destPath := filepath.Join(container.RootMount, path)
+				destPath, err := resolveContainerRootPath(container.RootMount, path)
+				if err != nil {
+					return err
+				}
 				if err := removeExactPathWithEmptyParentDirs(ctx, destPath, spec.KeepParentDirs); err != nil {
 					return fmt.Errorf("unable to remove %q: %w", path, err)
 				}
 			}
 		case RemoveInsidePath:
 			for _, path := range spec.Paths {
-				destPath := filepath.Join(container.RootMount, path)
+				destPath, err := resolveContainerRootPath(container.RootMount, path)
+				if err != nil {
+					return err
+				}
 				if err := removeInsidePath(ctx, destPath); err != nil {
 					return fmt.Errorf("unable to remove %q: %w", path, err)
 				}
@@ -569,8 +596,14 @@ func (backend *BuildahBackend) applyDependenciesImports(ctx context.Context, con
 				continue
 			}
 
-			absFrom := filepath.Join(dep.RootMount, imp.FromPath)
-			absTo := filepath.Join(container.RootMount, imp.ToPath)
+			absFrom, err := resolveContainerRootPath(dep.RootMount, imp.FromPath)
+			if err != nil {
+				return err
+			}
+			absTo, err := resolveContainerRootPath(container.RootMount, imp.ToPath)
+			if err != nil {
+				return err
+			}
 			if absTo, err = normalizeDependencyImportDestination(absFrom, absTo); err != nil {
 				return fmt.Errorf("normalize destination path for dependency import from %q to %q: %w", imp.FromPath, imp.ToPath, err)
 			}
@@ -1184,7 +1217,11 @@ func getUID(userNameOrUID, fsRoot string) (*uint32, error) {
 	var uid *uint32
 	if userNameOrUID != "" {
 		if parsed, err := strconv.ParseUint(userNameOrUID, 10, 32); errors.Is(err, strconv.ErrSyntax) {
-			result, err := getUIDFromUserName(userNameOrUID, filepath.Join(fsRoot, "etc", "passwd"))
+			etcPasswdPath, err := resolveContainerRootPath(fsRoot, "etc/passwd")
+			if err != nil {
+				return nil, err
+			}
+			result, err := getUIDFromUserName(userNameOrUID, etcPasswdPath)
 			if err != nil {
 				return nil, fmt.Errorf("error getting UID from user name: %w", err)
 			}
@@ -1204,7 +1241,11 @@ func getGID(groupNameOrGID, fsRoot string) (*uint32, error) {
 	var gid *uint32
 	if groupNameOrGID != "" {
 		if parsed, err := strconv.ParseUint(groupNameOrGID, 10, 32); errors.Is(err, strconv.ErrSyntax) {
-			result, err := getGIDFromGroupName(groupNameOrGID, filepath.Join(fsRoot, "etc", "group"))
+			etcGroupPath, err := resolveContainerRootPath(fsRoot, "etc/group")
+			if err != nil {
+				return nil, err
+			}
+			result, err := getGIDFromGroupName(groupNameOrGID, etcGroupPath)
 			if err != nil {
 				return nil, fmt.Errorf("error getting GID from group name: %w", err)
 			}

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -261,6 +261,18 @@ func resolveContainerRootPath(rootMount, containerPath string) (string, error) {
 	return resolvedPath, nil
 }
 
+// resolveContainerRootPathNoFollow resolves the parent directories of containerPath the
+// same way, but keeps the final component unresolved, preserving lstat semantics for
+// paths that are themselves symlinks (import sources, removed paths).
+func resolveContainerRootPathNoFollow(rootMount, containerPath string) (string, error) {
+	containerPath = filepath.Clean(containerPath)
+	resolvedDir, err := resolveContainerRootPath(rootMount, filepath.Dir(containerPath))
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(resolvedDir, filepath.Base(containerPath)), nil
+}
+
 func makeScript(commands []string, verbose bool) []byte {
 	var scriptCommands []string
 	for _, c := range commands {
@@ -375,7 +387,7 @@ func (backend *BuildahBackend) CalculateDependencyImportChecksum(ctx context.Con
 		}
 	}()
 
-	fromPath, err := resolveContainerRootPath(container.RootMount, dependencyImport.FromPath)
+	fromPath, err := resolveContainerRootPathNoFollow(container.RootMount, dependencyImport.FromPath)
 	if err != nil {
 		return "", err
 	}
@@ -517,7 +529,7 @@ func (backend *BuildahBackend) applyRemoveData(ctx context.Context, container *c
 		switch spec.Type {
 		case RemoveExactPath:
 			for _, path := range spec.Paths {
-				destPath, err := resolveContainerRootPath(container.RootMount, path)
+				destPath, err := resolveContainerRootPathNoFollow(container.RootMount, path)
 				if err != nil {
 					return err
 				}
@@ -527,7 +539,7 @@ func (backend *BuildahBackend) applyRemoveData(ctx context.Context, container *c
 			}
 		case RemoveExactPathWithEmptyParentDirs:
 			for _, path := range spec.Paths {
-				destPath, err := resolveContainerRootPath(container.RootMount, path)
+				destPath, err := resolveContainerRootPathNoFollow(container.RootMount, path)
 				if err != nil {
 					return err
 				}
@@ -596,7 +608,7 @@ func (backend *BuildahBackend) applyDependenciesImports(ctx context.Context, con
 				continue
 			}
 
-			absFrom, err := resolveContainerRootPath(dep.RootMount, imp.FromPath)
+			absFrom, err := resolveContainerRootPathNoFollow(dep.RootMount, imp.FromPath)
 			if err != nil {
 				return err
 			}

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -546,12 +546,21 @@ func (backend *BuildahBackend) applyRemoveData(ctx context.Context, container *c
 				}
 			}
 		case RemoveExactPathWithEmptyParentDirs:
+			keepParentDirs := []string{container.RootMount}
+			for _, keepPath := range spec.KeepParentDirs {
+				resolvedKeepPath, err := resolveContainerRootPath(container.RootMount, keepPath)
+				if err != nil {
+					return err
+				}
+				keepParentDirs = append(keepParentDirs, resolvedKeepPath)
+			}
+
 			for _, path := range spec.Paths {
 				destPath, err := resolveContainerRootPathNoFollow(container.RootMount, path)
 				if err != nil {
 					return err
 				}
-				if err := removeExactPathWithEmptyParentDirs(ctx, destPath, spec.KeepParentDirs); err != nil {
+				if err := removeExactPathWithEmptyParentDirs(ctx, destPath, keepParentDirs); err != nil {
 					return fmt.Errorf("unable to remove %q: %w", path, err)
 				}
 			}

--- a/pkg/container_backend/buildah_backend_data_archives_test.go
+++ b/pkg/container_backend/buildah_backend_data_archives_test.go
@@ -107,6 +107,26 @@ var _ = Describe("BuildahBackend data archives", func() {
 		Expect(string(data)).To(Equal("data"))
 	})
 
+	It("applyDataArchives resolves absolute symlink destination against container root", func(ctx SpecContext) {
+		var testCtx context.Context = logging.WithLogger(ctx)
+		rootMount := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootMount, "usr", "bin"), 0o755)).To(Succeed())
+		Expect(os.Symlink("/usr/bin", filepath.Join(rootMount, "bin"))).To(Succeed())
+
+		archiveReader := newTestTarArchive(map[string]string{"gotestsum": "binary"})
+		backend := &BuildahBackend{}
+
+		Expect(backend.applyDataArchives(testCtx, &containerDesc{RootMount: rootMount}, []DataArchiveSpec{{
+			Archive: archiveReader,
+			Type:    DirectoryArchive,
+			To:      "/bin",
+		}})).To(Succeed())
+
+		data, err := os.ReadFile(filepath.Join(rootMount, "usr", "bin", "gotestsum"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(data)).To(Equal("binary"))
+	})
+
 	It("normalizes dependency import destination for regular file into root directory", func() {
 		sourceRoot := GinkgoT().TempDir()
 		containerRoot := GinkgoT().TempDir()

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 
 	"github.com/containers/storage/types"
@@ -66,6 +68,46 @@ var _ = Describe("BuildahBackend pulledImageIDs", func() {
 		id, ok := backend.getPulledImageID("alpine:latest", "linux/amd64")
 		Expect(ok).To(BeTrue())
 		Expect(id).To(Equal("sha256:amd64"))
+	})
+})
+
+var _ = Describe("resolveContainerRootPath", func() {
+	It("resolves an absolute symlink against the container root, not the host root", func() {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootMount, "usr", "bin"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(rootMount, "usr", "bin", "gotestsum"), []byte("bin"), 0o755)).To(Succeed())
+		Expect(os.Symlink("/usr/bin", filepath.Join(rootMount, "bin"))).To(Succeed())
+
+		resolved, err := resolveContainerRootPath(rootMount, "/bin/gotestsum")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(filepath.Join(rootMount, "usr", "bin", "gotestsum")))
+	})
+
+	It("resolves a relative symlink within the container root", func() {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootMount, "usr", "bin"), 0o755)).To(Succeed())
+		Expect(os.Symlink("usr/bin", filepath.Join(rootMount, "bin"))).To(Succeed())
+
+		resolved, err := resolveContainerRootPath(rootMount, "/bin/tool")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(filepath.Join(rootMount, "usr", "bin", "tool")))
+	})
+
+	It("keeps a symlink escaping the container root scoped to it", func() {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.Symlink("../../../etc", filepath.Join(rootMount, "escape"))).To(Succeed())
+
+		resolved, err := resolveContainerRootPath(rootMount, "/escape/passwd")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(filepath.Join(rootMount, "etc", "passwd")))
+	})
+
+	It("returns the joined path for a nonexistent destination", func() {
+		rootMount := GinkgoT().TempDir()
+
+		resolved, err := resolveContainerRootPath(rootMount, "/app/newfile")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(filepath.Join(rootMount, "app", "newfile")))
 	})
 })
 

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -237,6 +237,40 @@ var _ = Describe("calculateDependencyImportChecksum", func() {
 	})
 })
 
+var _ = Describe("BuildahBackend applyRemoveData", func() {
+	It("keeps a symlinked parent dir when removing the last file under it", func(ctx SpecContext) {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootMount, "usr", "bin"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(rootMount, "usr", "bin", "last-file"), []byte("data"), 0o644)).To(Succeed())
+		Expect(os.Symlink("/usr/bin", filepath.Join(rootMount, "bin"))).To(Succeed())
+
+		backend := &BuildahBackend{}
+		Expect(backend.applyRemoveData(ctx, &containerDesc{RootMount: rootMount}, []RemoveDataSpec{{
+			Type:           RemoveExactPathWithEmptyParentDirs,
+			Paths:          []string{"/bin/last-file"},
+			KeepParentDirs: []string{"/bin"},
+		}})).To(Succeed())
+
+		Expect(filepath.Join(rootMount, "usr", "bin", "last-file")).ToNot(BeAnExistingFile())
+		Expect(filepath.Join(rootMount, "usr", "bin")).To(BeADirectory())
+	})
+
+	It("never prunes empty parent dirs above the container root", func(ctx SpecContext) {
+		rootMount := filepath.Join(GinkgoT().TempDir(), "merged")
+		Expect(os.MkdirAll(filepath.Join(rootMount, "app"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(rootMount, "app", "last-file"), []byte("data"), 0o644)).To(Succeed())
+
+		backend := &BuildahBackend{}
+		Expect(backend.applyRemoveData(ctx, &containerDesc{RootMount: rootMount}, []RemoveDataSpec{{
+			Type:  RemoveExactPathWithEmptyParentDirs,
+			Paths: []string{"/app/last-file"},
+		}})).To(Succeed())
+
+		Expect(filepath.Join(rootMount, "app")).ToNot(BeADirectory())
+		Expect(rootMount).To(BeADirectory())
+	})
+})
+
 var _ = Describe("platformMatches", func() {
 	DescribeTable("validates platform",
 		func(os, arch, variant, targetPlatform string, expected bool) {

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -2,6 +2,7 @@ package container_backend
 
 import (
 	"context"
+	"crypto/md5"
 	"errors"
 	"fmt"
 	"os"
@@ -154,6 +155,85 @@ var _ = Describe("resolveContainerRootPathNoFollow", func() {
 		resolved, err := resolveContainerRootPathNoFollow(rootMount, "/escape/passwd")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resolved).To(Equal(filepath.Join(rootMount, "etc", "passwd")))
+	})
+})
+
+var _ = Describe("calculateDependencyImportChecksum", func() {
+	calc := func(rootMount string, spec DependencyImportSpec) string {
+		fromPath, err := resolveContainerRootPathNoFollow(rootMount, spec.FromPath)
+		Expect(err).ToNot(HaveOccurred())
+		checksum, err := calculateDependencyImportChecksum(context.Background(), fromPath, spec)
+		Expect(err).ToNot(HaveOccurred())
+		return checksum
+	}
+
+	// entries: {content or symlink target, keyed path}, in sorted walk order.
+	expectedChecksum := func(entries ...[2]string) string {
+		hash := md5.New()
+		for _, e := range entries {
+			fmt.Fprintf(hash, "%x  %s\n", md5.Sum([]byte(e[0])), e[1])
+		}
+		return fmt.Sprintf("%x", hash.Sum(nil))
+	}
+
+	It("keys hash entries by the configured FromPath, not the mount location", func() {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootMount, "bin"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(rootMount, "bin", "gotestsum"), []byte("gotestsum-binary"), 0o755)).To(Succeed())
+
+		checksum := calc(rootMount, DependencyImportSpec{FromPath: "/bin/gotestsum"})
+		Expect(checksum).To(Equal(expectedChecksum([2]string{"gotestsum-binary", "/bin/gotestsum"})))
+	})
+
+	It("is identical between two different mount locations with the same content", func() {
+		spec := DependencyImportSpec{FromPath: "/app"}
+
+		var checksums []string
+		for range 2 {
+			rootMount := GinkgoT().TempDir()
+			Expect(os.MkdirAll(filepath.Join(rootMount, "app"), 0o755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(rootMount, "app", "server"), []byte("server-binary"), 0o755)).To(Succeed())
+			checksums = append(checksums, calc(rootMount, spec))
+		}
+
+		Expect(checksums[0]).To(Equal(checksums[1]))
+	})
+
+	It("is identical between a plain directory and the same content behind an absolute parent symlink", func() {
+		plainRoot := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(plainRoot, "bin"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(plainRoot, "bin", "gotestsum"), []byte("gotestsum-binary"), 0o755)).To(Succeed())
+
+		usrmergeRoot := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(usrmergeRoot, "usr", "bin"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(usrmergeRoot, "usr", "bin", "gotestsum"), []byte("gotestsum-binary"), 0o755)).To(Succeed())
+		Expect(os.Symlink("/usr/bin", filepath.Join(usrmergeRoot, "bin"))).To(Succeed())
+
+		spec := DependencyImportSpec{FromPath: "/bin/gotestsum"}
+		Expect(calc(usrmergeRoot, spec)).To(Equal(calc(plainRoot, spec)))
+	})
+
+	It("hashes a FromPath that is itself a symlink as a symlink, not its target tree", func() {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootMount, "usr", "bin"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(rootMount, "usr", "bin", "gotestsum"), []byte("gotestsum-binary"), 0o755)).To(Succeed())
+		Expect(os.Symlink("/usr/bin", filepath.Join(rootMount, "bin"))).To(Succeed())
+
+		checksum := calc(rootMount, DependencyImportSpec{FromPath: "/bin"})
+		Expect(checksum).To(Equal(expectedChecksum([2]string{"/usr/bin", "/bin"})))
+	})
+
+	It("honors include and exclude globs", func() {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootMount, "app"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(rootMount, "app", "keep.txt"), []byte("keep"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(rootMount, "app", "skip.log"), []byte("skip"), 0o644)).To(Succeed())
+
+		checksum := calc(rootMount, DependencyImportSpec{FromPath: "/app", IncludePaths: []string{"*.txt"}})
+		Expect(checksum).To(Equal(expectedChecksum([2]string{"keep", "/app/keep.txt"})))
+
+		checksum = calc(rootMount, DependencyImportSpec{FromPath: "/app", ExcludePaths: []string{"*.log"}})
+		Expect(checksum).To(Equal(expectedChecksum([2]string{"keep", "/app/keep.txt"})))
 	})
 })
 

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -111,6 +111,52 @@ var _ = Describe("resolveContainerRootPath", func() {
 	})
 })
 
+var _ = Describe("resolveContainerRootPathNoFollow", func() {
+	It("resolves absolute symlink parents but keeps the final component unresolved", func() {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootMount, "usr", "bin"), 0o755)).To(Succeed())
+		Expect(os.Symlink("/usr/bin", filepath.Join(rootMount, "bin"))).To(Succeed())
+		Expect(os.Symlink("gotestsum-real", filepath.Join(rootMount, "usr", "bin", "gotestsum"))).To(Succeed())
+
+		resolved, err := resolveContainerRootPathNoFollow(rootMount, "/bin/gotestsum")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(filepath.Join(rootMount, "usr", "bin", "gotestsum")))
+
+		info, err := os.Lstat(resolved)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(info.Mode() & os.ModeSymlink).ToNot(BeZero())
+	})
+
+	It("keeps a path that is itself a symlink pointing at its unresolved location", func() {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootMount, "usr", "bin"), 0o755)).To(Succeed())
+		Expect(os.Symlink("/usr/bin", filepath.Join(rootMount, "bin"))).To(Succeed())
+
+		resolved, err := resolveContainerRootPathNoFollow(rootMount, "/bin")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(filepath.Join(rootMount, "bin")))
+	})
+
+	It("normalizes a trailing slash before splitting off the final component", func() {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(rootMount, "usr", "bin"), 0o755)).To(Succeed())
+		Expect(os.Symlink("/usr/bin", filepath.Join(rootMount, "bin"))).To(Succeed())
+
+		resolved, err := resolveContainerRootPathNoFollow(rootMount, "/bin/")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(filepath.Join(rootMount, "bin")))
+	})
+
+	It("clamps a parent symlink escaping the container root", func() {
+		rootMount := GinkgoT().TempDir()
+		Expect(os.Symlink("../../../etc", filepath.Join(rootMount, "escape"))).To(Succeed())
+
+		resolved, err := resolveContainerRootPathNoFollow(rootMount, "/escape/passwd")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(filepath.Join(rootMount, "etc", "passwd")))
+	})
+})
+
 var _ = Describe("platformMatches", func() {
 	DescribeTable("validates platform",
 		func(os, arch, variant, targetPlatform string, expected bool) {

--- a/pkg/container_backend/file_utils.go
+++ b/pkg/container_backend/file_utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 func removeExactPath(ctx context.Context, path string) error {
-	_, err := os.Stat(path)
+	_, err := os.Lstat(path)
 	switch {
 	case os.IsNotExist(err):
 	case err != nil:
@@ -28,7 +28,7 @@ func removeExactPath(ctx context.Context, path string) error {
 }
 
 func removeExactPathWithEmptyParentDirs(ctx context.Context, path string, keepParentDirs []string) error {
-	_, err := os.Stat(path)
+	_, err := os.Lstat(path)
 	switch {
 	case os.IsNotExist(err):
 	case err != nil:


### PR DESCRIPTION
## Summary

On the Buildah backend, an import whose path traverses a symlink with an absolute target inside the source image (e.g. `/bin -> /usr/bin` on usrmerge distros) fails at the import checksum step with `error accessing <storage>/overlay/<id>/merged/bin/<file>: lstat ...: no such file or directory`. werf resolved such symlinks against the host root instead of the mounted image rootfs; now they are resolved strictly within it. It needs no special host state — only a source image where the configured import path goes through an absolute symlink.

## What

### Imports

- An `import` whose `add` path traverses an absolute symlink in the source image no longer fails checksum calculation with "no such file or directory"; parent components are resolved inside the image rootfs.
  - VERIFIED: on a Linux host with rootless Buildah — a Stapel `import` with `add: /opt/link/tool` where `/opt/link -> /opt/real` reproduced the exact reported error on a main-built binary and built successfully on this branch, with the file present in the image and a rebuild fully reusing cache.
- An `add` path whose final component is itself a symlink keeps its previous meaning: the symlink is hashed and imported as a symlink, never its target tree, so existing checksums do not change and no stage rebuilds are triggered — for any previously working configuration, symlink-final or not. The checksum format is pinned by unit tests computing expected values independently.
- `owner`/`group` name lookup for imports reads `etc/passwd`/`etc/group` of the image rootfs even when `/etc` in the image is a symlink; previously it silently read the host files.

### Writes and cleanup inside the image rootfs

- Import copying, git/data archive extraction, and remove-inside-path cleanup resolve destination paths fully inside the container rootfs; previously a destination behind an absolute symlink was written to the host filesystem path the symlink named.
  - A destination whose final component is a symlinked directory now receives files in its target inside the rootfs — for relative symlinks that is what already happened, for absolute ones it previously hit the host.
- Exact-path removal of a path that is itself a symlink removes the link, not its target; a dangling symlink is now removed too, where it was previously skipped.
- Git-mapping cleanup keeps the mapped destination directory after removing its last file: the keep-parent-dirs check compared container paths against rootMount-prefixed on-disk parents and never matched — broken on main as well, not introduced by this branch.
- Empty-parent pruning after git cleanup can never climb past the container root mount into the host directory tree.
- A symlink pointing outside the image rootfs (`../../../etc`) is clamped to the rootfs root and can never reach the host.

### Unchanged

- The Docker backend and the legacy Stapel builder are unchanged: they calculate import checksums inside a container, where symlinks always resolve against the container root.
- `github.com/cyphar/filepath-securejoin` moves from indirect to direct dependency; version pinned before and after at v0.2.5.

## Why

In-container paths were joined onto the mounted rootfs with a plain `filepath.Join`, so the kernel resolved any absolute symlink component against the host root: reads miss (`/usr/bin/<file>` of the host does not exist) and writes land on the host — a correctness bug on every usrmerge image and a host-filesystem escape in rootful mode. Running the checksum inside a container, as the legacy Stapel builder does, would fix resolution too, but costs a container run per import; `securejoin.SecureJoin` is the containers-stack standard for host-side rootfs path handling and is already in the dependency graph. Resolving every component including the final one was rejected for sources and exact removals: it silently changes checksums and imported content for `add` paths that are themselves symlinks, so only parent components are resolved there.
