### PR TITLE
fix(build): stop losing host image locks taken by parallel image builds

### DIFF
--- a/pkg/storage/manager/storage_manager.go
+++ b/pkg/storage/manager/storage_manager.go
@@ -194,7 +194,8 @@ type StorageManager struct {
 	SecondaryStagesStorageList []storage.StagesStorage
 
 	// These will be released automatically when current process exits
-	SharedHostImagesLocks []lockgate.LockHandle
+	SharedHostImagesLocks   []lockgate.LockHandle
+	sharedHostImagesLocksMu sync.Mutex
 
 	FinalStagesListCacheMux sync.Mutex
 	FinalStagesListCache    *StagesList
@@ -380,9 +381,15 @@ func (m *StorageManager) LockStageImage(ctx context.Context, imageName string) e
 		return fmt.Errorf("error locking %q shared lock: %w", imageLockName, err)
 	}
 
-	m.SharedHostImagesLocks = append(m.SharedHostImagesLocks, l)
+	m.addSharedHostImageLock(l)
 
 	return nil
+}
+
+func (m *StorageManager) addSharedHostImageLock(lock lockgate.LockHandle) {
+	m.sharedHostImagesLocksMu.Lock()
+	defer m.sharedHostImagesLocksMu.Unlock()
+	m.SharedHostImagesLocks = append(m.SharedHostImagesLocks, lock)
 }
 
 func doFetchStage(ctx context.Context, projectName string, stagesStorage storage.StagesStorage, stageID image.StageID, img container_backend.LegacyImageInterface) error {

--- a/pkg/storage/manager/storage_manager_locks_test.go
+++ b/pkg/storage/manager/storage_manager_locks_test.go
@@ -1,0 +1,31 @@
+package manager
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/lockgate"
+)
+
+var _ = Describe("StorageManager shared host image locks", func() {
+	It("keeps every lock taken by concurrent image builds", func() {
+		const goroutines = 50
+
+		m := &StorageManager{}
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				m.addSharedHostImageLock(lockgate.LockHandle{})
+			}()
+		}
+		wg.Wait()
+
+		Expect(m.SharedHostImagesLocks).To(HaveLen(goroutines))
+	})
+})


### PR DESCRIPTION
## Summary

`StorageManager.SharedHostImagesLocks` is appended to from every image build that fetches a stage, and image builds run in parallel, so the appends race. A lost append drops a lock handle the process still depends on: automatic host cleanup run by a concurrent werf skips only locked stage images, so an unlocked one can be deleted while a build is using it as a base image.

## What

- Host image locks taken by parallel image builds are all retained; before, concurrent appends could drop one.
- No user-visible surface changes: no flag, log line or error text is added or altered.
- The race is on the slice header only. A dropped handle does not release the underlying host lock early — it stops the manager from tracking it, which matters for a lock the process holds until it exits.

## Why

`LockStageImage` is reached from `BuildPhase.fetchBaseImageForStage` for the parent of every stage, and `Conveyor.doImagesInParallel` runs those builds concurrently, so the unsynchronized `append` in it is a plain data race on the slice header.

The append now lives in `addSharedHostImageLock`, so the locking is in one place and the race is testable without standing up a host locker.