### PR TITLE
test(ci): run the race detector across all daily tests only

### DIFF
--- a/.github/actions/set-up-prebuilt-werf-test-binary/action.yml
+++ b/.github/actions/set-up-prebuilt-werf-test-binary/action.yml
@@ -3,6 +3,9 @@ inputs:
   coverage:
     default: false
     type: string
+  raceDetectorEnabled:
+    default: false
+    type: string
 runs:
   using: composite
   steps:
@@ -31,9 +34,9 @@ runs:
     - name: Build werf test binary
       run: |
         if ${{ inputs.coverage }}; then
-          task --yes -p build-with-coverage
+          task --yes -p build-with-coverage raceDetectorEnabled=${{ inputs.raceDetectorEnabled }}
         else
-          task --yes -p build
+          task --yes -p build raceDetectorEnabled=${{ inputs.raceDetectorEnabled }}
         fi
       shell: bash
       env:

--- a/.github/workflows/_test_e2e_per-k8s-version.yml
+++ b/.github/workflows/_test_e2e_per-k8s-version.yml
@@ -15,6 +15,9 @@ on:
       coverage:
         default: false
         type: string
+      raceDetectorEnabled:
+        default: false
+        type: string
       forceSkip:
         default: false
         type: string
@@ -68,6 +71,7 @@ jobs:
         uses: ./.github/actions/set-up-prebuilt-werf-test-binary
         with:
           coverage: ${{ inputs.coverage }}
+          raceDetectorEnabled: ${{ inputs.raceDetectorEnabled }}
 
       - name: Set up git config
         uses: ./.github/actions/set-up-git-config

--- a/.github/workflows/_test_integration_per-container-registry.yml
+++ b/.github/workflows/_test_integration_per-container-registry.yml
@@ -6,6 +6,9 @@ on:
       coverage:
         default: false
         type: string
+      raceDetectorEnabled:
+        default: false
+        type: string
       linuxAmd64Runner:
         default: ubuntu-22.04
         type: string
@@ -35,7 +38,7 @@ jobs:
           - harbor
           - quay
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
       WERF_TEST_DOCKER_REGISTRY_IMPLEMENTATION_ACR: 1
       WERF_TEST_ACR_PASSWORD: ${{ secrets.WERF_TEST_ACR_PASSWORD }}
@@ -95,6 +98,7 @@ jobs:
         uses: ./.github/actions/set-up-prebuilt-werf-test-binary
         with:
           coverage: ${{ inputs.coverage }}
+          raceDetectorEnabled: ${{ inputs.raceDetectorEnabled }}
 
       - if: matrix.cr == 'acr'
         name: Login to ACR

--- a/.github/workflows/_test_integration_per-k8s-version-and-container-registry.yml
+++ b/.github/workflows/_test_integration_per-k8s-version-and-container-registry.yml
@@ -6,6 +6,9 @@ on:
       coverage:
         default: false
         type: string
+      raceDetectorEnabled:
+        default: false
+        type: string
       linuxAmd64Runner:
         default: ubuntu-22.04
         type: string
@@ -27,7 +30,7 @@ jobs:
           - ${{ inputs.linuxAmd64Runner }}
         kubeVersion: [1.34.8, 1.36.1]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
       WERF_TEST_DOCKER_REGISTRY_IMPLEMENTATION_ACR: 1
       WERF_TEST_ACR_PASSWORD: ${{ secrets.WERF_TEST_ACR_PASSWORD }}
@@ -87,6 +90,7 @@ jobs:
         uses: ./.github/actions/set-up-prebuilt-werf-test-binary
         with:
           coverage: ${{ inputs.coverage }}
+          raceDetectorEnabled: ${{ inputs.raceDetectorEnabled }}
 
       - name: Login to ACR
         uses: azure/login@v3

--- a/.github/workflows/_test_integration_per-k8s-version.yml
+++ b/.github/workflows/_test_integration_per-k8s-version.yml
@@ -6,6 +6,9 @@ on:
       coverage:
         default: false
         type: string
+      raceDetectorEnabled:
+        default: false
+        type: string
       linuxAmd64Runner:
         default: ubuntu-22.04
         type: string
@@ -27,7 +30,7 @@ jobs:
           - ${{ inputs.linuxAmd64Runner }}
         kubeVersion: [1.34.8, 1.36.1]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Install werf build dependencies
         run: sudo apt-get install -y libbtrfs-dev
@@ -50,6 +53,7 @@ jobs:
         uses: ./.github/actions/set-up-prebuilt-werf-test-binary
         with:
           coverage: ${{ inputs.coverage }}
+          raceDetectorEnabled: ${{ inputs.raceDetectorEnabled }}
 
       - name: Set up git config
         uses: ./.github/actions/set-up-git-config

--- a/.github/workflows/_test_integration_regular.yml
+++ b/.github/workflows/_test_integration_regular.yml
@@ -12,6 +12,9 @@ on:
       coverage:
         default: false
         type: string
+      raceDetectorEnabled:
+        default: false
+        type: string
       linuxAmd64Runner:
         default: ubuntu-22.04
         type: string
