### PR TITLE
chore(ci): install slirp4netns for rootless e2e

### DIFF
--- a/.github/workflows/_test_e2e_regular.yml
+++ b/.github/workflows/_test_e2e_regular.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          sudo apt install -y libbtrfs-dev buildah qemu-user qemu-user-binfmt
+          sudo apt install -y libbtrfs-dev buildah qemu-user qemu-user-binfmt slirp4netns
 
       - name: Prepare system for multiarch builds
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
## Summary

Rootless Buildah E2E jobs require `slirp4netns` on the GitHub runner. The regular E2E workflow now declares this system dependency instead of relying on the runner image.

## What

- Regular E2E CI installs `slirp4netns` before executing native-rootless Buildah cases.
- UNVERIFIED: The GitHub-hosted E2E jobs must pass with the declared runner dependency.

## Why

The `e2e_extra` and `e2e_complex` jobs failed in native-rootless Buildah cases because their workflow installed Buildah but relied on the runner to supply its `slirp4netns` network helper; the runner no longer did so.