### PR TITLE
fix(storage): prevent concurrent final-stage list access

### DIFF
--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -168,6 +168,13 @@ func (stages *StagesList) AddStageID(stageID image.StageID) {
 	stages.StageIDs = append(stages.StageIDs, stageID)
 }
 
+func (stages *StagesList) Len() int {
+	stages.Mux.Lock()
+	defer stages.Mux.Unlock()
+
+	return len(stages.StageIDs)
+}
+
 type StorageManager struct {
 	parallel           bool
 	parallelTasksLimit int
@@ -297,7 +304,7 @@ func (m *StorageManager) GetFinalStageDescSet(ctx context.Context) (image.StageD
 		return nil, fmt.Errorf("error getting existing stages list of final repo %s: %w", m.FinalStagesStorage.String(), err)
 	}
 
-	logboek.Context(ctx).Debug().LogF("[%p] Got existing final stages list cache (%d stages)\n", m, len(existingStagesListCache.StageIDs))
+	logboek.Context(ctx).Debug().LogF("[%p] Got existing final stages list cache (%d stages)\n", m, existingStagesListCache.Len())
 
 	stageIDs := existingStagesListCache.GetStageIDs()
 	stageDescSet := image.NewStageDescSet()
@@ -647,7 +654,7 @@ func (m *StorageManager) CopyStageIntoFinalStorage(ctx context.Context, stageID 
 		return nil, fmt.Errorf("error getting existing stages list of final repo %s: %w", finalStagesStorage.String(), err)
 	}
 
-	logboek.Context(ctx).Debug().LogF("[%p] Got existing final stages list cache (%d stages)\n", m, len(existingStagesListCache.StageIDs))
+	logboek.Context(ctx).Debug().LogF("[%p] Got existing final stages list cache (%d stages)\n", m, existingStagesListCache.Len())
 
 	finalImageName := finalStagesStorage.ConstructStageImageName(m.ProjectName, stageID.Digest, stageID.CreationTs)
 
@@ -700,7 +707,7 @@ func (m *StorageManager) CopyStageIntoFinalStorage(ctx context.Context, stageID 
 	}
 
 	existingStagesListCache.AddStageID(stageID)
-	logboek.Context(ctx).Debug().LogF("Updated existing final stages list (%d stages)\n", len(m.FinalStagesListCache.StageIDs))
+	logboek.Context(ctx).Debug().LogF("Updated existing final stages list (%d stages)\n", existingStagesListCache.Len())
 
 	return stageDescCopy, nil
 }

--- a/pkg/storage/manager/storage_manager_test.go
+++ b/pkg/storage/manager/storage_manager_test.go
@@ -3,11 +3,13 @@ package manager
 import (
 	"context"
 	"errors"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 
+	"github.com/werf/werf/v2/pkg/image"
 	"github.com/werf/werf/v2/pkg/logging"
 )
 
@@ -71,5 +73,32 @@ var _ = Describe("RetryOnUnexpectedStagesStorageState", func() {
 
 		Expect(err).To(MatchError(context.Canceled))
 		Expect(callCount).To(Equal(1))
+	})
+
+	It("should read stage count while adding stages", func() {
+		stages := NewStagesList(nil)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < 1_000; i++ {
+				stages.AddStageID(*image.NewStageID("digest", int64(i)))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < 1_000; i++ {
+				stages.Len()
+			}
+		}()
+
+		close(start)
+		wg.Wait()
+
+		Expect(stages.Len()).To(Equal(1_000))
 	})
 })


### PR DESCRIPTION
## Summary

Parallel final-stage copies could race with debug logging while updating the shared final-stage list cache. Stage-count reads now use the cache mutex.

## What

- Concurrent final-stage copy and stage-count logging access the cached list under its mutex.
- Final-stage cache contents and duplicate-stage handling remain unchanged.
- The storage-manager race test concurrently adds stages and reads their count.

## Why

Debug logging read the cache slice directly while another copy appended to it. The race detector reported this as `StagesList.AddStageID` concurrent access.