### PR TITLE
docs(dev): correct the local test requirements for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,11 +87,13 @@ After changing Go code, run these in order — `task format` mutates files, so i
 
 NEVER assume a change compiles. While iterating, scope the slow steps (`task lint:golangci-lint golangciPaths="./pkg/foo/..."`, `task test:unit paths="./pkg/foo/..."`), then run them unscoped before handing the work over.
 
+A failure in a package the diff does not touch is usually a host-environment flake, not your change: re-run that suite alone before investigating it.
+
 A green `task test:unit` does NOT prove a command runs. No unit test constructs the storage manager, so a command that dereferences a flag group it never registered dies with a SIGSEGV before doing any work while the whole unit suite stays green. After adding or changing a command, execute it once — via `task test:integration`, or the binary in `./bin/` — before calling it done.
 
 `git diff --check` cannot be a whole-repo gate. The CLI reference generator emits column-aligned help text, so the generated pages under `docs/_includes/reference/cli` and `docs/pages_en/reference/cli` carry trailing whitespace on every branch. Scope the check to authored files.
 
-On macOS `task build` produces a **non-CGO** binary — the Buildah backend is only built for linux/amd64 (`task build:dev:linux:amd64:cgo`), so Buildah changes cannot be compiled or exercised locally. Unit tests run anywhere; e2e and integration tests need Linux with Docker and kind (`task test:setup:environment`). Anything exercising registry deletion additionally needs `REGISTRY_STORAGE_DELETE_ENABLED=true` on that registry: stock `registry:2` answers every DELETE with `UNSUPPORTED: The operation is unsupported`, which reads like a werf bug.
+On macOS `task build` produces a **non-CGO** binary — the Buildah backend is only built for linux/amd64 (`task build:dev:linux:amd64:cgo`), so Buildah changes cannot be compiled or exercised locally. Unit tests run anywhere. e2e and integration suites need Docker plus a reachable registry in `WERF_TEST_K8S_DOCKER_REGISTRY`; `task test:setup:environment` provisions kind and that registry and writes `.env`, but any local registry works — the docker-backend specs run on macOS, only the Buildah-mode entries need Linux. Anything exercising registry deletion additionally needs `REGISTRY_STORAGE_DELETE_ENABLED=true` on that registry: stock `registry:2` answers every DELETE with `UNSUPPORTED: The operation is unsupported`, which reads like a werf bug.
 
 ## Testing (MANDATORY)
 


### PR DESCRIPTION
## Summary

`AGENTS.md` states that e2e and integration suites need Linux with Docker and kind, so an agent working on macOS records them as impossible to run and ships changes with no end-to-end evidence. The docker-backend specs do run there.

## What

- An agent on macOS now runs `task test:e2e` for docker-backend specs instead of reporting them as unrunnable: the stated prerequisites are Docker plus a reachable registry in `WERF_TEST_K8S_DOCKER_REGISTRY`, with `task test:setup:environment` presented as one way to get both rather than the only one.
- Only the Buildah-mode e2e entries are stated to need Linux, matching the same paragraph's existing note that the Buildah backend is not built on macOS.
- An agent that sees the unit suite fail in a package its diff does not touch now re-runs that suite alone before investigating, instead of treating it as its own regression.
- VERIFIED: the whole `legacy-stage-script` e2e label passed on macOS/arm64 against a plain local registry, 5 specs in 153 s, with no kind cluster provisioned for the suite and no Linux host.
- UNVERIFIED: `task test:integration` on macOS. Only `task test:e2e` was exercised, while the sentence covers both suites; running one legacy suite locally would settle it.
- The `task` command list, the verification order and the Buildah compilation note do not change.

## Why

Both sentences were written from CI's environment, where kind is always provisioned, so they state a CI precondition as the only one. Leaving that in place costs the evidence an agent could have produced: the same file tells agents to establish that a check cannot run here before concluding it, and a concrete "needs Linux and kind" beats that general instruction every time.
