### PR TITLE
test(ci): enable race detector in unit tests

### DIFF
--- a/.github/workflows/_test_unit.yml
+++ b/.github/workflows/_test_unit.yml
@@ -65,7 +65,7 @@ jobs:
             task --yes -p test:unit paths="$(echo ${{ inputs.packages }} | tr , ' ')" -- --coverprofile="$(openssl rand -hex 6)-coverage.out" --keep-going --skip-package '${{ inputs.excludePackages }}'
             mv *-coverage.out "$WERF_TEST_COVERAGE_DIR/"
           else
-            task --yes -p test:unit paths="$(echo ${{ inputs.packages }} | tr , ' ')" -- --keep-going --skip-package '${{ inputs.excludePackages }}'
+            task --yes -p test:unit paths="$(echo ${{ inputs.packages }} | tr , ' ')" -- --race --keep-going --skip-package '${{ inputs.excludePackages }}'
           fi
           echo loadavg: $(cat /proc/loadavg)
 


### PR DESCRIPTION
## Summary

Regular unit-test CI now runs with Go's race detector. The coverage path remains unchanged.

## What

- Non-coverage invocations of the reusable unit-test workflow pass `--race` to Ginkgo.
- Coverage invocations keep their existing command and coverage artifact behavior.

## Why

Regular unit tests previously did not detect unsafe concurrent memory access. Keep coverage separate so this change only adds race detection to the existing non-coverage CI path.
