### PR TITLE
fix(build): include build cache version in anchor digest

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -927,6 +927,7 @@ func (phase *BuildPhase) fetchBaseImageForStage(ctx context.Context, img *image.
 func (phase *BuildPhase) calculateStage(ctx context.Context, img *image.Image, stg stage.Interface) (bool, cleanup.Func, error) {
 	var opts calculateDigestOptions
 	opts.TargetPlatform = img.TargetPlatform
+	opts.BuildCacheVersion = imagePkg.BuildCacheVersion
 
 	var stageDependencies string
 	var prevNonEmptyStage stage.Interface
@@ -997,7 +998,10 @@ func (phase *BuildPhase) calculateStage(ctx context.Context, img *image.Image, s
 			panic(fmt.Sprintf("expected stage %q content digest label to be set!", stg.Name()))
 		}
 	} else {
-		stageContentSig, err = calculateDigest(ctx, fmt.Sprintf("%s-content", stg.Name()), "", stg, phase.Conveyor, calculateDigestOptions{TargetPlatform: img.TargetPlatform})
+		stageContentSig, err = calculateDigest(ctx, fmt.Sprintf("%s-content", stg.Name()), "", stg, phase.Conveyor, calculateDigestOptions{
+			TargetPlatform:    img.TargetPlatform,
+			BuildCacheVersion: imagePkg.BuildCacheVersion,
+		})
 		if err != nil {
 			return false, phase.Conveyor.GetStageDigestMutex(stg.GetDigest()).Unlock, fmt.Errorf("unable to calculate stage %s content digest: %w", stg.Name(), err)
 		}
@@ -1281,17 +1285,18 @@ func introspectStage(ctx context.Context, s stage.Interface) error {
 }
 
 type calculateDigestOptions struct {
-	TargetPlatform string
-	BaseImage      string
+	TargetPlatform    string
+	BuildCacheVersion string
+	BaseImage         string
 	// Anchor switches calculateDigest to the anchor path:
-	// Sha3_224(TargetPlatform, HolisticInputs...).
+	// Sha3_224(BuildCacheVersion, TargetPlatform, HolisticInputs...).
 	Anchor         bool
 	HolisticInputs []string
 }
 
 func calculateDigest(ctx context.Context, stageName, stageDependencies string, prevNonEmptyStage stage.Interface, conveyor *Conveyor, opts calculateDigestOptions) (string, error) {
 	if opts.Anchor {
-		args := []string{opts.TargetPlatform}
+		args := []string{opts.BuildCacheVersion, opts.TargetPlatform}
 		for _, s := range opts.HolisticInputs {
 			if s == "" {
 				continue
@@ -1315,7 +1320,7 @@ func calculateDigest(ctx context.Context, stageName, stageDependencies string, p
 		checksumArgsNames = append(checksumArgsNames, "TargetPlatform")
 	}
 
-	checksumArgs = append(checksumArgs, imagePkg.BuildCacheVersion, stageName, stageDependencies)
+	checksumArgs = append(checksumArgs, opts.BuildCacheVersion, stageName, stageDependencies)
 	checksumArgsNames = append(checksumArgsNames,
 		"BuildCacheVersion",
 		"StageName",

--- a/pkg/build/content_digest_test.go
+++ b/pkg/build/content_digest_test.go
@@ -81,21 +81,6 @@ var _ = Describe("anchor holistic digest", func() {
 		Expect(anchorDigestWithOptions(changed)).NotTo(Equal(anchorDigestWithOptions(base)))
 	})
 
-	It("changes when the build cache version changes", func() {
-		base := calculateDigestOptions{
-			BuildCacheVersion: "cache-v1",
-			TargetPlatform:    targetPlatform,
-			Anchor:            true,
-			HolisticInputs:    []string{"from-digest"},
-		}
-
-		Expect(anchorDigestWithOptions(base)).To(Equal(anchorDigestWithOptions(base)))
-
-		changed := base
-		changed.BuildCacheVersion = "cache-v2"
-		Expect(anchorDigestWithOptions(changed)).NotTo(Equal(anchorDigestWithOptions(base)))
-	})
-
 	It("changes when the target platform changes", func() {
 		deps := []string{"from-digest", "git-archive-digest"}
 		Expect(anchorDigest("linux/amd64", deps)).

--- a/pkg/build/content_digest_test.go
+++ b/pkg/build/content_digest_test.go
@@ -5,15 +5,18 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	imagePkg "github.com/werf/werf/v2/pkg/image"
 )
 
 // anchorDigest is a thin wrapper that exercises the anchor branch of
 // calculateDigest: pass HolisticInputs, get the platform-scoped hash.
 func anchorDigest(targetPlatform string, deps []string) string {
 	return anchorDigestWithOptions(calculateDigestOptions{
-		TargetPlatform: targetPlatform,
-		Anchor:         true,
-		HolisticInputs: deps,
+		BuildCacheVersion: imagePkg.BuildCacheVersion,
+		TargetPlatform:    targetPlatform,
+		Anchor:            true,
+		HolisticInputs:    deps,
 	})
 }
 
@@ -67,6 +70,21 @@ var _ = Describe("anchor holistic digest", func() {
 		base := calculateDigestOptions{
 			TargetPlatform:    targetPlatform,
 			BuildCacheVersion: "cache-v1",
+			Anchor:            true,
+			HolisticInputs:    []string{"from-digest"},
+		}
+
+		Expect(anchorDigestWithOptions(base)).To(Equal(anchorDigestWithOptions(base)))
+
+		changed := base
+		changed.BuildCacheVersion = "cache-v2"
+		Expect(anchorDigestWithOptions(changed)).NotTo(Equal(anchorDigestWithOptions(base)))
+	})
+
+	It("changes when the build cache version changes", func() {
+		base := calculateDigestOptions{
+			BuildCacheVersion: "cache-v1",
+			TargetPlatform:    targetPlatform,
 			Anchor:            true,
 			HolisticInputs:    []string{"from-digest"},
 		}

--- a/pkg/build/content_digest_test.go
+++ b/pkg/build/content_digest_test.go
@@ -10,11 +10,15 @@ import (
 // anchorDigest is a thin wrapper that exercises the anchor branch of
 // calculateDigest: pass HolisticInputs, get the platform-scoped hash.
 func anchorDigest(targetPlatform string, deps []string) string {
-	d, err := calculateDigest(context.Background(), "anchor", "", nil, nil, calculateDigestOptions{
+	return anchorDigestWithOptions(calculateDigestOptions{
 		TargetPlatform: targetPlatform,
 		Anchor:         true,
 		HolisticInputs: deps,
 	})
+}
+
+func anchorDigestWithOptions(opts calculateDigestOptions) string {
+	d, err := calculateDigest(context.Background(), "anchor", "", nil, nil, opts)
 	if err != nil {
 		panic(err)
 	}
@@ -57,6 +61,21 @@ var _ = Describe("anchor holistic digest", func() {
 	It("changes when a contributing stage changes", func() {
 		Expect(anchorDigest(targetPlatform, []string{"from-digest", "git-archive-v1"})).
 			NotTo(Equal(anchorDigest(targetPlatform, []string{"from-digest", "git-archive-v2"})))
+	})
+
+	It("changes when the explicitly supplied build cache version changes", func() {
+		base := calculateDigestOptions{
+			TargetPlatform:    targetPlatform,
+			BuildCacheVersion: "cache-v1",
+			Anchor:            true,
+			HolisticInputs:    []string{"from-digest"},
+		}
+
+		Expect(anchorDigestWithOptions(base)).To(Equal(anchorDigestWithOptions(base)))
+
+		changed := base
+		changed.BuildCacheVersion = "cache-v2"
+		Expect(anchorDigestWithOptions(changed)).NotTo(Equal(anchorDigestWithOptions(base)))
 	})
 
 	It("changes when the target platform changes", func() {

--- a/test/legacy_e2e/suites/build/dockerfile_image/context_test.go
+++ b/test/legacy_e2e/suites/build/dockerfile_image/context_test.go
@@ -59,7 +59,7 @@ var _ = Describe("context", func() {
 				utils.RunSucceedCommand(ctx, SuiteData.WerfRepoWorktreeDir, "git", "add", "werf.yaml", ".dockerignore", "Dockerfile")
 				utils.RunSucceedCommand(ctx, SuiteData.WerfRepoWorktreeDir, "git", "commit", "-m", "+")
 			},
-			expectedDigest: "cfd0121a39722eb3a9f45e91ea0535ec121cb15128540fd4337d880d",
+			expectedDigest: "44c6c1a7428c84ddbf4d963f12e49f1d3b22b563fc4c3e92bfd5f2f7",
 		}),
 		Entry("file from contextAddFile added to context", entry{
 			prepareFixturesFunc: func(ctx SpecContext) {
@@ -68,7 +68,7 @@ var _ = Describe("context", func() {
 				utils.RunSucceedCommand(ctx, SuiteData.WerfRepoWorktreeDir, "git", "add", "werf.yaml", "werf-giterminism.yaml", ".dockerignore", "Dockerfile")
 				utils.RunSucceedCommand(ctx, SuiteData.WerfRepoWorktreeDir, "git", "commit", "-m", "+")
 			},
-			expectedDigest: "f5b05959538394c8efa45be592d98cdccf34535beaacffc28df82d4c",
+			expectedDigest: "edd4ea1e135074302c19c756ba4230ee18c59b52c1c5c7d994e11c2e",
 		}),
 		Entry("symlinks from contextAddFiles added to context as is", entry{
 			prepareFixturesFunc: func(ctx SpecContext) {
@@ -77,7 +77,7 @@ var _ = Describe("context", func() {
 				utils.RunSucceedCommand(ctx, SuiteData.WerfRepoWorktreeDir, "git", "add", "werf.yaml", "werf-giterminism.yaml", ".dockerignore", "Dockerfile")
 				utils.RunSucceedCommand(ctx, SuiteData.WerfRepoWorktreeDir, "git", "commit", "-m", "+")
 			},
-			expectedDigest: "c4f00158d62efd73f700511e860bae19d6eaa8dfe8c2f93ebecff626",
+			expectedDigest: "aa446554dc9cb114239e63af470685b8b03ad68375a143552bd2be44",
 		}),
 		Entry("dir from contextAddFiles added to context", entry{
 			prepareFixturesFunc: func(ctx SpecContext) {
@@ -86,7 +86,7 @@ var _ = Describe("context", func() {
 				utils.RunSucceedCommand(ctx, SuiteData.WerfRepoWorktreeDir, "git", "add", "werf.yaml", "werf-giterminism.yaml", ".dockerignore", "Dockerfile")
 				utils.RunSucceedCommand(ctx, SuiteData.WerfRepoWorktreeDir, "git", "commit", "-m", "+")
 			},
-			expectedDigest: "64751fd93aa7b8ed2991a9812cdd67fa6bf45d6059785ae8ef19e116",
+			expectedDigest: "be6c378e5683b87cd7a07b8ec4baa1c1ef322131ed1aa32f0525c43f",
 		}),
 		Entry("specified files from dir allowed in allowContextAddFiles added to context", entry{
 			prepareFixturesFunc: func(ctx SpecContext) {
@@ -95,7 +95,7 @@ var _ = Describe("context", func() {
 				utils.RunSucceedCommand(ctx, SuiteData.WerfRepoWorktreeDir, "git", "add", "werf.yaml", "werf-giterminism.yaml", ".dockerignore", "Dockerfile")
 				utils.RunSucceedCommand(ctx, SuiteData.WerfRepoWorktreeDir, "git", "commit", "-m", "+")
 			},
-			expectedDigest: "4bc78bce84c4726410b2b2addb1a66a9bcd3b340a9d7be43200bd125",
+			expectedDigest: "b1c1af0277619594117b9885e6b07df6e2229529fc7127fd055c45fd",
 		}),
 	)
 })


### PR DESCRIPTION
Ensure stage and anchor digests invalidate when the cache version changes,
rather than relying on a hardcoded global value or omitting it from anchor
inputs.