### PR TITLE
fix(build, buildah): stop repeating stage output in the final build error

### DIFF
--- a/pkg/buildah/native_linux.go
+++ b/pkg/buildah/native_linux.go
@@ -454,19 +454,13 @@ func (b *NativeBuildah) BuildFromDockerfile(ctx context.Context, dockerfile stri
 		buildOpts.NoCache = true
 	}
 
-	errLog := &bytes.Buffer{}
-	if opts.LogWriter != nil {
-		buildOpts.Out = opts.LogWriter
-		buildOpts.Err = io.MultiWriter(opts.LogWriter, errLog)
-	} else {
-		buildOpts.Err = errLog
-	}
-
+	var stderrBuf *bytes.Buffer
+	buildOpts.Out, buildOpts.Err, stderrBuf = generateStdoutStderr(opts.LogWriter)
 	buildOpts.ContextDirectory = opts.ContextDir
 
 	imageId, _, err := imagebuildah.BuildDockerfiles(ctx, b.Store, buildOpts, dockerfile)
 	if err != nil {
-		return "", fmt.Errorf("unable to build Dockerfile %q:\n%s\n%w", dockerfile, errLog.String(), err)
+		return "", wrapStderrError(fmt.Sprintf("unable to build Dockerfile %q", dockerfile), stderrBuf, err)
 	}
 
 	return imageId, nil
@@ -544,7 +538,7 @@ func (b *NativeBuildah) RunCommand(ctx context.Context, container string, comman
 	}
 
 	if err := builder.Run(command, runOpts); err != nil {
-		return fmt.Errorf("RunCommand failed:\n%s\n%w", stderrBuf.String(), err)
+		return wrapStderrError("RunCommand failed", stderrBuf, err)
 	}
 
 	return nil
@@ -1412,16 +1406,25 @@ func generateContextDir(rawContextDir string, runMounts []*instructions.Mount) s
 	return contextDir
 }
 
-func generateStdoutStderr(optionalLogWriter io.Writer) (stdout, stderr io.Writer, stderrBuf *bytes.Buffer) {
-	stderrBuf = &bytes.Buffer{}
+// Stderr is captured into the buffer only when nothing else receives it, so the
+// returned errors do not repeat output already streamed to the log. The caller
+// passes nil when nothing would be shown, so stdout is dropped instead of leaking
+// to the process stdout as buildah does for a nil writer.
+func generateStdoutStderr(optionalLogWriter io.Writer) (io.Writer, io.Writer, *bytes.Buffer) {
+	stderrBuf := &bytes.Buffer{}
 	if optionalLogWriter != nil {
-		stdout = optionalLogWriter
-		stderr = io.MultiWriter(optionalLogWriter, stderrBuf)
-	} else {
-		stderr = stderrBuf
+		return optionalLogWriter, optionalLogWriter, stderrBuf
 	}
 
-	return stdout, stderr, stderrBuf
+	return io.Discard, stderrBuf, stderrBuf
+}
+
+func wrapStderrError(msg string, stderrBuf *bytes.Buffer, err error) error {
+	if stderrBuf.Len() == 0 {
+		return fmt.Errorf("%s: %w", msg, err)
+	}
+
+	return fmt.Errorf("%s:\n%s\n%w", msg, stderrBuf.String(), err)
 }
 
 func prependShellToCommand(prependShell bool, shell, command []string, builder *buildah.Builder) []string {

--- a/pkg/buildah/native_linux_test.go
+++ b/pkg/buildah/native_linux_test.go
@@ -1,7 +1,11 @@
 package buildah
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -680,6 +684,30 @@ location = "dropin-mirror.example.com"
 			result, err := GetRegistryMirrorsFromConfig(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainElement("https://dropin-mirror.example.com"))
+		})
+	})
+
+	Describe("stderr handling", func() {
+		It("should stream stderr to the log writer without keeping a copy for the error", func() {
+			logWriter := &bytes.Buffer{}
+			stdout, stderr, stderrBuf := generateStdoutStderr(logWriter)
+			fmt.Fprint(stdout, "out\n")
+			fmt.Fprint(stderr, "MARKER-STDERR-LINE\n")
+
+			Expect(logWriter.String()).To(Equal("out\nMARKER-STDERR-LINE\n"))
+			Expect(stderrBuf.Len()).To(BeZero())
+
+			err := wrapStderrError("RunCommand failed", stderrBuf, errors.New("exit status 1"))
+			Expect(err.Error()).To(Equal("RunCommand failed: exit status 1"))
+		})
+
+		It("should keep stderr for the error and drop stdout when there is no log writer", func() {
+			stdout, stderr, stderrBuf := generateStdoutStderr(nil)
+			Expect(stdout).To(Equal(io.Discard))
+			fmt.Fprint(stderr, "MARKER-STDERR-LINE\n")
+
+			err := wrapStderrError("RunCommand failed", stderrBuf, errors.New("exit status 1"))
+			Expect(err.Error()).To(Equal("RunCommand failed:\nMARKER-STDERR-LINE\n\nexit status 1"))
 		})
 	})
 })

