### PR TITLE
chore(ci): drop references to the removed ansible e2e suite

### DIFF
--- a/.github/workflows/test_daily.yml
+++ b/.github/workflows/test_daily.yml
@@ -54,7 +54,7 @@ jobs:
     uses: ./.github/workflows/_test_integration_regular.yml
     with:
       packages: test/legacy_e2e/suites
-      excludePackages: test/legacy_e2e/suites/deploy,test/legacy_e2e/suites/cleanup_after_converge,test/legacy_e2e/suites/helm/deploy_rollback,test/legacy_e2e/suites/bundles,test/legacy_e2e/suites/ansible,test/legacy_e2e/suites/build/stapel_image/git,test/legacy_e2e/suites/docs
+      excludePackages: test/legacy_e2e/suites/deploy,test/legacy_e2e/suites/cleanup_after_converge,test/legacy_e2e/suites/helm/deploy_rollback,test/legacy_e2e/suites/bundles,test/legacy_e2e/suites/build/stapel_image/git,test/legacy_e2e/suites/docs
       fetchDepth: 0 # Git history as fixtures for tests.
       coverage: true
     secrets: inherit
@@ -64,14 +64,6 @@ jobs:
     uses: ./.github/workflows/_test_integration_regular.yml
     with:
       packages: test/legacy_e2e/suites/build/stapel_image/git
-      coverage: true
-    secrets: inherit
-
-  integration_ansible:
-    needs: gate
-    uses: ./.github/workflows/_test_integration_regular.yml
-    with:
-      packages: test/legacy_e2e/suites/ansible
       coverage: true
     secrets: inherit
 
@@ -102,7 +94,6 @@ jobs:
       - unit
       - integration_main
       - integration_git
-      - integration_ansible
       - integration_per-k8s
       - integration_per-cr
       - integration_per-k8s-and-cr


### PR DESCRIPTION
The ansible builder and its `test/legacy_e2e/suites/ansible` suite were removed, but `test_daily.yml` still referenced them. This removes the three dead references: the `integration_ansible` job, its entry in `coverage_report.needs`, and the `ansible` path in `integration_main` `excludePackages`.

No behavior change to any suite that still exists — the removed job pointed at a non-existent package path.