@@ -35,7 +38,7 @@ jobs:
         os:
           - ${{ inputs.linuxAmd64Runner }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Install werf build dependencies
         run: sudo apt-get install -y libbtrfs-dev slirp4netns
@@ -60,6 +63,7 @@ jobs:
         uses: ./.github/actions/set-up-prebuilt-werf-test-binary
         with:
           coverage: ${{ inputs.coverage }}
+          raceDetectorEnabled: ${{ inputs.raceDetectorEnabled }}
 
       - name: Set up git config
         uses: ./.github/actions/set-up-git-config

--- a/.github/workflows/test_daily.yml
+++ b/.github/workflows/test_daily.yml
@@ -29,6 +29,7 @@ jobs:
     uses: ./.github/workflows/_test_e2e_per-k8s-version.yml
     with:
       scope: simple
+      raceDetectorEnabled: true
       coverage: true
     secrets: inherit
 
@@ -38,6 +39,7 @@ jobs:
     with:
       scope: complex
       timeout: 120
+      raceDetectorEnabled: true
       coverage: true
     secrets: inherit
 
@@ -46,6 +48,7 @@ jobs:
     uses: ./.github/workflows/_test_e2e_per-k8s-version.yml
     with:
       scope: extra
+      raceDetectorEnabled: true
       coverage: true
     secrets: inherit
 
@@ -56,6 +59,7 @@ jobs:
       packages: test/legacy_e2e/suites
       excludePackages: test/legacy_e2e/suites/deploy,test/legacy_e2e/suites/cleanup_after_converge,test/legacy_e2e/suites/helm/deploy_rollback,test/legacy_e2e/suites/bundles,test/legacy_e2e/suites/build/stapel_image/git,test/legacy_e2e/suites/docs
       fetchDepth: 0 # Git history as fixtures for tests.
+      raceDetectorEnabled: true
       coverage: true
     secrets: inherit
 
@@ -64,6 +68,7 @@ jobs:
     uses: ./.github/workflows/_test_integration_regular.yml
     with:
       packages: test/legacy_e2e/suites/build/stapel_image/git
+      raceDetectorEnabled: true
       coverage: true
     secrets: inherit
 
@@ -71,6 +76,7 @@ jobs:
     needs: gate
     uses: ./.github/workflows/_test_integration_per-k8s-version.yml
     with:
+      raceDetectorEnabled: true
       coverage: true
     secrets: inherit
 
@@ -78,6 +84,7 @@ jobs:
     needs: gate
     uses: ./.github/workflows/_test_integration_per-container-registry.yml
     with:
+      raceDetectorEnabled: true
       coverage: true
     secrets: inherit
 
@@ -85,6 +92,7 @@ jobs:
     needs: gate
     uses: ./.github/workflows/_test_integration_per-k8s-version-and-container-registry.yml
     with:
+      raceDetectorEnabled: true
       coverage: true
     secrets: inherit
 

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -338,6 +338,7 @@ tasks:
         vars:
           outputDir: '{{.outputDir | default "./bin"}}'
           extraGoBuildArgs: "-cover -coverpkg=./..."
+          raceDetectorEnabled: '{{.raceDetectorEnabled | default "false"}}'
 
   _test:go-test:cgo:
     cmds:


### PR DESCRIPTION
## Summary

Enable Go's race detector across the full daily test matrix instead of on every pull request. Per-PR CI keeps race only on `unit` (which already builds with `-race`); all e2e and integration scopes now run against a `-race` werf binary on the daily schedule, where a 1.5–3× slowdown is acceptable.

## What

- Per-PR `tests.yml` runs no race-instrumented e2e/integration jobs; `unit` stays `-race` as before.
- Every `test_daily.yml` test job runs against a `-race` binary: e2e per-k8s-version (simple/complex/extra), integration_main, integration_git, and the per-k8s / per-container-registry / per-k8s-and-cr matrices.
- The `set-up-prebuilt-werf-test-binary` action and the `build-with-coverage` task forward `raceDetectorEnabled`, so daily coverage builds are race-instrumented (`-race` and `-cover` combine in one `go build`; VERIFIED: `go version -m` on the built binary shows `-race=true -cover=true`).
- `raceDetectorEnabled` input added to `_test_e2e_per-k8s-version.yml`, `_test_integration_per-k8s-version.yml`, `_test_integration_per-container-registry.yml`, `_test_integration_per-k8s-version-and-container-registry.yml`; it already existed on the regular workflows.
- Integration workflow job timeouts raised from 60 to 120 minutes to absorb race overhead.
- No product code, CLI, or persisted-data changes; workflow and Taskfile only.

## Why

Race coverage found and drove fixes for several concurrency bugs (buildx log pause, Buildah build options, go-containerregistry writer, logboek state, nelm progress printer), but a full `-race` run costs 1.5× on most scopes and ~3× on `e2e_complex` (51m vs 17m). Paying that on every PR slows the feedback loop for no proportional benefit once the known races are fixed; the daily schedule keeps ongoing race coverage without taxing per-PR CI. `unit` is cheap under race and already always instrumented, so it stays on the PR path.
