### PR TITLE
fix(build, stapel): stop builds failing with many imports

### DIFF
--- a/pkg/container_backend/legacy_stage_image.go
+++ b/pkg/container_backend/legacy_stage_image.go
@@ -115,11 +115,7 @@ func (i *LegacyStageImage) Build(ctx context.Context, options BuildOptions) erro
 			return err
 		}
 
-		fmt.Printf("Docker run command:\ndocker run %s\n", strings.Join(runArgs, " "))
-
-		if len(i.container.prepareAllRunCommands()) != 0 {
-			fmt.Printf("Decoded command:\n%s\n", strings.Join(i.container.prepareAllRunCommands(), " && "))
-		}
+		fmt.Printf("Docker run command (stage script piped to stdin):\n%s\n", i.container.prepareDebugRunCommand(runArgs))
 	}
 
 	if containerRunErr := i.container.run(ctx); containerRunErr != nil {

--- a/pkg/container_backend/legacy_stage_image_container.go
+++ b/pkg/container_backend/legacy_stage_image_container.go
@@ -3,9 +3,9 @@ package container_backend
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
 
+	"github.com/alessio/shellescape"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/runconfig/opts"
@@ -92,11 +92,22 @@ func (c *LegacyStageImageContainer) prepareRunArgs(ctx context.Context) ([]strin
 	runArgs = append(runArgs, setColumnsEnv)
 
 	args = append(args, runArgs...)
-	// Drain the script before eval, then give build commands EOF on stdin.
-	args = append(args, "-i", c.imageRef(c.image.fromImage), "-ec",
-		fmt.Sprintf(`eval "$(%s)" < /dev/null`, path.Join(stapel.CONTAINER_MOUNT_ROOT, "stapel/embedded/bin/cat")))
+	args = append(args, c.prepareRunCommandArgs()...)
 
 	return args, nil
+}
+
+func (c *LegacyStageImageContainer) prepareRunCommandArgs() []string {
+	// The assignment reads the script to EOF, so a reader failure aborts before eval
+	// and build commands find stdin already drained. The redirect only makes that explicit.
+	return []string{
+		"-i", c.imageRef(c.image.fromImage), "-ec",
+		fmt.Sprintf(`script=$(%s); eval "$script" < /dev/null`, stapel.CatBinPath()),
+	}
+}
+
+func (c *LegacyStageImageContainer) prepareDebugRunCommand(runArgs []string) string {
+	return fmt.Sprintf("printf '%%s' %s | docker run %s", shellescape.Quote(c.prepareRunCommand()), shellescape.QuoteCommand(runArgs))
 }
 
 func (c *LegacyStageImageContainer) prepareRunCommand() string {

--- a/pkg/container_backend/legacy_stage_image_container.go
+++ b/pkg/container_backend/legacy_stage_image_container.go
@@ -2,7 +2,6 @@ package container_backend
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -92,15 +91,17 @@ func (c *LegacyStageImageContainer) prepareRunArgs(ctx context.Context) ([]strin
 	runArgs = append(runArgs, setColumnsEnv)
 
 	args = append(args, runArgs...)
-	args = append(args, c.imageRef(c.image.fromImage))
-	args = append(args, "-ec")
-	args = append(args, c.prepareRunCommand())
+	args = append(args, c.prepareRunCommandArgs()...)
 
 	return args, nil
 }
 
 func (c *LegacyStageImageContainer) prepareRunCommand() string {
-	return ShelloutPack(strings.Join(c.prepareRunCommands(), " && "))
+	return strings.Join(c.prepareRunCommands(), " && ")
+}
+
+func (c *LegacyStageImageContainer) prepareRunCommandArgs() []string {
+	return []string{"-i", c.imageRef(c.image.fromImage), "-se"}
 }
 
 func (c *LegacyStageImageContainer) prepareRunCommands() []string {
@@ -123,10 +124,6 @@ func (c *LegacyStageImageContainer) prepareAllRunCommands() []string {
 	commands = append(commands, c.runCommands...)
 
 	return commands
-}
-
-func ShelloutPack(command string) string {
-	return fmt.Sprintf("eval $(echo %s | %s --decode)", base64.StdEncoding.EncodeToString([]byte(command)), stapel.Base64BinPath())
 }
 
 func (c *LegacyStageImageContainer) imageRef(img *LegacyStageImage) string {
@@ -300,7 +297,7 @@ func (c *LegacyStageImageContainer) run(ctx context.Context) error {
 	}
 
 	RegisterRunningContainer(c.name, ctx)
-	err = docker.CliRun_LiveOutput(ctx, runArgs...)
+	err = docker.CliRunWithInput_LiveOutput(ctx, strings.NewReader(c.prepareRunCommand()), runArgs...)
 	UnregisterRunningContainer(c.name)
 	if err != nil {
 		return fmt.Errorf("container run failed: %w", CliErrorByCode(err))

--- a/pkg/container_backend/legacy_stage_image_container.go
+++ b/pkg/container_backend/legacy_stage_image_container.go
@@ -3,6 +3,7 @@ package container_backend
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -91,17 +92,15 @@ func (c *LegacyStageImageContainer) prepareRunArgs(ctx context.Context) ([]strin
 	runArgs = append(runArgs, setColumnsEnv)
 
 	args = append(args, runArgs...)
-	args = append(args, c.prepareRunCommandArgs()...)
+	// Drain the script before eval, then give build commands EOF on stdin.
+	args = append(args, "-i", c.imageRef(c.image.fromImage), "-ec",
+		fmt.Sprintf(`eval "$(%s)" < /dev/null`, path.Join(stapel.CONTAINER_MOUNT_ROOT, "stapel/embedded/bin/cat")))
 
 	return args, nil
 }
 
 func (c *LegacyStageImageContainer) prepareRunCommand() string {
 	return strings.Join(c.prepareRunCommands(), " && ")
-}
-
-func (c *LegacyStageImageContainer) prepareRunCommandArgs() []string {
-	return []string{"-i", c.imageRef(c.image.fromImage), "-se"}
 }
 
 func (c *LegacyStageImageContainer) prepareRunCommands() []string {
@@ -297,7 +296,7 @@ func (c *LegacyStageImageContainer) run(ctx context.Context) error {
 	}
 
 	RegisterRunningContainer(c.name, ctx)
-	err = docker.CliRunWithInput_LiveOutput(ctx, strings.NewReader(c.prepareRunCommand()), runArgs...)
+	err = docker.CliRunWithInput_LiveOutput(ctx, c.prepareRunCommand(), runArgs...)
 	UnregisterRunningContainer(c.name)
 	if err != nil {
 		return fmt.Errorf("container run failed: %w", CliErrorByCode(err))

--- a/pkg/container_backend/legacy_stage_image_container_test.go
+++ b/pkg/container_backend/legacy_stage_image_container_test.go
@@ -1,9 +1,27 @@
 package container_backend
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("LegacyStageImageContainer run arguments", func() {
+	It("streams large commands through standard input", func() {
+		baseImage := NewLegacyStageImage(nil, "base", nil, "")
+		stageImage := NewLegacyStageImage(baseImage, "stage", nil, "")
+		stageImage.container.AddRunCommands(strings.Repeat("echo import\n", 300_000))
+
+		args := stageImage.container.prepareRunCommandArgs()
+
+		Expect(args).To(ContainElement("-i"))
+		Expect(args).To(ContainElement("-se"))
+		for _, arg := range args {
+			Expect(arg).NotTo(ContainSubstring("echo import"))
+		}
+	})
+})
 
 var _ = Describe("LegacyStageImageContainer imageRef", func() {
 	const (

--- a/pkg/container_backend/legacy_stage_image_container_test.go
+++ b/pkg/container_backend/legacy_stage_image_container_test.go
@@ -1,27 +1,9 @@
 package container_backend
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-var _ = Describe("LegacyStageImageContainer run arguments", func() {
-	It("streams large commands through standard input", func() {
-		baseImage := NewLegacyStageImage(nil, "base", nil, "")
-		stageImage := NewLegacyStageImage(baseImage, "stage", nil, "")
-		stageImage.container.AddRunCommands(strings.Repeat("echo import\n", 300_000))
-
-		args := stageImage.container.prepareRunCommandArgs()
-
-		Expect(args).To(ContainElement("-i"))
-		Expect(args).To(ContainElement("-se"))
-		for _, arg := range args {
-			Expect(arg).NotTo(ContainSubstring("echo import"))
-		}
-	})
-})
 
 var _ = Describe("LegacyStageImageContainer imageRef", func() {
 	const (

--- a/pkg/container_backend/legacy_stage_run_test.go
+++ b/pkg/container_backend/legacy_stage_run_test.go
@@ -1,0 +1,70 @@
+package container_backend
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/werf/v2/pkg/stapel"
+)
+
+var _ = Describe("Legacy stage command transport", func() {
+	var container *LegacyStageImageContainer
+
+	BeforeEach(func() {
+		container = newLegacyStageImageContainer(&LegacyStageImage{
+			targetPlatform: "linux/amd64",
+			fromImage: &LegacyStageImage{
+				legacyBaseImage: &legacyBaseImage{name: "base"},
+			},
+		})
+	})
+
+	It("keeps large scripts intact and outside argv", func() {
+		commands := []string{strings.Repeat(": import-padding\n", 200_000) + ":", "printf complete"}
+		container.AddRunCommands(commands...)
+
+		Expect(container.prepareRunCommand()).To(Equal(strings.Join(commands, " && ")))
+		args := container.prepareRunCommandArgs()
+		Expect(args[:3]).To(Equal([]string{"-i", "base", "-ec"}))
+		for _, arg := range args {
+			Expect(len(arg)).To(BeNumerically("<", 128*1024))
+			Expect(arg).NotTo(ContainSubstring("import-padding"))
+		}
+	})
+
+	DescribeTable("propagates script reader failures before evaluation", func(ctx SpecContext, reader string, exitCode int) {
+		args := container.prepareRunCommandArgs()
+		loader := strings.ReplaceAll(args[3], stapel.CatBinPath(), reader)
+		cmd := exec.CommandContext(ctx, "bash", args[2], loader)
+		cmd.Stdin = strings.NewReader("cat > /dev/null; printf complete")
+		output, err := cmd.Output()
+		if exitCode == 0 {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(output)).To(Equal("complete"))
+			return
+		}
+		Expect(err).To(HaveOccurred())
+		var exitErr *exec.ExitError
+		Expect(errors.As(err, &exitErr)).To(BeTrue())
+		Expect(exitErr.ExitCode()).To(Equal(exitCode))
+		Expect(output).To(BeEmpty())
+	},
+		Entry("successful reader", "cat", 0),
+		Entry("failed reader", "false", 1),
+		Entry("failed reader with partial script", "printf 'printf unexpected'; false", 1),
+	)
+
+	It("prints a runnable debug command preserving stdin and argument quoting", func(ctx SpecContext) {
+		script := "printf '%s\\n' '$HOME' \"a'b\"; $(not-a-host-command)\n"
+		container.AddRunCommands(script)
+		args := []string{"-i", "--env=VALUE=spaces 'quotes' $HOME", "base", "-ec", "reader; eval"}
+		cmd := exec.CommandContext(ctx, "bash", "-c", "docker() { printf '%s\\n' \"$@\"; cat; }\n"+container.prepareDebugRunCommand(args))
+		output, err := cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), string(output))
+		Expect(string(output)).To(Equal("run\n" + strings.Join(args, "\n") + "\n" + script))
+	})
+})

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"io"
+	"strings"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/container"
@@ -75,8 +76,8 @@ func CliRun_LiveOutput(ctx context.Context, args ...string) error {
 	return doCliRun(ctx, cli(ctx), args...)
 }
 
-func CliRunWithInput_LiveOutput(ctx context.Context, input io.Reader, args ...string) error {
-	return cliWithCustomOptions(ctx, []command.CLIOption{command.WithInputStream(io.NopCloser(input))}, func(c command.Cli) error {
+func CliRunWithInput_LiveOutput(ctx context.Context, input string, args ...string) error {
+	return cliWithCustomOptions(ctx, []command.CLIOption{command.WithInputStream(io.NopCloser(strings.NewReader(input)))}, func(c command.Cli) error {
 		return doCliRun(ctx, c, args...)
 	})
 }

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -75,6 +75,12 @@ func CliRun_LiveOutput(ctx context.Context, args ...string) error {
 	return doCliRun(ctx, cli(ctx), args...)
 }
 
+func CliRunWithInput_LiveOutput(ctx context.Context, input io.Reader, args ...string) error {
+	return cliWithCustomOptions(ctx, []command.CLIOption{command.WithInputStream(io.NopCloser(input))}, func(c command.Cli) error {
+		return doCliRun(ctx, c, args...)
+	})
+}
+
 func CliRun_RecordedOutput(ctx context.Context, args ...string) (string, error) {
 	return callCliWithRecordedOutput(ctx, func(c command.Cli) error {
 		return doCliRun(ctx, c, args...)

--- a/pkg/stapel/stapel.go
+++ b/pkg/stapel/stapel.go
@@ -118,8 +118,8 @@ func TrueBinPath() string {
 	return embeddedBinPath("true")
 }
 
-func Base64BinPath() string {
-	return embeddedBinPath("base64")
+func CatBinPath() string {
+	return embeddedBinPath("cat")
 }
 
 func LsBinPath() string {

--- a/test/e2e/build/_fixtures/legacy-stage-script/state0/werf.yaml
+++ b/test/e2e/build/_fixtures/legacy-stage-script/state0/werf.yaml
@@ -1,0 +1,26 @@
+project: werf-test-e2e-build-legacy-stage-script
+configVersion: 1
+---
+image: source
+from: registry.werf.io/base/ubuntu:22.04
+shell:
+  setup:
+    - printf payload > /payload
+---
+image: target
+from: registry.werf.io/base/ubuntu:22.04
+# The import count must keep the generated stage script above the 128 KiB
+# single-argument limit. At the current size of RsyncServer.GetCopyCommand the
+# threshold is ~194 imports.
+import:
+{{- range $i := until 256 }}
+  - image: source
+    add: /payload
+    to: /imports/{{ $i }}
+    after: install
+{{- end }}
+shell:
+  setup:
+    - cat > /tmp/eaten
+    - test ! -s /tmp/eaten
+    - touch /stage-complete

--- a/test/e2e/build/legacy_stage_script_test.go
+++ b/test/e2e/build/legacy_stage_script_test.go
@@ -1,0 +1,50 @@
+package e2e_build_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/werf/werf/v2/pkg/container_backend"
+	"github.com/werf/werf/v2/pkg/docker"
+	"github.com/werf/werf/v2/pkg/werf"
+	"github.com/werf/werf/v2/test/pkg/utils"
+)
+
+var _ = ginkgo.Describe("Legacy stage script", ginkgo.Label("e2e", "build", "legacy-stage-script"), func() {
+	ginkgo.DescribeTable("executes the complete script with closed command stdin", func(ctx ginkgo.SpecContext, script string, exitCode int) {
+		gomega.Expect(werf.Init(SuiteData.TmpDir, "")).To(gomega.Succeed())
+		gomega.Expect(docker.Init(ctx, docker.InitOptions{})).To(gomega.Succeed())
+		buildCtx := utils.WithDependencies(ctx)
+		backend := container_backend.NewDockerServerBackend(werf.HostLocker().Locker())
+		const baseRef = "registry.werf.io/base/ubuntu:22.04"
+		utils.RunSucceedCommand(ctx, "", "docker", "pull", "--platform=linux/amd64", baseRef)
+		base := container_backend.NewLegacyStageImage(nil, baseRef, backend, "linux/amd64")
+		stage := container_backend.NewLegacyStageImage(base, SuiteData.ProjectName, backend, "linux/amd64")
+		stage.BuilderContainer().AddRunCommands(script, "printf complete > /stage-complete")
+
+		err := stage.Build(buildCtx, container_backend.BuildOptions{})
+		ginkgo.DeferCleanup(func(ctx ginkgo.SpecContext) {
+			if stage.BuiltID() != "" {
+				utils.RunSucceedCommand(ctx, "", "docker", "rmi", stage.BuiltID())
+			}
+		})
+		if exitCode != 0 {
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring(fmt.Sprintf("Code: %d", exitCode)))
+			gomega.Expect(stage.BuiltID()).To(gomega.BeEmpty())
+			return
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		out, err := docker.CliRun_RecordedOutput(buildCtx, "--rm", "--platform=linux/amd64", "--entrypoint=/bin/cat", stage.BuiltID(), "/stage-complete")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), out)
+		gomega.Expect(out).To(gomega.Equal("complete"))
+	},
+		ginkgo.Entry("stdin consumers cannot eat later commands", "cat > /tmp/eaten\n! read -r line\ntest ! -s /tmp/eaten", 0),
+		ginkgo.Entry("a script exceeding the argument-size limit", strings.Repeat(": import-padding\n", 200_000)+":", 0),
+		ginkgo.Entry("a failing command prevents a committed image", "exit 23", 23),
+		ginkgo.Entry("a syntax error prevents a committed image", "printf early\n)", 2),
+	)
+})

--- a/test/e2e/build/legacy_stage_script_test.go
+++ b/test/e2e/build/legacy_stage_script_test.go
@@ -4,47 +4,85 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/werf/werf/v2/pkg/container_backend"
 	"github.com/werf/werf/v2/pkg/docker"
 	"github.com/werf/werf/v2/pkg/werf"
+	"github.com/werf/werf/v2/test/pkg/contback"
+	"github.com/werf/werf/v2/test/pkg/report"
 	"github.com/werf/werf/v2/test/pkg/utils"
+	werftest "github.com/werf/werf/v2/test/pkg/werf"
 )
 
-var _ = ginkgo.Describe("Legacy stage script", ginkgo.Label("e2e", "build", "legacy-stage-script"), func() {
-	ginkgo.DescribeTable("executes the complete script with closed command stdin", func(ctx ginkgo.SpecContext, script string, exitCode int) {
-		gomega.Expect(werf.Init(SuiteData.TmpDir, "")).To(gomega.Succeed())
-		gomega.Expect(docker.Init(ctx, docker.InitOptions{})).To(gomega.Succeed())
-		buildCtx := utils.WithDependencies(ctx)
-		backend := container_backend.NewDockerServerBackend(werf.HostLocker().Locker())
-		const baseRef = "registry.werf.io/base/ubuntu:22.04"
-		utils.RunSucceedCommand(ctx, "", "docker", "pull", "--platform=linux/amd64", baseRef)
-		base := container_backend.NewLegacyStageImage(nil, baseRef, backend, "linux/amd64")
-		stage := container_backend.NewLegacyStageImage(base, SuiteData.ProjectName, backend, "linux/amd64")
-		stage.BuilderContainer().AddRunCommands(script, "printf complete > /stage-complete")
+const (
+	legacyStageScriptBaseImage = "registry.werf.io/base/ubuntu:22.04"
 
-		err := stage.Build(buildCtx, container_backend.BuildOptions{})
-		ginkgo.DeferCleanup(func(ctx ginkgo.SpecContext) {
-			if stage.BuiltID() != "" {
-				utils.RunSucceedCommand(ctx, "", "docker", "rmi", stage.BuiltID())
-			}
-		})
-		if exitCode != 0 {
-			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring(fmt.Sprintf("Code: %d", exitCode)))
-			gomega.Expect(stage.BuiltID()).To(gomega.BeEmpty())
-			return
+	// The build must fail without werf reporting the container exit code verbatim.
+	legacyStageScriptAnyExitCode = -1
+)
+
+var _ = Describe("Legacy stage script", Label("e2e", "build", "legacy-stage-script"), func() {
+	It("builds a werf.yaml with many imports", func(ctx SpecContext) {
+		setupEnv(setupEnvOptions{ContainerBackendMode: "vanilla-docker", WithLocalRepo: true})
+		contRuntime, err := contback.NewContainerBackend("vanilla-docker")
+		if err == contback.ErrRuntimeUnavailable {
+			Skip(err.Error())
+		} else if err != nil {
+			Fail(err.Error())
 		}
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		out, err := docker.CliRun_RecordedOutput(buildCtx, "--rm", "--platform=linux/amd64", "--entrypoint=/bin/cat", stage.BuiltID(), "/stage-complete")
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), out)
-		gomega.Expect(out).To(gomega.Equal("complete"))
-	},
-		ginkgo.Entry("stdin consumers cannot eat later commands", "cat > /tmp/eaten\n! read -r line\ntest ! -s /tmp/eaten", 0),
-		ginkgo.Entry("a script exceeding the argument-size limit", strings.Repeat(": import-padding\n", 200_000)+":", 0),
-		ginkgo.Entry("a failing command prevents a committed image", "exit 23", 23),
-		ginkgo.Entry("a syntax error prevents a committed image", "printf early\n)", 2),
-	)
+
+		SuiteData.InitTestRepo(ctx, "repo0", "legacy-stage-script/state0")
+		werfProject := werftest.NewProject(SuiteData.WerfBinPath, SuiteData.GetTestRepoPath("repo0"))
+		_, buildReport := report.NewProjectWithReport(werfProject).BuildWithReport(ctx, SuiteData.GetBuildReportPath("report.json"), &werftest.WithReportOptions{
+			CommonOptions: werftest.CommonOptions{ExtraArgs: []string{"--platform=linux/amd64"}},
+		})
+
+		contRuntime.ExpectCmdsToSucceed(ctx, buildReport.Images["target"].DockerImageName,
+			`for i in $(seq 0 255); do test "$(cat /imports/$i)" = payload || exit 1; done`,
+			"test ! -s /tmp/eaten",
+			"test -f /stage-complete",
+		)
+	})
+
+	Describe("stage script transport", func() {
+		BeforeEach(func(ctx SpecContext) {
+			Expect(werf.Init(SuiteData.TmpDir, "")).To(Succeed())
+			Expect(docker.Init(ctx, docker.InitOptions{})).To(Succeed())
+			utils.RunSucceedCommand(ctx, "", "docker", "pull", "--platform=linux/amd64", legacyStageScriptBaseImage)
+		})
+
+		DescribeTable("executes the complete script with closed command stdin", func(ctx SpecContext, script string, exitCode int) {
+			buildCtx := utils.WithDependencies(ctx)
+			backend := container_backend.NewDockerServerBackend(werf.HostLocker().Locker())
+			base := container_backend.NewLegacyStageImage(nil, legacyStageScriptBaseImage, backend, "linux/amd64")
+			stage := container_backend.NewLegacyStageImage(base, SuiteData.ProjectName, backend, "linux/amd64")
+			stage.BuilderContainer().AddRunCommands(script, "printf complete > /stage-complete")
+
+			err := stage.Build(buildCtx, container_backend.BuildOptions{})
+			DeferCleanup(func(ctx SpecContext) {
+				if stage.BuiltID() != "" {
+					utils.RunSucceedCommand(ctx, "", "docker", "rmi", stage.BuiltID())
+				}
+			})
+			if exitCode != 0 {
+				Expect(err).To(HaveOccurred())
+				Expect(stage.BuiltID()).To(BeEmpty())
+				if exitCode != legacyStageScriptAnyExitCode {
+					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Code: %d", exitCode)))
+				}
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			out, err := docker.CliRun_RecordedOutput(buildCtx, "--rm", "--platform=linux/amd64", "--entrypoint=/bin/cat", stage.BuiltID(), "/stage-complete")
+			Expect(err).NotTo(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("complete"))
+		},
+			Entry("stdin consumers cannot eat later commands", "cat > /tmp/eaten\n! read -r line\ntest ! -s /tmp/eaten", 0),
+			Entry("a script exceeding the argument-size limit", strings.Repeat(": import-padding\n", 200_000)+":", 0),
+			Entry("a failing command prevents a committed image", "exit 23", 23),
+			Entry("a syntax error prevents a committed image", "printf early\n)", legacyStageScriptAnyExitCode),
+		)
+	})
 })


### PR DESCRIPTION
## Summary

Legacy Stapel builds could fail with `argument list too long` when imports generated a script beyond the container shell's argument-size limit. Large stage scripts now execute without being passed as an argument.

## What

- Legacy Stapel stages transport the script through standard input, keeping the shell argument list independent of script size.
- Build commands cannot consume the rest of the stage: the script is read to EOF before anything is evaluated, so `cat` or `read` find standard input already drained.
- A failing script reader aborts the stage instead of committing an empty image, even when it has already produced part of the script.
- Command failures and syntax errors still fail the build without committing a stage image under the default build options.
- The script is evaluated quoted, so generated commands are no longer word-split and glob-expanded before evaluation. Only rsync filters generated from `includePaths`/`excludePaths` were exposed to that; user commands reach the container as mounted script files and never were.
- The debug dump of the build command prints the pipe form and stays runnable.
- Command ordering, `&&` chaining, CLI options, and `werf.yaml` syntax remain unchanged.

## Why

The whole encoded script previously occupied one `bash -ec` argument, eventually exceeding the operating system's argument-size limits when the container runtime started Bash. Reading it directly with `bash -s` removes that limit but shares the script stream with build commands, allowing a command to swallow the rest of the stage silently.

Assign the stream to a variable with Stapel's bundled `cat` before `eval`. The assignment keeps the script out of argv, leaves standard input at EOF for every evaluated command, and propagates a reader failure; the redirect to `/dev/null` on `eval` only makes the EOF guarantee explicit. A host script file plus bind mount would work as well and is what the Shell builder and the Buildah backend already do, but `LegacyStageImageContainer` owns no temporary directory, so that route would add tmp-dir plumbing and cleanup that leaks on SIGKILL. The script remains memory-backed; this removes the argument-size ceiling, not resource limits.
