### PR TITLE
fix(build, stapel): name the exit code of a failed stage command

### DIFF
--- a/pkg/container_backend/legacy_stage_container_exit_test.go
+++ b/pkg/container_backend/legacy_stage_container_exit_test.go
@@ -1,0 +1,56 @@
+package container_backend
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/docker/cli/cli"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Legacy stage container exit status", func() {
+	DescribeTable("containerExitCode",
+		func(err error, expectedCode int, expectedOK bool) {
+			code, ok := containerExitCode(err)
+			Expect(ok).To(Equal(expectedOK))
+			Expect(code).To(Equal(expectedCode))
+		},
+		Entry("a bare status error", cli.StatusError{StatusCode: 23}, 23, true),
+		Entry("a wrapped status error", fmt.Errorf("container run failed: %w", cli.StatusError{StatusCode: 23}), 23, true),
+		Entry("a status error carrying a message", cli.StatusError{StatusCode: 125, Status: "no such image"}, 125, true),
+		Entry("any other error", errors.New("no such host"), 0, false),
+	)
+
+	DescribeTable("IsStartContainerErr",
+		func(err error, expected bool) {
+			Expect(IsStartContainerErr(err)).To(Equal(expected))
+		},
+		Entry("125 is a start failure", cli.StatusError{StatusCode: 125}, true),
+		Entry("126 is a start failure", cli.StatusError{StatusCode: 126}, true),
+		Entry("127 is a start failure", cli.StatusError{StatusCode: 127}, true),
+		Entry("a command exit code is not", cli.StatusError{StatusCode: 127 + 1}, false),
+		Entry("a wrapped start failure", fmt.Errorf("container run failed: %w", cli.StatusError{StatusCode: 126}), true),
+		Entry("any other error", errors.New("no such host"), false),
+	)
+
+	DescribeTable("namedContainerExitErr",
+		func(err error, expectedMessage string) {
+			named := namedContainerExitErr(err)
+			Expect(named.Error()).To(Equal(expectedMessage))
+			Expect(errors.Is(named, err)).To(BeTrue())
+		},
+		Entry("a message-less status error gets its code spelled out", cli.StatusError{StatusCode: 23}, "exit code 23"),
+		Entry("a status error with a message keeps it", cli.StatusError{StatusCode: 125, Status: "no such image"}, "no such image"),
+		Entry("any other error is left alone", errors.New("no such host"), "no such host"),
+	)
+
+	It("reports the exit code through the run wrapping", func() {
+		err := fmt.Errorf("container run failed: %w", namedContainerExitErr(cli.StatusError{StatusCode: 23}))
+
+		Expect(err.Error()).To(Equal("container run failed: exit code 23"))
+		code, ok := containerExitCode(err)
+		Expect(ok).To(BeTrue())
+		Expect(code).To(Equal(23))
+	})
+})

--- a/pkg/container_backend/legacy_stage_image_container.go
+++ b/pkg/container_backend/legacy_stage_image_container.go
@@ -3,11 +3,14 @@ package container_backend
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/docker/cli/cli"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
+	"github.com/samber/lo"
 
 	"github.com/werf/common-go/pkg/util"
 	"github.com/werf/logboek"
@@ -326,9 +329,29 @@ func (c *LegacyStageImageContainer) run(ctx context.Context) error {
 	err = docker.CliRun_LiveOutput(ctx, runArgs...)
 	UnregisterRunningContainer(c.name)
 	if err != nil {
-		return fmt.Errorf("container run failed: %w", err)
+		return fmt.Errorf("container run failed: %w", namedContainerExitErr(err))
 	}
 	return nil
+}
+
+func containerExitCode(err error) (int, bool) {
+	var statusErr cli.StatusError
+	if !errors.As(err, &statusErr) {
+		return 0, false
+	}
+
+	return statusErr.StatusCode, true
+}
+
+// docker/cli reports a non-zero container exit as a cli.StatusError with an empty message, so the
+// code has to be spelled out for the user. The empty verb keeps the error chain without a separator.
+func namedContainerExitErr(err error) error {
+	code, ok := containerExitCode(err)
+	if !ok || err.Error() != "" {
+		return err
+	}
+
+	return fmt.Errorf("exit code %d%w", code, err)
 }
 
 func (c *LegacyStageImageContainer) introspect(ctx context.Context) error {
@@ -340,7 +363,7 @@ func (c *LegacyStageImageContainer) introspect(ctx context.Context) error {
 	}
 
 	if err := docker.CliRun_LiveOutput(ctx, runArgs...); err != nil {
-		if !strings.Contains(err.Error(), "Code: ") || IsStartContainerErr(err) {
+		if _, ok := containerExitCode(err); !ok || IsStartContainerErr(err) {
 			return err
 		}
 	}
@@ -357,7 +380,7 @@ func (c *LegacyStageImageContainer) introspectBefore(ctx context.Context) error 
 	}
 
 	if err := docker.CliRun_LiveOutput(ctx, runArgs...); err != nil {
-		if !strings.Contains(err.Error(), "Code: ") || IsStartContainerErr(err) {
+		if _, ok := containerExitCode(err); !ok || IsStartContainerErr(err) {
 			return err
 		}
 	}
@@ -367,13 +390,9 @@ func (c *LegacyStageImageContainer) introspectBefore(ctx context.Context) error 
 
 // https://docs.docker.com/engine/reference/run/#exit-status
 func IsStartContainerErr(err error) bool {
-	for _, code := range []string{"125", "126", "127"} {
-		if strings.HasPrefix(err.Error(), fmt.Sprintf("Code: %s", code)) {
-			return true
-		}
-	}
+	code, ok := containerExitCode(err)
 
-	return false
+	return ok && lo.Contains([]int{125, 126, 127}, code)
 }
 
 func (c *LegacyStageImageContainer) commit(ctx context.Context) (string, error) {


### PR DESCRIPTION
## Summary

With the Docker Server backend a failed stapel stage command ends with `container run failed: ` and nothing after the colon, so the user is told the build failed but not why. Reproduces from a clean checkout:

```yaml
project: exitcode
configVersion: 1
---
image: app
from: registry.werf.io/base/ubuntu:22.04
shell:
  install:
  - exit 23
```

```sh
werf build --platform=linux/amd64
```

## What

- A stapel stage command exiting non-zero now ends with `container run failed: exit code 23`; before, everything after `container run failed: ` was empty. VERIFIED: the repro above, before and after, against a local Docker daemon.
- `--introspect-error` and `--introspect-before-error` again enter the introspection shell instead of failing the command with the shell's own exit status. Docker start failures (125, 126, 127) still abort as before. UNVERIFIED: the introspection paths were not exercised by hand; `werf build --introspect-error` on a failing stage would settle it.
- The error still wraps `cli.StatusError`, so a caller reading the exit code with `errors.As` keeps working.
- No flag, no output format and no other error text changes.

## Why

`docker/cli` used to render a container exit as `Status: , Code: 23`, and this code both printed that message and matched it as a string. Since the pin moved to v29, `cli.StatusError.Error()` returns the empty string when only `StatusCode` is set, which silently emptied the final error and turned two string matches into dead code: `strings.Contains(err.Error(), "Code: ")` never held, so the introspection paths treated every container exit as fatal, and `IsStartContainerErr` could never report a start failure.

Reading `StatusError.StatusCode` instead of the rendered message keeps the behavior independent of how the CLI decides to format its errors. Formatting the code into the message at the `docker.CliRun_LiveOutput` call sites was rejected: the exit status has to survive as a typed error for `werf run`, which propagates it as its own exit code.
