### PR TITLE
fix(build): ignore a cache repo pointing at the primary repo

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -928,7 +928,7 @@ func GetOptionalFinalStagesStorage(ctx context.Context, containerBackend contain
 	})
 }
 
-func GetCacheStagesStorageList(ctx context.Context, containerBackend container_backend.ContainerBackend, cmdData *CmdData) ([]storage.StagesStorage, error) {
+func GetCacheStagesStorageList(ctx context.Context, stagesStorage storage.StagesStorage, containerBackend container_backend.ContainerBackend, cmdData *CmdData) ([]storage.StagesStorage, error) {
 	var res []storage.StagesStorage
 
 	buildahMode, _, err := GetBuildahMode()
@@ -942,6 +942,11 @@ func GetCacheStagesStorageList(ctx context.Context, containerBackend container_b
 	}
 
 	for _, address := range GetCacheStagesStorage(cmdData) {
+		if address == stagesStorage.Address() {
+			logboek.Context(ctx).Warn().LogF("WARNING: Ignoring cache repo %s: same address as the primary repo.\n", address)
+			continue
+		}
+
 		repoData := NewRepoData("cache-repo", RepoDataOptions{OnlyAddress: true})
 		repoData.Address = &address
 

--- a/cmd/werf/common/storage.go
+++ b/cmd/werf/common/storage.go
@@ -84,7 +84,7 @@ func NewStorageManagerWithOptions(ctx context.Context, c *NewStorageManagerConfi
 	if err != nil {
 		return nil, fmt.Errorf("error get secondary stages storage list: %w", err)
 	}
-	cacheStagesStorageList, err := GetCacheStagesStorageList(ctx, c.ContainerBackend, c.CmdData)
+	cacheStagesStorageList, err := GetCacheStagesStorageList(ctx, stagesStorage, c.ContainerBackend, c.CmdData)
 	if err != nil {
 		return nil, fmt.Errorf("error get chache storage list: %w", err)
 	}


### PR DESCRIPTION
## Summary

A `--cache-repo` whose address equals the `--repo` address made werf delete the stage image it had just pulled: promoting a stage fetched from a cache repo renames it onto the primary name and drops the old name, and with both addresses equal that is `docker tag X X` followed by `docker rmi X`. A single build recovered without a trace, because `docker run` pulls the missing image again; a build running next to it on the same container backend could lose the image while using it as the base image of the stage it was building, and die (#7819).

## What

- A cache repo whose address equals the primary repo address is ignored, with `WARNING: Ignoring cache repo <address>: same address as the primary repo.` printed once per command. Such a repo can cache nothing by definition.
- No stage image is untagged or deleted while promoting a fetched stage in that configuration, because the promotion never runs.
- Cache repos with any other address are unaffected: they are still fetched from and promoted as before.
- `--secondary-repo` and `--final-repo` are untouched; only the cache repo list is filtered.

## Why

`StorageManager.FetchStageImage` fetches a stage from every cache repo before the primary one and then promotes the fetched image to the primary name via `RenameImage(..., removeOldName: true)`. The name comes from `ConstructStageImageName`, which depends only on the repo address, the digest and the creation timestamp — so with the two addresses equal, the old and the new name are the same string, and removing the old name removes the image.

Guarding `RenameImage` against a rename onto itself was the alternative. It would have to be repeated per backend and would still leave werf fetching a "cache" that is the primary repo it fetches from anyway; dropping the repo removes the whole degenerate path in one place.
