### PR TITLE
fix(config): stop werf.yaml loading taking minutes on large image graphs

### DIFF
--- a/pkg/config/stubs_test.go
+++ b/pkg/config/stubs_test.go
@@ -89,10 +89,6 @@ func (image *ImageStub) GetName() string {
 	return image.name
 }
 
-func (image *ImageStub) IsFinal() bool {
-	return true
-}
-
 func (image *ImageStub) dependsOn() DependsOn {
 	return image.deps
 }

--- a/pkg/config/stubs_test.go
+++ b/pkg/config/stubs_test.go
@@ -70,3 +70,29 @@ func NewGitRepoArchiveStub() *GitRepoArchiveStub {
 func (archive *GitRepoArchiveStub) GetFilePath() string {
 	return "no-such-file"
 }
+
+type ImageStub struct {
+	ImageInterface
+
+	name string
+	deps DependsOn
+}
+
+func NewImageStub(name string, dependsOn DependsOn) *ImageStub {
+	return &ImageStub{
+		name: name,
+		deps: dependsOn,
+	}
+}
+
+func (image *ImageStub) GetName() string {
+	return image.name
+}
+
+func (image *ImageStub) IsFinal() bool {
+	return true
+}
+
+func (image *ImageStub) dependsOn() DependsOn {
+	return image.deps
+}

--- a/pkg/config/werf.go
+++ b/pkg/config/werf.go
@@ -113,9 +113,10 @@ func (c *WerfConfig) validateInfiniteLoopBetweenRelatedImages() error {
 	return nil
 }
 
-// acyclic holds images whose whole dependency subgraph was already walked without finding a loop:
-// a loop through such an image would have been reported by that walk, so it is safe to skip.
-// Without it the walk enumerates every path, which is exponential on diamond-shaped graphs.
+// validateImageInfiniteLoop walks the image dependency graph depth-first. The acyclic argument holds
+// images whose whole dependency subgraph was already walked without finding a loop: a loop through such
+// an image would have been reported by that walk, so it is safe to skip. Without it the walk enumerates
+// every path, which is exponential on diamond-shaped graphs.
 func (c *WerfConfig) validateImageInfiniteLoop(imageName string, imageNameStack []string, acyclic map[string]struct{}) (error, []string) {
 	if _, ok := acyclic[imageName]; ok {
 		return nil, nil

--- a/pkg/config/werf.go
+++ b/pkg/config/werf.go
@@ -103,8 +103,9 @@ func (c *WerfConfig) validateRelatedImages() error {
 }
 
 func (c *WerfConfig) validateInfiniteLoopBetweenRelatedImages() error {
+	acyclic := map[string]struct{}{}
 	for _, image := range c.Images(false) {
-		if err, errImageStack := c.validateImageInfiniteLoop(image.GetName(), []string{}); err != nil {
+		if err, errImageStack := c.validateImageInfiniteLoop(image.GetName(), []string{}, acyclic); err != nil {
 			return fmt.Errorf("%w: %s", err, strings.Join(errImageStack, " -> "))
 		}
 	}
@@ -112,7 +113,14 @@ func (c *WerfConfig) validateInfiniteLoopBetweenRelatedImages() error {
 	return nil
 }
 
-func (c *WerfConfig) validateImageInfiniteLoop(imageName string, imageNameStack []string) (error, []string) {
+// acyclic holds images whose whole dependency subgraph was already walked without finding a loop:
+// a loop through such an image would have been reported by that walk, so it is safe to skip.
+// Without it the walk enumerates every path, which is exponential on diamond-shaped graphs.
+func (c *WerfConfig) validateImageInfiniteLoop(imageName string, imageNameStack []string, acyclic map[string]struct{}) (error, []string) {
+	if _, ok := acyclic[imageName]; ok {
+		return nil, nil
+	}
+
 	for _, stackImageName := range imageNameStack {
 		if stackImageName == imageName {
 			return errors.New("infinite loop detected"), []string{imageName}
@@ -126,10 +134,12 @@ func (c *WerfConfig) validateImageInfiniteLoop(imageName string, imageNameStack 
 	}
 
 	for _, relatedImageName := range image.dependsOn().relatedImageNameList() {
-		if err, errImagesStack := c.validateImageInfiniteLoop(relatedImageName, imageNameStack); err != nil {
+		if err, errImagesStack := c.validateImageInfiniteLoop(relatedImageName, imageNameStack, acyclic); err != nil {
 			return err, append([]string{imageName}, errImagesStack...)
 		}
 	}
+
+	acyclic[imageName] = struct{}{}
 
 	return nil, nil
 }

--- a/pkg/config/werf_test.go
+++ b/pkg/config/werf_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"github.com/samber/lo"
+)
+
+var _ = Describe("WerfConfig", func() {
+	Describe("validateInfiniteLoopBetweenRelatedImages", func() {
+		DescribeTable("detects loops and accepts acyclic graphs",
+			func(ctx SpecContext, images []ImageInterface, expectedErr types.GomegaMatcher) {
+				werfConfig := NewWerfConfig(nil, images)
+
+				Expect(werfConfig.validateInfiniteLoopBetweenRelatedImages()).To(expectedErr)
+			},
+			Entry("no related images", []ImageInterface{
+				NewImageStub("a", DependsOn{}),
+				NewImageStub("b", DependsOn{}),
+			}, Succeed()),
+			Entry("linear chain a -> b -> c", []ImageInterface{
+				NewImageStub("a", DependsOn{From: "b"}),
+				NewImageStub("b", DependsOn{Imports: []string{"c"}}),
+				NewImageStub("c", DependsOn{}),
+			}, Succeed()),
+			Entry("self reference a -> a", []ImageInterface{
+				NewImageStub("a", DependsOn{From: "a"}),
+			}, MatchError("infinite loop detected: a -> a")),
+			Entry("loop through from a -> b -> a", []ImageInterface{
+				NewImageStub("a", DependsOn{From: "b"}),
+				NewImageStub("b", DependsOn{From: "a"}),
+			}, MatchError("infinite loop detected: a -> b -> a")),
+			Entry("loop through import a -> b -> c -> a", []ImageInterface{
+				NewImageStub("a", DependsOn{Imports: []string{"b"}}),
+				NewImageStub("b", DependsOn{Imports: []string{"c"}}),
+				NewImageStub("c", DependsOn{Imports: []string{"a"}}),
+			}, MatchError("infinite loop detected: a -> b -> c -> a")),
+			Entry("loop through dependencies b -> c -> b, reported from the first image reaching it", []ImageInterface{
+				NewImageStub("a", DependsOn{Dependencies: []string{"b"}}),
+				NewImageStub("b", DependsOn{Dependencies: []string{"c"}}),
+				NewImageStub("c", DependsOn{Dependencies: []string{"b"}}),
+			}, MatchError("infinite loop detected: a -> b -> c -> b")),
+			Entry("loop reachable only from the second image, after the first one is fully walked", []ImageInterface{
+				NewImageStub("a", DependsOn{From: "shared"}),
+				NewImageStub("shared", DependsOn{}),
+				NewImageStub("b", DependsOn{From: "shared", Imports: []string{"c"}}),
+				NewImageStub("c", DependsOn{Dependencies: []string{"b"}}),
+			}, MatchError("infinite loop detected: b -> c -> b")),
+			Entry("loop below a shared image, reached through it from two images", []ImageInterface{
+				NewImageStub("a", DependsOn{From: "shared"}),
+				NewImageStub("b", DependsOn{From: "shared"}),
+				NewImageStub("shared", DependsOn{Imports: []string{"x"}}),
+				NewImageStub("x", DependsOn{Imports: []string{"y"}}),
+				NewImageStub("y", DependsOn{Imports: []string{"x"}}),
+			}, MatchError("infinite loop detected: a -> shared -> x -> y -> x")),
+			Entry("diamond DAG of 30 layers by 2 images (2^29 root-to-leaf paths) is validated within the timeout",
+				SpecTimeout(10*time.Second),
+				newDiamondDAGImages(30, 2), Succeed()),
+			Entry("diamond DAG of 30 layers by 2 images with an edge from the bottom back to the top is a loop",
+				SpecTimeout(10*time.Second),
+				newDiamondDAGImagesWithLoop(30, 2),
+				MatchError("infinite loop detected: "+diamondDAGColumn(0, 28, 0)+" -> l29-1 -> l0-1 -> l1-0")),
+		)
+	})
+})
+
+// newDiamondDAGImages builds layers*width images named l<layer>-<i>, where every image of layer i
+// depends on every image of layer i+1 (the first one via from, the rest via import), so the number
+// of root-to-leaf paths is width^(layers-1).
+func newDiamondDAGImages(layers, width int) []ImageInterface {
+	return lo.Map(newDiamondDAGImageStubs(layers, width), func(image *ImageStub, _ int) ImageInterface { return image })
+}
+
+func newDiamondDAGImagesWithLoop(layers, width int) []ImageInterface {
+	images := newDiamondDAGImageStubs(layers, width)
+	images[len(images)-1].deps = DependsOn{From: fmt.Sprintf("l0-%d", width-1)}
+	return lo.Map(images, func(image *ImageStub, _ int) ImageInterface { return image })
+}
+
+func newDiamondDAGImageStubs(layers, width int) []*ImageStub {
+	var images []*ImageStub
+	for layer := 0; layer < layers; layer++ {
+		for i := 0; i < width; i++ {
+			var deps DependsOn
+			if layer+1 < layers {
+				deps.From = fmt.Sprintf("l%d-%d", layer+1, 0)
+				for j := 1; j < width; j++ {
+					deps.Imports = append(deps.Imports, fmt.Sprintf("l%d-%d", layer+1, j))
+				}
+			}
+			images = append(images, NewImageStub(fmt.Sprintf("l%d-%d", layer, i), deps))
+		}
+	}
+	return images
+}
+
+func diamondDAGColumn(fromLayer, toLayer, i int) string {
+	var names []string
+	for layer := fromLayer; layer <= toLayer; layer++ {
+		names = append(names, fmt.Sprintf("l%d-%d", layer, i))
+	}
+	return strings.Join(names, " -> ")
+}


### PR DESCRIPTION
## Summary

Every werf command that loads `werf.yaml` runs a loop check over the image dependency graph (`fromImage`, `import`, `dependencies`) that restarts a depth-first walk from every image and forgets what it has already walked, so every shared base image doubles the number of paths. On a project with ~1300 images and ~6700 edges `werf config render` spent ~45 s in that check while the templates themselves rendered in a few seconds. It reproduces with any config where many images share the same intermediate images; a 30-layer graph of 2 images per layer, each depending on both images of the previous layer, is enough to hang the old check indefinitely.

## What

- Loading a `werf.yaml` whose image graph is a DAG with many shared images completes in time linear in the graph size; the 30x2 diamond graph above is validated in milliseconds instead of never.
- A loop through `fromImage`, `import` or `dependencies` is still rejected with the same `infinite loop detected: a -> b -> a` error, including a loop that is reachable only through an image that another image had already walked.
- VERIFIED: on a real project with 1332 images `werf config render` drops from ~47 s to ~7 s with byte-identical output.
- The rendered output, the order of images and every other validation do not change.

## Why

The walk enumerated every root-to-leaf path instead of every edge. Remembering the images whose whole dependency subgraph was already walked without finding a loop and skipping them later is safe: a loop through such an image would have been reported by the walk that finished it, because that walk keeps the image on its stack until it returns. The neighbouring graph walks (`GroupImagesByIndependentSets`, `getImageRelativesInOrder`) deduplicate visited images already and stay polynomial, so they are left alone.
