### PR TITLE
fix(build, stapel): stop build reuse across different external bases

### DIFF
--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -86,6 +86,11 @@ func (s *FromStage) GetDependencies(_ context.Context, c Conveyor, _ container_b
 		args = append(args, "scratch")
 	} else if s.fromImageName != "" && !s.fromExternal {
 		args = append(args, c.GetImageContentTagStageID(s.targetPlatform, s.fromImageName))
+	} else if s.fromImageName != "" {
+		// GetContentDependencies has no prevImage, so an external base must be appended here:
+		// otherwise every image with an external base contributes the same empty argument list
+		// to the content anchor and such images reuse each other's builds.
+		args = append(args, s.fromImageName)
 	} else if prevImage != nil {
 		args = append(args, prevImage.Image.Name())
 	}

--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -86,7 +86,7 @@ func (s *FromStage) GetDependencies(_ context.Context, c Conveyor, _ container_b
 		args = append(args, "scratch")
 	} else if s.fromImageName != "" && !s.fromExternal {
 		args = append(args, c.GetImageContentTagStageID(s.targetPlatform, s.fromImageName))
-	} else if s.fromImageName != "" {
+	} else if s.fromExternal {
 		// GetContentDependencies has no prevImage, so an external base must be appended here:
 		// otherwise every image with an external base contributes the same empty argument list
 		// to the content anchor and such images reuse each other's builds.

--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -63,7 +63,7 @@ func (s *FromStage) IsMutable() bool {
 	return s.fromScratch
 }
 
-func (s *FromStage) GetDependencies(_ context.Context, c Conveyor, _ container_backend.ContainerBackend, prevImage, _ *StageImage, _ container_backend.BuildContextArchiver) (string, error) {
+func (s *FromStage) GetDependencies(_ context.Context, c Conveyor, _ container_backend.ContainerBackend, _, _ *StageImage, _ container_backend.BuildContextArchiver) (string, error) {
 	var args []string
 
 	if s.imageCacheVersion != "" {
@@ -87,12 +87,9 @@ func (s *FromStage) GetDependencies(_ context.Context, c Conveyor, _ container_b
 	} else if s.fromImageName != "" && !s.fromExternal {
 		args = append(args, c.GetImageContentTagStageID(s.targetPlatform, s.fromImageName))
 	} else if s.fromExternal {
-		// GetContentDependencies has no prevImage, so an external base must be appended here:
-		// otherwise every image with an external base contributes the same empty argument list
-		// to the content anchor and such images reuse each other's builds.
+		// The reference is the base identity werf promises for an external image: a mutable tag
+		// is followed only with fromLatest, which adds the resolved repo id above.
 		args = append(args, s.fromImageName)
-	} else if prevImage != nil {
-		args = append(args, prevImage.Image.Name())
 	}
 
 	return util.Sha256Hash(args...), nil

--- a/pkg/build/stage/from_test.go
+++ b/pkg/build/stage/from_test.go
@@ -28,6 +28,7 @@ var _ = Describe("FromStage", func() {
 
 			fromStage := &FromStage{
 				fromImageName:         data.FromImageName,
+				fromExternal:          data.FromExternal,
 				baseImageRepoIdOrNone: data.BaseImageRepoIdOrNone,
 				fromCacheVersion:      data.FromCacheVersion,
 				imageCacheVersion:     data.ImageCacheVersion,
@@ -82,6 +83,16 @@ var _ = Describe("FromStage", func() {
 				ExpectedDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			}),
 
+		// The expected digest is what the pre-fix code produced when the build phase passed the
+		// external base as prevImage, so this entry pins stage digests across the change.
+		Entry("should calculate from stage digest for external base image",
+			testDataFrom{
+				FromImageName: externalBaseRef,
+				FromExternal:  true,
+
+				ExpectedDigest: externalBaseDigest,
+			}),
+
 		Entry("should calculate from stage digest for scratch base image",
 			testDataFrom{
 				FromScratch: true,
@@ -91,11 +102,6 @@ var _ = Describe("FromStage", func() {
 	)
 
 	Describe("external base image identity", func() {
-		const (
-			golangRef     = "registry.example.com/factory@sha256:1111111111111111111111111111111111111111111111111111111111111111"
-			distrolessRef = "registry.example.com/factory@sha256:2222222222222222222222222222222222222222222222222222222222222222"
-		)
-
 		newExternalFromStage := func(ref string) *FromStage {
 			imageBaseConfig := &config.StapelImageBase{From: ref}
 			imageBaseConfig.SetFromExternal()
@@ -106,48 +112,25 @@ var _ = Describe("FromStage", func() {
 			return NewConveyorStubForDependencies(NewGiterminismManagerStub(NewLocalGitRepoStub("9d8059842b6fde712c58315ca0ab4713d90761c0"), NewGiterminismInspectorStub()), make([]*TestDependency, 0))
 		}
 
-		newBaseStageImage := func(ctrl *gomock.Controller, ref string) *StageImage {
-			legacyImage := mock.NewMockLegacyImageInterface(ctrl)
-			legacyImage.EXPECT().Name().Return(ref).AnyTimes()
-			return NewStageImage(NewContainerBackendStub(), ref, legacyImage)
-		}
-
-		It("gives different stage digests to from stages with different external bases", func(ctx SpecContext) {
-			ctrl := gomock.NewController(GinkgoT())
-			conveyor := newConveyor()
-
-			golangDigest, err := newExternalFromStage(golangRef).GetDependencies(ctx, conveyor, nil, newBaseStageImage(ctrl, golangRef), nil, nil)
+		It("gives the content digest the same value as the stage digest", func(ctx SpecContext) {
+			digest, err := newExternalFromStage(externalBaseRef).GetContentDependencies(ctx, newConveyor(), nil)
 			Expect(err).To(Succeed())
 
-			distrolessDigest, err := newExternalFromStage(distrolessRef).GetDependencies(ctx, conveyor, nil, newBaseStageImage(ctrl, distrolessRef), nil, nil)
-			Expect(err).To(Succeed())
-
-			Expect(golangDigest).NotTo(Equal(distrolessDigest))
+			Expect(digest).To(Equal(externalBaseDigest),
+				"content-anchor input must carry the external base the same way the stage digest does")
 		})
 
 		It("gives different content digests to from stages with different external bases", func(ctx SpecContext) {
 			conveyor := newConveyor()
 
-			golangDigest, err := newExternalFromStage(golangRef).GetContentDependencies(ctx, conveyor, nil)
+			digestOne, err := newExternalFromStage(externalBaseRef).GetContentDependencies(ctx, conveyor, nil)
 			Expect(err).To(Succeed())
 
-			distrolessDigest, err := newExternalFromStage(distrolessRef).GetContentDependencies(ctx, conveyor, nil)
+			digestTwo, err := newExternalFromStage("registry.example.com/factory@sha256:2222222222222222222222222222222222222222222222222222222222222222").GetContentDependencies(ctx, conveyor, nil)
 			Expect(err).To(Succeed())
 
-			Expect(golangDigest).NotTo(Equal(distrolessDigest),
+			Expect(digestOne).NotTo(Equal(digestTwo),
 				"content-anchor input must not match a from stage built from a different external base image")
-		})
-
-		It("gives equal content digests to from stages with the same external base", func(ctx SpecContext) {
-			conveyor := newConveyor()
-
-			digestOne, err := newExternalFromStage(golangRef).GetContentDependencies(ctx, conveyor, nil)
-			Expect(err).To(Succeed())
-
-			digestTwo, err := newExternalFromStage(golangRef).GetContentDependencies(ctx, conveyor, nil)
-			Expect(err).To(Succeed())
-
-			Expect(digestOne).To(Equal(digestTwo))
 		})
 	})
 
@@ -226,8 +209,14 @@ var _ = Describe("FromStage", func() {
 	})
 })
 
+const (
+	externalBaseRef    = "registry.example.com/factory@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	externalBaseDigest = "7148bcbd6a0899be6c6185bbc660dc857bcc9b55866c78189401dca5f9588a3e"
+)
+
 type testDataFrom struct {
 	FromImageName         string
+	FromExternal          bool
 	BaseImageRepoIdOrNone string
 	FromCacheVersion      string
 	ImageCacheVersion     string

--- a/pkg/build/stage/from_test.go
+++ b/pkg/build/stage/from_test.go
@@ -6,25 +6,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 
 	"github.com/werf/werf/v2/pkg/config"
 	"github.com/werf/werf/v2/pkg/container_backend"
 	imagePkg "github.com/werf/werf/v2/pkg/image"
-	"github.com/werf/werf/v2/test/mock"
 )
 
 var _ = Describe("FromStage", func() {
 	DescribeTable("GetDependencies()",
 		func(ctx SpecContext, data testDataFrom) {
-			ctrl := gomock.NewController(GinkgoT())
-
 			conveyor := NewConveyorStubForDependencies(NewGiterminismManagerStub(NewLocalGitRepoStub("9d8059842b6fde712c58315ca0ab4713d90761c0"), NewGiterminismInspectorStub()), make([]*TestDependency, 0))
-
-			legacyImage := mock.NewMockLegacyImageInterface(ctrl)
-			containerBackend := NewContainerBackendStub()
-
-			prevImage := NewStageImage(containerBackend, "base-image", legacyImage)
 
 			fromStage := &FromStage{
 				fromImageName:         data.FromImageName,
@@ -36,13 +27,7 @@ var _ = Describe("FromStage", func() {
 				BaseStage:             NewBaseStage(From, &BaseStageOptions{}),
 			}
 
-			if fromStage.fromScratch || fromStage.fromImageName != "" {
-				// do nothing
-			} else {
-				legacyImage.EXPECT().Name().Return(data.PrevImageImageName)
-			}
-
-			digest, err := fromStage.GetDependencies(ctx, conveyor, nil, prevImage, nil, nil)
+			digest, err := fromStage.GetDependencies(ctx, conveyor, nil, nil, nil, nil)
 			Expect(err).To(Succeed())
 
 			Expect(digest).To(Equal(data.ExpectedDigest),
@@ -58,27 +43,26 @@ var _ = Describe("FromStage", func() {
 			testDataFrom{
 				ImageCacheVersion: "image-cache-version",
 
-				ExpectedDigest: "62cc7cbbeb4189a01f9071091675d14e56faffbb1cd910e7e26858546028ef8f",
+				ExpectedDigest: "52a335b26821a21ae8a47eb3a36a1ab5f388dd44dd1ab369c0578c173d88a752",
 			}),
 
 		Entry("should calculate from stage digest with fromCacheVersion param",
 			testDataFrom{
 				FromCacheVersion: "from-cache-version",
 
-				ExpectedDigest: "30a820396785223b2734a036e91697e727e16c01cd30fe64cbb04d81fbc6c1ae",
+				ExpectedDigest: "e6bb62452421c2e2ca95e9c5c88abf9aa5ccef94073de4aa4c84ba442f5da449",
 			}),
 
 		Entry("should calculate from stage digest with baseImageRepoIdOrNone param",
 			testDataFrom{
 				BaseImageRepoIdOrNone: "base-image-repo-id-or-none",
 
-				ExpectedDigest: "29e4de9b8f38c28e4fffb47f5a22f2c8ac76986cffd81133d5180586ebf85adf",
+				ExpectedDigest: "3d805b3dc9b36b26bb95a7723399b2767548d080e31af2148f69130f70a0b66f",
 			}),
 
 		Entry("should calculate from stage digest with fromImageName param",
 			testDataFrom{
-				FromImageName:      "from-image-or-artifact-image-name",
-				PrevImageImageName: "prev-image-image-name",
+				FromImageName: "from-image-or-artifact-image-name",
 
 				ExpectedDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			}),
@@ -223,7 +207,6 @@ type testDataFrom struct {
 	FromScratch           bool
 
 	ImageContentDigest string
-	PrevImageImageName string
 
 	ExpectedDigest string
 }

--- a/pkg/build/stage/from_test.go
+++ b/pkg/build/stage/from_test.go
@@ -90,6 +90,67 @@ var _ = Describe("FromStage", func() {
 			}),
 	)
 
+	Describe("external base image identity", func() {
+		const (
+			golangRef     = "registry.example.com/factory@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+			distrolessRef = "registry.example.com/factory@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+		)
+
+		newExternalFromStage := func(ref string) *FromStage {
+			imageBaseConfig := &config.StapelImageBase{From: ref}
+			imageBaseConfig.SetFromExternal()
+			return GenerateFromStage(imageBaseConfig, "", "", &BaseStageOptions{})
+		}
+
+		newConveyor := func() Conveyor {
+			return NewConveyorStubForDependencies(NewGiterminismManagerStub(NewLocalGitRepoStub("9d8059842b6fde712c58315ca0ab4713d90761c0"), NewGiterminismInspectorStub()), make([]*TestDependency, 0))
+		}
+
+		newBaseStageImage := func(ctrl *gomock.Controller, ref string) *StageImage {
+			legacyImage := mock.NewMockLegacyImageInterface(ctrl)
+			legacyImage.EXPECT().Name().Return(ref).AnyTimes()
+			return NewStageImage(NewContainerBackendStub(), ref, legacyImage)
+		}
+
+		It("gives different stage digests to from stages with different external bases", func(ctx SpecContext) {
+			ctrl := gomock.NewController(GinkgoT())
+			conveyor := newConveyor()
+
+			golangDigest, err := newExternalFromStage(golangRef).GetDependencies(ctx, conveyor, nil, newBaseStageImage(ctrl, golangRef), nil, nil)
+			Expect(err).To(Succeed())
+
+			distrolessDigest, err := newExternalFromStage(distrolessRef).GetDependencies(ctx, conveyor, nil, newBaseStageImage(ctrl, distrolessRef), nil, nil)
+			Expect(err).To(Succeed())
+
+			Expect(golangDigest).NotTo(Equal(distrolessDigest))
+		})
+
+		It("gives different content digests to from stages with different external bases", func(ctx SpecContext) {
+			conveyor := newConveyor()
+
+			golangDigest, err := newExternalFromStage(golangRef).GetContentDependencies(ctx, conveyor, nil)
+			Expect(err).To(Succeed())
+
+			distrolessDigest, err := newExternalFromStage(distrolessRef).GetContentDependencies(ctx, conveyor, nil)
+			Expect(err).To(Succeed())
+
+			Expect(golangDigest).NotTo(Equal(distrolessDigest),
+				"content-anchor input must not match a from stage built from a different external base image")
+		})
+
+		It("gives equal content digests to from stages with the same external base", func(ctx SpecContext) {
+			conveyor := newConveyor()
+
+			digestOne, err := newExternalFromStage(golangRef).GetContentDependencies(ctx, conveyor, nil)
+			Expect(err).To(Succeed())
+
+			digestTwo, err := newExternalFromStage(golangRef).GetContentDependencies(ctx, conveyor, nil)
+			Expect(err).To(Succeed())
+
+			Expect(digestOne).To(Equal(digestTwo))
+		})
+	})
+
 	Describe("scratch semantics", func() {
 		It("marks scratch from stage as mutable and not buildable", func() {
 			stage := GenerateFromStage(&config.StapelImageBase{From: "scratch"}, "", "", &BaseStageOptions{})

--- a/test/e2e/build/_fixtures/content_tag/external_bases/state0/file
+++ b/test/e2e/build/_fixtures/content_tag/external_bases/state0/file
@@ -1,0 +1,1 @@
+content

--- a/test/e2e/build/_fixtures/content_tag/external_bases/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/content_tag/external_bases/state0/werf.yaml
@@ -1,0 +1,26 @@
+project: werf-test-e2e-build-content-tag
+configVersion: 1
+
+---
+image: on-ubuntu
+from: registry.werf.io/base/ubuntu:22.04
+git:
+  - add: /file
+    to: /file
+shell:
+  install:
+    - "echo install > /install.txt"
+  setup:
+    - "echo setup > /setup.txt"
+
+---
+image: on-alpine
+from: registry.werf.io/base/alpine:3.21
+git:
+  - add: /file
+    to: /file
+shell:
+  install:
+    - "echo install > /install.txt"
+  setup:
+    - "echo setup > /setup.txt"

--- a/test/e2e/build/content_tag_test.go
+++ b/test/e2e/build/content_tag_test.go
@@ -114,4 +114,38 @@ var _ = Describe("Content tag reuse", Label("e2e", "build", "content-tag"), func
 		Expect(buildOut).To(ContainSubstring("Copy suitable stage from secondary :local"))
 		Expect(buildOut).NotTo(ContainSubstring("Building stage app/"))
 	})
+
+	It("does not reuse the content tag across images with different external base images", func(ctx SpecContext) {
+		By("initializing")
+		setupEnv(setupEnvOptions{})
+
+		repoDirName := "repo0"
+		fixtureRelPath := "content_tag/external_bases/state0"
+
+		By("preparing test repo")
+		SuiteData.InitTestRepo(ctx, repoDirName, fixtureRelPath)
+		werfProject := werf.NewProject(SuiteData.WerfBinPath, SuiteData.GetTestRepoPath(repoDirName))
+
+		By("[1, :local] building the ubuntu-based image from scratch")
+		buildOut := werfProject.Build(ctx, &werf.BuildOptions{
+			CommonOptions: werf.CommonOptions{ExtraArgs: []string{"on-ubuntu"}},
+		})
+		Expect(buildOut).To(ContainSubstring("Building stage on-ubuntu/from"))
+		Expect(buildOut).To(ContainSubstring("Building stage on-ubuntu/setup"))
+
+		By("[2, :local] building the alpine-based image with the same instructions must not reuse the ubuntu-based one")
+		buildOut = werfProject.Build(ctx, &werf.BuildOptions{
+			CommonOptions: werf.CommonOptions{ExtraArgs: []string{"on-alpine"}},
+		})
+		Expect(buildOut).NotTo(ContainSubstring("Use previously built image for on-alpine by content-based tag"))
+		Expect(buildOut).To(ContainSubstring("Building stage on-alpine/from"))
+		Expect(buildOut).To(ContainSubstring("Building stage on-alpine/setup"))
+
+		By("[3, :local] rebuilding both images reuses each by its own content-based tag")
+		buildOut = werfProject.Build(ctx, &werf.BuildOptions{})
+		Expect(buildOut).To(ContainSubstring("Use previously built image for on-ubuntu by content-based tag"))
+		Expect(buildOut).To(ContainSubstring("Use previously built image for on-alpine by content-based tag"))
+		Expect(buildOut).NotTo(ContainSubstring("Building stage on-ubuntu/"))
+		Expect(buildOut).NotTo(ContainSubstring("Building stage on-alpine/"))
+	})
 })


### PR DESCRIPTION
## Summary

Stapel images whose only difference is an external `from:` reference shared one
content-anchor digest, so werf skipped their builds entirely and served an image built
from a different base. Needs several stapel images in one project with identical
instructions and different external base references, built into the same repo.

## What

- Two stapel images with different external `from:` references now get different
  content-anchor digests; before, every external-base from stage contributed an empty
  argument list to the anchor and they collided.
- Stage digests are unchanged for every `from:` variant, so the layer cache is not
  invalidated: for an external base the build phase already appended that same
  reference string via prevImage, and a unit test pins the digest to the pre-fix value.
- Content-anchor digests of external-base stapel images shift once, so on the first run
  after the upgrade each such image rebuilds only its last stage, the anchor; every
  preceding stage hits the existing cache. No other image is affected.
- Unaffected, where a reader would expect otherwise: `from: scratch`, `from:` naming a
  werf image, `fromLatest: true`, and all Dockerfile images — each already carried its
  base identity into the anchor.
- An e2e case builds two stapel images that differ only in their external base and
  asserts the second is built rather than reused by content tag, then that a rebuild
  reuses each image by its own tag.

## Why

The from stage learns an external base only from the caller-supplied prevImage. The
build phase supplies it, but the content-dependencies path feeding the anchor has no
prevImage at all, so the anchor input for the from stage was the hash of an empty list —
identical for every external base. The anchor digest deliberately excludes the image
name so that genuinely identical images share work, which makes the base reference the
only thing that could tell these images apart, and it was missing. The collision is
stable by construction, so a `cacheVersion` bump shifts both digests equally and does
not break the tie.

Rejected alternative: appending the resolved manifest digest instead of the reference.
That would silently change `from:` semantics — a mutable tag would start being chased
without `fromLatest`.
