### PR TITLE
chore(deps): merge main into 3

### DIFF
--- a/.github/workflows/_test_unit.yml
+++ b/.github/workflows/_test_unit.yml
@@ -65,7 +65,7 @@ jobs:
             task --yes -p test:unit paths="$(echo ${{ inputs.packages }} | tr , ' ')" -- --coverprofile="$(openssl rand -hex 6)-coverage.out" --keep-going --skip-package '${{ inputs.excludePackages }}'
             mv *-coverage.out "$WERF_TEST_COVERAGE_DIR/"
           else
-            task --yes -p test:unit paths="$(echo ${{ inputs.packages }} | tr , ' ')" -- --keep-going --skip-package '${{ inputs.excludePackages }}'
+            task --yes -p test:unit paths="$(echo ${{ inputs.packages }} | tr , ' ')" -- --race --keep-going --skip-package '${{ inputs.excludePackages }}'
           fi
           echo loadavg: $(cat /proc/loadavg)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,16 @@ Follow [Effective Go](https://go.dev/doc/effective_go) and [Go Code Review Comme
 
 ## Commands (MANDATORY)
 
-ALWAYS use these `task` commands. NEVER use raw `go build`, `go test`, `go fmt`, `go vet`, or `golangci-lint` directly. Pass extra args after `--` to forward them to the underlying command (e.g., `task test:unit -- -run TestMyFunc`).
+ALWAYS use these `task` commands. NEVER use raw `go build`, `go test`, `go fmt`, `go vet`, or `golangci-lint` directly.
+
+**`--` separator rule**: Pass `KEY=VALUE` variable assignments BEFORE `--` (they become task variables). Use `--` ONLY for flags to forward to the underlying command (ginkgo/go test). NEVER place `KEY=VALUE` after `--` — it pollutes `CLI_ARGS`, causing ginkgo to compile ALL tests instead of targeted ones.
+
+Correct: `task test:e2e paths="./test/e2e/sbom/..." labelFilter="sbom"`
+Correct: `task test:unit paths="./pkg/sbom/..." -- -focus=MyTest`
 
 - NEVER `go build` → ALWAYS `task build`. Builds binary to `./bin/`. Accepts `pkg=...`.
 - NEVER `go test` → ALWAYS `task test:unit`. Accepts `paths="./pkg/..."`.
-- NEVER `go test` (e2e) → ALWAYS `task test:e2e` with `paths="./pkg/..."` and `labelFilter="..."` (Ginkgo label filter) to target specific tests.
+- NEVER `go test` (e2e) → ALWAYS `task test:e2e` with `paths="./test/e2e/..."` and `labelFilter="..."` (Ginkgo label filter).
 - NEVER `go test` (integration) → ALWAYS `task test:integration`. Legacy e2e tests.
 - NEVER `go vet` → ALWAYS `task lint:golangci-lint`. golangci-lint includes vet checks. Accepts `golangciPaths="./pkg/..."`.
 - NEVER `go fmt`/`gofmt` → ALWAYS `task format`. Accepts `paths="pkg/foo"` — plain directories only; the `./pkg/foo/...` wildcard the test and lint tasks take makes the formatters fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.75.4](https://github.com/werf/werf/compare/v2.75.3...v2.75.4) (2026-08-06)
+
+
+### Bug Fixes
+
+* **build, buildah:** retry pull when cached image id is missing ([#7669](https://github.com/werf/werf/issues/7669)) ([9d64035](https://github.com/werf/werf/commit/9d640357576a029456d94516b64c0eda1214025a))
+* **build, buildah:** serialize concurrent base image pulls ([#7664](https://github.com/werf/werf/issues/7664)) ([6eb9144](https://github.com/werf/werf/commit/6eb9144a1f0b71b6c6df3d5ec8ba8b6d3bd14b82))
+* **build, stapel:** make service script executable regardless of umask ([#7720](https://github.com/werf/werf/issues/7720)) ([8b67264](https://github.com/werf/werf/commit/8b67264f781b361119a9d6be0a390afec616e258)), closes [#2339](https://github.com/werf/werf/issues/2339)
+* **build:** drop empty image digest warnings from the build report ([#7717](https://github.com/werf/werf/issues/7717)) ([24babbb](https://github.com/werf/werf/commit/24babbbbb2bde473e45a1a8bd72c3ff4c64ea532)), closes [#7667](https://github.com/werf/werf/issues/7667)
+* **build:** make repo-built from:scratch images readable by dive ([#7765](https://github.com/werf/werf/issues/7765)) ([54b0921](https://github.com/werf/werf/commit/54b092177796f41c5fce2944f4bf73f45e058da8))
+
 ## [2.75.3](https://github.com/werf/werf/compare/v2.75.2...v2.75.3) (2026-07-29)
 
 

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -540,12 +540,12 @@ tasks:
       - go install github.com/dmarkham/enumer@v1.5.11
 
   sign:
-    desc: 'Sign last version tag + origin/main and push signatures. Important vars: "refs".'
+    desc: 'Sign last created version tag + origin/main and push signatures. Important vars: "refs".'
     cmds:
       - git fetch --tags -f
       - git signatures pull {{.CLI_ARGS}}
       - |
-        for ref in {{.refs | default "$(git tag --sort=v:refname | tail -n1) origin/main"}}; do
+        for ref in {{.refs | default "$(git for-each-ref --sort=-creatordate --count=1 --format='%(refname:short)' 'refs/tags/v*') origin/main"}}; do
           echo Signing $ref...
           git signatures add {{.CLI_ARGS}} $ref
           git signatures show {{.CLI_ARGS}} $ref

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -182,14 +182,24 @@ func (backend *BuildahBackend) createContainers(ctx context.Context, images []st
 		if err != nil && opts.TargetPlatform != "" && usedCachedImageID && isImageNotKnownError(err) {
 			logboek.Context(ctx).Debug().LogF("Cached imageID %q for %q not found locally, pulling by ref and retrying\n", resolvedImg, img)
 
-			pulledImageID, pullErr := backend.buildah.Pull(ctx, img, buildah.PullOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+			pulledImageID, pullErr := func() (string, error) {
+				mu := backend.getPullMutex(img)
+				mu.Lock()
+				defer mu.Unlock()
+
+				pulledImageID, pullErr := backend.buildah.Pull(ctx, img, buildah.PullOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+				if pullErr == nil && pulledImageID != "" {
+					backend.storePulledImageID(img, opts.TargetPlatform, pulledImageID)
+				}
+
+				return pulledImageID, pullErr
+			}()
 			if pullErr != nil {
 				return nil, fmt.Errorf("unable to pull image %q after cached imageID miss: %w", img, pullErr)
 			}
 
 			resolvedImg = img
 			if pulledImageID != "" {
-				backend.storePulledImageID(img, opts.TargetPlatform, pulledImageID)
 				resolvedImg = pulledImageID
 			}
 

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containers/storage/types"
 	"github.com/google/uuid"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
@@ -110,6 +111,14 @@ func platformMatches(inspect *thirdparty.BuilderInfo, targetPlatform string) boo
 	return true
 }
 
+func isImageNotKnownError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.HasSuffix(err.Error(), types.ErrImageUnknown.Error())
+}
+
 func (backend *BuildahBackend) Info(ctx context.Context) (info.Info, error) {
 	return backend.buildah.Info(ctx)
 }
@@ -156,9 +165,11 @@ func (backend *BuildahBackend) createContainers(ctx context.Context, images []st
 		}
 
 		resolvedImg := img
+		usedCachedImageID := false
 		if opts.TargetPlatform != "" {
 			if id, ok := backend.getPulledImageID(img, opts.TargetPlatform); ok {
 				resolvedImg = id
+				usedCachedImageID = true
 			} else if inspect, err := backend.buildah.Inspect(ctx, img); err == nil && inspect != nil {
 				if !platformMatches(inspect, opts.TargetPlatform) {
 					return nil, fmt.Errorf("local image %q has platform %s/%s, but target platform is %q; pull the correct image first", img, inspect.OCIv1.OS, inspect.OCIv1.Architecture, opts.TargetPlatform)
@@ -166,7 +177,24 @@ func (backend *BuildahBackend) createContainers(ctx context.Context, images []st
 			}
 		}
 
-		_, err := backend.buildah.FromCommand(ctx, containerID, resolvedImg, buildah.FromCommandOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+		fromCommandOpts := buildah.FromCommandOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform))
+		_, err := backend.buildah.FromCommand(ctx, containerID, resolvedImg, fromCommandOpts)
+		if err != nil && opts.TargetPlatform != "" && usedCachedImageID && isImageNotKnownError(err) {
+			logboek.Context(ctx).Debug().LogF("Cached imageID %q for %q not found locally, pulling by ref and retrying\n", resolvedImg, img)
+
+			pulledImageID, pullErr := backend.buildah.Pull(ctx, img, buildah.PullOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+			if pullErr != nil {
+				return nil, fmt.Errorf("unable to pull image %q after cached imageID miss: %w", img, pullErr)
+			}
+
+			resolvedImg = img
+			if pulledImageID != "" {
+				backend.storePulledImageID(img, opts.TargetPlatform, pulledImageID)
+				resolvedImg = pulledImageID
+			}
+
+			_, err = backend.buildah.FromCommand(ctx, containerID, resolvedImg, fromCommandOpts)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("unable to create container using base image %q: %w", img, err)
 		}

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -1,11 +1,18 @@
 package container_backend
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/containers/storage/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/werf/werf/v2/pkg/buildah"
 	"github.com/werf/werf/v2/pkg/buildah/thirdparty"
+	"github.com/werf/werf/v2/test/pkg/buildahstub"
 )
 
 var _ = Describe("BuildahBackend pulledImageIDs", func() {
@@ -81,4 +88,37 @@ var _ = Describe("platformMatches", func() {
 		// (OCI default: arm64 without explicit variant is equivalent to v8)
 		Entry("target has variant, image variant empty", "linux", "arm64", "", "linux/arm64/v8", true),
 	)
+})
+
+var _ = Describe("BuildahBackend createContainers", func() {
+	It("re-pulls image by ref when cached imageID is missing locally", func() {
+		fakeBuildah := &buildahstub.BuildahStub{}
+		fakeBuildah.FromCommandFunc = func(_ context.Context, _, imageRef string, _ buildah.FromCommandOpts) (string, error) {
+			switch imageRef {
+			case "sha256:stale":
+				return "", fmt.Errorf("locating image with name %q: %w", imageRef, types.ErrImageUnknown)
+			case "sha256:fresh":
+				return "container-id", nil
+			default:
+				return "", errors.New("unexpected image ref")
+			}
+		}
+		fakeBuildah.PullFunc = func(_ context.Context, ref string, _ buildah.PullOpts) (string, error) {
+			Expect(ref).To(Equal("registry.example.org/project/stage:tag"))
+			return "sha256:fresh", nil
+		}
+
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+		backend.storePulledImageID("registry.example.org/project/stage:tag", "linux/amd64", "sha256:stale")
+
+		containers, err := backend.createContainers(context.Background(), []string{"registry.example.org/project/stage:tag"}, CommonOpts{TargetPlatform: "linux/amd64"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(containers).To(HaveLen(1))
+		Expect(fakeBuildah.FromCommandImages).To(Equal([]string{"sha256:stale", "sha256:fresh"}))
+		Expect(fakeBuildah.PullRefs).To(Equal([]string{"registry.example.org/project/stage:tag"}))
+
+		cachedID, ok := backend.getPulledImageID("registry.example.org/project/stage:tag", "linux/amd64")
+		Expect(ok).To(BeTrue())
+		Expect(cachedID).To(Equal("sha256:fresh"))
+	})
 })

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/containers/storage/types"
 	. "github.com/onsi/ginkgo/v2"
@@ -120,5 +121,74 @@ var _ = Describe("BuildahBackend createContainers", func() {
 		cachedID, ok := backend.getPulledImageID("registry.example.org/project/stage:tag", "linux/amd64")
 		Expect(ok).To(BeTrue())
 		Expect(cachedID).To(Equal("sha256:fresh"))
+	})
+
+	It("serializes re-pulls after cached imageID misses", func() {
+		const (
+			imageRef     = "registry.example.org/project/stage:tag"
+			platform     = "linux/amd64"
+			staleImageID = "sha256:stale"
+			freshImageID = "sha256:fresh"
+		)
+
+		firstPullStarted := make(chan struct{})
+		releaseFirstPull := make(chan struct{})
+		secondPullStarted := make(chan struct{}, 1)
+		var pullCalls atomic.Int32
+		var staleFromCalls atomic.Int32
+
+		fakeBuildah := &buildahstub.BuildahStub{}
+		fakeBuildah.FromCommandFunc = func(_ context.Context, _, imageRef string, _ buildah.FromCommandOpts) (string, error) {
+			switch imageRef {
+			case staleImageID:
+				staleFromCalls.Add(1)
+				return "", fmt.Errorf("locating image with name %q: %w", imageRef, types.ErrImageUnknown)
+			case freshImageID:
+				return "container-id", nil
+			default:
+				return "", fmt.Errorf("unexpected image ref %q", imageRef)
+			}
+		}
+		fakeBuildah.PullFunc = func(_ context.Context, ref string, _ buildah.PullOpts) (string, error) {
+			if ref != imageRef {
+				return "", fmt.Errorf("unexpected image ref %q", ref)
+			}
+
+			switch pullCalls.Add(1) {
+			case 1:
+				close(firstPullStarted)
+				<-releaseFirstPull
+			case 2:
+				secondPullStarted <- struct{}{}
+			default:
+				return "", errors.New("unexpected pull")
+			}
+
+			return freshImageID, nil
+		}
+
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+		backend.storePulledImageID(imageRef, platform, staleImageID)
+
+		createContainers := func() <-chan error {
+			done := make(chan error, 1)
+			go func() {
+				_, err := backend.createContainers(context.Background(), []string{imageRef}, CommonOpts{TargetPlatform: platform})
+				done <- err
+			}()
+			return done
+		}
+
+		firstDone := createContainers()
+		Eventually(firstPullStarted).Should(BeClosed())
+
+		secondDone := createContainers()
+		Eventually(staleFromCalls.Load).Should(Equal(int32(2)))
+		Consistently(secondPullStarted).ShouldNot(Receive())
+
+		close(releaseFirstPull)
+		Eventually(firstDone).Should(Receive(Succeed()))
+		Eventually(secondDone).Should(Receive(Succeed()))
+		Expect(pullCalls.Load()).To(Equal(int32(2)))
 	})
 })

--- a/pkg/docker/main.go
+++ b/pkg/docker/main.go
@@ -196,21 +196,12 @@ func defaultCliOptions(ctx context.Context) []command.CLIOption {
 }
 
 func cliWithCustomOptions(ctx context.Context, options []command.CLIOption, f func(cli command.Cli) error) error {
-	if err := cli(ctx).Apply(options...); err != nil {
-		return err
+	customCli, err := newDockerCli(append(defaultCliOptions(ctx), options...))
+	if err != nil {
+		return fmt.Errorf("create docker cli: %w", err)
 	}
 
-	err := f(cli(ctx))
-
-	if applyErr := cli(ctx).Apply(defaultCliOptions(ctx)...); applyErr != nil {
-		if err != nil {
-			return err
-		} else {
-			return applyErr
-		}
-	}
-
-	return err
+	return f(customCli)
 }
 
 func NewContext(ctx context.Context) (context.Context, error) {

--- a/pkg/docker/system_test.go
+++ b/pkg/docker/system_test.go
@@ -1,13 +1,32 @@
 package docker
 
 import (
+	"context"
 	"errors"
 
+	"github.com/docker/cli/cli/command"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("docker system", func() {
+	Describe("cliWithCustomOptions", func() {
+		It("uses a separate Docker CLI", func() {
+			ctx, err := NewContext(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+
+			originalCli := cli(ctx)
+			var customCli command.Cli
+			err = cliWithCustomOptions(ctx, nil, func(c command.Cli) error {
+				customCli = c
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(customCli).NotTo(Equal(originalCli))
+			Expect(cli(ctx)).To(Equal(originalCli))
+		})
+	})
+
 	Describe("isDaemonUnavailableErr", func() {
 		It("should return false for nil error", func() {
 			Expect(isDaemonUnavailableErr(nil)).To(BeFalse())

--- a/pkg/docker_registry/container_registry_extensions/manifest_only_image_test.go
+++ b/pkg/docker_registry/container_registry_extensions/manifest_only_image_test.go
@@ -1,0 +1,47 @@
+package container_registry_extensions
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The manifest-only image is pushed to registries as the scratch from stage base, and every
+// descendant stage inherits its layer. A zero-byte layer body is not a parseable tar and breaks
+// consumers like dive with EOF, so the layer must always be a valid, non-empty tar archive.
+var _ = Describe("manifest-only image", func() {
+	It("has a single valid empty tar layer with a matching diffID", func() {
+		img := NewManifestOnlyImage(map[string]string{"werf": "test"})
+
+		layers, err := img.Layers()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(layers).To(HaveLen(1))
+
+		rc, err := layers[0].Uncompressed()
+		Expect(err).NotTo(HaveOccurred())
+		data, err := io.ReadAll(rc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rc.Close()).To(Succeed())
+
+		Expect(len(data)).To(BeNumerically(">", 0), "a valid tar archive is never zero bytes")
+
+		tr := tar.NewReader(bytes.NewReader(data))
+		_, err = tr.Next()
+		Expect(err).To(Equal(io.EOF), "expected a well-formed empty tar with no entries")
+
+		expectedDiffID, _, err := v1.SHA256(bytes.NewReader(data))
+		Expect(err).NotTo(HaveOccurred())
+		diffID, err := layers[0].DiffID()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(diffID).To(Equal(expectedDiffID))
+
+		cfg, err := img.ConfigFile()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.RootFS.DiffIDs).To(Equal([]v1.Hash{expectedDiffID}))
+		Expect(cfg.Config.Labels).To(Equal(map[string]string{"werf": "test"}))
+	})
+})

--- a/pkg/docker_registry/container_registry_extensions/suite_test.go
+++ b/pkg/docker_registry/container_registry_extensions/suite_test.go
@@ -1,0 +1,13 @@
+package container_registry_extensions
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestContainerRegistryExtensions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Container Registry Extensions Suite")
+}

--- a/pkg/docker_registry/container_registry_extensions/uncompressed_layer.go
+++ b/pkg/docker_registry/container_registry_extensions/uncompressed_layer.go
@@ -1,20 +1,39 @@
 package container_registry_extensions
 
 import (
+	"archive/tar"
 	"bytes"
+	"fmt"
 	"io"
-	"io/ioutil"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-var EmptyUncompressedLayer = &uncompressedLayer{
-	diffID: v1.Hash{
-		Algorithm: "sha256",
-		Hex:       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-	},
-	mediaType: types.DockerLayer,
+var _ partial.UncompressedLayer = (*uncompressedLayer)(nil)
+
+var EmptyUncompressedLayer = newEmptyUncompressedLayer()
+
+// newEmptyUncompressedLayer returns a layer whose content is a valid empty tar archive.
+// A zero-byte body is not a parseable tar: registries accept it, but consumers such as
+// dive or docker save readers fail with EOF on every image that inherits the layer.
+func newEmptyUncompressedLayer() *uncompressedLayer {
+	var buf bytes.Buffer
+	if err := tar.NewWriter(&buf).Close(); err != nil {
+		panic(fmt.Sprintf("write empty tar archive: %s", err))
+	}
+
+	diffID, _, err := v1.SHA256(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		panic(fmt.Sprintf("calculate empty tar archive diffID: %s", err))
+	}
+
+	return &uncompressedLayer{
+		diffID:    diffID,
+		mediaType: types.DockerLayer,
+		content:   buf.Bytes(),
+	}
 }
 
 type uncompressedLayer struct {
@@ -28,7 +47,7 @@ func (layer *uncompressedLayer) DiffID() (v1.Hash, error) {
 }
 
 func (layer *uncompressedLayer) Uncompressed() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewBuffer(layer.content)), nil
+	return io.NopCloser(bytes.NewReader(layer.content)), nil
 }
 
 func (layer *uncompressedLayer) MediaType() (types.MediaType, error) {

--- a/test/pkg/buildahstub/stub.go
+++ b/test/pkg/buildahstub/stub.go
@@ -1,0 +1,118 @@
+package buildahstub
+
+import (
+	"context"
+	"io"
+
+	"github.com/werf/werf/v2/pkg/buildah"
+	"github.com/werf/werf/v2/pkg/buildah/thirdparty"
+	"github.com/werf/werf/v2/pkg/container_backend/info"
+	"github.com/werf/werf/v2/pkg/image"
+)
+
+type BuildahStub struct {
+	FromCommandFunc   func(ctx context.Context, container, image string, opts buildah.FromCommandOpts) (string, error)
+	PullFunc          func(ctx context.Context, ref string, opts buildah.PullOpts) (string, error)
+	FromCommandImages []string
+	PullRefs          []string
+}
+
+func (b *BuildahStub) Info(context.Context) (info.Info, error) {
+	return info.Info{}, nil
+}
+
+func (b *BuildahStub) GetDefaultPlatform() string {
+	return ""
+}
+
+func (b *BuildahStub) GetRuntimePlatform() string {
+	return ""
+}
+
+func (b *BuildahStub) Tag(context.Context, string, string, buildah.TagOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Push(context.Context, string, buildah.PushOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) BuildFromDockerfile(context.Context, string, buildah.BuildFromDockerfileOpts) (string, error) {
+	return "", nil
+}
+
+func (b *BuildahStub) RunCommand(context.Context, string, []string, buildah.RunCommandOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) FromCommand(ctx context.Context, container, image string, opts buildah.FromCommandOpts) (string, error) {
+	b.FromCommandImages = append(b.FromCommandImages, image)
+	if b.FromCommandFunc != nil {
+		return b.FromCommandFunc(ctx, container, image, opts)
+	}
+	return "", nil
+}
+
+func (b *BuildahStub) Pull(ctx context.Context, ref string, opts buildah.PullOpts) (string, error) {
+	b.PullRefs = append(b.PullRefs, ref)
+	if b.PullFunc != nil {
+		return b.PullFunc(ctx, ref, opts)
+	}
+	return "", nil
+}
+
+func (b *BuildahStub) Inspect(context.Context, string) (*thirdparty.BuilderInfo, error) {
+	return nil, nil
+}
+
+func (b *BuildahStub) Rm(context.Context, string, buildah.RmOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Rmi(context.Context, string, buildah.RmiOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Mount(context.Context, string, buildah.MountOpts) (string, error) {
+	return "", nil
+}
+
+func (b *BuildahStub) Umount(context.Context, string, buildah.UmountOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Commit(context.Context, string, buildah.CommitOpts) (string, error) {
+	return "", nil
+}
+
+func (b *BuildahStub) Config(context.Context, string, buildah.ConfigOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Copy(context.Context, string, string, []string, string, buildah.CopyOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Add(context.Context, string, []string, string, buildah.AddOpts) error {
+	return nil
+}
+
+func (b *BuildahStub) Images(context.Context, buildah.ImagesOptions) (image.ImagesList, error) {
+	return nil, nil
+}
+
+func (b *BuildahStub) Containers(context.Context, buildah.ContainersOptions) (image.ContainerList, error) {
+	return nil, nil
+}
+
+func (b *BuildahStub) PruneImages(context.Context, buildah.PruneImagesOptions) (buildah.PruneImagesReport, error) {
+	return buildah.PruneImagesReport{}, nil
+}
+
+func (b *BuildahStub) SaveImageToStream(context.Context, string) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (b *BuildahStub) LoadImageFromStream(context.Context, io.Reader) (string, error) {
+	return "", nil
+}

--- a/test/pkg/buildahstub/stub.go
+++ b/test/pkg/buildahstub/stub.go
@@ -3,6 +3,7 @@ package buildahstub
 import (
 	"context"
 	"io"
+	"sync"
 
 	"github.com/werf/werf/v2/pkg/buildah"
 	"github.com/werf/werf/v2/pkg/buildah/thirdparty"
@@ -11,11 +12,14 @@ import (
 )
 
 type BuildahStub struct {
+	callsMutex        sync.Mutex
 	FromCommandFunc   func(ctx context.Context, container, image string, opts buildah.FromCommandOpts) (string, error)
 	PullFunc          func(ctx context.Context, ref string, opts buildah.PullOpts) (string, error)
 	FromCommandImages []string
 	PullRefs          []string
 }
+
+var _ buildah.Buildah = (*BuildahStub)(nil)
 
 func (b *BuildahStub) Info(context.Context) (info.Info, error) {
 	return info.Info{}, nil
@@ -46,7 +50,10 @@ func (b *BuildahStub) RunCommand(context.Context, string, []string, buildah.RunC
 }
 
 func (b *BuildahStub) FromCommand(ctx context.Context, container, image string, opts buildah.FromCommandOpts) (string, error) {
+	b.callsMutex.Lock()
 	b.FromCommandImages = append(b.FromCommandImages, image)
+	b.callsMutex.Unlock()
+
 	if b.FromCommandFunc != nil {
 		return b.FromCommandFunc(ctx, container, image, opts)
 	}
@@ -54,7 +61,10 @@ func (b *BuildahStub) FromCommand(ctx context.Context, container, image string, 
 }
 
 func (b *BuildahStub) Pull(ctx context.Context, ref string, opts buildah.PullOpts) (string, error) {
+	b.callsMutex.Lock()
 	b.PullRefs = append(b.PullRefs, ref)
+	b.callsMutex.Unlock()
+
 	if b.PullFunc != nil {
 		return b.PullFunc(ctx, ref, opts)
 	}

--- a/test/pkg/utils/image.go
+++ b/test/pkg/utils/image.go
@@ -62,8 +62,11 @@ func ExpectImageIsReadable(ctx context.Context, backendMode, imageName string) {
 	for i, layer := range layers {
 		rc, err := layer.Uncompressed()
 		Expect(err).NotTo(HaveOccurred(), "expected layer %d to be readable for %s", i, imageName)
-		_, err = io.Copy(io.Discard, rc)
+		n, err := io.Copy(io.Discard, rc)
 		Expect(err).NotTo(HaveOccurred(), "expected layer %d to be fully readable for %s", i, imageName)
+		// A zero-byte layer is not a parseable tar even though go-containerregistry
+		// reads it back as gracefully empty; tools like dive fail on it with EOF.
+		Expect(n).To(BeNumerically(">", 0), "expected layer %d to be a non-empty tar archive for %s", i, imageName)
 		Expect(rc.Close()).To(Succeed())
 	}
 

--- a/trdl_channels.yaml
+++ b/trdl_channels.yaml
@@ -38,15 +38,15 @@ groups:
   - name: "2"
     channels:
       - name: alpha
-        version: 2.75.3
+        version: 2.75.4
       - name: beta
         version: 2.75.3
       - name: ea
         version: 2.75.3
       - name: stable
-        version: 2.74.0
+        version: 2.75.3
       - name: rock-solid
-        version: 2.73.2
+        version: 2.74.0
   - name: "3"
     channels:
       - name: dev

--- a/trdl_channels.yaml
+++ b/trdl_channels.yaml
@@ -50,4 +50,4 @@ groups:
   - name: "3"
     channels:
       - name: dev
-        version: 3.0.2
+        version: 3.1.0


### PR DESCRIPTION
## Summary

Synchronizes release branch `3` with `main` at `6d6af8d02be5f1a58e5dc8806c7e64d5c9f150c6`.

## What

- Branch `3` receives the behavior and tests already merged into `main` through that commit.
- Docker commands that temporarily redirect CLI output use a separate CLI instance, so concurrent commands do not mutate one another's output streams.
- Buildah retries a pull when a cached image ID no longer exists locally and serializes concurrent recovery pulls.
- UNVERIFIED: the native Buildah backend is Linux/cgo-only; this macOS verification did not build or run that implementation.

## Why

Branch `3` had diverged from `main`, leaving it without fixes already available on the primary release branch. Its newer Docker and storage dependencies are incompatible with `main`'s old APIs, so the merge keeps the v3-compatible APIs while applying the behavioral fixes.