### PR TITLE
fix(build, buildah): stop re-compressing parent layers on stage push

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -415,5 +415,6 @@ replace (
 	github.com/deislabs/oras => github.com/werf/3p-oras v0.9.1-0.20240115121544-03962ecbd40a // upstream not maintained
 	github.com/docker/buildx => github.com/werf/3p-docker-buildx v0.13.0-rc2.0.20241111114615-d77c2e1444ad // upstream not maintained
 	github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305 // upstream not maintained
+	github.com/mattn/go-sqlite3 => github.com/mattn/go-sqlite3 v1.14.22 // v2.0.1+incompatible is a mistagged 2019 release bundling SQLite 3.30.1; containers/image blob-info cache needs sqlite_schema (SQLite >= 3.33)
 	github.com/spf13/cobra => github.com/andremueller/cobra v0.0.0-20241025091859-0d550c15a8a4 // remove after merge to upstream
 )

--- a/go.sum
+++ b/go.sum
@@ -104,7 +104,6 @@ github.com/Microsoft/hcsshim v0.12.2 h1:AcXy+yfRvrx20g9v7qYaJv5Rh+8GaHOS6b8G6Wx/
 github.com/Microsoft/hcsshim v0.12.2/go.mod h1:RZV12pcHCXQ42XnlQ3pz6FZfmrC1C+R4gaOHhRNML1g=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
-github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
@@ -143,7 +142,6 @@ github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9 h1:6CO
 github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/andremueller/cobra v0.0.0-20241025091859-0d550c15a8a4 h1:behIQV+NveRm5cqXAfvYDEA2AkjwE8rdJjyA7YT5XlM=
 github.com/andremueller/cobra v0.0.0-20241025091859-0d550c15a8a4/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
-github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
@@ -957,12 +955,8 @@ github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
-github.com/mattn/go-sqlite3 v1.6.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
-github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v2.0.1+incompatible h1:xQ15muvnzGBHpIpdrNi1DA5x0+TcBZzsIDwmw9uTHzw=
-github.com/mattn/go-sqlite3 v2.0.1+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/go-zglob v0.0.1/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/mattn/go-zglob v0.0.6 h1:mP8RnmCgho4oaUYDIDn6GNxYk+qJGUs8fJLn+twYj2A=
 github.com/mattn/go-zglob v0.0.6/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
@@ -1632,7 +1626,6 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.26.0 h1:EGMPT//Ezu+ylkCijjPc+f4Aih7sZvaAr+O3EHBxvZg=
 golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
-golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/buildah/blob_info_cache_linux_test.go
+++ b/pkg/buildah/blob_info_cache_linux_test.go
@@ -1,0 +1,29 @@
+//go:build cgo
+
+package buildah
+
+import (
+	"reflect"
+
+	"github.com/containers/image/v5/pkg/blobinfocache"
+	"github.com/containers/image/v5/pkg/blobinfocache/memory"
+	imgtypes "github.com/containers/image/v5/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
+)
+
+var _ = Describe("blob info cache", func() {
+	It("persists digest mappings across cache instances", func() {
+		sysCtx := &imgtypes.SystemContext{BlobInfoCacheDir: GinkgoT().TempDir()}
+		compressed := digest.FromString("compressed")
+		uncompressed := digest.FromString("uncompressed")
+
+		first := blobinfocache.DefaultCache(sysCtx)
+		Expect(reflect.TypeOf(first)).NotTo(Equal(reflect.TypeOf(memory.New())), "fell back to a memory-only cache")
+		first.RecordDigestUncompressedPair(compressed, uncompressed)
+
+		second := blobinfocache.DefaultCache(sysCtx)
+		Expect(second.UncompressedDigest(compressed)).To(Equal(uncompressed))
+	})
+})


### PR DESCRIPTION
## Summary

In Buildah mode, storing a Stapel stage into the repo re-exported and gzip-compressed every layer of the image — including all parent layers already present in the registry — before checking whether the registry had them. On multi-image projects with large base layers this made stages with a zero or byte-sized delta take minutes and write tens of gigabytes to disk per build. Reproduces from a clean checkout with any Stapel image whose `from` has several layers, once the parent stages are already in the repo and only a later stage is invalidated:

```yaml
project: blobcache
configVersion: 1
---
image: app
from: python:3.12-slim
shell:
  beforeInstall:
  - apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
  install:
  - echo v1 > /version
```

```sh
WERF_BUILDAH_MODE=auto werf build --repo <repo>
# change the install script, empty the local containers storage, rebuild:
WERF_DEBUG_BUILDAH=1 WERF_BUILDAH_MODE=auto werf build --repo <repo>
```

## What

- In Buildah mode `WERF_DEBUG_BUILDAH=1` no longer prints `Error creating a SQLite blob info cache at .../blob-info-cache-v1.sqlite, using a memory-only cache: ... no such table: sqlite_schema`; the file is created and populated on the first pull or push.
  - VERIFIED: on a rootless Buildah host with the repro above, pushing the invalidated `install` stage exports and compresses 1 layer instead of 7 (`Compressing blob on the fly` 7 → 1, `Skipping blob ... (already present)` for every parent layer).
- Parent layers pulled from the same registry earlier in the run are reused on push by their known compressed digest — a `HEAD` per layer and no export or compression.
  - The cache lives in `$XDG_DATA_HOME/containers/cache` (default `~/.local/share/containers/cache`); an ephemeral home still gets the benefit within one werf run, since the pull of the base stage seeds it.
- The Docker backend, the pull/push protocol, and the produced image digests do not change.
- A Linux/CGO unit test in `pkg/buildah` fails whenever the default blob-info cache degrades to memory-only, so a future dependency bump that reintroduces an incompatible SQLite breaks CI instead of silently slowing builds.

## Why

`containers/image` v5.30 stores the blob-info cache in SQLite and probes it with `SELECT 1 FROM sqlite_schema`, a table name that exists only since SQLite 3.33. werf linked SQLite 3.30.1: `go.mod` resolved `github.com/mattn/go-sqlite3` to the mistagged `v2.0.1+incompatible` (a 2019 snapshot) because `jmoiron/sqlx`, reached via `3p-helm-for-werf-helm`, requires that tag and `+incompatible` v2 wins module selection over the `v1.14.22` that `containers/image` requires. On the schema error `containers/image` silently falls back to a per-call in-memory cache, so with `DockerRegistryPushPrecomputeDigests` (enabled in werf) every push has to re-derive the compressed digest of every layer before it can ask the registry for it.

Pinning `go-sqlite3` to `v1.14.22` via `replace` restores the version `containers/image` is tested against. Excluding the bad tag instead would leave module selection with no valid v2 candidate for `sqlx`; upgrading `sqlx` is out of scope since the driver is only used in its tests.

