### PR TITLE
feat(build): support from in image dependencies

### DIFF
--- a/docs/_data/werf_yaml.yml
+++ b/docs/_data/werf_yaml.yml
@@ -359,11 +359,16 @@ sections:
         collapsible: true
         isCollapsedByDefault: false
         directiveList:
-          - name: image
+          - name: from
             value: "string"
             description:
               en: "Dependency image name, which should be built before building current image"
               ru: "Имя зависимого образа, который должен быть собран до сборки текущего образа"
+          - name: image
+            value: "string"
+            description:
+              en: "Dependency image name, which should be built before building current image (DEPRECATED, use from)"
+              ru: "Имя зависимого образа, который должен быть собран до сборки текущего образа (DEPRECATED, используйте from)"
           - name: imports
             description:
               en: "Define target build args to import image information into current image (optional)"
@@ -1048,11 +1053,16 @@ sections:
         collapsible: true
         isCollapsedByDefault: false
         directiveList:
-          - name: image
+          - name: from
             value: "string"
             description:
               en: "Dependency image name, which should be built before building current image"
               ru: "Имя зависимого образа, который должен быть собран до сборки текущего образа"
+          - name: image
+            value: "string"
+            description:
+              en: "Dependency image name, which should be built before building current image (DEPRECATED, use from)"
+              ru: "Имя зависимого образа, который должен быть собран до сборки текущего образа (DEPRECATED, используйте from)"
           - name: before
             value: "string"
             description:

--- a/pkg/config/raw_dependency.go
+++ b/pkg/config/raw_dependency.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 
+	"github.com/werf/werf/v2/pkg/util/option"
 	"github.com/werf/werf/v2/pkg/werf/global_warnings"
 )
 
