### PR TITLE
fix(build): avoid panicking on late worker logs

### DIFF
--- a/pkg/util/parallel/parallel_test.go
+++ b/pkg/util/parallel/parallel_test.go
@@ -294,6 +294,31 @@ var _ = DescribeTable("parallel task",
 	),
 )
 
+var _ = It("does not panic when a task writes after completion", func() {
+	output := newSpyOutput(1)
+	ctx := logboek.NewContext(context.Background(), logboek.NewLogger(output, output))
+	write := make(chan struct{})
+	written := make(chan struct{})
+
+	Expect(werf.Init(GinkgoT().TempDir(), "")).To(Succeed())
+
+	err := parallel.DoTasks(ctx, 1, parallel.DoTasksOptions{}, func(ctx context.Context, _ int) error {
+		go func() {
+			defer GinkgoRecover()
+			defer close(written)
+			<-write
+			logboek.Context(ctx).LogLn("late output")
+		}()
+
+		return errors.New("task failed")
+	})
+	Expect(err).To(MatchError("task failed"))
+
+	close(write)
+	Eventually(written).Should(BeClosed())
+	Expect(output.Lines()).NotTo(ContainElement(ContainSubstring("late output")))
+})
+
 type spyTaskFunc struct {
 	callsCount atomic.Int32 // prevent race condition
 	callback   parallel.TaskFunc

--- a/pkg/util/parallel/worker.go
+++ b/pkg/util/parallel/worker.go
@@ -3,6 +3,7 @@ package parallel
 import (
 	"fmt"
 	"os"
+	"sync"
 	"sync/atomic"
 
 	"github.com/werf/werf/v2/pkg/tmp_manager"
@@ -20,6 +21,7 @@ type Worker struct {
 	readOffset  atomic.Int64
 	writeOffset atomic.Int64
 
+	mutex      sync.Mutex
 	halfClosed atomic.Bool
 
 	file *os.File
@@ -30,8 +32,11 @@ type Worker struct {
 // Write implements io.Writer.
 // It appends to file and accumulates total write offset.
 func (w *Worker) Write(p []byte) (int, error) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
 	if w.halfClosed.Load() {
-		return 0, fmt.Errorf("worker is half closed but tries to write: %s", p)
+		return len(p), nil
 	}
 
 	offset, err := w.file.Write(p)
@@ -50,6 +55,9 @@ func (w *Worker) Read(p []byte) (int, error) {
 
 // HalfClose closes writing or returns error if already half-closed
 func (w *Worker) HalfClose() error {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
 	if w.halfClosed.Load() {
 		return fmt.Errorf("worker %d is already half closed", w.ID)
 	}
@@ -68,6 +76,9 @@ func (w *Worker) Readable() bool {
 // Close implements io.Closer closing tmp file.
 // It ensures that worker is half closed
 func (w *Worker) Close() error {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
 	w.halfClosed.Store(true)
 
 	if err := w.file.Close(); err != nil {

--- a/pkg/util/parallel/worker_test.go
+++ b/pkg/util/parallel/worker_test.go
@@ -2,7 +2,6 @@ package parallel_test
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,7 +12,7 @@ import (
 )
 
 var _ = DescribeTable(
-	"worker should return writing error if it was half-closed",
+	"worker should discard writes after half-close",
 	func(doHalfClose, doClose bool) {
 		Expect(werf.Init(GinkgoT().TempDir(), "")).To(Succeed())
 
@@ -36,8 +35,14 @@ var _ = DescribeTable(
 		}
 
 		offset, err := io.Copy(worker, reader)
-		Expect(err).To(MatchError(fmt.Errorf("worker is half closed but tries to write: %s", data)))
-		Expect(offset).To(Equal(int64(0)))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(offset).To(Equal(int64(len(data))))
+
+		if doHalfClose {
+			content, err := io.ReadAll(worker)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(content).To(BeEmpty())
+		}
 	},
 	Entry(
 		"half-close explicitly",


### PR DESCRIPTION
## Summary

A parallel build no longer panics and hides its original error when a subprocess flushes log output after its task completes. Late output is ignored once the worker has finished.

## What

- A parallel worker accepts and discards writes after completion instead of returning an error that makes the logger panic.
- Process output emitted after its owning task completes is not included in the build log.

## Why

Task completion and subprocess output completion can race. Previously, a late write reached the half-closed worker, and the logger panicked while reporting the original build error. Waiting for every third-party stream would require lifecycle ownership the worker does not have; ignoring only post-completion output preserves the original error.