### PR TITLE
fix(buildah): prevent concurrent stderr access

### DIFF
--- a/pkg/buildah/native_linux.go
+++ b/pkg/buildah/native_linux.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"text/template"
 	"time"
@@ -1531,8 +1532,29 @@ func generateContextDir(rawContextDir string, runMounts []*instructions.Mount) s
 	return contextDir
 }
 
-func generateStdoutStderr(optionalLogWriter io.Writer) (stdout, stderr io.Writer, stderrBuf *bytes.Buffer) {
-	stderrBuf = &bytes.Buffer{}
+type lockedBuffer struct {
+	mux    sync.Mutex
+	buffer bytes.Buffer
+}
+
+var _ io.Writer = (*lockedBuffer)(nil)
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	return b.buffer.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	return b.buffer.String()
+}
+
+func generateStdoutStderr(optionalLogWriter io.Writer) (stdout, stderr io.Writer, stderrBuf *lockedBuffer) {
+	stderrBuf = &lockedBuffer{}
 	if optionalLogWriter != nil {
 		stdout = optionalLogWriter
 		stderr = io.MultiWriter(optionalLogWriter, stderrBuf)

--- a/pkg/buildah/native_linux_test.go
+++ b/pkg/buildah/native_linux_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"strings"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,6 +32,37 @@ var _ = Describe("buildah", func() {
 			[]string{"foo=bar", "key=value"},
 		),
 	)
+
+	Describe("generateStdoutStderr", func() {
+		It("should read stderr while it is written", func() {
+			_, stderr, stderrBuf := generateStdoutStderr(nil)
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			go func() {
+				defer wg.Done()
+				<-start
+				for i := 0; i < 1_000; i++ {
+					if _, err := stderr.Write([]byte("stderr")); err != nil {
+						panic(err)
+					}
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				<-start
+				for i := 0; i < 1_000; i++ {
+					stderrBuf.String()
+				}
+			}()
+
+			close(start)
+			wg.Wait()
+
+			Expect(stderrBuf.String()).To(HaveLen(6_000))
+		})
+	})
 
 	Describe("generateRegistriesConfig", func() {
 		It("should mark http:// mirrors as insecure", func() {


### PR DESCRIPTION
## Summary

Buildah can continue writing command stderr while werf formats a returned error. The stderr collector now serializes those writes and reads.

## What

- Buildah command stderr uses a mutex-protected buffer.
- Error messages retain collected stderr output.
- A Linux race test reads the collected stderr while another goroutine writes it.

## Why

A plain `bytes.Buffer` was read after `Builder.Run` returned while its subprocess output writer could still append. The race detector reported concurrent buffer access.