### PR TITLE
feat(skills): run challenge checks for risky reviews

### DIFF
--- a/.agents/skills/adversarial-review/SKILL.md
+++ b/.agents/skills/adversarial-review/SKILL.md
@@ -1,14 +1,13 @@
 ---
-name: agent-code-review
+name: adversarial-review
 description: >
-  Adversarial verification layer for reviewing agent-generated or otherwise untrusted
-  implementations. Use when the author of a diff, patch, commit, or test suite is an agent,
-  when a change touches tests or verification infrastructure, or when invoked as
-  /agent-code-review. Adds test falsifiability checks and check-gaming detection on top of
-  ordinary review; does not replace it.
+  Independent adversarial verification pass for a non-trivial or high-risk change. Use for a
+  fresh second opinion, when a change touches tests or verification infrastructure, or when
+  invoked as /adversarial-review. Adds test falsifiability checks and check-gaming detection
+  on top of ordinary review; does not replace it.
 ---
 
-# Agent Code Review
+# Adversarial Review
 
 Treat the change as an untrusted implementation candidate. Readable code, passing tests,
 high coverage, and the author's confidence are not evidence of correctness. Coverage
@@ -64,7 +63,7 @@ back.
 For low-risk mechanical changes with strong evidence, targeted inspection is enough. No
 line-by-line narration in either case.
 
-## Know this review's limits when you are the author
+## Independence matters
 
 If you wrote the diff you are now reviewing, this pass is necessary but not sufficient.
 Self-review — even done adversarially, even by mutating your own tests — inherits your own

--- a/.agents/skills/challenge-review/SKILL.md
+++ b/.agents/skills/challenge-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: adversarial-review
+name: challenge-review
 description: >
-  Independent adversarial verification pass for a non-trivial or high-risk change. Use for a
-  fresh second opinion, when a change touches tests or verification infrastructure, or when
-  invoked as /adversarial-review. Adds test falsifiability checks and check-gaming detection
-  on top of ordinary review; does not replace it.
+  Independent challenge pass for a non-trivial or high-risk change. Use for a fresh second
+  opinion, when a change touches tests or verification infrastructure, or when invoked as
+  /challenge-review. Attempts to disprove implementation claims through contract recovery,
+  test falsification, and check-gaming detection; complements ordinary review.
 ---
 
-# Adversarial Review
+# Challenge Review
 
 Treat the change as an untrusted implementation candidate. Readable code, passing tests,
 high coverage, and the author's confidence are not evidence of correctness. Coverage

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -9,7 +9,7 @@ Evidence-based and blunt. Every finding references a specific `file:line`, funct
 
 ## If you are the diff's author
 
-If you wrote the diff you are reviewing now, say so explicitly in the report's Verdict and treat this pass as necessary but insufficient. `adversarial-review/SKILL.md` covers why self-review inherits your own design assumptions and what to recommend instead — read it, don't re-derive it here.
+If you wrote the diff you are reviewing now, say so explicitly in the report's Verdict and treat this pass as necessary but insufficient. `challenge-review/SKILL.md` covers why self-review inherits your own design assumptions and what to recommend instead — read it, don't re-derive it here.
 
 ## Before reviewing
 
@@ -37,7 +37,7 @@ Cover the ones the diff actually touches; stay silent about the rest.
 
 Passing tests, high coverage, and the author's confidence are not evidence of correctness, whoever wrote the diff. Read `test-the-tests/SKILL.md` and run its mutation loop against every load-bearing test: mutate the implementation and confirm the test fails, rather than reading the assertions and trusting they'd catch a regression. This is not optional — skipping it because the tests "look thorough" is exactly the failure mode it exists to catch.
 
-For a non-trivial or high-risk diff, or a diff that touches tests or verification infrastructure, also read `adversarial-review/SKILL.md` as an independent second pass. It covers check-gaming detection (weakened assertions, quietly skipped tests, mocked-out critical behavior, and more) in one place, so this list doesn't drift from it again.
+For a non-trivial or high-risk diff, or a diff that touches tests or verification infrastructure, also read `challenge-review/SKILL.md` as an independent challenge pass. It covers check-gaming detection (weakened assertions, quietly skipped tests, mocked-out critical behavior, and more) in one place, so this list doesn't drift from it again.
 
 ## Product perspective
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -9,7 +9,7 @@ Evidence-based and blunt. Every finding references a specific `file:line`, funct
 
 ## If you are the diff's author
 
-If you wrote the diff you are reviewing now, say so explicitly in the report's Verdict and treat this pass as necessary but insufficient. `agent-code-review/SKILL.md` covers why self-review inherits your own design assumptions and what to recommend instead — read it, don't re-derive it here.
+If you wrote the diff you are reviewing now, say so explicitly in the report's Verdict and treat this pass as necessary but insufficient. `adversarial-review/SKILL.md` covers why self-review inherits your own design assumptions and what to recommend instead — read it, don't re-derive it here.
 
 ## Before reviewing
 
@@ -37,7 +37,7 @@ Cover the ones the diff actually touches; stay silent about the rest.
 
 Passing tests, high coverage, and the author's confidence are not evidence of correctness, whoever wrote the diff. Read `test-the-tests/SKILL.md` and run its mutation loop against every load-bearing test: mutate the implementation and confirm the test fails, rather than reading the assertions and trusting they'd catch a regression. This is not optional — skipping it because the tests "look thorough" is exactly the failure mode it exists to catch.
 
-If the diff's author is an agent, or the diff touches tests or verification infrastructure, also read `agent-code-review/SKILL.md` — it covers check-gaming detection (weakened assertions, quietly skipped tests, mocked-out critical behavior, and more) in one place, so this list doesn't drift from it again.
+For a non-trivial or high-risk diff, or a diff that touches tests or verification infrastructure, also read `adversarial-review/SKILL.md` as an independent second pass. It covers check-gaming detection (weakened assertions, quietly skipped tests, mocked-out critical behavior, and more) in one place, so this list doesn't drift from it again.
 
 ## Product perspective
 


### PR DESCRIPTION
## Summary

Reviews can now request an independent challenge pass based on change risk rather than the diff author's identity.

## What

- Renames `agent-code-review` to `challenge-review`.
- Routes non-trivial, high-risk, test, and verification changes through the independent challenge pass.
- Keeps mutation testing through `test-the-tests` and check-gaming detection in the second pass.

## Why

A reviewer often cannot establish who authored a diff, so author-based routing skips the verification pass precisely when a fresh second opinion is needed.