### PR TITLE
fix(docker): prevent race reports during Docker builds

### DIFF
--- a/pkg/docker/main.go
+++ b/pkg/docker/main.go
@@ -196,21 +196,12 @@ func defaultCliOptions(ctx context.Context) []command.CLIOption {
 }
 
 func cliWithCustomOptions(ctx context.Context, options []command.CLIOption, f func(cli command.Cli) error) error {
-	if err := cli(ctx).Apply(options...); err != nil {
-		return err
+	customCli, err := newDockerCli(append(defaultCliOptions(ctx), options...))
+	if err != nil {
+		return fmt.Errorf("create docker cli: %w", err)
 	}
 
-	err := f(cli(ctx))
-
-	if applyErr := cli(ctx).Apply(defaultCliOptions(ctx)...); applyErr != nil {
-		if err != nil {
-			return err
-		} else {
-			return applyErr
-		}
-	}
-
-	return err
+	return f(customCli)
 }
 
 func NewContext(ctx context.Context) (context.Context, error) {

--- a/pkg/docker/system_test.go
+++ b/pkg/docker/system_test.go
@@ -1,13 +1,32 @@
 package docker
 
 import (
+	"context"
 	"errors"
 
+	"github.com/docker/cli/cli/command"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("docker system", func() {
+	Describe("cliWithCustomOptions", func() {
+		It("uses a separate Docker CLI", func() {
+			ctx, err := NewContext(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+
+			originalCli := cli(ctx)
+			var customCli command.Cli
+			err = cliWithCustomOptions(ctx, nil, func(c command.Cli) error {
+				customCli = c
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(customCli).NotTo(Equal(originalCli))
+			Expect(cli(ctx)).To(Equal(originalCli))
+		})
+	})
+
 	Describe("isDaemonUnavailableErr", func() {
 		It("should return false for nil error", func() {
 			Expect(isDaemonUnavailableErr(nil)).To(BeFalse())


### PR DESCRIPTION
## Summary

Docker commands that need custom streams now use an isolated Docker CLI instead of modifying the context-bound CLI. This prevents Buildx progress from racing with stream reconfiguration.

## What

- Custom Docker CLI operations create a new CLI initialized with the default and requested stream options.
- The context-bound Docker CLI remains unchanged during those operations.
- VERIFIED: a race-instrumented Vanilla Docker e2e build completes without the previous `pkg/docker/main.go:205` race report.

## Why

The previous implementation applied custom streams to the shared Docker CLI and restored them after the command. Buildx can read that CLI concurrently for progress output, producing a race report and terminating werf with exit code 66.

Tracked in #7775.
