### PR TITLE
fix(build, stapel): stop panicking when the base image is gone at commit

### DIFF
--- a/pkg/container_backend/legacy_base_image.go
+++ b/pkg/container_backend/legacy_base_image.go
@@ -1,8 +1,6 @@
 package container_backend
 
 import (
-	"context"
-	"fmt"
 	"sync"
 
 	"github.com/werf/werf/v2/pkg/image"
@@ -32,19 +30,6 @@ func (i *legacyBaseImage) Name() string {
 
 func (i *legacyBaseImage) SetName(name string) {
 	i.name = name
-}
-
-func (i *legacyBaseImage) MustResetInfo(ctx context.Context) error {
-	if info, err := i.ContainerBackend.GetImageInfo(ctx, i.Name(), GetImageInfoOpts{}); err != nil {
-		return fmt.Errorf("unable to get info for image %s: %w", i.Name(), err)
-	} else {
-		i.SetInfo(info)
-	}
-
-	if i.info == nil {
-		panic(fmt.Sprintf("runtime error: info must be set for image %q", i.name))
-	}
-	return nil
 }
 
 func (i *legacyBaseImage) GetInfo() *image.Info {

--- a/pkg/container_backend/legacy_stage_image.go
+++ b/pkg/container_backend/legacy_stage_image.go
@@ -207,14 +207,6 @@ func (i *LegacyStageImage) introspectBefore(ctx context.Context) error {
 	return nil
 }
 
-func (i *LegacyStageImage) MustResetInfo(ctx context.Context) error {
-	if i.buildImage != nil {
-		return i.buildImage.MustResetInfo(ctx)
-	} else {
-		return i.legacyBaseImage.MustResetInfo(ctx)
-	}
-}
-
 func (i *LegacyStageImage) GetInfo() *image.Info {
 	if i.buildImage != nil {
 		return i.buildImage.GetInfo()

--- a/pkg/container_backend/legacy_stage_image_commit_options_test.go
+++ b/pkg/container_backend/legacy_stage_image_commit_options_test.go
@@ -1,0 +1,34 @@
+package container_backend
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LegacyStageImageContainer commit options", func() {
+	newContainer := func() *LegacyStageImageContainer {
+		return newLegacyStageImageContainer(NewLegacyStageImage(nil, "repo:tag", nil, ""))
+	}
+
+	It("fails when the base image config has not been read before the run", func() {
+		c := newContainer()
+
+		_, err := c.prepareCommitOptions()
+
+		Expect(err).To(MatchError(ContainSubstring("are not prepared")))
+	})
+
+	It("restores the base image config read before the run", func() {
+		c := newContainer()
+		c.inheritedCommitOptions = newLegacyStageContainerOptions()
+		c.inheritedCommitOptions.Entrypoint = `["/bin/base-entrypoint"]`
+		c.inheritedCommitOptions.User = "base-user"
+		c.commitChangeOptions.AddUser("stage-user")
+
+		opts, err := c.prepareCommitOptions()
+
+		Expect(err).To(Succeed())
+		Expect(opts.Entrypoint).To(Equal(`["/bin/base-entrypoint"]`))
+		Expect(opts.User).To(Equal("stage-user"))
+	})
+})

--- a/pkg/container_backend/legacy_stage_image_container.go
+++ b/pkg/container_backend/legacy_stage_image_container.go
@@ -25,6 +25,7 @@ type LegacyStageImageContainer struct {
 	runOptions                 *LegacyStageImageContainerOptions
 	commitChangeOptions        *LegacyStageImageContainerOptions
 	serviceCommitChangeOptions *LegacyStageImageContainerOptions
+	inheritedCommitOptions     *LegacyStageImageContainerOptions
 }
 
 func newLegacyStageImageContainer(img *LegacyStageImage) *LegacyStageImageContainer {
@@ -218,7 +219,7 @@ func (c *LegacyStageImageContainer) prepareIntrospectOptions(ctx context.Context
 }
 
 func (c *LegacyStageImageContainer) prepareCommitChanges(ctx context.Context, opts LegacyCommitChangeOptions) ([]string, error) {
-	commitOptions, err := c.prepareCommitOptions(ctx)
+	commitOptions, err := c.prepareCommitOptions()
 	if err != nil {
 		return nil, err
 	}
@@ -230,32 +231,29 @@ func (c *LegacyStageImageContainer) prepareCommitChanges(ctx context.Context, op
 	return commitChanges, nil
 }
 
-func (c *LegacyStageImageContainer) prepareCommitOptions(ctx context.Context) (*LegacyStageImageContainerOptions, error) {
-	inheritedCommitOptions, err := c.prepareInheritedCommitOptions(ctx)
-	if err != nil {
-		return nil, err
+func (c *LegacyStageImageContainer) prepareCommitOptions() (*LegacyStageImageContainerOptions, error) {
+	if c.inheritedCommitOptions == nil {
+		return nil, fmt.Errorf("commit options inherited from the base image are not prepared for image %s", c.image.name)
 	}
 
-	commitOptions := inheritedCommitOptions.merge(c.serviceCommitChangeOptions.merge(c.commitChangeOptions))
+	commitOptions := c.inheritedCommitOptions.merge(c.serviceCommitChangeOptions.merge(c.commitChangeOptions))
 	return commitOptions, nil
 }
 
-func (c *LegacyStageImageContainer) prepareInheritedCommitOptions(ctx context.Context) (*LegacyStageImageContainerOptions, error) {
+// prepareInheritedCommitOptions reads the config of the base image to restore in the committed image
+// what running the build container overrides. It must be called while the container has not been
+// committed yet: the base image is guaranteed to be available locally only until then.
+func (c *LegacyStageImageContainer) prepareInheritedCommitOptions(ctx context.Context, fromImageRef string) (*LegacyStageImageContainerOptions, error) {
 	inheritedOptions := newLegacyStageContainerOptions()
-
-	if c.image.fromImage == nil {
-		panic(fmt.Sprintf("runtime error: FromImage should be (%s)", c.image.name))
-	}
-
-	if err := c.image.fromImage.MustResetInfo(ctx); err != nil {
-		return nil, fmt.Errorf("unable to reset info for image %s: %w", c.image.fromImage.Name(), err)
-	}
 
 	dockerServerBackend := c.image.ContainerBackend.(*DockerServerBackend)
 
-	fromImageInspect, err := dockerServerBackend.GetImageInspect(ctx, c.image.fromImage.Name())
+	fromImageInspect, err := dockerServerBackend.GetImageInspect(ctx, fromImageRef)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get image inspect: %w", err)
+	}
+	if fromImageInspect == nil {
+		return nil, fmt.Errorf("image %s is not available locally", fromImageRef)
 	}
 
 	if len(fromImageInspect.Config.Cmd) != 0 {
@@ -285,6 +283,16 @@ func (c *LegacyStageImageContainer) prepareInheritedCommitOptions(ctx context.Co
 
 func (c *LegacyStageImageContainer) run(ctx context.Context) error {
 	_ = c.image.ContainerBackend.(*DockerServerBackend)
+
+	if c.image.fromImage == nil {
+		panic(fmt.Sprintf("runtime error: FromImage should be (%s)", c.image.name))
+	}
+
+	inheritedCommitOptions, err := c.prepareInheritedCommitOptions(ctx, c.imageRef(c.image.fromImage))
+	if err != nil {
+		return err
+	}
+	c.inheritedCommitOptions = inheritedCommitOptions
 
 	runArgs, err := c.prepareRunArgs(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

Building a stapel stage with the Docker Server backend aborted with `panic: runtime error: info must be set for image "<ref>"` when the base image reference disappeared from the local backend while the stage's build container was running. The panic needs a pre-existing host state — something outside the werf process removing local images mid-build, e.g. a prune on a container backend shared with other jobs — so it does not reproduce from a clean checkout.

## What

- A stage whose base image tag is removed after its build container has started now commits normally instead of failing. VERIFIED: on a Linux host, `docker rmi -f <base stage tag>` during the stage's run panics before this change and builds through after it.
- A base image missing before the container starts still fails the build, now with the `docker run` error rather than a panic.
- The base image is inspected once per stage, before the container runs, by the same reference `docker run` receives — the committed image id when the stage was built in this process, the stage name otherwise. Previously commit inspected it a second time, and always by name, so the two could disagree.
- An inspect that finds nothing reports `image <ref> is not available locally`; it used to be dereferenced immediately. VERIFIED: with the base image built by the same process and its tag removed mid-run, that path is a SIGSEGV before this change.
- What lands in the committed image does not change: `Cmd`, `Entrypoint`, `User`, `WorkingDir` and the `LANG`/`LC_ALL` envs are still restored from the base image config, because the build container overrides them.

## Why

The build container is created from the base image with its entrypoint and command replaced by the stapel build script, so committing it would keep those overrides. werf restored the original config by inspecting the base image again at commit time — after the container had run, at a point where nothing guarantees the image is still there, and where a missing image was answered with a panic. The image config is immutable, so reading it before the run and reusing it removes the window instead of coping with it.

The alternative was to keep the second inspect and fall back to the image id when the name no longer resolves. That keeps a lookup in the commit path that can still fail for a reason nobody can act on, and leaves the two references (`run` by id, commit by name) diverging.

Fixes: 69140cdeff4e ("feat(buildah): refactor container-runtime interface and fix usage of runtime")