--- a/pkg/container_backend/buildah_backend.go
+++ b/pkg/container_backend/buildah_backend.go
@@ -141,7 +141,7 @@ func (backend *BuildahBackend) getBuildahCommonOpts(ctx context.Context, suppres
 	if !suppressLog {
 		if logWriterOverride != nil {
 			opts.LogWriter = logWriterOverride
-		} else {
+		} else if logboek.Context(ctx).Default().IsAccepted() {
 			opts.LogWriter = logboek.Context(ctx).OutStream()
 		}
 	}

--- a/pkg/container_backend/buildah_backend_test.go
+++ b/pkg/container_backend/buildah_backend_test.go
@@ -1,10 +1,12 @@
 package container_backend
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -15,10 +17,36 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/werf/logboek"
+	"github.com/werf/logboek/pkg/level"
 	"github.com/werf/werf/v2/pkg/buildah"
 	"github.com/werf/werf/v2/pkg/buildah/thirdparty"
 	"github.com/werf/werf/v2/test/pkg/buildahstub"
 )
+
+var _ = Describe("BuildahBackend getBuildahCommonOpts", func() {
+	newCtx := func(lvl level.Level) context.Context {
+		logger := logboek.NewLogger(io.Discard, io.Discard)
+		logger.SetAcceptedLevel(lvl)
+		return logboek.NewContext(context.Background(), logger)
+	}
+
+	It("passes the log stream when the default level is shown", func() {
+		opts := (&BuildahBackend{}).getBuildahCommonOpts(newCtx(level.Default), false, nil, "")
+		Expect(opts.LogWriter).NotTo(BeNil())
+	})
+
+	It("passes no log writer under --log-quiet so stderr reaches the error", func() {
+		opts := (&BuildahBackend{}).getBuildahCommonOpts(newCtx(level.Error), false, nil, "")
+		Expect(opts.LogWriter).To(BeNil())
+	})
+
+	It("keeps an explicit override regardless of level", func() {
+		override := &bytes.Buffer{}
+		opts := (&BuildahBackend{}).getBuildahCommonOpts(newCtx(level.Error), false, override, "")
+		Expect(opts.LogWriter).To(BeIdenticalTo(override))
+	})
+})
 
 var _ = Describe("BuildahBackend pulledImageIDs", func() {
 	var backend *BuildahBackend


### PR DESCRIPTION
## Summary

When a stapel stage command or a Dockerfile `RUN` step fails under the Buildah backend, the final `Error:` line repeats the whole stderr of the stage that was already printed in the stage log, so a failing step shows its output twice. The Docker backend reports only the exit status. Reproduces from a clean checkout:

```yaml
project: stderrtest
configVersion: 1
---
image: app
from: alpine:3.20
shell:
  install:
  - echo MARKER-STDOUT-LINE
  - echo MARKER-STDERR-LINE >&2
  - exit 1
```

```sh
WERF_BUILDAH_MODE=auto werf build
```

The same happens with `dockerfile: Dockerfile` and `RUN echo MARKER-STDERR-LINE >&2 && exit 1`.

## What

- A failed stapel stage command under the Buildah backend ends with `unable to run commands script: RunCommand failed: exit status 1` and no stage output in the error; the stage log above it is unchanged. VERIFIED: on a Linux host with buildah 1.23.1, chroot isolation, before/after the patch.
- A failed `RUN` step in a Dockerfile image under the Buildah backend ends with `unable to build Dockerfile "...": building at STEP "RUN ...": exit status 1` and no stage output in the error. VERIFIED: same host, before/after.
- Under `--log-quiet` the stage stderr is still embedded in the final error for both stapel and Dockerfile builds, as on `main`, and the stage stdout is not printed anywhere. VERIFIED: same host, both repros with `--log-quiet`.
- The stage log still shows `subprocess exited with status 1` twice. This is printed by buildah itself for chroot isolation, once per level of its reexec chain; werf only relays the container stderr, and this PR does not change it.
- When a Buildah command or Dockerfile build runs without a log writer, its stderr is still embedded in the returned error, so output is never dropped.

## Why

Both `RunCommand` and `BuildFromDockerfile` sent stderr to the stage log writer and to a buffer, then appended that buffer to the error unconditionally. The buffer only carries information when nothing else receives the stream; with a log writer present it is a second copy that reaches the top-level error and makes the Buildah backend noisier than the Docker one for the same failure. Capturing into the buffer only when no log writer is set removes the duplication without losing output on the log-less paths.

`pkg/buildah` cannot tell a visible writer from a discarding one: under `--log-quiet` the logboek stream it receives is a level-bound proxy that swallows writes, so "a writer exists" would silently mean "nothing is shown" and the stderr would vanish from both the log and the error. The backend therefore passes a log writer only when logboek's default level is shown; the alternative of probing the writer inside `pkg/buildah` would tie it to logboek internals. With no log writer, stdout goes to `io.Discard` rather than nil, because buildah substitutes the process stdout for a nil writer and quiet builds would start printing stage output.
