### PR TITLE
fix(buildah): prevent concurrent Dockerfile build races

### DIFF
--- a/pkg/buildah/native_linux.go
+++ b/pkg/buildah/native_linux.go
@@ -418,6 +418,7 @@ func (b *NativeBuildah) BuildFromDockerfile(ctx context.Context, dockerfile stri
 		return "", err
 	}
 
+	commonBuildOpts := b.defaultCommonBuildOptions
 	buildOpts := define.BuildOptions{
 		Isolation:               define.Isolation(b.Isolation),
 		Args:                    opts.BuildArgs,
@@ -426,7 +427,7 @@ func (b *NativeBuildah) BuildFromDockerfile(ctx context.Context, dockerfile stri
 		OutputFormat:            buildah.Dockerv2ImageManifest,
 		SystemContext:           sysCtx,
 		ConfigureNetwork:        define.NetworkEnabled,
-		CommonBuildOpts:         &b.defaultCommonBuildOptions,
+		CommonBuildOpts:         &commonBuildOpts,
 		Target:                  opts.Target,
 		Platforms:               targetPlatforms,
 		MaxPullPushRetries:      MaxPullPushRetries,
@@ -557,6 +558,7 @@ func (b *NativeBuildah) FromCommand(ctx context.Context, container, image string
 		return "", err
 	}
 
+	commonBuildOpts := b.defaultCommonBuildOptions
 	builder, err := buildah.NewBuilder(ctx, b.Store, buildah.BuilderOptions{
 		FromImage:           image,
 		Container:           container,
@@ -565,7 +567,7 @@ func (b *NativeBuildah) FromCommand(ctx context.Context, container, image string
 		SystemContext:       sysCtx,
 		Isolation:           define.Isolation(b.Isolation),
 		ConfigureNetwork:    define.NetworkEnabled,
-		CommonBuildOpts:     &b.defaultCommonBuildOptions,
+		CommonBuildOpts:     &commonBuildOpts,
 		Format:              buildah.Dockerv2ImageManifest,
 		MaxPullRetries:      MaxPullPushRetries,
 		PullRetryDelay:      PullPushRetryDelay,


### PR DESCRIPTION
## Summary

Concurrent native Buildah Dockerfile builds no longer mutate one shared Buildah options object. Parallel image builds no longer produce a race-detector failure in this path.

## What

- Create a per-operation copy of native Buildah common build options before Dockerfile build and builder creation.
- Preserve parallel Dockerfile build execution; no user-facing flag or configuration changes.
- VERIFIED: focused remote Linux race E2E `Build with dockerfile outside context.*Native Buildah with chroot isolation` passed.

## Why

`BuildFromDockerfile` passed a pointer to shared `defaultCommonBuildOptions`, then assigned operation-specific secrets and SSH sources through that pointer. Concurrent builds therefore wrote the same object. Each operation now owns its options copy.

Tracked in #7775.