### PR TITLE
fix(build): reuse content anchors without git commits

### DIFF
--- a/pkg/build/stage/git.go
+++ b/pkg/build/stage/git.go
@@ -33,6 +33,10 @@ func (s *GitStage) PrepareImage(ctx context.Context, c Conveyor, cb container_ba
 	return s.BaseStage.PrepareImage(ctx, c, cb, prevBuiltImage, stageImage, nil)
 }
 
-func (s *GitStage) SelectSuitableStageDesc(ctx context.Context, _ Conveyor, stageDescSet image.StageDescSet) (*image.StageDesc, error) {
+func (s *GitStage) SelectSuitableStageDesc(ctx context.Context, c Conveyor, stageDescSet image.StageDescSet) (*image.StageDesc, error) {
+	if s.IsContentAnchor() {
+		return s.BaseStage.SelectSuitableStageDesc(ctx, c, stageDescSet)
+	}
+
 	return s.selectStageDescByExistingGitCommits(ctx, stageDescSet)
 }

--- a/pkg/build/stage/git_test.go
+++ b/pkg/build/stage/git_test.go
@@ -1,0 +1,48 @@
+package stage
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/werf/v2/pkg/git_repo"
+	"github.com/werf/werf/v2/pkg/image"
+)
+
+type gitRepoStringStub struct {
+	git_repo.GitRepo
+}
+
+func (r *gitRepoStringStub) String() string {
+	return "test"
+}
+
+func (r *gitRepoStringStub) GetName() string {
+	return "test"
+}
+
+var _ = Describe("GitStage", func() {
+	It("selects the oldest cached content anchor without its git commit", func() {
+		gitMapping := NewGitMapping()
+		gitMapping.SetGitRepo(&gitRepoStringStub{})
+
+		stg := newGitStage(GitLatestPatch, &BaseStageOptions{})
+		stg.SetGitMappings([]*GitMapping{gitMapping})
+		stg.SetContentAnchor(true)
+
+		oldest := &image.StageDesc{
+			StageID: image.NewStageID("anchor", 1),
+			Info:    &image.Info{Name: "repo:oldest"},
+		}
+		newest := &image.StageDesc{
+			StageID: image.NewStageID("anchor", 2),
+			Info:    &image.Info{Name: "repo:newest"},
+		}
+
+		selected, err := stg.SelectSuitableStageDesc(context.Background(), nil, image.NewStageDescSet(newest, oldest))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(selected).To(BeIdenticalTo(oldest))
+	})
+})


### PR DESCRIPTION
## Summary

Cached content anchors from Git-backed images are now reused even when the source commit recorded by an existing stage is unavailable. Ordinary Git stages retain commit validation because they need history to generate patches.

## What

- A cached content anchor with a matching digest is selected without requiring its recorded Git commit to exist.
- Non-anchor Git stages continue to reject cached stages whose recorded commits are unavailable.

## Why

The terminal Git stage serving as a content anchor inherited ordinary stage selection, which validates the cached stage's recorded commit. A content anchor is content-addressed, so that validation wrongly prevents reuse when the commit is unavailable despite an intact remote stage. Selecting it through the base-stage policy removes the unnecessary Git dependency without weakening patch-stage safety.