### PR TITLE
docs(dev): strengthen PR review guidance

### DIFF
--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -15,9 +15,10 @@ If you wrote the diff you are reviewing now, say so explicitly in the report's V
 
 1. Ask the user for numbered acceptance criteria (DoD). If there are none, derive them from the PR description or the linked issue, mark them `(inferred)`, and proceed — do not stall, and do not invent criteria silently.
 2. Resolve the base first: `git fetch`, then diff against the branch the PR actually targets. werf maintains release branches (`1.2`, `2.63`, `3`, …), so `main` is the wrong base for a backport. State the resolved base in the report. For uncommitted work, review `git diff` / `git diff --cached` instead.
-3. Read every changed file. Then trace callers of the changed exported symbols whose signature or behavior changed, and of anything crossing a persistence boundary — via LSP call hierarchy and references, not grep.
-4. For 10+ changed files, split the reading by area (e.g. new files, storage/cleanup, build pipeline) across subagents if your harness has them, and synthesize the findings yourself.
-5. If the worktree holds the branch and `task` works, run `task build` and `task test:unit` — a review that never compiled the change is an opinion. NEVER run `task format`: it would rewrite the diff under review.
+3. If the PR head is not checked out, take every `file:line` from that commit's blob (`git show <head>:<path>`), never from the worktree. The worktree sits on the base, so any file the PR itself changed has different line numbers there, and a comment anchored on a worktree line number lands on the wrong line — or is rejected outright.
+4. Read every changed file. Then trace callers of the changed exported symbols whose signature or behavior changed, and of anything crossing a persistence boundary — via LSP call hierarchy and references, not grep. LSP indexes the worktree, so when the head is not checked out it answers about the base: add a worktree at the head first, or read blobs and say in the report that call tracing was limited.
+5. For 10+ changed files, split the reading by area (e.g. new files, storage/cleanup, build pipeline) across subagents if your harness has them, and synthesize the findings yourself.
+6. If the worktree holds the branch and `task` works, run `task build` and `task test:unit` — a review that never compiled the change is an opinion. NEVER run `task format`: it would rewrite the diff under review.
 
 ## Technical perspective
 
@@ -64,6 +65,7 @@ Classify each risk as Technical, Security, UX/Product, or Operational, and repor
 - Persisted formats (stage metadata, bundles, storage records) need backward compatibility.
 - `go.mod` replaces cobra, buildah, oras and buildx with forks — upstream documentation is not authoritative for them.
 - Build and test only via `task` commands, never raw Go tools.
+- The PR description outlives the review — werf squashes, so it becomes the commit body. Audit its claims against your findings: a safety property asserted there that a finding contradicts is itself a defect, and inline comments anchored to code lines never reach whoever reads it.
 
 ## Output
 


### PR DESCRIPTION
## Summary

Review guidance now handles pull-request heads that are not checked out and catches safety claims in PR descriptions that review findings disprove.

## What

- A review of an un-checked-out PR head reads `file:line` from that head's blobs, preventing inline comments from targeting base-branch lines.
- In that condition, reviewers check out the head before using LSP call tracing or record that tracing was limited; base-worktree LSP results are not treated as evidence about the PR.
- A PR description safety claim that a review finding contradicts is reported as a defect, so the squashed commit body does not preserve a false guarantee.
- Existing dependency and fork guidance remains unchanged for `main`.

## Why

A base worktree has different source lines and LSP symbols from an un-checked-out PR head, which can create wrong comments and false caller conclusions. PR descriptions outlive inline review comments after squash merging, so contradicted safety guarantees need an explicit review rule.
