### PR TITLE
fix(build): make repo-built from:scratch images readable by dive

### DIFF
--- a/pkg/docker_registry/container_registry_extensions/manifest_only_image_test.go
+++ b/pkg/docker_registry/container_registry_extensions/manifest_only_image_test.go
@@ -1,0 +1,47 @@
+package container_registry_extensions
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The manifest-only image is pushed to registries as the scratch from stage base, and every
+// descendant stage inherits its layer. A zero-byte layer body is not a parseable tar and breaks
+// consumers like dive with EOF, so the layer must always be a valid, non-empty tar archive.
+var _ = Describe("manifest-only image", func() {
+	It("has a single valid empty tar layer with a matching diffID", func() {
+		img := NewManifestOnlyImage(map[string]string{"werf": "test"})
+
+		layers, err := img.Layers()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(layers).To(HaveLen(1))
+
+		rc, err := layers[0].Uncompressed()
+		Expect(err).NotTo(HaveOccurred())
+		data, err := io.ReadAll(rc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rc.Close()).To(Succeed())
+
+		Expect(len(data)).To(BeNumerically(">", 0), "a valid tar archive is never zero bytes")
+
+		tr := tar.NewReader(bytes.NewReader(data))
+		_, err = tr.Next()
+		Expect(err).To(Equal(io.EOF), "expected a well-formed empty tar with no entries")
+
+		expectedDiffID, _, err := v1.SHA256(bytes.NewReader(data))
+		Expect(err).NotTo(HaveOccurred())
+		diffID, err := layers[0].DiffID()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(diffID).To(Equal(expectedDiffID))
+
+		cfg, err := img.ConfigFile()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.RootFS.DiffIDs).To(Equal([]v1.Hash{expectedDiffID}))
+		Expect(cfg.Config.Labels).To(Equal(map[string]string{"werf": "test"}))
+	})
+})

--- a/pkg/docker_registry/container_registry_extensions/suite_test.go
+++ b/pkg/docker_registry/container_registry_extensions/suite_test.go
@@ -1,5 +1,4 @@
 package container_registry_extensions
-package container_registry_extensions
 
 import (
 	"testing"

--- a/pkg/docker_registry/container_registry_extensions/suite_test.go
+++ b/pkg/docker_registry/container_registry_extensions/suite_test.go
@@ -1,0 +1,14 @@
+package container_registry_extensions
+package container_registry_extensions
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestContainerRegistryExtensions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Container Registry Extensions Suite")
+}

