### PR TITLE
chore(docs): add v3 docs deploy routing

### DIFF
--- a/.github/workflows/_docs_deploy_production.yml
+++ b/.github/workflows/_docs_deploy_production.yml
@@ -47,6 +47,10 @@ jobs:
           fi
 
           case "$github_ref_value" in
+            3|v3|v3.*)
+              docs_ref_value="v3"
+              release_name="werfio-v3-production"
+              ;;
             2|v2|v2.*)
               docs_ref_value="v2"
               release_name="werfio-v2-production"

--- a/.github/workflows/docs_deploy_latest.yml
+++ b/.github/workflows/docs_deploy_latest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "3"
       - "2"
       - "1.2"
     paths:
@@ -24,7 +25,7 @@ on:
 
 jobs:
   deploy-prod-ru:
-    if: ${{ (github.event_name == 'push') || github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && (github.ref_name == 'main' || github.ref_name == '2' || github.ref_name == '1.2') && (github.event.inputs.targetCluster == 'all' || github.event.inputs.targetCluster == 'ru')) }}
+    if: ${{ (github.event_name == 'push') || github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && (github.ref_name == 'main' || github.ref_name == '3' || github.ref_name == '2' || github.ref_name == '1.2') && (github.event.inputs.targetCluster == 'all' || github.event.inputs.targetCluster == 'ru')) }}
     permissions:
       contents: read
       id-token: write
@@ -36,7 +37,7 @@ jobs:
       kubeConfigSecretPath: projects/data/b454e6aa-39f0-45f4-aa7c-a9465ab154cb/KUBE_CONFIG_RU
 
   deploy-prod-eu:
-    if: ${{ (github.event_name == 'push') || github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && (github.ref_name == 'main' || github.ref_name == '2' || github.ref_name == '1.2') && (github.event.inputs.targetCluster == 'all' || github.event.inputs.targetCluster == 'eu')) }}
+    if: ${{ (github.event_name == 'push') || github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_dispatch' && (github.ref_name == 'main' || github.ref_name == '3' || github.ref_name == '2' || github.ref_name == '1.2') && (github.event.inputs.targetCluster == 'all' || github.event.inputs.targetCluster == 'eu')) }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/docs_deploy_test_versions.yml
+++ b/.github/workflows/docs_deploy_test_versions.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - all
+          - v3
           - v2
           - v1.2
           - latest
@@ -19,6 +20,35 @@ defaults:
     shell: bash
 
 jobs:
+  deploy-v3:
+    if: ${{ github.event.inputs.version == 'all' || github.event.inputs.version == 'v3' }}
+    runs-on: prod-github-runner-0
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install werf
+        uses: werf/actions/install@v2
+
+      - name: Deploy v3 docs to test
+        run: |
+          . $(werf ci-env github --as-file)
+          werf converge --virtual-merge=false
+        env:
+          WERF_NAMESPACE: werfio-test
+          WERF_DIR: docs
+          WERF_ENV: test
+          WERF_RELEASE: werfio-v3-test
+          WERF_SET_GITHUB_REF: global.github_ref=v3
+          WERF_REPO: ghcr.io/${{ github.repository_owner }}/werfio
+          WERF_KUBE_CONFIG_BASE64: ${{ secrets.KUBECONFIG_BASE64_DEV }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   deploy-v2:
     if: ${{ github.event.inputs.version == 'all' || github.event.inputs.version == 'v2' }}
     runs-on: prod-github-runner-0

--- a/docs/.helm/values.yaml
+++ b/docs/.helm/values.yaml
@@ -41,5 +41,5 @@ resources:
 
 docs:
   currentRoot: v2
-  supportedRoots: [v2, v1.2]
+  supportedRoots: [v3, v2, v1.2]
   latestAliasEnabled: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,7 +5,7 @@ site_title: werf
 company_name: Flant
 company_url: https://flant.com
 url: https://werf.io
-canonical_url_prefix: /docs/v2
+canonical_url_prefix: /docs/v3
 site_lang: en
 site_urls:
   ru: https://ru.werf.io


### PR DESCRIPTION
## Summary

Wire up deployment and routing for the v3 documentation so pushes to the `3` branch publish a separate `werfio-v3-production` release and `/docs/v3` becomes an addressable docs root. The default docs root stays `v2` until v3 lands on `main`.

## What

- Push to branch `3` (also `repository_dispatch`/`workflow_dispatch` for it) now deploys production docs as the `werfio-v3-production` release.
- The production deploy maps refs `3`/`v3`/`v3.*` to docs root `v3`; previously such a ref exited with `Unsupported docs production ref`.
- `docs:deploy:test-versions` gains a `v3` target (`werfio-v3-test`, `global.github_ref=v3`).
- `/docs/v3` and `/docs/v3.*` are addressable docs roots; `supportedRoots` is now `[v3, v2, v1.2]`. Bare `/docs/` still redirects to `/docs/v2/`.
- v3 pages declare canonical URL prefix `/docs/v3`.
- Does NOT change the default docs root or the v2/v1.2 deploys.

## Why

werf 3 is released on the `3` branch but had no docs deploy path: the production workflow's ref mapping and the deploy-latest trigger knew only `main`/`2`/`1.2`, and the routing values listed only `v2`/`v1.2`, so v3 docs were neither built nor reachable. The production Helm templates are already generic over `global.github_ref`, so wiring is limited to the ref mapping, trigger, supported-roots list and canonical prefix. Keeping `currentRoot` at `v2` avoids flipping the public default before v3 is promoted on `main`.