@@ -63,16 +64,12 @@ func (d *rawDependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func (d *rawDependency) toDirective() (*Dependency, error) {
-	imageName := d.From
-	if imageName == "" {
-		imageName = d.Image
-		if d.Image != "" {
-			global_warnings.GlobalDeprecationWarningLn(context.Background(), "The `dependencies[].image` directive is deprecated and will be removed in v3. Please use `dependencies[].from` instead.")
-		}
+	if d.From == "" && d.Image != "" {
+		global_warnings.GlobalDeprecationWarningLn(context.Background(), "The `dependencies[].image` directive is deprecated and will be removed in v3. Please use `dependencies[].from` instead.")
 	}
 
 	dependency := &Dependency{
-		ImageName: imageName,
+		ImageName: d.imageName(),
 		Before:    d.Before,
 		After:     d.After,
 		raw:       d,
@@ -92,6 +89,10 @@ func (d *rawDependency) toDirective() (*Dependency, error) {
 	}
 
 	return dependency, nil
+}
+
+func (d *rawDependency) imageName() string {
+	return option.ValueOrDefault(d.From, d.Image)
 }
 
 func (d *rawDependency) imageType() dependencyImageType {

--- a/pkg/config/raw_dependency.go
+++ b/pkg/config/raw_dependency.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"context"
+
+	"github.com/werf/werf/v2/pkg/werf/global_warnings"
+)
+
 type dependencyImageType string
 
 var (
@@ -10,6 +16,7 @@ var (
 
 type rawDependency struct {
 	Image   string                 `yaml:"image,omitempty"`
+	From    string                 `yaml:"from,omitempty"`
 	Before  string                 `yaml:"before,omitempty"`
 	After   string                 `yaml:"after,omitempty"`
 	Imports []*rawDependencyImport `yaml:"imports,omitempty"`
@@ -56,8 +63,16 @@ func (d *rawDependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func (d *rawDependency) toDirective() (*Dependency, error) {
+	imageName := d.From
+	if imageName == "" {
+		imageName = d.Image
+		if d.Image != "" {
+			global_warnings.GlobalDeprecationWarningLn(context.Background(), "The `dependencies[].image` directive is deprecated and will be removed in v3. Please use `dependencies[].from` instead.")
+		}
+	}
+
 	dependency := &Dependency{
-		ImageName: d.Image,
+		ImageName: imageName,
 		Before:    d.Before,
 		After:     d.After,
 		raw:       d,

--- a/pkg/config/raw_image_from_dockerfile_test.go
+++ b/pkg/config/raw_image_from_dockerfile_test.go
@@ -108,6 +108,19 @@ var _ = Describe("rawImageFromDockerfile", func() {
 			}},
 		),
 		Entry(
+			"with from dependency",
+			map[string]interface{}{
+				"image":      "image1",
+				"dockerfile": "Dockerfile",
+				"dependencies": []map[string]interface{}{{
+					"from": "image2",
+				}},
+			},
+			[]*Dependency{{
+				ImageName: "image2",
+			}},
+		),
+		Entry(
 			"with ImageTag dependency",
 			map[string]interface{}{
 				"image":      "image1",

--- a/pkg/config/raw_image_from_dockerfile_test.go
+++ b/pkg/config/raw_image_from_dockerfile_test.go
@@ -121,6 +121,20 @@ var _ = Describe("rawImageFromDockerfile", func() {
 			}},
 		),
 		Entry(
+			"with from taking precedence over image dependency",
+			map[string]interface{}{
+				"image":      "image1",
+				"dockerfile": "Dockerfile",
+				"dependencies": []map[string]interface{}{{
+					"image": "image2",
+					"from":  "image3",
+				}},
+			},
+			[]*Dependency{{
+				ImageName: "image3",
+			}},
+		),
+		Entry(
 			"with ImageTag dependency",
 			map[string]interface{}{
 				"image":      "image1",

--- a/pkg/config/raw_stapel_image_test.go
+++ b/pkg/config/raw_stapel_image_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"bytes"
 	"context"
 	"errors"
 
@@ -10,7 +9,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/werf/common-go/pkg/util"
-	"github.com/werf/logboek"
 	"github.com/werf/werf/v2/pkg/werf/global_warnings"
 )
 
@@ -271,29 +269,35 @@ var _ = Describe("rawStapelImage", func() {
 		),
 	)
 
-	It("registers deprecation warning for image dependency", func() {
-		rawYaml, err := yaml.Marshal(map[string]interface{}{
-			"image": "image1",
-			"from":  "alpine",
-			"dependencies": []map[string]interface{}{{
-				"image":  "image2",
-				"before": "install",
-			}},
-		})
-		Expect(err).To(Succeed())
+	DescribeTable("dependency image deprecation warning",
+		func(dependency map[string]interface{}, expectedWarnings int) {
+			rawYaml, err := yaml.Marshal(map[string]interface{}{
+				"image":        "image1",
+				"from":         "alpine",
+				"dependencies": []map[string]interface{}{dependency},
+			})
+			Expect(err).To(Succeed())
 
-		doc := &doc{Content: rawYaml}
-		rawStapelImage := &rawStapelImage{doc: doc}
-		Expect(yaml.UnmarshalStrict(doc.Content, rawStapelImage)).To(Succeed())
+			doc := &doc{Content: rawYaml}
+			rawStapelImage := &rawStapelImage{doc: doc}
+			Expect(yaml.UnmarshalStrict(doc.Content, rawStapelImage)).To(Succeed())
 
-		_, err = rawStapelImage.toStapelImageDirective(giterminismManager, "image1")
-		Expect(err).To(Succeed())
+			ctx := context.Background()
+			warningsBefore := global_warnings.GlobalDeprecationWarnings(ctx)
 
-		var output bytes.Buffer
-		ctx := logboek.NewContext(context.Background(), logboek.NewLogger(&output, &output))
-		global_warnings.PrintGlobalWarnings(ctx)
-		Expect(output.String()).To(ContainSubstring("The `dependencies[].image` directive is deprecated and will be removed in v3. Please use `dependencies[].from` instead."))
-	})
+			_, err = rawStapelImage.toStapelImageDirective(giterminismManager, "image1")
+			Expect(err).To(Succeed())
+
+			newWarnings := global_warnings.GlobalDeprecationWarnings(ctx)[len(warningsBefore):]
+			Expect(newWarnings).To(HaveLen(expectedWarnings))
+			for _, warning := range newWarnings {
+				Expect(warning).To(Equal("The `dependencies[].image` directive is deprecated and will be removed in v3. Please use `dependencies[].from` instead."))
+			}
+		},
+		Entry("registered for image", map[string]interface{}{"image": "image2", "before": "install"}, 1),
+		Entry("not registered for from", map[string]interface{}{"from": "image2", "before": "install"}, 0),
+		Entry("not registered for from with image", map[string]interface{}{"image": "image2", "from": "image3", "before": "install"}, 0),
+	)
 
 	DescribeTable("unmarshal and convert to directive fail with configError",
 		func(yamlMap map[string]interface{}) {

--- a/pkg/config/raw_stapel_image_test.go
+++ b/pkg/config/raw_stapel_image_test.go
@@ -113,6 +113,37 @@ var _ = Describe("rawStapelImage", func() {
 			}},
 		),
 		Entry(
+			"with from dependency",
+			map[string]interface{}{
+				"image": "image1",
+				"from":  "alpine",
+				"dependencies": []map[string]interface{}{{
+					"from":   "image2",
+					"before": "install",
+				}},
+			},
+			[]*Dependency{{
+				ImageName: "image2",
+				Before:    "install",
+			}},
+		),
+		Entry(
+			"with from taking precedence over image dependency",
+			map[string]interface{}{
+				"image": "image1",
+				"from":  "alpine",
+				"dependencies": []map[string]interface{}{{
+					"image":  "image2",
+					"from":   "image3",
+					"before": "install",
+				}},
+			},
+			[]*Dependency{{
+				ImageName: "image3",
+				Before:    "install",
+			}},
+		),
+		Entry(
 			"with ImageTag dependency",
 			map[string]interface{}{
 				"image": "image1",

--- a/pkg/config/raw_stapel_image_test.go
+++ b/pkg/config/raw_stapel_image_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"bytes"
+	"context"
 	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -8,6 +10,8 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/werf/common-go/pkg/util"
+	"github.com/werf/logboek"
+	"github.com/werf/werf/v2/pkg/werf/global_warnings"
 )
 
 var _ = Describe("rawStapelImage", func() {
@@ -266,6 +270,30 @@ var _ = Describe("rawStapelImage", func() {
 			},
 		),
 	)
+
+	It("registers deprecation warning for image dependency", func() {
+		rawYaml, err := yaml.Marshal(map[string]interface{}{
+			"image": "image1",
+			"from":  "alpine",
+			"dependencies": []map[string]interface{}{{
+				"image":  "image2",
+				"before": "install",
+			}},
+		})
+		Expect(err).To(Succeed())
+
+		doc := &doc{Content: rawYaml}
+		rawStapelImage := &rawStapelImage{doc: doc}
+		Expect(yaml.UnmarshalStrict(doc.Content, rawStapelImage)).To(Succeed())
+
+		_, err = rawStapelImage.toStapelImageDirective(giterminismManager, "image1")
+		Expect(err).To(Succeed())
+
+		var output bytes.Buffer
+		ctx := logboek.NewContext(context.Background(), logboek.NewLogger(&output, &output))
+		global_warnings.PrintGlobalWarnings(ctx)
+		Expect(output.String()).To(ContainSubstring("The `dependencies[].image` directive is deprecated and will be removed in v3. Please use `dependencies[].from` instead."))
+	})
 
 	DescribeTable("unmarshal and convert to directive fail with configError",
 		func(yamlMap map[string]interface{}) {

--- a/pkg/config/validator_image_platform.go
+++ b/pkg/config/validator_image_platform.go
@@ -56,7 +56,7 @@ func (v *imagePlatformValidator) Validate(rawStapelImages []*rawStapelImage, raw
 
 	for _, img := range rawStapelImages {
 		for _, dep := range img.RawDependencies {
-			_, rightDiff := lo.Difference(allImagesPlatforms, v.crossJoinImagesPlatforms([]string{dep.Image}, img.Platform))
+			_, rightDiff := lo.Difference(allImagesPlatforms, v.crossJoinImagesPlatforms([]string{dep.imageName()}, img.Platform))
 
 			if len(rightDiff) > 0 {
 				return v.newDependencyError(img.Images[0], rightDiff[0].A, rightDiff[0].B)
@@ -80,7 +80,7 @@ func (v *imagePlatformValidator) Validate(rawStapelImages []*rawStapelImage, raw
 
 	for _, img := range rawImagesFromDockerfile {
 		for _, dep := range img.RawDependencies {
-			_, rightDiff := lo.Difference(allImagesPlatforms, v.crossJoinImagesPlatforms([]string{dep.Image}, img.Platform))
+			_, rightDiff := lo.Difference(allImagesPlatforms, v.crossJoinImagesPlatforms([]string{dep.imageName()}, img.Platform))
 
 			if len(rightDiff) > 0 {
 				return v.newDependencyError(img.Images[0], rightDiff[0].A, rightDiff[0].B)

--- a/pkg/config/validator_image_platform_test.go
+++ b/pkg/config/validator_image_platform_test.go
@@ -49,6 +49,40 @@ var _ = Describe("imagePlatformValidator", func() {
 				[]*rawImageFromDockerfile{},
 				BeNil(),
 			),
+			Entry("should validate successfully when dependency is specified with from field",
+				[]*rawStapelImage{
+					{
+						Images:   []string{"app"},
+						Platform: []string{"linux/amd64"},
+					},
+					{
+						Images:   []string{"test-dependency"},
+						Platform: []string{"linux/amd64"},
+						RawDependencies: []*rawDependency{
+							{From: "app"},
+						},
+					},
+				},
+				[]*rawImageFromDockerfile{},
+				BeNil(),
+			),
+			Entry("should return error when dependency from field takes precedence over missing image",
+				[]*rawStapelImage{
+					{
+						Images:   []string{"app"},
+						Platform: []string{"linux/amd64"},
+					},
+					{
+						Images:   []string{"test-dependency"},
+						Platform: []string{"linux/amd64"},
+						RawDependencies: []*rawDependency{
+							{Image: "app", From: "missing-base"},
+						},
+					},
+				},
+				[]*rawImageFromDockerfile{},
+				MatchError(`image="test-dependency" platform="linux/amd64" requires dependency image="missing-base" platform="linux/amd64" which is not present in configuration`),
+			),
 		)
 
 		DescribeTable("Stapel x Stapel with import cases", testImagePlatformValidator,

--- a/pkg/werf/global_warnings/global_warnings.go
+++ b/pkg/werf/global_warnings/global_warnings.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver"
@@ -56,6 +57,10 @@ func PrintGlobalWarnings(ctx context.Context) {
 func GlobalDeprecationWarningLn(ctx context.Context, line string) {
 	globalDeprecationWarningMessages = append(globalDeprecationWarningMessages, line)
 	printGlobalWarningLn(ctx, "DEPRECATION WARNING! "+line)
+}
+
+func GlobalDeprecationWarnings(ctx context.Context) []string {
+	return slices.Clone(globalDeprecationWarningMessages)
 }
 
 func GlobalWarningLn(ctx context.Context, line string) {

--- a/test/e2e/build/_fixtures/images_dependencies/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/images_dependencies/state0/werf.yaml
@@ -13,7 +13,7 @@ shell:
 image: stapel
 from: registry.werf.io/base/alpine:latest
 dependencies:
-  - image: base-stapel
+  - from: base-stapel
     after: install
     imports:
       - type: ImageName
@@ -24,7 +24,7 @@ dependencies:
         targetEnv: BASE_STAPEL_IMAGE_REPO
       - type: ImageTag
         targetEnv: BASE_STAPEL_IMAGE_TAG
-  - image: base-dockerfile
+  - from: base-dockerfile
     after: install
     imports:
       - type: ImageName
@@ -64,7 +64,7 @@ shell:
 image: dockerfile
 dockerfile: ./Dockerfile
 dependencies:
-  - image: base-stapel
+  - from: base-stapel
     imports:
       - type: ImageName
         targetBuildArg: BASE_STAPEL_IMAGE_NAME
@@ -76,7 +76,7 @@ dependencies:
         targetBuildArg: BASE_STAPEL_IMAGE_TAG
       - type: ImageName
         targetBuildArg: BASE_IMAGE
-  - image: base-dockerfile
+  - from: base-dockerfile
     imports:
       - type: ImageName
         targetBuildArg: BASE_DOCKERFILE_IMAGE_NAME


### PR DESCRIPTION
## Summary

Users can specify `from` in every image dependency while migrating configurations toward v3. The existing `image` field remains supported for now and emits a deprecation warning that directs users to `dependencies[].from`.

## What

- `dependencies[].from` is accepted for Stapel and Dockerfile image dependencies, including the image platform cross-reference validation that runs before the build.
- When both `dependencies[].from` and `dependencies[].image` are set, werf uses the value of `from` for both image kinds.
- When only `dependencies[].image` is set, werf preserves the existing dependency behavior and prints: `The dependencies[].image directive is deprecated and will be removed in v3. Please use dependencies[].from instead.` The warning is repeated in the `DEPRECATION WARNINGS` block at the end of the command output.
- The `werf.yaml` reference (`docs/_data/werf_yaml.yml`) lists `from` in both `dependencies` blocks and marks `image` as `DEPRECATED, use from`; EN and RU pages are generated from that schema. Prose examples keep `image`; the v3 branch migrates them together with the other deprecated directives.
- Dependency stage validation and imports remain unchanged.

## Why

Strict YAML decoding rejected the v3-compatible `dependencies[].from` field, preventing configurations from being prepared or backported before the migration. Keeping the legacy field without a warning would leave users without a migration path; rejecting configurations that contain both fields would make incremental adoption difficult.