--- a/pkg/docker_registry/container_registry_extensions/uncompressed_layer.go
+++ b/pkg/docker_registry/container_registry_extensions/uncompressed_layer.go
@@ -1,20 +1,39 @@
 package container_registry_extensions
 
 import (
+	"archive/tar"
 	"bytes"
+	"fmt"
 	"io"
-	"io/ioutil"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-var EmptyUncompressedLayer = &uncompressedLayer{
-	diffID: v1.Hash{
-		Algorithm: "sha256",
-		Hex:       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-	},
-	mediaType: types.DockerLayer,
+var _ partial.UncompressedLayer = (*uncompressedLayer)(nil)
+
+var EmptyUncompressedLayer = newEmptyUncompressedLayer()
+
+// newEmptyUncompressedLayer returns a layer whose content is a valid empty tar archive.
+// A zero-byte body is not a parseable tar: registries accept it, but consumers such as
+// dive or docker save readers fail with EOF on every image that inherits the layer.
+func newEmptyUncompressedLayer() *uncompressedLayer {
+	var buf bytes.Buffer
+	if err := tar.NewWriter(&buf).Close(); err != nil {
+		panic(fmt.Sprintf("write empty tar archive: %s", err))
+	}
+
+	diffID, _, err := v1.SHA256(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		panic(fmt.Sprintf("calculate empty tar archive diffID: %s", err))
+	}
+
+	return &uncompressedLayer{
+		diffID:    diffID,
+		mediaType: types.DockerLayer,
+		content:   buf.Bytes(),
+	}
 }
 
 type uncompressedLayer struct {
@@ -28,7 +47,7 @@ func (layer *uncompressedLayer) DiffID() (v1.Hash, error) {
 }
 
 func (layer *uncompressedLayer) Uncompressed() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewBuffer(layer.content)), nil
+	return io.NopCloser(bytes.NewReader(layer.content)), nil
 }
 
 func (layer *uncompressedLayer) MediaType() (types.MediaType, error) {

--- a/test/pkg/utils/image.go
+++ b/test/pkg/utils/image.go
@@ -62,8 +62,11 @@ func ExpectImageIsReadable(ctx context.Context, backendMode, imageName string) {
 	for i, layer := range layers {
 		rc, err := layer.Uncompressed()
 		Expect(err).NotTo(HaveOccurred(), "expected layer %d to be readable for %s", i, imageName)
-		_, err = io.Copy(io.Discard, rc)
+		n, err := io.Copy(io.Discard, rc)
 		Expect(err).NotTo(HaveOccurred(), "expected layer %d to be fully readable for %s", i, imageName)
+		// A zero-byte layer is not a parseable tar even though go-containerregistry
+		// reads it back as gracefully empty; tools like dive fail on it with EOF.
+		Expect(n).To(BeNumerically(">", 0), "expected layer %d to be a non-empty tar archive for %s", i, imageName)
 		Expect(rc.Close()).To(Succeed())
 	}
 


### PR DESCRIPTION
## Summary

Images built with `from: scratch` and a stages repo (`--repo`) could not be read by `dive` and other `docker save` consumers on Linux Docker engines: they failed with "cannot fetch image: EOF" on the `from` stage and every stage inheriting it. Reproduces from a clean checkout when no local stage cache exists:

```yaml
# werf.yaml
project: scratch
configVersion: 1
---
image: source
from: alpine:latest
shell:
  install:
    - apk add wget
---
image: destination
from: scratch
import:
  - image: source
    add: /usr/bin/wget
    to: /usr/bin/wget
    before: install
```

```shell
werf build --repo localhost:5000/scratch
docker pull localhost:5000/scratch:<final-stage-tag>
dive localhost:5000/scratch:<final-stage-tag>   # cannot fetch image: EOF
```

## What

- The empty base layer of a `from: scratch` stage created directly in the stages repo is now a valid empty tar archive (diffID `sha256:5f70bf18…`, same as the local build path) instead of a zero-byte blob (`sha256:e3b0c442…`).
- `dive` and `docker save` readers no longer fail with "cannot fetch image: EOF" on repo-built scratch stages or their descendants. VERIFIED: hand-run on Ubuntu 22.04 (Docker 29.2.1, overlay2, dive 0.13.1) — stock v2.74.0 fails on all scratch-chain stages, the patched binary passes on all of them.
- The fix covers both backends in repo mode: the broken layer came from the backend-agnostic manifest push, and with it reverted the e2e scratch suite fails on the vanilla-docker and the native-chroot repo entries alike.
- Stage digests do not change: existing build caches stay valid, no rebuilds are triggered.
- Already-published scratch stages keep the broken layer — werf reuses them by digest; recreating the `from` stage (e.g. bumping `fromCacheVersion`) is required to heal an existing project.
- The e2e readability helper (`ExpectImageIsReadable`) now rejects zero-byte layers; previously go-containerregistry read them back as gracefully empty, which is why CI never caught this.
- The local Docker build path (fixed in #7609) and local Buildah behavior do not change.

## Why

`RepoStagesStorage.PostManifest` creates the scratch `from` stage as a manifest-only image whose rootfs was `EmptyUncompressedLayer`: nil content with a hardcoded diffID of the empty string. Registries and `docker pull` accept a zero-byte layer blob, but it is not a parseable tar archive, so any consumer that streams the image back (dive, `docker save` readers on graphdriver engines) hits EOF — and every descendant stage inherits the layer, poisoning the whole chain. Docker Desktop on macOS (containerd image store) tolerates it, which masked the bug outside Linux. #7609 fixed the same symptom for the local `ImageImport` path only; this aligns the repo path with it.

Fixes: 490d6e0df8d0 ("feat(build): scratch stapel docker backend")
