### PR TITLE
fix(buildx): restore concurrent Dockerfile builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -456,7 +456,6 @@ require (
 )
 
 replace (
-	github.com/docker/buildx => github.com/werf/3p-buildx v0.0.0-20260807135054-ec8211f6fecb // temporary race fix; remove after docker/buildx#4003 merges
 	github.com/deislabs/oras => github.com/werf/3p-oras v0.9.1-0.20260408144000-3b8c77eb09e8 // used by bundles, not maintained
 	github.com/spf13/cobra => github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324 // adds EnableErrorOnUnknownSubcommand, not yet in upstream
 	oras.land/oras-go => github.com/werf/3p-oras-go v1.2.8-0.20260408140625-72dd516ce0aa // used by bundles, not maintained

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,6 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/wI2L/jsondiff v0.7.0 h1:1lH1G37GhBPqCfp/lrs91rf/2j3DktX6qYAKZkLuCQQ=
 github.com/wI2L/jsondiff v0.7.0/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
-github.com/werf/3p-buildx v0.0.0-20260807135054-ec8211f6fecb h1:WLpozmsdzC4AvB7/FYLOIsjT4Iymn6j4J/SLmwaXXxg=
-github.com/werf/3p-buildx v0.0.0-20260807135054-ec8211f6fecb/go.mod h1:7JVma62htERKE5iy5YD1q64PKiAHUzXuhSBd4oq3I74=
 github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324 h1:aqEM5aboMpBfsILjaxxRKhGFv9rGtNcd5YzMUDyVX+U=
 github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/werf/3p-oras v0.9.1-0.20260408144000-3b8c77eb09e8 h1:QwXLtEoLw/d1Vj2Lk0KXUZA0dOE3h1n6OgONl4S6TKU=


### PR DESCRIPTION
## Summary

Restore concurrent Dockerfile builds by removing the temporary Buildx replacement from branch `3`.

## What

- Remove the `werf/3p-buildx` replacement introduced by #7797.
- Restore the upstream Buildx `v0.33.0` dependency used before the replacement.
- No CLI, configuration, or persisted-data changes.

## Why

The temporary fork serializes Buildx log pauses with a process-global mutex. Its pause lifetime spans the whole Buildx progress display, so parallel Dockerfile builds can serialize for their full duration. Remove it until docker/buildx has a concurrency-safe upstream fix.

Tracked in #7775.