### PR TITLE
test(dev): use portable ps command field

### DIFF
--- a/pkg/werf/exec/detach_test.go
+++ b/pkg/werf/exec/detach_test.go
@@ -77,7 +77,7 @@ func findProcessLineByCommand(ctx context.Context, command string) (string, erro
 	b := backoff.NewConstantBackOff(time.Millisecond * 10)
 
 	operation := func() (string, error) {
-		cmd := exec.CommandContext(ctx, "ps", "-eo", "pid,cmd")
+		cmd := exec.CommandContext(ctx, "ps", "-eo", "pid,command")
 		outBytes, err := cmd.Output()
 		Expect(err).To(Succeed())
 


### PR DESCRIPTION
## Summary

The detach test now uses a `ps` field available on both GNU and BSD implementations. It no longer fails on macOS with `ps: cmd: keyword not found`.

## What

- The detach test queries `ps -eo pid,command` to locate the detached test process.

## Why

BSD `ps` does not support the GNU-only `cmd` field used by the test. The `command` field provides the same full command line on both platforms.