### PR TITLE
chore(release): sign newest version tag

### DIFF
--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -540,12 +540,12 @@ tasks:
       - go install github.com/dmarkham/enumer@v1.5.11
 
   sign:
-    desc: 'Sign last version tag + origin/main and push signatures. Important vars: "refs".'
+    desc: 'Sign last created version tag + origin/main and push signatures. Important vars: "refs".'
     cmds:
       - git fetch --tags -f
       - git signatures pull {{.CLI_ARGS}}
       - |
-        for ref in {{.refs | default "$(git tag --sort=v:refname | tail -n1) origin/main"}}; do
+        for ref in {{.refs | default "$(git for-each-ref --sort=-creatordate --count=1 --format='%(refname:short)' 'refs/tags/v*') origin/main"}}; do
           echo Signing $ref...
           git signatures add {{.CLI_ARGS}} $ref
           git signatures show {{.CLI_ARGS}} $ref


### PR DESCRIPTION
## Summary

`task sign` now signs most recently created `v*` version tag instead of tag with highest semantic version. This keeps automatic signing aligned with release creation order.

## What

- Without `refs`, `task sign` selects one `v*` tag by newest Git `creatordate`.
- Automatic selection excludes non-version tags, including git-signatures bookkeeping tags.
- Explicit `refs` and signing `origin/main` remain unchanged.
- UNVERIFIED: remote signature update was not run because it pulls, adds, and pushes signature refs.

## Why

Semantic-version ordering can select an older release when a new tag is cut on a maintained release line after a higher version already exists. Selecting by tag creation date signs tag created by current release workflow.