### PR TITLE
fix(build, buildah): prevent parallel recovery failures

### DIFF
--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -182,14 +182,24 @@ func (backend *BuildahBackend) createContainers(ctx context.Context, images []st
 		if err != nil && opts.TargetPlatform != "" && usedCachedImageID && isImageNotKnownError(err) {
 			logboek.Context(ctx).Debug().LogF("Cached imageID %q for %q not found locally, pulling by ref and retrying\n", resolvedImg, img)
 
-			pulledImageID, pullErr := backend.buildah.Pull(ctx, img, buildah.PullOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+			pulledImageID, pullErr := func() (string, error) {
+				mu := backend.getPullMutex(img)
+				mu.Lock()
+				defer mu.Unlock()
+
+				pulledImageID, pullErr := backend.buildah.Pull(ctx, img, buildah.PullOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+				if pullErr == nil && pulledImageID != "" {
+					backend.storePulledImageID(img, opts.TargetPlatform, pulledImageID)
+				}
+
+				return pulledImageID, pullErr
+			}()
 			if pullErr != nil {
 				return nil, fmt.Errorf("unable to pull image %q after cached imageID miss: %w", img, pullErr)
 			}
 
 			resolvedImg = img
 			if pulledImageID != "" {
-				backend.storePulledImageID(img, opts.TargetPlatform, pulledImageID)
 				resolvedImg = pulledImageID
 			}
 

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/containers/storage/types"
 	. "github.com/onsi/ginkgo/v2"
@@ -120,5 +121,74 @@ var _ = Describe("BuildahBackend createContainers", func() {
 		cachedID, ok := backend.getPulledImageID("registry.example.org/project/stage:tag", "linux/amd64")
 		Expect(ok).To(BeTrue())
 		Expect(cachedID).To(Equal("sha256:fresh"))
+	})
+
+	It("serializes re-pulls after cached imageID misses", func() {
+		const (
+			imageRef     = "registry.example.org/project/stage:tag"
+			platform     = "linux/amd64"
+			staleImageID = "sha256:stale"
+			freshImageID = "sha256:fresh"
+		)
+
+		firstPullStarted := make(chan struct{})
+		releaseFirstPull := make(chan struct{})
+		secondPullStarted := make(chan struct{}, 1)
+		var pullCalls atomic.Int32
+		var staleFromCalls atomic.Int32
+
+		fakeBuildah := &buildahstub.BuildahStub{}
+		fakeBuildah.FromCommandFunc = func(_ context.Context, _, imageRef string, _ buildah.FromCommandOpts) (string, error) {
+			switch imageRef {
+			case staleImageID:
+				staleFromCalls.Add(1)
+				return "", fmt.Errorf("locating image with name %q: %w", imageRef, types.ErrImageUnknown)
+			case freshImageID:
+				return "container-id", nil
+			default:
+				return "", fmt.Errorf("unexpected image ref %q", imageRef)
+			}
+		}
+		fakeBuildah.PullFunc = func(_ context.Context, ref string, _ buildah.PullOpts) (string, error) {
+			if ref != imageRef {
+				return "", fmt.Errorf("unexpected image ref %q", ref)
+			}
+
+			switch pullCalls.Add(1) {
+			case 1:
+				close(firstPullStarted)
+				<-releaseFirstPull
+			case 2:
+				secondPullStarted <- struct{}{}
+			default:
+				return "", errors.New("unexpected pull")
+			}
+
+			return freshImageID, nil
+		}
+
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+		backend.storePulledImageID(imageRef, platform, staleImageID)
+
+		createContainers := func() <-chan error {
+			done := make(chan error, 1)
+			go func() {
+				_, err := backend.createContainers(context.Background(), []string{imageRef}, CommonOpts{TargetPlatform: platform})
+				done <- err
+			}()
+			return done
+		}
+
+		firstDone := createContainers()
+		Eventually(firstPullStarted).Should(BeClosed())
+
+		secondDone := createContainers()
+		Eventually(staleFromCalls.Load).Should(Equal(int32(2)))
+		Consistently(secondPullStarted).ShouldNot(Receive())
+
+		close(releaseFirstPull)
+		Eventually(firstDone).Should(Receive(Succeed()))
+		Eventually(secondDone).Should(Receive(Succeed()))
+		Expect(pullCalls.Load()).To(Equal(int32(2)))
 	})
 })

--- a/test/pkg/buildahstub/stub.go
+++ b/test/pkg/buildahstub/stub.go
@@ -3,6 +3,7 @@ package buildahstub
 import (
 	"context"
 	"io"
+	"sync"
 
 	"github.com/werf/werf/v2/pkg/buildah"
 	"github.com/werf/werf/v2/pkg/buildah/thirdparty"
@@ -11,11 +12,14 @@ import (
 )
 
 type BuildahStub struct {
+	callsMutex        sync.Mutex
 	FromCommandFunc   func(ctx context.Context, container, image string, opts buildah.FromCommandOpts) (string, error)
 	PullFunc          func(ctx context.Context, ref string, opts buildah.PullOpts) (string, error)
 	FromCommandImages []string
 	PullRefs          []string
 }
+
+var _ buildah.Buildah = (*BuildahStub)(nil)
 
 func (b *BuildahStub) Info(context.Context) (info.Info, error) {
 	return info.Info{}, nil
@@ -46,7 +50,10 @@ func (b *BuildahStub) RunCommand(context.Context, string, []string, buildah.RunC
 }
 
 func (b *BuildahStub) FromCommand(ctx context.Context, container, image string, opts buildah.FromCommandOpts) (string, error) {
+	b.callsMutex.Lock()
 	b.FromCommandImages = append(b.FromCommandImages, image)
+	b.callsMutex.Unlock()
+
 	if b.FromCommandFunc != nil {
 		return b.FromCommandFunc(ctx, container, image, opts)
 	}
@@ -54,7 +61,10 @@ func (b *BuildahStub) FromCommand(ctx context.Context, container, image string, 
 }
 
 func (b *BuildahStub) Pull(ctx context.Context, ref string, opts buildah.PullOpts) (string, error) {
+	b.callsMutex.Lock()
 	b.PullRefs = append(b.PullRefs, ref)
+	b.callsMutex.Unlock()
+
 	if b.PullFunc != nil {
 		return b.PullFunc(ctx, ref, opts)
 	}


### PR DESCRIPTION
## Summary

Buildah staged builds can recover the same stale cached image ID concurrently after local image cleanup. Recovery pulls for one image ref now serialize, so shared containers storage does not return `image not known` again.

## What

- When multiple target-platform build stages find the same cached image ID missing locally, only one recovery pull for that image ref enters Buildah at a time.
- A successful recovery stores its image ID in the cache before another recovery pull for that ref starts.
- UNVERIFIED: live Linux Buildah recovery with local-image removal and concurrent consumers has not run; a Linux e2e that removes the local image between stages would settle it.
- No flags, environment variables, output, or retry count change.

## Why

The original stale-ID fallback pulled through the low-level Buildah client, bypassing the existing per-ref lock. Concurrent recovery could therefore recreate the documented containers-storage race and fail a build with `image not known`. Reuse the existing ref-only mutex because storage names are ref-based across platforms.

Fixes: 9d640357576a ("fix(build, buildah): retry pull when cached image id is missing (#7669)")