### PR TITLE
test(buildx): use race-fix fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -456,6 +456,7 @@ require (
 )
 
 replace (
+	github.com/docker/buildx => github.com/werf/3p-buildx v0.0.0-20260807135054-ec8211f6fecb // temporary race fix; remove after docker/buildx#4003 merges
 	github.com/deislabs/oras => github.com/werf/3p-oras v0.9.1-0.20260408144000-3b8c77eb09e8 // used by bundles, not maintained
 	github.com/spf13/cobra => github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324 // adds EnableErrorOnUnknownSubcommand, not yet in upstream
 	oras.land/oras-go => github.com/werf/3p-oras-go v1.2.8-0.20260408140625-72dd516ce0aa // used by bundles, not maintained

--- a/go.sum
+++ b/go.sum
@@ -1022,6 +1022,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/wI2L/jsondiff v0.7.0 h1:1lH1G37GhBPqCfp/lrs91rf/2j3DktX6qYAKZkLuCQQ=
 github.com/wI2L/jsondiff v0.7.0/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
+github.com/werf/3p-buildx v0.0.0-20260807135054-ec8211f6fecb h1:WLpozmsdzC4AvB7/FYLOIsjT4Iymn6j4J/SLmwaXXxg=
+github.com/werf/3p-buildx v0.0.0-20260807135054-ec8211f6fecb/go.mod h1:7JVma62htERKE5iy5YD1q64PKiAHUzXuhSBd4oq3I74=
 github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324 h1:aqEM5aboMpBfsILjaxxRKhGFv9rGtNcd5YzMUDyVX+U=
 github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/werf/3p-oras v0.9.1-0.20260408144000-3b8c77eb09e8 h1:QwXLtEoLw/d1Vj2Lk0KXUZA0dOE3h1n6OgONl4S6TKU=


### PR DESCRIPTION
## Summary

Race-instrumented Docker builds temporarily use `werf/3p-buildx` while the upstream Buildx log-output race is pending review. This lets the bounded compose race scope finish and exposes later reports instead of exiting on the known Buildx race.

## What

- Replace `github.com/docker/buildx` with `github.com/werf/3p-buildx` at the `docker/buildx#4003` fix commit.
- Keep an in-line `go.mod` removal condition: remove the replacement after upstream PR `#4003` merges.
- VERIFIED: local `task format && task build && task lint && task test:unit` passed.
- VERIFIED: focused remote Linux race compose build-report scope passed with the replacement.
- No werf API, flag, configuration, or non-race build behavior changes.

## Why

Buildx progress printers mutate one process-global logrus output and race during concurrent Dockerfile builds. The upstream patch serializes those pauses; until it lands in a released dependency, this fork prevents that known report from masking subsequent race investigation.

Depends on [docker/buildx#4003](https://github.com/docker/buildx/pull/4003).