### PR TITLE
fix(ci): stop rootless buildah e2e builds failing

### DIFF
--- a/.github/workflows/_test_e2e_regular.yml
+++ b/.github/workflows/_test_e2e_regular.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          sudo apt install -y libbtrfs-dev buildah qemu-user qemu-user-binfmt
+          sudo apt install -y libbtrfs-dev buildah qemu-user qemu-user-binfmt slirp4netns
 
       - name: Prepare system for multiarch builds
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
## Summary

Rootless Buildah E2E jobs still fail when a GitHub runner image lacks `slirp4netns`. They use a separate workflow from the integration job fixed in #7782, so this workflow now installs the same required runtime helper.

## What

- Regular E2E CI installs `slirp4netns`, allowing native-rootless Buildah to configure its network namespace.
- UNVERIFIED: The GitHub-hosted E2E jobs must pass with the updated runner dependency.

## Why

The `e2e_extra` and `e2e_complex` jobs failed in native-rootless Buildah cases in the same Actions run as #7782. Their workflow installed Buildah but relied on the runner to supply its `slirp4netns` network helper; the runner no longer did so.