### PR TITLE
fix(build, buildah): stop "image not known" error in RUN --mount builds

### DIFF
--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -724,8 +724,65 @@ func normalizeDependencyImportDestination(absFrom, absTo string) (string, error)
 	}
 }
 
+// ensureImageLocally makes ref resolvable by buildah operations that only look up
+// the local containers storage (e.g. RUN --mount from=image resolution).
+func (backend *BuildahBackend) ensureImageLocally(ctx context.Context, ref string, opts CommonOpts) error {
+	inspect, err := backend.buildah.Inspect(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("unable to inspect image %q: %w", ref, err)
+	}
+	if inspect != nil {
+		if opts.TargetPlatform != "" && !platformMatches(inspect, opts.TargetPlatform) {
+			return fmt.Errorf("local image %q has platform %s/%s, but target platform is %q; pull the correct image first", ref, inspect.OCIv1.OS, inspect.OCIv1.Architecture, opts.TargetPlatform)
+		}
+		return nil
+	}
+
+	logboek.Context(ctx).Debug().LogF("Image %q not found locally, pulling\n", ref)
+
+	mu := backend.getPullMutex(ref)
+	mu.Lock()
+	defer mu.Unlock()
+
+	imageID, err := backend.buildah.Pull(ctx, ref, buildah.PullOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
+	if err != nil {
+		return fmt.Errorf("unable to pull image %q: %w", ref, err)
+	}
+	if opts.TargetPlatform != "" && imageID != "" {
+		backend.storePulledImageID(ref, opts.TargetPlatform, imageID)
+	}
+
+	return nil
+}
+
+func (backend *BuildahBackend) ensureRunMountImages(ctx context.Context, instrs []InstructionInterface, opts CommonOpts) error {
+	for _, instr := range instrs {
+		mounter, ok := instr.(MountsInterface)
+		if !ok {
+			continue
+		}
+
+		for _, mount := range mounter.GetMounts() {
+			if mount.From == "" {
+				continue
+			}
+
+			if err := backend.ensureImageLocally(ctx, mount.From, opts); err != nil {
+				return fmt.Errorf("unable to ensure local image for run mount %q: %w", mount.From, err)
+			}
+		}
+	}
+
+	return nil
+}
+
 func (backend *BuildahBackend) BuildDockerfileStage(ctx context.Context, baseImage string, opts BuildDockerfileStageOptions, instructions ...InstructionInterface) (string, error) {
 	defer opstats.Observe(ctx, opstats.OperationImageBuild)()
+
+	if err := backend.ensureRunMountImages(ctx, instructions, opts.CommonOpts); err != nil {
+		return "", err
+	}
+
 	var container *containerDesc
 	if c, err := backend.createContainers(ctx, []string{baseImage}, opts.CommonOpts); err != nil {
 		return "", err

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -727,15 +727,22 @@ func normalizeDependencyImportDestination(absFrom, absTo string) (string, error)
 // ensureImageLocally makes ref resolvable by buildah operations that only look up
 // the local containers storage (e.g. RUN --mount from=image resolution).
 func (backend *BuildahBackend) ensureImageLocally(ctx context.Context, ref string, opts CommonOpts) error {
-	inspect, err := backend.buildah.Inspect(ctx, ref)
-	if err != nil {
-		return fmt.Errorf("unable to inspect image %q: %w", ref, err)
-	}
-	if inspect != nil {
-		if opts.TargetPlatform != "" && !platformMatches(inspect, opts.TargetPlatform) {
-			return fmt.Errorf("local image %q has platform %s/%s, but target platform is %q; pull the correct image first", ref, inspect.OCIv1.OS, inspect.OCIv1.Architecture, opts.TargetPlatform)
+	checkLocal := func() (bool, error) {
+		inspect, err := backend.buildah.Inspect(ctx, ref)
+		if err != nil {
+			return false, fmt.Errorf("unable to inspect image %q: %w", ref, err)
 		}
-		return nil
+		if inspect == nil {
+			return false, nil
+		}
+		if opts.TargetPlatform != "" && !platformMatches(inspect, opts.TargetPlatform) {
+			return false, fmt.Errorf("local image %q has platform %s/%s, but target platform is %q; pull the correct image first", ref, inspect.OCIv1.OS, inspect.OCIv1.Architecture, opts.TargetPlatform)
+		}
+		return true, nil
+	}
+
+	if found, err := checkLocal(); err != nil || found {
+		return err
 	}
 
 	logboek.Context(ctx).Debug().LogF("Image %q not found locally, pulling\n", ref)
@@ -743,6 +750,11 @@ func (backend *BuildahBackend) ensureImageLocally(ctx context.Context, ref strin
 	mu := backend.getPullMutex(ref)
 	mu.Lock()
 	defer mu.Unlock()
+
+	// A concurrent caller holding the lock may have pulled the image already.
+	if found, err := checkLocal(); err != nil || found {
+		return err
+	}
 
 	imageID, err := backend.buildah.Pull(ctx, ref, buildah.PullOpts(backend.getBuildahCommonOpts(ctx, true, nil, opts.TargetPlatform)))
 	if err != nil {

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/containers/storage/types"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -392,5 +393,91 @@ var _ = Describe("BuildahBackend createContainers", func() {
 		Eventually(firstDone).Should(Receive(Succeed()))
 		Eventually(secondDone).Should(Receive(Succeed()))
 		Expect(pullCalls.Load()).To(Equal(int32(2)))
+	})
+})
+
+type stubMountsInstruction struct {
+	mounts []*instructions.Mount
+}
+
+func (i *stubMountsInstruction) Name() string { return "RUN" }
+
+func (i *stubMountsInstruction) Apply(_ context.Context, _ string, _ buildah.Buildah, _ buildah.CommonOpts, _ BuildContextArchiver) error {
+	return nil
+}
+
+func (i *stubMountsInstruction) UsesBuildContext() bool { return false }
+
+func (i *stubMountsInstruction) GetMounts() []*instructions.Mount { return i.mounts }
+
+var _ = Describe("BuildahBackend ensureRunMountImages", func() {
+	const (
+		imageRef = "registry.example.org/project/stage:tag"
+		platform = "linux/amd64"
+	)
+
+	newRunInstruction := func(from string) *stubMountsInstruction {
+		return &stubMountsInstruction{mounts: []*instructions.Mount{
+			{Type: instructions.MountTypeBind, From: from, Target: "/mnt"},
+			{Type: instructions.MountTypeTmpfs, Target: "/tmp"},
+		}}
+	}
+
+	It("pulls the run mount from-image missing in local storage", func() {
+		fakeBuildah := &buildahstub.BuildahStub{}
+		fakeBuildah.PullFunc = func(_ context.Context, ref string, _ buildah.PullOpts) (string, error) {
+			Expect(ref).To(Equal(imageRef))
+			return "sha256:fresh", nil
+		}
+
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+
+		err := backend.ensureRunMountImages(context.Background(), []InstructionInterface{newRunInstruction(imageRef)}, CommonOpts{TargetPlatform: platform})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fakeBuildah.InspectRefs).To(Equal([]string{imageRef}))
+		Expect(fakeBuildah.PullRefs).To(Equal([]string{imageRef}))
+
+		cachedID, ok := backend.getPulledImageID(imageRef, platform)
+		Expect(ok).To(BeTrue())
+		Expect(cachedID).To(Equal("sha256:fresh"))
+	})
+
+	It("does not pull when the from-image is already in local storage", func() {
+		fakeBuildah := &buildahstub.BuildahStub{}
+		fakeBuildah.InspectFunc = func(_ context.Context, _ string) (*thirdparty.BuilderInfo, error) {
+			return &thirdparty.BuilderInfo{OCIv1: v1.Image{Platform: v1.Platform{OS: "linux", Architecture: "amd64"}}}, nil
+		}
+
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+
+		err := backend.ensureRunMountImages(context.Background(), []InstructionInterface{newRunInstruction(imageRef)}, CommonOpts{TargetPlatform: platform})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fakeBuildah.PullRefs).To(BeEmpty())
+	})
+
+	It("fails when the pull fails", func() {
+		fakeBuildah := &buildahstub.BuildahStub{}
+		fakeBuildah.PullFunc = func(_ context.Context, _ string, _ buildah.PullOpts) (string, error) {
+			return "", errors.New("no such host")
+		}
+
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+
+		err := backend.ensureRunMountImages(context.Background(), []InstructionInterface{newRunInstruction(imageRef)}, CommonOpts{TargetPlatform: platform})
+		Expect(err).To(MatchError(ContainSubstring("unable to pull image")))
+	})
+
+	It("skips instructions without mounts and mounts without from", func() {
+		fakeBuildah := &buildahstub.BuildahStub{}
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+
+		instrs := []InstructionInterface{
+			&stubMountsInstruction{mounts: []*instructions.Mount{{Type: instructions.MountTypeBind, Target: "/ctx"}}},
+		}
+
+		err := backend.ensureRunMountImages(context.Background(), instrs, CommonOpts{TargetPlatform: platform})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fakeBuildah.InspectRefs).To(BeEmpty())
+		Expect(fakeBuildah.PullRefs).To(BeEmpty())
 	})
 })

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -397,12 +397,16 @@ var _ = Describe("BuildahBackend createContainers", func() {
 })
 
 type stubMountsInstruction struct {
-	mounts []*instructions.Mount
+	mounts    []*instructions.Mount
+	applyFunc func() error
 }
 
 func (i *stubMountsInstruction) Name() string { return "RUN" }
 
 func (i *stubMountsInstruction) Apply(_ context.Context, _ string, _ buildah.Buildah, _ buildah.CommonOpts, _ BuildContextArchiver) error {
+	if i.applyFunc != nil {
+		return i.applyFunc()
+	}
 	return nil
 }
 
@@ -542,5 +546,30 @@ var _ = Describe("BuildahBackend ensureRunMountImages", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fakeBuildah.InspectRefs).To(BeEmpty())
 		Expect(fakeBuildah.PullRefs).To(BeEmpty())
+	})
+
+	It("BuildDockerfileStage pulls the missing run mount image before applying instructions", func() {
+		var events []string
+
+		fakeBuildah := &buildahstub.BuildahStub{}
+		fakeBuildah.PullFunc = func(_ context.Context, ref string, _ buildah.PullOpts) (string, error) {
+			Expect(ref).To(Equal(imageRef))
+			events = append(events, "pull")
+			return "sha256:fresh", nil
+		}
+
+		instr := newRunInstruction(imageRef)
+		instr.applyFunc = func() error {
+			events = append(events, "apply")
+			return nil
+		}
+
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+
+		_, err := backend.BuildDockerfileStage(context.Background(), "base-image:tag", BuildDockerfileStageOptions{
+			CommonOpts: CommonOpts{TargetPlatform: platform},
+		}, instr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(events).To(Equal([]string{"pull", "apply"}))
 	})
 })

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -434,7 +434,7 @@ var _ = Describe("BuildahBackend ensureRunMountImages", func() {
 
 		err := backend.ensureRunMountImages(context.Background(), []InstructionInterface{newRunInstruction(imageRef)}, CommonOpts{TargetPlatform: platform})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(fakeBuildah.InspectRefs).To(Equal([]string{imageRef}))
+		Expect(fakeBuildah.InspectRefs).To(Equal([]string{imageRef, imageRef}))
 		Expect(fakeBuildah.PullRefs).To(Equal([]string{imageRef}))
 
 		cachedID, ok := backend.getPulledImageID(imageRef, platform)
@@ -453,6 +453,69 @@ var _ = Describe("BuildahBackend ensureRunMountImages", func() {
 		err := backend.ensureRunMountImages(context.Background(), []InstructionInterface{newRunInstruction(imageRef)}, CommonOpts{TargetPlatform: platform})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fakeBuildah.PullRefs).To(BeEmpty())
+	})
+
+	It("fails without pulling when the local from-image platform mismatches the target platform", func() {
+		fakeBuildah := &buildahstub.BuildahStub{}
+		fakeBuildah.InspectFunc = func(_ context.Context, _ string) (*thirdparty.BuilderInfo, error) {
+			return &thirdparty.BuilderInfo{OCIv1: v1.Image{Platform: v1.Platform{OS: "linux", Architecture: "arm64"}}}, nil
+		}
+
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+
+		err := backend.ensureRunMountImages(context.Background(), []InstructionInterface{newRunInstruction(imageRef)}, CommonOpts{TargetPlatform: platform})
+		Expect(err).To(MatchError(ContainSubstring("but target platform is")))
+		Expect(fakeBuildah.PullRefs).To(BeEmpty())
+	})
+
+	It("does not pull again when a concurrent caller already pulled the image", func() {
+		var pulled atomic.Bool
+		var inspectCalls atomic.Int32
+		firstPullStarted := make(chan struct{})
+		releaseFirstPull := make(chan struct{})
+		var pullCalls atomic.Int32
+
+		fakeBuildah := &buildahstub.BuildahStub{}
+		fakeBuildah.InspectFunc = func(_ context.Context, _ string) (*thirdparty.BuilderInfo, error) {
+			inspectCalls.Add(1)
+			if pulled.Load() {
+				return &thirdparty.BuilderInfo{OCIv1: v1.Image{Platform: v1.Platform{OS: "linux", Architecture: "amd64"}}}, nil
+			}
+			return nil, nil
+		}
+		fakeBuildah.PullFunc = func(_ context.Context, ref string, _ buildah.PullOpts) (string, error) {
+			if ref != imageRef {
+				return "", fmt.Errorf("unexpected image ref %q", ref)
+			}
+			if pullCalls.Add(1) > 1 {
+				return "", errors.New("unexpected second pull")
+			}
+			close(firstPullStarted)
+			<-releaseFirstPull
+			pulled.Store(true)
+			return "sha256:fresh", nil
+		}
+
+		backend := NewBuildahBackend(fakeBuildah, BuildahBackendOptions{})
+
+		ensure := func() <-chan error {
+			done := make(chan error, 1)
+			go func() {
+				done <- backend.ensureImageLocally(context.Background(), imageRef, CommonOpts{TargetPlatform: platform})
+			}()
+			return done
+		}
+
+		firstDone := ensure()
+		Eventually(firstPullStarted).Should(BeClosed())
+
+		secondDone := ensure()
+		Eventually(inspectCalls.Load).Should(BeNumerically(">=", 3))
+
+		close(releaseFirstPull)
+		Eventually(firstDone).Should(Receive(Succeed()))
+		Eventually(secondDone).Should(Receive(Succeed()))
+		Expect(pullCalls.Load()).To(Equal(int32(1)))
 	})
 
 	It("fails when the pull fails", func() {

--- a/pkg/container_backend/instruction.go
+++ b/pkg/container_backend/instruction.go
@@ -3,6 +3,8 @@ package container_backend
 import (
 	"context"
 
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
 	"github.com/werf/werf/v2/pkg/buildah"
 )
 
@@ -10,4 +12,8 @@ type InstructionInterface interface {
 	Name() string
 	Apply(ctx context.Context, containerName string, drv buildah.Buildah, drvOpts buildah.CommonOpts, buildContextArchive BuildContextArchiver) error
 	UsesBuildContext() bool
+}
+
+type MountsInterface interface {
+	GetMounts() []*instructions.Mount
 }

--- a/pkg/container_backend/instruction/run.go
+++ b/pkg/container_backend/instruction/run.go
@@ -20,6 +20,8 @@ type Run struct {
 	SSH     string
 }
 
+var _ container_backend.MountsInterface = (*Run)(nil)
+
 func NewRun(i instructions.RunCommand, envs, secrets []string, ssh string) *Run {
 	return &Run{RunCommand: i, Envs: envs, Secrets: secrets, SSH: ssh}
 }

--- a/test/e2e/build/_fixtures/staged_dockerfile_run_mount/state0/Dockerfile
+++ b/test/e2e/build/_fixtures/staged_dockerfile_run_mount/state0/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.werf.io/base/ubuntu:22.04 AS os
+RUN mkdir /apk && echo pkg-v1 > /apk/pkg.txt
+
+FROM registry.werf.io/base/ubuntu:22.04
+RUN --mount=type=bind,from=os,source=/apk,target=/apk cat /apk/pkg.txt > /result && echo run-v1

--- a/test/e2e/build/_fixtures/staged_dockerfile_run_mount/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/staged_dockerfile_run_mount/state0/werf.yaml
@@ -1,0 +1,7 @@
+project: werf-test-e2e-build-staged-dockerfile-run-mount
+configVersion: 1
+
+---
+image: app
+dockerfile: Dockerfile
+staged: true

--- a/test/e2e/build/_fixtures/staged_dockerfile_run_mount/state1/Dockerfile
+++ b/test/e2e/build/_fixtures/staged_dockerfile_run_mount/state1/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.werf.io/base/ubuntu:22.04 AS os
+RUN mkdir /apk && echo pkg-v1 > /apk/pkg.txt
+
+FROM registry.werf.io/base/ubuntu:22.04
+RUN --mount=type=bind,from=os,source=/apk,target=/apk cat /apk/pkg.txt > /result && echo run-v2

--- a/test/e2e/build/_fixtures/staged_dockerfile_run_mount/state1/werf.yaml
+++ b/test/e2e/build/_fixtures/staged_dockerfile_run_mount/state1/werf.yaml
@@ -1,0 +1,7 @@
+project: werf-test-e2e-build-staged-dockerfile-run-mount
+configVersion: 1
+
+---
+image: app
+dockerfile: Dockerfile
+staged: true

--- a/test/e2e/build/staged_dockerfile_run_mount_test.go
+++ b/test/e2e/build/staged_dockerfile_run_mount_test.go
@@ -1,0 +1,59 @@
+package e2e_build_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/werf/v2/test/pkg/contback"
+	"github.com/werf/werf/v2/test/pkg/suite_init"
+	"github.com/werf/werf/v2/test/pkg/werf"
+)
+
+type stagedDockerfileRunMountTestOptions struct {
+	setupEnvOptions
+}
+
+var _ = Describe("Staged Dockerfile build with RUN --mount from stage", Label("e2e", "build", "staged_dockerfile_run_mount"), func() {
+	DescribeTable("should pull the mount source stage missing in the local containers storage",
+		func(ctx SpecContext, testOpts stagedDockerfileRunMountTestOptions) {
+			By("initializing")
+			setupEnv(testOpts.setupEnvOptions)
+			contRuntime, err := contback.NewContainerBackend(testOpts.ContainerBackendMode)
+			if err == contback.ErrRuntimeUnavailable {
+				Skip(err.Error())
+			} else if err != nil {
+				Fail(err.Error())
+			}
+			buildahRuntime, ok := contRuntime.(*contback.NativeBuildahBackend)
+			Expect(ok).To(BeTrue(), "test requires the native buildah backend")
+
+			repoDirname := "repo0"
+
+			By("state0: preparing test repo")
+			SuiteData.InitTestRepo(ctx, repoDirname, "staged_dockerfile_run_mount/state0")
+			werfProject := werf.NewProject(SuiteData.WerfBinPath, SuiteData.GetTestRepoPath(repoDirname))
+
+			By("state0: building images")
+			Expect(werfProject.Build(ctx, nil)).To(ContainSubstring("Building stage"))
+
+			By("state0: removing project images from the local containers storage")
+			buildahRuntime.RmiByRepoRef(ctx, suite_init.TestRepo(SuiteData.ProjectName))
+
+			By("state1: changing the final stage only")
+			SuiteData.UpdateTestRepo(ctx, repoDirname, "staged_dockerfile_run_mount/state1")
+
+			By("state1: rebuilding with the mount source stage present only in repo")
+			buildOut := werfProject.Build(ctx, nil)
+			Expect(buildOut).To(ContainSubstring("Use previously built image"))
+			Expect(buildOut).To(ContainSubstring("Building stage"))
+		},
+		Entry("with local repo using Native Buildah with rootless isolation", stagedDockerfileRunMountTestOptions{setupEnvOptions{
+			ContainerBackendMode: "native-rootless",
+			WithLocalRepo:        true,
+		}}),
+		Entry("with local repo using Native Buildah with chroot isolation", stagedDockerfileRunMountTestOptions{setupEnvOptions{
+			ContainerBackendMode: "native-chroot",
+			WithLocalRepo:        true,
+		}}),
+	)
+})

--- a/test/pkg/buildahstub/stub.go
+++ b/test/pkg/buildahstub/stub.go
@@ -15,8 +15,10 @@ type BuildahStub struct {
 	callsMutex        sync.Mutex
 	FromCommandFunc   func(ctx context.Context, container, image string, opts buildah.FromCommandOpts) (string, error)
 	PullFunc          func(ctx context.Context, ref string, opts buildah.PullOpts) (string, error)
+	InspectFunc       func(ctx context.Context, ref string) (*thirdparty.BuilderInfo, error)
 	FromCommandImages []string
 	PullRefs          []string
+	InspectRefs       []string
 }
 
 var _ buildah.Buildah = (*BuildahStub)(nil)
@@ -71,7 +73,14 @@ func (b *BuildahStub) Pull(ctx context.Context, ref string, opts buildah.PullOpt
 	return "", nil
 }
 
-func (b *BuildahStub) Inspect(context.Context, string) (*thirdparty.BuilderInfo, error) {
+func (b *BuildahStub) Inspect(ctx context.Context, ref string) (*thirdparty.BuilderInfo, error) {
+	b.callsMutex.Lock()
+	b.InspectRefs = append(b.InspectRefs, ref)
+	b.callsMutex.Unlock()
+
+	if b.InspectFunc != nil {
+		return b.InspectFunc(ctx, ref)
+	}
 	return nil, nil
 }
 

--- a/test/pkg/contback/buildah.go
+++ b/test/pkg/contback/buildah.go
@@ -3,6 +3,7 @@ package contback
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	. "github.com/onsi/gomega"
 
@@ -60,6 +61,20 @@ func (r *NativeBuildahBackend) Pull(ctx context.Context, image string) {
 	args := r.CommonCliArgs
 	args = append(args, "pull", "--tls-verify=false", image)
 	utils.RunSucceedCommand(ctx, "/", "buildah", args...)
+}
+
+// RmiByRepoRef removes every local image tagged under repoRef from the containers storage.
+func (r *NativeBuildahBackend) RmiByRepoRef(ctx context.Context, repoRef string) {
+	listArgs := append(append([]string{}, r.CommonCliArgs...), "images", "--format", "{{.Name}}:{{.Tag}}")
+	output := utils.SucceedCommandOutputString(ctx, "/", "buildah", listArgs...)
+
+	for _, ref := range strings.Fields(output) {
+		if !strings.HasPrefix(ref, repoRef+":") {
+			continue
+		}
+		rmiArgs := append(append([]string{}, r.CommonCliArgs...), "rmi", "--force", ref)
+		utils.RunSucceedCommand(ctx, "/", "buildah", rmiArgs...)
+	}
 }
 
 func (r *NativeBuildahBackend) GetImageInspect(ctx context.Context, image string) DockerImageInspect {


### PR DESCRIPTION
## Summary

With the Buildah backend a staged Dockerfile build fails with `resolving mountpoints for container ...: <stage tag>: image not known` when a `RUN --mount=from=<stage>` instruction references a stage werf found up-to-date in the stages storage. It needs a pre-existing host state: the referenced stage image exists in the repo but not in the host's local containers storage (fresh runner, or host cleanup between runs):

```shell
# werf.yaml: staged: true Dockerfile image; Dockerfile:
#   FROM alpine AS os
#   RUN mkdir /apk && apk fetch --no-cache -o /apk make
#   FROM alpine
#   RUN --mount=type=bind,from=os,source=/apk,target=/apk ls /apk
werf build --repo $REPO        # everything built and pushed
buildah rmi --all --force      # local storage cleaned
# invalidate only the final RUN, commit
werf build --repo $REPO        # os is "previously built"; RUN fails: image not known
```

## What

- A Dockerfile stage whose `RUN --mount=from=...` source image is missing from local containers storage now pulls it by ref before running the instruction, instead of failing with `resolving mountpoints for container ...: image not known`. Covered end-to-end by the new `staged_dockerfile_run_mount` e2e spec (build to repo → remove project images from local storage → invalidate only the final stage → rebuild); also VERIFIED by hand on a Linux host against fresh `main` (see comment).
- An image already present locally is not re-pulled and the registry is not contacted for it; parallel stage builds referencing the same missing image pull it once — the loser of the pull lock re-checks local storage instead of pulling again.
- A locally present mount-source image that does not match the target platform fails the build with `local image ... has platform ..., but target platform is ...` — the same check base images already get.
- A failed pull fails the build with `unable to ensure local image for run mount ...`.
- Deliberately unchanged: `COPY --from` (its source container is created with pull-if-missing) and stapel `import`/`dependencies` (pulled via container creation) — only the run-mount path lacked the pull.

## Why

werf rewrites `--mount from=<stage>` to the stage's registry tag and drives buildah's `builder.Run` directly, bypassing buildah's imagebuildah executor that pre-mounts stage images for its own builds. Buildah resolves run-mount `from=` images against local containers storage only and never pulls them. #7669 added the missing-image fallback only to the base-image path (`FromCommand`), so a host where a previously built stage exists only in the repo kept failing on run mounts.
