### PR TITLE
test: prevent command output deadlocks

### DIFF
--- a/test/pkg/utils/command.go
+++ b/test/pkg/utils/command.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -10,12 +9,12 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/werf/werf/v2/pkg/util/option"
 	werfExec "github.com/werf/werf/v2/pkg/werf/exec"
 )
 
@@ -56,62 +55,84 @@ func RunCommandWithOptions(ctx context.Context, dir, command string, args []stri
 		cmd.Stdin = bytes.NewReader([]byte(options.ToStdin))
 	}
 
-	stdout, err := cmd.StdoutPipe()
-	Expect(err).To(Succeed())
-
-	stderr, err := cmd.StderrPipe()
-	Expect(err).To(Succeed())
-
-	var outputReader io.Reader
-
-	if options.NoStderr {
-		outputReader = stdout
-	} else {
-		outputReader = io.MultiReader(stdout, stderr)
+	res := newCommandOutput(options.CancelOnOutput)
+	cmd.Stdout = res
+	if !options.NoStderr {
+		cmd.Stderr = res
 	}
-
-	res := &bytes.Buffer{}
 
 	Expect(cmd.Start()).To(Succeed())
 
 	if options.CancelOnOutput != "" {
-		copyReader := io.TeeReader(outputReader, res)
-		waitForOutput(copyReader, options.CancelOnOutput, options.CancelOnOutputTimeout)
+		res.waitForOutput(options.CancelOnOutputTimeout)
 		Expect(cmd.Cancel()).To(Succeed())
 	}
 
-	_, err = io.Copy(res, outputReader)
-	Expect(err).To(Succeed())
+	err := cmd.Wait()
+	output := res.Bytes()
 
-	err = cmd.Wait()
-
-	_, _ = GinkgoWriter.Write(res.Bytes())
+	_, _ = GinkgoWriter.Write(output)
 
 	if options.ShouldSucceed {
 		errorDesc := fmt.Sprintf("%[2]s %[3]s (dir: %[1]s)", dir, command, strings.Join(args, " "))
 		Expect(err).ShouldNot(HaveOccurred(), errorDesc)
 	}
 
-	return res.Bytes(), err
+	return output, err
+}
+
+type commandOutput struct {
+	mux            sync.Mutex
+	buffer         bytes.Buffer
+	cancelOnOutput string
+	outputDetected chan struct{}
+	outputOnce     sync.Once
+}
+
+var _ io.Writer = (*commandOutput)(nil)
+
+func newCommandOutput(cancelOnOutput string) *commandOutput {
+	return &commandOutput{
+		cancelOnOutput: cancelOnOutput,
+		outputDetected: make(chan struct{}),
+	}
+}
+
+func (output *commandOutput) Write(p []byte) (int, error) {
+	output.mux.Lock()
+	defer output.mux.Unlock()
+
+	n, err := output.buffer.Write(p)
+	if output.cancelOnOutput != "" && bytes.Contains(output.buffer.Bytes(), []byte(output.cancelOnOutput)) {
+		output.outputOnce.Do(func() {
+			close(output.outputDetected)
+		})
+	}
+
+	return n, err
+}
+
+func (output *commandOutput) Bytes() []byte {
+	output.mux.Lock()
+	defer output.mux.Unlock()
+
+	return bytes.Clone(output.buffer.Bytes())
+}
+
+func (output *commandOutput) waitForOutput(timeout time.Duration) {
+	if timeout == 0 {
+		timeout = time.Minute
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-output.outputDetected:
+	case <-timer.C:
+	}
 }
 
 func ShelloutPack(command string) string {
 	return fmt.Sprintf("eval $(echo %s | base64 -d)", base64.StdEncoding.EncodeToString([]byte(command)))
-}
-
-// waitForOutput waits for output and exits early or exits by timeout
-func waitForOutput(reader io.Reader, output string, timeout time.Duration) {
-	scanner := bufio.NewScanner(reader)
-	tmr := time.NewTimer(option.ValueOrDefault(timeout, time.Minute))
-
-	for scanner.Scan() {
-		select {
-		case <-tmr.C:
-			return
-		default:
-			if strings.Contains(scanner.Text(), output) {
-				return
-			}
-		}
-	}
 }

--- a/test/pkg/utils/command_test.go
+++ b/test/pkg/utils/command_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}
+
+var _ = Describe("RunCommandWithOptions", func() {
+	It("drains stderr while command writes", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		output, err := RunCommandWithOptions(ctx, "", "sh", []string{"-c", "dd if=/dev/zero bs=1024 count=128 >&2; printf done"}, RunCommandOptions{})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(output)).To(ContainSubstring("done"))
+	})
+})


### PR DESCRIPTION
## Summary

E2E command capture no longer blocks a verbose child process when stderr fills before stdout closes. Stdout and stderr now share a synchronized collector.

## What

- Test command execution drains stdout and stderr concurrently.
- `CancelOnOutput` continues to detect its marker in combined command output.
- The command helper regression test writes 128 KiB to stderr before stdout and completes before its context deadline.
- VERIFIED: on Linux, the previously hanging race-instrumented compose build-report spec completed; it then reported the separately tracked Nelm race.

## Why

`io.MultiReader` drained stdout to EOF before stderr. A child that filled stderr while keeping stdout open blocked in `pipe_write`, while the test harness waited for stdout EOF. The resulting deadlock hid race reports and exhausted E2E job timeouts.

Tracked in #7775.