### PR TITLE
fix(build): keep host cleanup of another werf from deleting a stage in use

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -1172,6 +1172,12 @@ func (phase *BuildPhase) atomicBuildStageImage(ctx context.Context, img *image.I
 	stageImage.Image.SetName(newStageImageName)
 	phase.Conveyor.SetStageImage(stageImage)
 
+	// Hold the image against host cleanup of a concurrent werf process for as long as this build runs:
+	// the stage is going to be used as the base image of the next stage.
+	if err := phase.Conveyor.StorageManager.LockStageImage(ctx, newStageImageName); err != nil {
+		return fmt.Errorf("unable to lock stage %s image %s: %w", stg.LogDetailedName(), newStageImageName, err)
+	}
+
 	if err := logboek.Context(ctx).Default().LogProcess("Store stage into %s", phase.Conveyor.StorageManager.GetStagesStorage().String()).DoError(func() error {
 		if stg.IsMutable() {
 			prevBuiltImage := phase.StagesIterator.GetPrevBuiltImage(img, stg)

--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -194,7 +194,8 @@ type StorageManager struct {
 	SecondaryStagesStorageList []storage.StagesStorage
 
 	// These will be released automatically when current process exits
-	SharedHostImagesLocks []lockgate.LockHandle
+	SharedHostImagesLocks   []lockgate.LockHandle
+	sharedHostImagesLocksMu sync.Mutex
 
 	FinalStagesListCacheMux sync.Mutex
 	FinalStagesListCache    *StagesList
@@ -380,6 +381,8 @@ func (m *StorageManager) LockStageImage(ctx context.Context, imageName string) e
 		return fmt.Errorf("error locking %q shared lock: %w", imageLockName, err)
 	}
 
+	m.sharedHostImagesLocksMu.Lock()
+	defer m.sharedHostImagesLocksMu.Unlock()
 	m.SharedHostImagesLocks = append(m.SharedHostImagesLocks, l)
 
 	return nil


### PR DESCRIPTION
## Summary

Automatic host cleanup removes least recently used werf stage images and skips only those a running werf holds a host lock on — and that lock was taken for fetched stages only. A stage built by the current process stayed unlocked, so a cleanup forked by another werf on the same container backend could delete it while it was the base image of the stage being built; that build then failed on a base image that had vanished (#7819). Every `werf build` forks such a cleanup once the backend storage is over its allowed volume usage, so on a busy host with parallel builds this needs no unusual setup.

## What

- A stage image built by the current process is locked as soon as it gets its final name, so host cleanup run by any other werf process skips it, the same way it already skips fetched stages.
- The lock is held until the process exits, so a stage stays protected while the later stages of the same image are built. UNVERIFIED: a hand-run check on Linux — build a stage, run `werf host cleanup --force` from a second process, confirm the stage image survives — is in progress.
- Failing to take the lock fails the build with `unable to lock stage <stage> image <name>`, instead of silently building on an unprotected image.
- The list of held locks is guarded by a mutex; parallel image builds append to it concurrently, and only the fetch path did so before.
- Nothing changes for stages that are fetched rather than built: they were already locked at fetch time.

## Why

`StorageManager.LockStageImage` had a single caller, `FetchStageImage`, so the protection came for free only when the image arrived from a repo. A stage built locally is exactly as much in use — the next stage's build container is created from it — but nothing marked it, and `LocalBackendCleaner.removeImageByRepoTags` deletes any werf stage tag it finds unlocked.

The alternative was to make host cleanup avoid recently created images altogether. It already does that for dangling images, with a 15 minute window, and stretching the same idea to tagged stages trades a correctness signal for a heuristic: the lock states that a specific image is in use, an age filter guesses it.
