### PR TITLE
fix(bundle): drop the publisher's release channel from published bundles

### DIFF
--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -310,8 +310,6 @@ func runPublish(ctx context.Context, imageNameListFromArgs []string) error {
 		return fmt.Errorf("get user extra annotations: %w", err)
 	} else {
 		for key, value := range annos {
-			// The release channel of the werf that publishes the bundle says nothing about
-			// the werf that applies it, so it must not be baked into the bundle.
 			if key == "werf.io/release-channel" {
 				continue
 			}

--- a/cmd/werf/bundle/publish/publish.go
+++ b/cmd/werf/bundle/publish/publish.go
@@ -310,9 +310,14 @@ func runPublish(ctx context.Context, imageNameListFromArgs []string) error {
 		return fmt.Errorf("get user extra annotations: %w", err)
 	} else {
 		for key, value := range annos {
+			// The release channel of the werf that publishes the bundle says nothing about
+			// the werf that applies it, so it must not be baked into the bundle.
+			if key == "werf.io/release-channel" {
+				continue
+			}
+
 			if strings.HasPrefix(key, "project.werf.io/") ||
-				strings.Contains(key, "ci.werf.io/") ||
-				key == "werf.io/release-channel" {
+				strings.Contains(key, "ci.werf.io/") {
 				serviceAnnotations[key] = value
 			} else {
 				extraAnnotations[key] = value


### PR DESCRIPTION
## Summary

`werf bundle publish` no longer stores `werf.io/release-channel` in the bundle. Previously the channel of the publishing werf — exported by `werf ci-env` as `WERF_ADD_ANNOTATION_WERF_RELEASE_CHANNEL` from `TRDL_USE_WERF_GROUP_CHANNEL` — was written into the bundle's `extra_annotations.json` and then stamped on every resource deployed from that bundle, describing a binary that had no part in the deployment.

## What

- BREAKING: resources deployed from a bundle published by this version carry no `werf.io/release-channel` unless the applying werf is given one; anyone selecting or reporting on that annotation over bundle-deployed resources sees it disappear. The way out is passing `--add-annotation=werf.io/release-channel=<channel>` (or letting `werf ci-env` export it) on the apply side, where it names the werf that actually deploys.
- When `--add-annotation=werf.io/release-channel=<channel>` is passed to `werf bundle publish`, the annotation is dropped: it reaches neither the service nor the extra annotations of the bundle. No warning is emitted and the exit code is unchanged.
- Every other annotation keeps its current classification: `project.werf.io/*` and `*ci.werf.io/*` stay service annotations, anything else stays an extra annotation, and `project.werf.io/name` and `project.werf.io/env` are still set from `werf.yaml` and `--env`.
- VERIFIED: publishing the same project with a binary built before and after this change, then unpacking the chart layer from a local `registry:2`, differs by exactly this one key in `extra_annotations.json`.
- `werf bundle apply`, `bundle plan` and `bundle render` do not change: they still read the channel from `--add-annotation` and from the `WERF_ADD_ANNOTATION_*` variables, and a bundle published by an earlier werf still renders the channel stored in it.
- `werf.io/version` does not change either — `werf bundle publish` never wrote it, and the applying werf still sets it to its own version.

## Why

The release channel is a property of a werf binary, not of a chart. Baking the publisher's channel into the artifact makes it outlive the process it described: a bundle published from a `stable` pipeline reported `werf.io/release-channel: stable` on resources deployed by an `alpha` werf, or by one with no channel at all, so the annotation could not be trusted for the question it exists to answer. `werf/nelm` already holds this view — `werf.io/release-channel` sits in `CleanWerfIoRuntimeAnnos` and is stripped before resources are compared (`pkg/resource/spec/unstruct.go`), so the value was never part of the desired state anyway.

Dropping the key from the service-annotation condition alone would not have worked: the annotation would have fallen through to `extraAnnotations` and still reached the bundle, which is why it is skipped before classification.
