### PR TITLE
fix(build, stapel): stop tying stage builds to the stapel image cat

### DIFF
--- a/pkg/container_backend/legacy_stage_image_container.go
+++ b/pkg/container_backend/legacy_stage_image_container.go
@@ -98,11 +98,12 @@ func (c *LegacyStageImageContainer) prepareRunArgs(ctx context.Context) ([]strin
 }
 
 func (c *LegacyStageImageContainer) prepareRunCommandArgs() []string {
-	// The assignment reads the script to EOF, so a reader failure aborts before eval
-	// and build commands find stdin already drained. The redirect only makes that explicit.
+	// The assignment reads the script to EOF with Bash alone, so it needs no binary from the
+	// base or the stapel image, a reader failure aborts before eval, and build commands find
+	// stdin already drained. The redirect only makes that explicit.
 	return []string{
 		"-i", c.imageRef(c.image.fromImage), "-ec",
-		fmt.Sprintf(`script=$(%s); eval "$script" < /dev/null`, stapel.CatBinPath()),
+		`script=$(</dev/stdin); eval "$script" < /dev/null`,
 	}
 }
 

--- a/pkg/container_backend/legacy_stage_run_test.go
+++ b/pkg/container_backend/legacy_stage_run_test.go
@@ -2,6 +2,7 @@ package container_backend
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -30,15 +31,27 @@ var _ = Describe("Legacy stage command transport", func() {
 		Expect(container.prepareRunCommand()).To(Equal(strings.Join(commands, " && ")))
 		args := container.prepareRunCommandArgs()
 		Expect(args[:3]).To(Equal([]string{"-i", "base", "-ec"}))
+		Expect(args[3]).NotTo(ContainSubstring(stapel.CONTAINER_MOUNT_ROOT), "the script loader must not depend on a binary of the pinned stapel image")
 		for _, arg := range args {
 			Expect(len(arg)).To(BeNumerically("<", 128*1024))
 			Expect(arg).NotTo(ContainSubstring("import-padding"))
 		}
 	})
 
+	It("loads the script with no executable available", func(ctx SpecContext) {
+		args := container.prepareRunCommandArgs()
+		cmd := exec.CommandContext(ctx, "bash", args[2], args[3])
+		cmd.Env = append(os.Environ(), "PATH=")
+		cmd.Stdin = strings.NewReader("printf complete")
+
+		output, err := cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), string(output))
+		Expect(string(output)).To(Equal("complete"))
+	})
+
 	DescribeTable("propagates script reader failures before evaluation", func(ctx SpecContext, reader string, exitCode int) {
 		args := container.prepareRunCommandArgs()
-		loader := strings.ReplaceAll(args[3], stapel.CatBinPath(), reader)
+		loader := strings.ReplaceAll(args[3], "</dev/stdin", reader)
 		cmd := exec.CommandContext(ctx, "bash", args[2], loader)
 		cmd.Stdin = strings.NewReader("cat > /dev/null; printf complete")
 		output, err := cmd.Output()

--- a/pkg/stapel/stapel.go
+++ b/pkg/stapel/stapel.go
@@ -118,10 +118,6 @@ func TrueBinPath() string {
 	return embeddedBinPath("true")
 }
 
-func CatBinPath() string {
-	return embeddedBinPath("cat")
-}
-
 func LsBinPath() string {
 	return embeddedBinPath("ls")
 }


### PR DESCRIPTION
## Summary

The legacy Stapel script loader runs `cat` from the stapel image, so it works only as long as the pinned image ships that binary. It does today (0.6.2) and it does not in 0.7.2, which the 3 branch already pins: there every stapel stage dies with `/.werf/stapel/embedded/bin/bash: line 1: /.werf/stapel/embedded/bin/cat: No such file or directory` before running a single command. Bash can read the piped script on its own, so the dependency is unnecessary.

## What

- A stapel stage builds without `cat` in the stapel image: the loader is now `script=$(</dev/stdin); eval "$script" < /dev/null`. VERIFIED: a two-image project with 256 imports (script far past the argv limit) builds against a local Docker daemon, and its `cat > /tmp/eaten` + `test ! -s /tmp/eaten` stage still proves stdin is drained before the first command.
- Everything #7845 guarantees is unchanged: the script stays out of argv, a failing reader aborts the stage before evaluation, and the debug dump stays runnable.
- `stapel.CatBinPath` is removed; no other caller referenced it.
- The unit specs now require that the loader reference nothing under the stapel mount root and that it still work with an empty `PATH`, so neither an embedded nor a base-image binary can creep back in.
- No flag, log line, error text or `werf.yaml` surface changes.

## Why

#7845 replaced the base64-packed argv script with a pipe and reached for `cat` because the stapel image happened to have it. That put a build-critical dependency on the content of an image werf bumps independently of this code, and nothing in the tests could see it: the reader-failure table substitutes its own reader, and the e2e base image has `cat` on `PATH`, so both stayed green when the binary disappeared from the stapel image. `$(<file)` is a Bash redirection, not a fork, so it holds whatever the image contains.

Bumping the stapel image to restore `cat` was rejected: it needs a new artifact to keep a dependency that buys nothing, and the same trap returns the next time the image is trimmed. Reading the script with `read`/`mapfile` builtins was rejected too: at EOF they return non-zero, which fights the `-e` that makes a reader failure abort the stage.
