### PR TITLE
fix(helm): prevent concurrent action initialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/werf/copy-recurse v0.3.1
 	github.com/werf/lockgate v0.2.0
 	github.com/werf/logboek v0.7.1
-	github.com/werf/nelm v1.26.2-0.20260807085132-ec98995b35c2
+	github.com/werf/nelm v1.28.1-0.20260807104951-8b420d326cbc
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0
@@ -194,7 +194,7 @@ require (
 	github.com/transparency-dev/merkle v0.0.2 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.30 // indirect
-	github.com/werf/kubedog v0.13.1-0.20260709123314-5d578345082f // indirect
+	github.com/werf/kubedog v0.13.1-0.20260806110242-85087f97ed99 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	github.com/yannh/kubeconform v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1032,6 +1032,8 @@ github.com/werf/copy-recurse v0.3.1 h1:1DXl5+CnxOP9pcvXu7qkY2hnqxUHnE5KWdydALL/Y
 github.com/werf/copy-recurse v0.3.1/go.mod h1:6Ypb+qN+hRBJgoCgEkX1vpbqcQ+8q69BQ3hi8s8Y6Qc=
 github.com/werf/kubedog v0.13.1-0.20260709123314-5d578345082f h1:A3dA97W1cJwUP9CegXunkiJ6gAhek7hyDXP89P7P8r0=
 github.com/werf/kubedog v0.13.1-0.20260709123314-5d578345082f/go.mod h1:tU8RyC5qXvJMPT2LmaNnVINWvwDHao0Ca3Bw9P8JC3E=
+github.com/werf/kubedog v0.13.1-0.20260806110242-85087f97ed99 h1:GOFrJ93iXCYV8FlDOSz3953jxRV0tNSK6/A+AiDRmuk=
+github.com/werf/kubedog v0.13.1-0.20260806110242-85087f97ed99/go.mod h1:5s5JQyn7rI+63ppk5MGPBYv6uRv0HARLD3kLN8FEFsw=
 github.com/werf/lockgate v0.2.0 h1:wntfccZmtHQuntPjrPUFA2FcKejhmteKEekQx3VsHC4=
 github.com/werf/lockgate v0.2.0/go.mod h1:h8P6tpGRZymd0bS5FlnS+AdIwO2jDlpOLy9St2tbs30=
 github.com/werf/logboek v0.7.1 h1:Ck8L7LVmj/wyrW/jk+EkkpGwdmpkOrsWAwoIgLHupc8=
@@ -1040,6 +1042,8 @@ github.com/werf/nelm v1.26.2-0.20260805091730-9d049189ce4e h1:s8rQIAEZFR0tIyc8ED
 github.com/werf/nelm v1.26.2-0.20260805091730-9d049189ce4e/go.mod h1:eI4z6u+zG3t+CLdqRvAxNjoLH/5Jq3wStjUILE4HjFc=
 github.com/werf/nelm v1.26.2-0.20260807085132-ec98995b35c2 h1:T/G27gYyAeDwK6nNL8VUocNIdNv6SG02C4z5sfzzwR4=
 github.com/werf/nelm v1.26.2-0.20260807085132-ec98995b35c2/go.mod h1:eI4z6u+zG3t+CLdqRvAxNjoLH/5Jq3wStjUILE4HjFc=
+github.com/werf/nelm v1.28.1-0.20260807104951-8b420d326cbc h1:ZpMT0WQwGPOYDxNtqOBF1AcjoEbPpgK6GBGzalaUNYc=
+github.com/werf/nelm v1.28.1-0.20260807104951-8b420d326cbc/go.mod h1:SSSDc2m6qgb0YOkWecYyXKOIkmUgIRdRumcVj74hPW4=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=


### PR DESCRIPTION
## Summary

werf `3` now uses Nelm `1.28` revision `8b420d326cbc`, which serializes concurrent action configuration initialization and hook-output setup. The authorized update also brings the Nelm `1.27` and `1.28` change range plus its required kubedog revision.

## What

- Parallel Helm commands sharing one configuration no longer race between `Configuration.Init` and hook-output setup, preventing race-instrumented werf from exiting with code 66 for that pair.
- Update `github.com/werf/nelm` from `v1.26.2-0.20260807085132-ec98995b35c2` to `v1.28.1-0.20260807104951-8b420d326cbc` and its transitive `github.com/werf/kubedog` requirement.
- Nelm `1.27` adds `--lookup-resources` for offline chart render/lint lookups and legacy release-lock control for install, uninstall, and rollback actions.
- Nelm `1.28` adds disabled-by-default `NELM_FEAT_ADOPT_DECKHOUSE_CONTROLLER_FIELDS` and `NELM_FEAT_CASE_INSENSITIVE_CONDITION_TRACKING` gates.
- Deploys create the release namespace under strict RBAC unless `--no-create-namespace` is set; managed-field reconstruction no longer blocks deployment on incompatible historical manifests; and `release get` is optimized.
- The Nelm changelog covers the released `v1.26.2...v1.28.0` range; post-release branch commits supply the configuration race fix and case-insensitive-condition gate.
- VERIFIED: `task format &amp;&amp; task build &amp;&amp; task lint &amp;&amp; task test:unit` passed locally.
- VERIFIED: focused remote Linux compose race E2E reports the independent Docker Buildx `logutil.Pause`/global logrus-output race and no longer reports the Nelm configuration race.

## Why

Nelm `#686` protected `Configuration.Init` but left `SetHookOutputFunc` unsynchronized, so parallel werf build workers could still write one shared Helm configuration concurrently. Nelm `#688` uses the existing configuration mutex for both writes; the broader 1.28 bump is explicitly authorized and provides the kubedog API required by its branch.

Tracked in #7775.

Depends on [werf/nelm#688](https://github.com/werf/nelm/pull/688).