### PR TITLE
fix(ci): stop rootless buildah CI builds failing

### DIFF
--- a/.github/workflows/_test_integration_regular.yml
+++ b/.github/workflows/_test_integration_regular.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Install werf build dependencies
-        run: sudo apt-get install -y libbtrfs-dev
+        run: sudo apt-get install -y libbtrfs-dev slirp4netns
 
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Rootless Buildah integration jobs fail when a GitHub runner image lacks `slirp4netns`. The workflow now installs this required runtime helper before executing the suite.

## What

- Regular integration CI installs `slirp4netns`, allowing native-rootless Buildah to configure its network namespace.
- UNVERIFIED: The GitHub-hosted integration job must pass with the updated runner dependency.

## Why

The failed job retried the native-rootless Buildah SSH case three times, each time reporting `could not find slirp4netns`. The runner previously supplied this dependency implicitly; declaring it in the workflow makes the test independent of that image detail.