### PR TITLE
fix(build): keep concurrent Dockerfile builds parallel under race fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -456,7 +456,7 @@ require (
 
 replace (
 	github.com/deislabs/oras => github.com/werf/3p-oras v0.9.1-0.20260408144000-3b8c77eb09e8 // used by bundles, not maintained
-	github.com/docker/buildx => github.com/werf/3p-buildx v0.0.0-20260807135054-ec8211f6fecb // temporary race fix; remove after docker/buildx#4003 merges
+	github.com/docker/buildx => github.com/werf/3p-buildx v0.0.0-20260810132822-84b2b5a524c2 // temporary race fix; remove after docker/buildx#4007 merges
 	github.com/spf13/cobra => github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324 // adds EnableErrorOnUnknownSubcommand, not yet in upstream
 	oras.land/oras-go => github.com/werf/3p-oras-go v1.2.8-0.20260408140625-72dd516ce0aa // used by bundles, not maintained
 )

--- a/go.sum
+++ b/go.sum
@@ -1020,6 +1020,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/wI2L/jsondiff v0.7.0 h1:1lH1G37GhBPqCfp/lrs91rf/2j3DktX6qYAKZkLuCQQ=
 github.com/wI2L/jsondiff v0.7.0/go.mod h1:KAEIojdQq66oJiHhDyQez2x+sRit0vIzC9KeK0yizxM=
+github.com/werf/3p-buildx v0.0.0-20260810132822-84b2b5a524c2 h1:j8I40r6Ky85ddaHCLjN0/oPyop8b2i+knv85iBC4K28=
+github.com/werf/3p-buildx v0.0.0-20260810132822-84b2b5a524c2/go.mod h1:7JVma62htERKE5iy5YD1q64PKiAHUzXuhSBd4oq3I74=
 github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324 h1:aqEM5aboMpBfsILjaxxRKhGFv9rGtNcd5YzMUDyVX+U=
 github.com/werf/3p-cobra v0.0.0-20260403075225-552c82797324/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/werf/3p-oras v0.9.1-0.20260408144000-3b8c77eb09e8 h1:QwXLtEoLw/d1Vj2Lk0KXUZA0dOE3h1n6OgONl4S6TKU=


### PR DESCRIPTION
## Summary

Branch `3` currently serializes concurrent Dockerfile builds: the `werf/3p-buildx`
replacement in `go.mod` fixes a data race in `docker/buildx`'s `logutil.Pause` with a
global mutex that is held for a build's entire progress-display lifetime, so two
Dockerfile builds in one process cannot run at the same time. This points the
replacement at a fork commit that fixes the same race without a global lock, restoring
concurrency.

## What

- Concurrent Dockerfile builds in a single werf process run in parallel again; the
  previous fork serialized them.
- The `-race`-detected data race on `logrus.StandardLogger()` in `logutil.Pause` stays
  fixed: pauses are multiplexed through one refcounted per-logger writer, and `Pause`
  never blocks on another active pause.
- Only the `go.mod`/`go.sum` `docker/buildx => werf/3p-buildx` pin changes; no CLI,
  configuration, or persisted-data changes.

## Why

#7800 removed this replacement precisely because its global mutex serialized concurrent
builds, and said to keep it out until an upstream-safe fix existed. #7802 was branched
before that revert and reintroduced the old pin on merge, so `3` regressed to the
serializing fork. The new fork commit (backport of docker/buildx#4007) replaces the
global mutex with a per-logger refcounting writer: the first `Pause` wraps the logger
output once, each `Pause` bumps a counter, output is buffered while any pause is active
and flushed in order when the last one resumes. Remove this replacement once the fix
lands in an upstream buildx release.

Fixes: f80e827577896 ("fix(logboek): prevent concurrent stream races (#7802)")
