### PR TITLE
fix(host-cleanup): report the real retention of pruned dangling images

### DIFF
--- a/pkg/host_cleaning/local_backend_cleaner.go
+++ b/pkg/host_cleaning/local_backend_cleaner.go
@@ -297,7 +297,7 @@ func (cleaner *LocalBackendCleaner) RunGC(ctx context.Context, options RunGCOpti
 	}
 
 	// Step 2. Prune werf dangling images
-	err = logboek.Context(ctx).LogBlock("Prune werf dangling images created more than 1 hour ago").DoError(func() error {
+	err = logboek.Context(ctx).LogBlock("Prune werf dangling images created more than %s ago", danglingImagesRetentionPeriod).DoError(func() error {
 		reportImages, err := cleaner.pruneImages(ctx, options)
 		if handleError(ctx, err) != nil {
 			return err
@@ -403,6 +403,10 @@ func (cleaner *LocalBackendCleaner) measureReclaimedSpace(ctx context.Context, s
 	return spaceReclaimed, vuAfter, nil
 }
 
+// danglingImagesRetentionPeriod keeps a dangling image out of the prune for a while: in Stapel mode
+// werf relies on such an image between committing a stage container and tagging the built image.
+const danglingImagesRetentionPeriod = "15m"
+
 // pruneImages removes werf dangling images
 func (cleaner *LocalBackendCleaner) pruneImages(ctx context.Context, options RunGCOptions) (cleanupReport, error) {
 	filters := filter.FilterList{
@@ -410,9 +414,8 @@ func (cleaner *LocalBackendCleaner) pruneImages(ctx context.Context, options Run
 		filter.DanglingTrue,
 		// 2. From all dangling images select only werf's dangling images.
 		filter.NewFilter("label", image.WerfLabel),
-		// 3. From werf's dangling images select only images which were created more than 15 minutes ago.
-		// Explanation: in Stapel mode werf relies on a "dangling" image for some time before tagging its image.
-		filter.NewFilter("until", "15m"),
+		// 3. From werf's dangling images select only images which are old enough.
+		filter.NewFilter("until", danglingImagesRetentionPeriod),
 
 		// Both backends support filters listed above:
 		// Docker: https://github.com/moby/moby/blob/25.0/daemon/containerd/image_prune.go#L22


### PR DESCRIPTION
`werf host cleanup` logged `Prune werf dangling images created more than 1 hour ago` while pruning images older than 15 minutes; it now prints the period the filter actually uses, taken from the same constant. VERIFIED: `werf host cleanup --dry-run` prints `Prune werf dangling images created more than 15m ago`. Nothing is pruned differently — only the message changes.

Fixes: b0aedf9d5ad5 ("fix(host-cleanup): decrease retention period of dangling images")
